### PR TITLE
updating sample test icon in left nav

### DIFF
--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -143,7 +143,7 @@ let menus = [
   {
     title: "Sample Test",
     link: "/sample",
-    icon: "fas fa-cog"
+    icon: "fas fa-medkit"
   },
   {
     title: "Shifting",


### PR DESCRIPTION
Today the icon for **sample test** section looks like a settings icons and does not convey anything about testing or medical field related.
Updating it to a more appropriate one.

old icon:
![image](https://user-images.githubusercontent.com/21201812/89558955-92bc4d80-d832-11ea-94f3-a13d396daf32.png)
Updated icon:
![image](https://user-images.githubusercontent.com/21201812/89559098-d1ea9e80-d832-11ea-8b77-f3800ee00166.png)

Feel free to close this if does not make sense.
