### PR TITLE
Staff user can create new staff only if linked to their facility

### DIFF
--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { GENDER_TYPES, USER_TYPES } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { validateEmailAddress, validatePassword, validateUsername } from "../../Common/validation";
-import { addUser, getDistrictByState, getLocalbodyByDistrict, getStates } from "../../Redux/actions";
+import { addUser, getDistrictByState, getLocalbodyByDistrict, getStates, getUserListFacility } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { DateInputField, PhoneNumberField, SelectField, TextInputField } from "../Common/HelperInputFields";
@@ -92,6 +92,7 @@ export const UserAdd = (props: UserProps) => {
   const [isStateLoading, setIsStateLoading] = useState(false);
   const [isDistrictLoading, setIsDistrictLoading] = useState(false);
   const [isLocalbodyLoading, setIsLocalbodyLoading] = useState(false);
+  const [current_user_facilities, setFacilities] = useState<Array<String>>([]);
   const [states, setStates] = useState(initialStates);
   const [districts, setDistricts] = useState(selectStates);
   const [localBody, setLocalBody] = useState(selectDistrict);
@@ -100,7 +101,11 @@ export const UserAdd = (props: UserProps) => {
   const rootState: any = useSelector((rootState) => rootState);
   const { currentUser } = rootState;
   const isSuperuser = currentUser.data.is_superuser;
+
+  const username = currentUser.data.username;
+
   const userType = currentUser.data.user_type;
+
   const userIndex = USER_TYPES.indexOf(userType);
   const userTypes = isSuperuser ? [...USER_TYPES] : USER_TYPES.slice(0, userIndex + 1)
 
@@ -137,6 +142,9 @@ export const UserAdd = (props: UserProps) => {
     },
     [dispatchAction]
   );
+
+
+
 
   // const fetchData = useCallback(
   //   async (status: statusType) => {
@@ -184,12 +192,26 @@ export const UserAdd = (props: UserProps) => {
     [dispatchAction]
   );
 
+  const fetchFacilities = useCallback(
+    async (status: any) => {
+      setIsStateLoading(true);
+      const res = await dispatchAction(getUserListFacility({ username }));
+      if (!status.aborted && res && res.data) {
+        const facilities = res.data.map((f: any) => f.id);
+        setFacilities(facilities);
+      }
+      setIsStateLoading(false);
+    }, [dispatchAction]
+  );
+
+
   useAbortableEffect(
     (status: statusType) => {
       // if (userId) {
       //   fetchData(status);
       // }
       fetchStates(status);
+      fetchFacilities(status);
     },
     [dispatch]
   );
@@ -230,6 +252,18 @@ export const UserAdd = (props: UserProps) => {
     let invalidForm = false;
     Object.keys(state.form).forEach(field => {
       switch (field) {
+        case "facilities":
+          if (userType === "Staff" && state.form["user_type"] === "Staff") {
+            invalidForm = true;
+            for (const facilityId of state.form[field]) {
+              if (current_user_facilities.indexOf(facilityId) !== -1) {
+                invalidForm = false;
+                return;
+              }
+            }
+            errors[field] = "Please select atleast one of your facilities";
+          }
+          return;
         case "user_type":
           if (!state.form[field]) {
             errors[field] = "Please select the User Type";
@@ -294,6 +328,7 @@ export const UserAdd = (props: UserProps) => {
             invalidForm = true;
           }
           return;
+
         default:
           return;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13658,7 +13658,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-phone-input-2@^2.13.9:
+react-phone-input-2@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/react-phone-input-2/-/react-phone-input-2-2.14.0.tgz#75dff7ba503becc7a19e0e8ff5aa3d878265af77"
   integrity sha512-gOY3jUpwO7ulryXPEdqzH7L6DPqI9RQxKfBxZbgqAwXyALGsmwLWFyi2RQwXlBLWN/EPPT4Nv6I9TESVY2YBcg==


### PR DESCRIPTION
A current staff user can now only create a new staff user if at least any one of their facilities have been selected. #1161 