### PR TITLE
Fascility Home Page Style fixes

### DIFF
--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -101,10 +101,10 @@ export const FacilityHome = (props: any) => {
 
     return (
         <div className={`w3-content ${classes.content}`}>
-            <h2>Facility</h2>
+            <h2 style={{ padding: "10px", marginBottom: '5px' }}>Facility</h2>
             <Grid container style={{ padding: "10px", marginBottom: '5px' }} spacing={2}>
                 <Grid item xs={12} md={7}>
-                    <Typography variant="h6" component="h6">{facilityData.name}</Typography>
+                    <Typography style={{ textTransform: 'capitalize' }} variant="h6" component="h6">{facilityData.name}</Typography>
                     <Typography>Address : {facilityData.address}</Typography>
                     <Typography>Phone : {facilityData.phone_number}</Typography>
                     <Typography>District : {facilityData?.district_object?.name}</Typography>


### PR DESCRIPTION
- Started contributing in the project
- Style Fixes in Facility Home Page

Aligned Heading and name with same margin and padding
<img width="565" alt="Screenshot 2020-03-31 at 3 24 29 PM" src="https://user-images.githubusercontent.com/9211987/78013235-d32b2c80-7363-11ea-8536-0a3426635221.png">
