### PR TITLE
Added flag for no consultation filed

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -388,6 +388,14 @@ export const PatientManager = (props: any) => {
                   text="Patient Expired"
                 />
               )}
+              {(!patient.last_consultation ||
+                patient.last_consultation?.facility !== patient.facility) && (
+                <Badge
+                  color="red"
+                  icon="notes-medical"
+                  text="No Consultation Filed"
+                />
+              )}
             </div>
             <div className="px-2">
               <div className="btn btn-default bg-white">Details</div>


### PR DESCRIPTION
Resolves #1368 

A flag is added for patients, who doesn't have a consultation filed yet.

![image](https://user-images.githubusercontent.com/62461536/121691711-efd4ff80-cae4-11eb-89b3-2c8cf52c76b9.png)

