### PR TITLE
admitted field patient consultation

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -358,6 +358,8 @@ export const ConsultationForm = (props: any) => {
     if (value === "A") {
       form.admitted = "true";
     }
+    else
+      form.admitted = "false"
     dispatch({ type: "set_form", form });
   };
 

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -357,9 +357,9 @@ export const ConsultationForm = (props: any) => {
     form[name] = value;
     if (value === "A") {
       form.admitted = "true";
+    } else {
+      form.admitted = "false";
     }
-    else
-      form.admitted = "false"
     dispatch({ type: "set_form", form });
   };
 


### PR DESCRIPTION
Closes #1289 

When `decision after consultation` is set to a value other than `Admitted`, `admitted` checkbox will be set to `No` automatically.