### PR TITLE
Modify option in Sample Management Request Form

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -350,6 +350,9 @@ export const SAMPLE_TYPE_CHOICES = [
   "Blood in EDTA",
   "Acute Sera",
   "Covalescent sera",
+  "Biopsy",
+  "AMR",
+  "Communicable Diseases",
   "OTHER TYPE",
 ];
 

--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -357,6 +357,7 @@ export const SAMPLE_TYPE_CHOICES = [
 ];
 
 export const ICMR_CATEGORY = [
+  "",
   "Cat 0",
   "Cat 1",
   "Cat 2",

--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -357,7 +357,6 @@ export const SAMPLE_TYPE_CHOICES = [
 ];
 
 export const ICMR_CATEGORY = [
-  "",
   "Cat 0",
   "Cat 1",
   "Cat 2",

--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -251,7 +251,7 @@ export const SampleTest = (props: any) => {
                   />
                 </div>
                 <div>
-                  <InputLabel>ICMR Category*</InputLabel>
+                  <InputLabel>ICMR Category (for COVID Test)</InputLabel>
                   <SelectField
                     name="icmr_category"
                     variant="outlined"

--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -38,7 +38,7 @@ const initForm: SampleTestModel = {
   is_atypical_presentation: false,
   is_unusual_course: false,
   sample_type: "UNKNOWN",
-  icmr_category: "Cat 0",
+  icmr_category: "",
   sample_type_other: "",
 };
 

--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -38,7 +38,7 @@ const initForm: SampleTestModel = {
   is_atypical_presentation: false,
   is_unusual_course: false,
   sample_type: "UNKNOWN",
-  icmr_category: "",
+  icmr_category: "Cat 0",
   sample_type_other: "",
 };
 

--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -120,12 +120,12 @@ export const SampleTest = (props: any) => {
             invalidForm = true;
           }
           break;
-        case "icmr_category":
-          if (!state.form[field]) {
-            errors[field] = "Please Choose a category";
-            invalidForm = true;
-          }
-          break;
+        // case "icmr_category":
+        //   if (!state.form[field]) {
+        //     errors[field] = "Please Choose a category";
+        //     invalidForm = true;
+        //   }
+        //   break;
         case "icmr_label":
           if (!state.form[field]) {
             errors[field] = "Please specify the label";


### PR DESCRIPTION
### Related Issue : #1380 

#### Related route : 
`/facility/<facility_id>/patient/<patient_id>/sample-test`. 
For example, [`localhost link`](http://localhost:4000/facility/fdad4400-bd11-49dd-9da1-5be0e79fa14e/patient/4f649c00-1bf7-486f-8527-22cf62234a52/sample-test) or [`care link`](https://care.coronasafe.in/facility/fdad4400-bd11-49dd-9da1-5be0e79fa14e/patient/4f649c00-1bf7-486f-8527-22cf62234a52/sample-test)

## Proposed Changes
- added 3 more option(Biopsy, AMR, Communicable Diseases) to  sample test types field  in commit 2946189e73c301e80b769ff964d5af5aca4e031a
- rename `ICMR` label to `ICMR Category (for COVID Test)` in commit e6fb795a236a1f0b6616e56715df5733bc9eb28b
- make ICMR Category field non mandatory by modifying the constant and initial state in commit 7a98d3b85849c0a46901440e1d1a4c44bc58fcb8

## Merge Checklist
- [x] Request Form working and sample test requested with correct details
- [ ] Code style correct

closes #1380 