### PR TITLE
Web config update

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "scripts": {
     "prebuild": "npm run re:build && npm run generate-build-meta",
-    "start": "npm run re:build && webpack-dev-server -p --mode=development",
+    "start": "npm run re:build && webpack-dev-server -p --open --mode=development",
     "start:Dev": "NODE_ENV=production http-server dist",
     "re:build": "bsb -make-world -clean-world",
     "re:watch": "bsb -make-world -clean-world -w",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "scripts": {
     "prebuild": "npm run re:build && npm run generate-build-meta",
-    "start": "npm run re:build && webpack-dev-server -p --open --mode=development",
+    "start": "npm run re:build && webpack-dev-server -p --mode=development",
     "start:Dev": "NODE_ENV=production http-server dist",
     "re:build": "bsb -make-world -clean-world",
     "re:watch": "bsb -make-world -clean-world -w",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,6 @@ module.exports = (env, argv) => {
     },
     output: {
       path: path.resolve(__dirname, "dist"),
-      pathinfo: false,
       filename: isDev ? "js/bundle.[hash].js" : "js/bundle.prod.[hash].js",
       chunkFilename: "[name].[chunkhash].chunk.js",
       publicPath: "/",
@@ -87,9 +86,6 @@ module.exports = (env, argv) => {
             path.resolve(__dirname, 'node_modules/@coronasafe')
           ],
           loader: "ts-loader",
-          options: {
-            transpileOnly: true
-          }
         },
         {
           enforce: "pre",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = (env, argv) => {
         name: entrypoint => `runtime-${entrypoint.name}`,
       },
     },
-    devtool: isDev ? "source-map" : "none",
+    devtool: isDev ? "eval-cheap-module-source-map" : "none",
     mode,
     resolve: {
       extensions: [".js", ".jsx", ".json", ".ts", ".tsx", ".manifest"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,10 @@ module.exports = (env, argv) => {
       rules: [
         {
           test: /\.(ts|tsx)$/,
-          include: path.resolve(__dirname, 'src'),
+          include: [
+            path.resolve(__dirname, 'src'),
+            path.resolve(__dirname, 'node_modules/@coronasafe')
+          ],
           loader: "ts-loader",
           options: {
             transpileOnly: true


### PR DESCRIPTION
A tiny effort to reduce build times.

Ran from my lap:
 old initial dev build time: 65320ms
 old rebuild time: 31148ms

 new initial dev build time: 65110ms
 new rebuild time: 26001ms

While initial build time remains the same(due to changing source map options to "eval-cheap-module-source-map"),
rebuild time is faster by about 5seconds.

Some other areas to explore are:
-   https://github.com/TypeStrong/ts-loader#faster-builds
-   using just reason.js or typescript but not both
-   using SplitChunksPlugin plugin (https://webpack.js.org/guides/build-performance/#smaller--faster)

