### PR TITLE
Removed volunteer from dropdown

### DIFF
--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -141,6 +141,8 @@ export const UserAdd = (props: UserProps) => {
     ? [...USER_TYPES]
     : userType === "StaffReadOnly"
     ? ["StaffReadOnly"]
+    : userType === "Pharmacist"
+    ? ["Pharmacist"]
     : USER_TYPES.slice(0, userIndex + 1);
 
   const headerText = !userId ? "Add User" : "Update User";


### PR DESCRIPTION
Resolves #1293

In add new users page, a pharmacist can create only other pharmacists. So the option for creating volunteers have been removed from the dropdown

## Before
<img src="https://user-images.githubusercontent.com/62461536/121913241-dafba480-cd4e-11eb-8117-bf109848b6f2.jpg" width=50%>

## After
<img src="https://user-images.githubusercontent.com/62461536/121913301-e64ed000-cd4e-11eb-8128-4332be0878fc.jpg" width=50%>


