### PR TITLE
Use person name instead of username for Assigned To in shifting

### DIFF
--- a/src/Components/Common/UserSelect2.tsx
+++ b/src/Components/Common/UserSelect2.tsx
@@ -27,6 +27,12 @@ export const UserSelect = (props: UserSelectProps) => {
   const [hasSearchText, setHasSearchText] = useState(false);
   const [UserList, setUserList] = useState<Array<UserModal>>([]);
 
+  const getPersonName = (user: any) => {
+    let personName = user.first_name + " " + user.last_name;
+
+    return personName.trim().length > 0 ? personName : user.username;
+  };
+
   const handleValueChange = (current: UserModal | UserModal[] | null) => {
     if (!current) {
       setUserList([]);
@@ -84,13 +90,13 @@ export const UserSelect = (props: UserSelectProps) => {
       renderOption={(option: any) => (
         <div className="flex items-center space-x-3">
           <span className="font-normal block truncate">
-            {option.first_name} {option.last_name} - ({option.user_type})
+            {getPersonName(option)} - ({option.user_type})
           </span>
         </div>
       )}
       getOptionSelected={(option: any, value: any) => option.id === value.id}
       getOptionLabel={(option: any) =>
-        `${option.first_name} ${option.last_name} - (${option.user_type})`
+        `${getPersonName(option)} - (${option.user_type})`
       }
       filterOptions={(options: UserModal[]) => options}
       errors={errors}

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -148,9 +148,15 @@ export default function ListFilter(props: any) {
   };
 
   const setAssignedUser = (user: any) => {
+    const getPersonName = (user: any) => {
+      let personName = user.first_name + " " + user.last_name;
+
+      return personName.trim().length > 0 ? personName : user.username;
+    };
+
     const filterData: any = { ...filterState };
     filterData.assigned_to = user ? user.id : "";
-    filterData.assigned_user = user ? user.username : "";
+    filterData.assigned_user = user ? getPersonName(user) : "";
     filterData.assigned_user_ref = user;
 
     setFilterState(filterData);


### PR DESCRIPTION
Fixes #1400 

This PR makes person name take precedence before relying on username of that user. This applies to badges and select fields.

## Select Field
### Before
![before_fix_1400](https://user-images.githubusercontent.com/16922883/121871512-d371d680-cd21-11eb-9a04-80c9d5ac39db.gif)
### After
![fixed_1400](https://user-images.githubusercontent.com/16922883/121871534-da004e00-cd21-11eb-827d-0b1861fa3add.gif)

## Filter Badge
### Before
![before_fix_1400](https://user-images.githubusercontent.com/16922883/121871559-e4224c80-cd21-11eb-967c-fa73cad61490.png)
### After
![fixed_1400](https://user-images.githubusercontent.com/16922883/121871579-e97f9700-cd21-11eb-95cb-0dbf84a4bb75.png)
