### PR TITLE
passing webpack mode as dev in npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^3.7.5"
   },
   "scripts": {
-    "start": "webpack-dev-server -p --open",
+    "start": "webpack-dev-server -p --open --mode=development",
     "start:Dev": "NODE_ENV=production http-server dist",
     "build": "NODE_ENV=production ./node_modules/.bin/webpack -p --mode=production"
   },


### PR DESCRIPTION
while build start time remains to be same. Rebuild time for development seeing a 50% improvement.

For me rebuild time changed from 14sec to 6sec.