### PR TITLE
Fixes #1336

### DIFF
--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -91,10 +91,14 @@ export const FacilityHome = (props: any) => {
     setOpenDeleteDialog(false);
   };
 
-  const handleDeleteSubmit = () => {
-    dispatch(deleteFacility(facilityId));
+  const handleDeleteSubmit = async () => {
+    const res = await dispatch(deleteFacility(facilityId));
+    if(res && res.status == 204){
+      Notification.Success({
+        msg: "Facility deleted successfully"
+      });
+    }
     navigate("/facility");
-    window.location.reload();
   };
 
   const state: any = useSelector((state) => state);


### PR DESCRIPTION
Closes #1336 

When a facility is deleted, even if it is unsuccessful the notification was not shown because the page reloads automatically. I have removed that. 
And when facility is deleted successfuly, there was no notification shown to user. I have added that.