### PR TITLE
fix for material-ui-pickers error: `unescaped latin alphabet character `n``

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "care_fe",
-  "version": "2.5.2",
+  "version": "2.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1646,18 +1646,11 @@
       "integrity": "sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA=="
     },
     "@date-io/date-fns": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.8.0.tgz",
-      "integrity": "sha512-7j2RtmXWbDDBROJNL/WMrC7dK9RgV8BBW1aQtO3JB3NU52ZP5DBgJ+M5xEoEWJ+50vaKxLPYq2QYkrWsqlbzxg==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-1.3.13.tgz",
+      "integrity": "sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==",
       "requires": {
-        "@date-io/core": "^2.8.0"
-      },
-      "dependencies": {
-        "@date-io/core": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.8.0.tgz",
-          "integrity": "sha512-MIL74B3O08gjjm5fcDSWME5MfdsvyQBX58zlWHIzM+m2h3+M5rP6P+T3qym3FWnpc8EKK5E8kF97nLqNiOwgkQ=="
-        }
+        "@date-io/core": "^1.3.13"
       }
     },
     "@emotion/hash": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/core": "^7.10.5",
     "@coronasafe/prescription-builder": "^0.1.13",
-    "@date-io/date-fns": "^2.8.0",
+    "@date-io/date-fns": "^1.3.13",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",


### PR DESCRIPTION
Fix for https://sentry.io/share/issue/e485aee30bf74d7491727ee36d4ee742/

@material-ui/pickers was having unsupported version of date-fns. 
as per their installation page - https://material-ui-pickers.dev/getting-started/installation, **For material-ui-pickers v3 use v1.x version of @date-io adapters**

https://github.com/mui-org/material-ui-pickers/issues/1440