### PR TITLE
Fixed issue with date filter in Shifting Page

### DIFF
--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -195,7 +195,6 @@ export default function ListFilter(props: any) {
       assigned_to,
       disease_status,
     } = filterState;
-    localStorage.setItem("shift-filters", JSON.stringify(filterState));
     const data = {
       orgin_facility: orgin_facility || "",
       shifting_approving_facility: shifting_approving_facility || "",
@@ -226,6 +225,10 @@ export default function ListFilter(props: any) {
       assigned_to: assigned_to || "",
       disease_status: disease_status || "",
     };
+    localStorage.setItem(
+      "shift-filters",
+      JSON.stringify({ ...filterState, ...data })
+    );
     onChange(data);
   };
 


### PR DESCRIPTION
Resolves #1420

## Before 
If the user add any date filters and switch the board/list view or if the user switches tabs and return to the page,  a blank page with the following error comes up.

<img src="https://user-images.githubusercontent.com/62461536/122252489-05816500-cee9-11eb-8023-7661ba559fda.png" width="50%">

## After
![date2](https://user-images.githubusercontent.com/62461536/122252450-fac6d000-cee8-11eb-96e3-7f37da22b2d4.gif)
