### PR TITLE
dev fix: making build-meta.json optional in development build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,8 +104,10 @@ module.exports = (env, argv) => {
             to: "robots.txt",
           },
           {
+            // build meata contains version no for latest build. check "generate-build-meta" package script
             from: "public/build-meta.json",
             to: "build-meta.json",
+            noErrorOnMissing: isDev
           }
         ],
       }),


### PR DESCRIPTION
if you do a npm start as of now it throws an error if "build-meta.json" file is not present in public. Unless you do a `npm run generate-build-meta`

But public/build-meta.json is not something essential for development flow(npm start) as of now.

updating webpack copy plugin so that, if "build-meta.json" file is not found in the development build, don't throw an error.