### PR TITLE
Fix notification filtering

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -35,7 +35,7 @@ export default function ResultList() {
       dispatch(getNotifications({ offset, event: eventFilter }))
         .then((res: any) => {
           if (res && res.data) {
-            setData((prev) => [...prev, ...res.data.results]);
+            setData(res.data.results);
             setTotalCount(res.data.count);
           }
           setIsLoading(false);


### PR DESCRIPTION
fixes #1387 
Now we can filter notification according to the categories
![notification_filter](https://user-images.githubusercontent.com/42417893/121882571-57ca5680-cd2e-11eb-9563-fc56ce3c20bc.gif)
