### PR TITLE
Phone number links to have Click to Call facility

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -141,7 +141,7 @@ export const ConsultationDetails = (props: any) => {
     return (
         <div className="px-2 pb-2">
             <PageTitle title={`Consultation #${consultationId}`} />
-            <div className="border rounded-lg bg-white shadow h-full cursor-pointer hover:border-primary-500 text-black mt-4 p-4">
+            <div className="border rounded-lg bg-white shadow h-full hover:border-primary-500 text-black mt-4 p-4">
                 <div className="flex justify-between">
                     <div className="grid gap-2 grid-cols-1">
                         <div className="capitalize">

--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -63,9 +63,7 @@ export const HospitalList = () => {
       return (
         <div key={`usr_${facility.id}`} className="w-full md:w-1/2 mt-6 md:px-4">
           <div
-            className="block rounded-lg bg-white shadow h-full cursor-pointer hover:border-primary-500 overflow-hidden"
-            onClick={() => navigate(`/facility/${facility.id}`)}
-          >
+            className="block rounded-lg bg-white shadow h-full hover:border-primary-500 overflow-hidden">
             <div className="h-full flex flex-col justify-between">
               <div className="px-6 py-4">
                 <div className="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium leading-5 bg-blue-100 text-blue-800">
@@ -83,10 +81,11 @@ export const HospitalList = () => {
                 <div className="flex py-4 justify-between">
                   <div>
                     <div className="text-gray-500 leading-relaxed">Phone:</div>
-                    <div className="font-semibold">{facility.phone_number || "-"}</div>
+                    <a href={`tel:${facility.phone_number}`} className="font-semibold">{facility.phone_number || "-"}</a>
                   </div>
                   <span className="inline-flex rounded-md shadow-sm">
-                    <button type="button" className="inline-flex items-center px-3 py-2 border border-green-500 text-sm leading-4 font-medium rounded-md text-green-700 bg-white hover:text-green-500 focus:outline-none focus:border-green-300 focus:shadow-outline-blue active:text-green-800 active:bg-gray-50 transition ease-in-out duration-150">
+                    <button type="button" className="inline-flex items-center px-3 py-2 border border-green-500 text-sm leading-4 font-medium rounded-md text-green-700 bg-white hover:text-green-500 focus:outline-none focus:border-green-300 focus:shadow-outline-blue active:text-green-800 active:bg-gray-50 transition ease-in-out duration-150 hover:shadow"
+                        onClick={() => navigate(`/facility/${facility.id}`)}>
                       View Facility
                     </button>
                   </span>

--- a/src/Components/Patient/DailyRoundListDetails.tsx
+++ b/src/Components/Patient/DailyRoundListDetails.tsx
@@ -62,7 +62,7 @@ export const DailyRoundListDetails = (props: any) => {
   return (
     <div className="px-2">
       <PageTitle title={`Daily Rounds #${id}`} />
-      <div className="border rounded-lg bg-white shadow h-full cursor-pointer hover:border-primary-500 text-black mt-4 p-4">
+      <div className="border rounded-lg bg-white shadow h-full hover:border-primary-500 text-black mt-4 p-4">
         <div className="flex justify-between">
           <div className="max-w-md">
             <div>

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -250,7 +250,7 @@ export const PatientHome = (props: any) => {
         />
       )}
       <PageTitle title={`Covid Suspect Details`} />
-      <div className="border rounded-lg bg-white shadow h-full cursor-pointer hover:border-primary-500 text-black mt-4 p-4">
+      <div className="border rounded-lg bg-white shadow h-full hover:border-primary-500 text-black mt-4 p-4">
         <div className="flex justify-between">
           <div className="grid gap-2 grid-cols-1">
             <div className="flex items-baseline">

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -309,7 +309,7 @@ export const PatientHome = (props: any) => {
           </div>
           <div>
             <span className="font-semibold leading-relaxed">Phone: </span>
-            {patientData.phone_number}
+            <a href={`tel:${patientData.phone_number}`}>{patientData.phone_number || "-"}</a>
           </div>
           <div>
             <span className="font-semibold leading-relaxed">Nationality: </span>

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -119,7 +119,7 @@ export default function ManageUsers(props: any) {
                 <div className="flex py-4 justify-between">
                   <div>
                     <div className="text-gray-500 leading-relaxed">Phone:</div>
-                    <div className="font-semibold">{user.phone_number || "-"}</div>
+                    <a href={`tel:${user.phone_number}`} className="font-semibold">{user.phone_number || "-"}</a>
                   </div>
                 </div>
               </div>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -60,4 +60,17 @@ h6 {
   @apply py-2 px-5 text-base h-10;
 }
 
+a {
+  @apply text-blue-800;
+}
+
+a:hover {
+  @apply text-blue-600;
+}
+
+a[href^="tel:"]:before {
+  content: "\260e";
+  @apply mr-1;
+}
+
 @import "tailwindcss/utilities";


### PR DESCRIPTION
Updating phone number in the application to behave such as when clicked open the phone dialer app.
video: https://drive.google.com/file/d/1R4VImv7wKSGTU_V_cYJSD6dkLNUe4sLx/view?usp=sharing

When clicked in a browser other than in mobile,
 if chrome and connected google account, send number to phone pops up.
else for all browsers, popup to choose VoIP application service comes up. 
Something like this:
![image](https://user-images.githubusercontent.com/21201812/85293486-07be0880-b4bb-11ea-9fd6-8cc1eaf567d4.png)

If in non-mobile browsers we need to hide this, it is also possible.

