### PR TITLE
changed date format to have AM/PM in InventoryLog

### DIFF
--- a/src/Components/Facility/InventoryLog.tsx
+++ b/src/Components/Facility/InventoryLog.tsx
@@ -103,7 +103,7 @@ export default function InventoryLog(props: any) {
             <div className="ml-3">
               <p className="text-gray-900 whitespace-no-wrap">
                 {moment(inventoryItem.created_date).format(
-                  "DD-MM-YYYY hh:mm:ss"
+                  "DD-MM-YYYY LTS"
                 )}
               </p>
             </div>


### PR DESCRIPTION
this resolves issue #1329
added AM/PM to the dates in InventoryLog

after the change the UI looks like, 
![image](https://user-images.githubusercontent.com/29787772/120739204-c4fc1180-c50e-11eb-93f7-58a848d6eb00.png)
