### PR TITLE
fixed inconsistencies caused by locally saved filters in Shifting

### DIFF
--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useQueryParams, navigate } from "raviger";
 import ListFilter from "./ListFilter";
 import ShiftingBoard from "./ShiftingBoard";
@@ -59,6 +59,10 @@ export default function BoardView() {
     updateQuery(filter);
     setShowFilters(false);
   };
+
+  useEffect(() => {
+    applyFilter(local);
+  }, []);
 
   const appliedFilters = formatFilter(qParams);
 

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -46,6 +46,10 @@ export default function ListView() {
     setShowFilters(false);
   };
 
+  useEffect(() => {
+    applyFilter(local);
+  }, []);
+
   const triggerDownload = async () => {
     const res = await dispatch(
       downloadShiftRequests({ ...formatFilter(qParams), csv: 1 })


### PR DESCRIPTION
this fixes #1393 

There were some inconsistencies in Shifting filters because of locally saving them, the inconsistencies were,
- filter badges show up but the results were not filtered
- similarly, the filters don't show up in the filter menu too

for detailed info check out issue #1393 

Now, the results are filtered, filters show up in the filter menu and badges also show up
![image](https://user-images.githubusercontent.com/29787772/121807443-cbf2f480-cc71-11eb-895b-07014f1e0b71.png)

