### PR TITLE
rearranged buttons in ConsultationDetails

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -268,13 +268,13 @@ export const ConsultationDetails = (props: any) => {
                   {consultationData.facility_name || "-"}
                 </div>
               </div>
-              <div className="flex flex-col">
+              <div className="flex flex-col lg:grid grid-rows-2 grid-flow-col lg:gap-2 justify-items-center items-center">
                 <div className="mt-2">
                   <Button
                     variant="contained"
                     color="primary"
                     size="small"
-                    className="float-right"
+                    className="float-right md:float-none truncate"
                     onClick={() =>
                       navigate(
                         `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/update`
@@ -289,7 +289,22 @@ export const ConsultationDetails = (props: any) => {
                     variant="contained"
                     color="primary"
                     size="small"
-                    className="float-right"
+                    className="float-right md:float-none truncate"
+                    onClick={() =>
+                      navigate(
+                        `/facility/${facilityId}/patient/${patientId}/shift/new`
+                      )
+                    }
+                  >
+                    SHIFT PATIENT
+                  </Button>
+                </div>
+                <div className="mt-2">
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    className="float-right md:float-none truncate"
                     onClick={() =>
                       navigate(
                         `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/investigation/`
@@ -304,7 +319,7 @@ export const ConsultationDetails = (props: any) => {
                     variant="contained"
                     color="primary"
                     size="small"
-                    className="float-right"
+                    className="float-right md:float-none truncate"
                     onClick={() =>
                       navigate(
                         `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/investigationSessions`
@@ -315,29 +330,13 @@ export const ConsultationDetails = (props: any) => {
                   </Button>
                 </div>
 
-                <div className="mt-2">
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    size="small"
-                    className="float-right"
-                    onClick={() =>
-                      navigate(
-                        `/facility/${facilityId}/patient/${patientId}/shift/new`
-                      )
-                    }
-                  >
-                    SHIFT PATIENT
-                  </Button>
-                </div>
-
                 {!consultationData.discharge_date && (
                   <div className="mt-2">
                     <Button
                       variant="contained"
                       color="primary"
                       size="small"
-                      className="float-right"
+                      className="float-right md:float-none truncate"
                       onClick={() => setIsPrintMode(true)}
                     >
                       Treatment Summary


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/29787772/121293568-76cd8080-c909-11eb-81b6-daed6951f2d0.png)

now:
![image](https://user-images.githubusercontent.com/29787772/121293493-543b6780-c909-11eb-9b8b-53838a41d09f.png)
