### PR TITLE
Required Oxygen in Resource Form and Approved Quantity in Resource Update

### DIFF
--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -48,6 +48,7 @@ const initForm: any = {
   reason: "",
   refering_facility_contact_name: "",
   refering_facility_contact_number: "",
+  required_quantity: null,
 };
 
 const requiredFields: any = {
@@ -180,6 +181,7 @@ export default function ResourceCreate(props: resourceProps) {
         refering_facility_contact_number: parsePhoneNumberFromString(
           state.form.refering_facility_contact_number
         )?.format("E.164"),
+        requested_quantity: state.form.requested_quantity || 0,
       };
 
       const res = await dispatchAction(createResource(data));
@@ -297,6 +299,19 @@ export default function ResourceCreate(props: resourceProps) {
                   className="bg-white h-14 w-1/3 mt-2 shadow-sm md:text-sm md:leading-5"
                 />
               </div>
+              
+              <div>
+                <InputLabel>Quantity Required</InputLabel>
+                <TextInputField
+                  name="requested_quantity"
+                  variant="outlined"
+                  margin="dense"
+                  type="number"
+                  value={state.form.required_quantity}
+                  onChange={handleChange}
+                  errors=""
+                />
+                </div>
               
               <div className="md:col-span-2">
                 <InputLabel>Request Title*</InputLabel>

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -301,7 +301,7 @@ export default function ResourceCreate(props: resourceProps) {
               </div>
               
               <div>
-                <InputLabel>Quantity Required</InputLabel>
+                <InputLabel>Required Quantity</InputLabel>
                 <TextInputField
                   name="requested_quantity"
                   variant="outlined"

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -175,6 +175,12 @@ export default function ResourceDetails(props: { id: string }) {
             </div>
             <div>
               <span className="font-semibold leading-relaxed">
+                Approved Quantity:{" "}
+              </span>
+              {data.assigned_quantity}
+            </div>
+            <div>
+              <span className="font-semibold leading-relaxed">
                 Contact person number:{" "}
               </span>
               {data.refering_facility_contact_number ? (

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -163,6 +163,12 @@ export default function ResourceDetails(props: { id: string }) {
             </div>
             <div>
               <span className="font-semibold leading-relaxed">
+                Quantity Required:{" "}
+              </span>
+              {data.requested_quantity || "--"}
+            </div>
+            <div>
+              <span className="font-semibold leading-relaxed">
                 Contact person at the facility:{" "}
               </span>
               {data.refering_facility_contact_name || "--"}

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -163,7 +163,7 @@ export default function ResourceDetails(props: { id: string }) {
             </div>
             <div>
               <span className="font-semibold leading-relaxed">
-                Quantity Required:{" "}
+                Required Quantity:{" "}
               </span>
               {data.requested_quantity || "--"}
             </div>

--- a/src/Components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/Components/Resource/ResourceDetailsUpdate.tsx
@@ -46,6 +46,7 @@ const initForm: any = {
   assigned_facility_type: "",
   assigned_to: "",
   requested_quantity: null,
+  assigned_quantity: null,
 };
 
 const requiredFields: any = {
@@ -74,6 +75,7 @@ const goBack = () => {
 export const ResourceDetailsUpdate = (props: resourceProps) => {
   const dispatchAction: any = useDispatch();
   const [isLoading, setIsLoading] = useState(true);
+  const [assignedQuantity, setAssignedQuantity] = useState(0);
 
   const resourceFormReducer = (state = initialState, action: any) => {
     switch (action.type) {
@@ -146,6 +148,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
         reason: state.form.reason,
         assigned_to: state.form.assigned_to,
         requested_quantity: state.form.requested_quantity || 0,
+        assigned_quantity: state.form.status === "PENDING"? state.form.assigned_quantity : assignedQuantity,
       };
 
       const res = await dispatchAction(updateResource(props.id, data));
@@ -170,6 +173,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
       const res = await dispatchAction(getResourceDetails({ id: props.id }));
       if (!status.aborted) {
         if (res && res.data) {
+          setAssignedQuantity(res.data.assigned_quantity);
           dispatch({ type: "set_form", form: res.data });
         }
         setIsLoading(false);
@@ -256,6 +260,19 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
                   onChange={handleChange}
                   errors=""
                 />
+              </div>
+              <div>
+                  <InputLabel>Approved Quantity</InputLabel>
+                  <TextInputField
+                    name="assigned_quantity"
+                    variant="outlined"
+                    margin="dense"
+                    type="number"
+                    value={state.form.assigned_quantity}
+                    onChange={handleChange}
+                    disabled={state.form.status !== "PENDING"}
+                    errors=""
+                  />
               </div>
               <div>
                 <InputLabel>Is this an emergency?</InputLabel>

--- a/src/Components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/Components/Resource/ResourceDetailsUpdate.tsx
@@ -45,6 +45,7 @@ const initForm: any = {
   reason: "",
   assigned_facility_type: "",
   assigned_to: "",
+  requested_quantity: null,
 };
 
 const requiredFields: any = {
@@ -144,6 +145,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
         title: state.form.title,
         reason: state.form.reason,
         assigned_to: state.form.assigned_to,
+        requested_quantity: state.form.requested_quantity || 0,
       };
 
       const res = await dispatchAction(updateResource(props.id, data));
@@ -243,7 +245,18 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
                   errors={state.errors.assigned_facility}
                 />
               </div>
-
+              <div>
+                <InputLabel>Required Quantity</InputLabel>
+                <TextInputField
+                  name="requested_quantity"
+                  variant="outlined"
+                  margin="dense"
+                  type="number"
+                  value={state.form.requested_quantity}
+                  onChange={handleChange}
+                  errors=""
+                />
+              </div>
               <div>
                 <InputLabel>Is this an emergency?</InputLabel>
                 <RadioGroup


### PR DESCRIPTION
Issue #1207

User can add required amounts of oxygen in the form. The quantity can be seen in the resource card and also be updated.

<img src="https://user-images.githubusercontent.com/62461536/120070475-58b18600-c0a8-11eb-8efa-caf05757ed06.jpg" width=75%>
<img src="https://user-images.githubusercontent.com/62461536/120070479-60712a80-c0a8-11eb-8ced-f77be9883db9.jpg" width=75%>
