### PR TITLE
Add permanent address field for patient

### DIFF
--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -121,6 +121,7 @@ const initForm: any = {
   local_body: "",
   ward: "",
   address: "",
+  permanent_address: "",
   village: "",
   allergies: "",
   pincode: "",
@@ -221,6 +222,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     transfer?: boolean;
     patientList: Array<DupPatientModel>;
   }>({ patientList: [] });
+  const [sameAddress, setSameAddress] = useState(true);
   const [{ extId }, setQuery] = useQueryParams();
 
   useEffect(() => {
@@ -303,6 +305,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
       form["address"] = res.data.address
         ? res.data.address
         : state.form.address;
+      form["permanent_address"] = res.data.permanent_address
+        ? res.data.permanent_address
+        : state.form.permanent_address;
       form["gender"] = res.data.gender
         ? parseGenderFromExt(res.data.gender, state.form.gender)
         : state.form.gender;
@@ -488,6 +493,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
         case "address":
         case "name":
         case "gender":
+        case "permanent_address":
           if (!state.form[field]) {
             errors[field] = "Field is required";
             invalidForm = true;
@@ -688,6 +694,11 @@ export const PatientRegister = (props: PatientRegisterProps) => {
         ward: state.form.ward,
         village: state.form.village,
         address: state.form.address ? state.form.address : undefined,
+        permanent_address: sameAddress
+          ? state.form.address
+          : state.form.permanent_address
+          ? state.form.permanent_address
+          : undefined,
         present_health: state.form.present_health
           ? state.form.present_health
           : undefined,
@@ -1393,7 +1404,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   )}
 
                   <div>
-                    <InputLabel id="address-label">Address*</InputLabel>
+                    <InputLabel id="address-label">Current Address*</InputLabel>
                     <MultilineInputField
                       rows={2}
                       name="address"
@@ -1405,6 +1416,29 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                       onChange={handleChange}
                       errors={state.errors.address}
                     />
+                  </div>
+                  <div>
+                    <InputLabel id="permanent-address-label">
+                      Permanent Address*
+                    </InputLabel>
+                    <CheckboxField
+                      checked={sameAddress}
+                      onChange={() => setSameAddress(!sameAddress)}
+                      label="Same as Current Address"
+                    />
+                    {sameAddress ? null : (
+                      <MultilineInputField
+                        rows={2}
+                        name="permanent_address"
+                        variant="outlined"
+                        margin="dense"
+                        type="text"
+                        placeholder="Enter the address"
+                        value={state.form.permanent_address}
+                        onChange={handleChange}
+                        errors={state.errors.permanent_address}
+                      />
+                    )}
                   </div>
                   <div>
                     <InputLabel id="ward-label">

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1411,7 +1411,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                       variant="outlined"
                       margin="dense"
                       type="text"
-                      placeholder="Enter the address"
+                      placeholder="Enter the current address"
                       value={state.form.address}
                       onChange={handleChange}
                       errors={state.errors.address}
@@ -1433,7 +1433,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                         variant="outlined"
                         margin="dense"
                         type="text"
-                        placeholder="Enter the address"
+                        placeholder="Enter the permanent address"
                         value={state.form.permanent_address}
                         onChange={handleChange}
                         errors={state.errors.permanent_address}

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -222,7 +222,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     transfer?: boolean;
     patientList: Array<DupPatientModel>;
   }>({ patientList: [] });
-  const [sameAddress, setSameAddress] = useState(true);
+  const [sameAddress, setSameAddress] = useState(false);
   const [{ extId }, setQuery] = useQueryParams();
 
   useEffect(() => {


### PR DESCRIPTION
Solves issue #741 
Added a permanent address field for patient creation and updation form, the staff could select the checkbox in case the permanent address is same as the current address like this:
![permanent_address_care](https://user-images.githubusercontent.com/42417893/120080066-d095a580-c0d4-11eb-8149-a5ed9fa994cc.gif)
