### PR TITLE
Shifting Page: Remove filters from the badges itself

### DIFF
--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+
+export default function BadgesList(props: any) {
+  const { filterParams, appliedFilters, local, updatedFilters } = props;
+
+  const removeFilter = (paramKey: any) => {
+    const localData: any = { ...local };
+    const params = { ...filterParams };
+
+    localData[paramKey] = "";
+    params[paramKey] = "";
+
+    if (paramKey === "assigned_to") {
+      //or "assigned_user"
+
+      localData["assigned_user"] = "";
+      localData["assigned_user_ref"] = "";
+
+      params["assigned_user"] = "";
+      params["assigned_user_ref"] = "";
+    } else if (
+      paramKey === "assigned_facility" ||
+      paramKey === "orgin_facility" ||
+      paramKey === "shifting_approving_facility"
+    ) {
+      localData[`${paramKey}_ref`] = "";
+      params[`${paramKey}_ref`] = "";
+    }
+    updatedFilters(params, localData);
+  };
+  const badge = (key: string, value: any, paramKey: any) => {
+    return (
+      value && (
+        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+          {key}
+          {": "}
+          {value}
+          <i
+            className="fas fa-times ml-2 rounded-full cursor-pointer hover:bg-gray-500 px-1 py-0.5"
+            onClick={(e) => removeFilter(paramKey)}
+          ></i>
+        </span>
+      )
+    );
+  };
+  return (
+    <div className="flex flex-wrap space-y-1 space-x-2 mt-2 ml-2">
+      {badge(
+        "status",
+        (appliedFilters.status != "--" && appliedFilters.status) ||
+          (local.status !== "--" && local.status),
+        "status"
+      )}
+      {badge(
+        "Emergency",
+        local.emergency === "yes" || appliedFilters.emergency === "true"
+          ? "yes"
+          : local.emergency === "no" || appliedFilters.emergency === "false"
+          ? "no"
+          : undefined,
+        "emergency"
+      )}
+      {badge(
+        "Is KASP",
+        local.is_kasp === "yes" || appliedFilters.is_kasp === "true"
+          ? "yes"
+          : local.is_kasp === "no" || appliedFilters.is_kasp === "false"
+          ? "no"
+          : undefined,
+        "is_kasp"
+      )}
+      {badge(
+        "Up Shift",
+        local.is_up_shift === "yes" || appliedFilters.is_up_shift === "true"
+          ? "yes"
+          : local.is_up_shift === "no" || appliedFilters.is_up_shift === "false"
+          ? "no"
+          : undefined,
+        "is_up_shift"
+      )}
+      {badge(
+        "Phone Number",
+        appliedFilters.patient_phone_number || local.patient_phone_number,
+        "patient_phone_number"
+      )}
+      {badge(
+        "Patient Name",
+        appliedFilters.patient_name || local.patient_name,
+        "patient_name"
+      )}
+      {badge(
+        "Modified After",
+        appliedFilters.modified_date_after || local.modified_date_after,
+        "modified_date_after"
+      )}
+      {badge(
+        "Modified Before",
+        appliedFilters.modified_date_before || local.modified_date_before,
+        "modified_date_before"
+      )}
+      {badge(
+        "Created Before",
+        appliedFilters.created_date_before || local.created_date_before,
+        "created_date_before"
+      )}
+      {badge(
+        "Created After",
+        appliedFilters.created_date_after || local.created_date_after,
+        "created_date_after"
+      )}
+      {badge(
+        "Disease Status",
+        appliedFilters.disease_status || local.disease_status,
+        "disease_status"
+      )}
+
+      {badge(
+        "AssigTo",
+        appliedFilters.assigned_user ||
+          appliedFilters.assigned_to ||
+          local.assigned_user ||
+          local.assigned_to,
+        "assigned_to"
+      )}
+
+      {badge(
+        "Filtered By",
+        (appliedFilters.assigned_facility || local.assigned_facility) &&
+          "Assigned Facility",
+        "assigned_facility"
+      )}
+      {badge(
+        "Filtered By",
+        (appliedFilters.orgin_facility || local.orgin_facility) &&
+          "Origin Facility",
+        "orgin_facility"
+      )}
+      {badge(
+        "Filtered By",
+        (appliedFilters.shifting_approving_facility ||
+          local.shifting_approving_facility) &&
+          "Shifting Approving Facility",
+        "shifting_approving_facility"
+      )}
+    </div>
+  );
+}

--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default function BadgesList(props: any) {
-  const { filterParams, appliedFilters, local, updatedFilters } = props;
+  const { filterParams, appliedFilters, local, updateFilter } = props;
 
   const removeFilter = (paramKey: any) => {
     const localData: any = { ...local };
@@ -11,22 +11,20 @@ export default function BadgesList(props: any) {
     params[paramKey] = "";
 
     if (paramKey === "assigned_to") {
-      //or "assigned_user"
-
       localData["assigned_user"] = "";
       localData["assigned_user_ref"] = "";
 
       params["assigned_user"] = "";
-      params["assigned_user_ref"] = "";
+      // params["assigned_user_ref"] = "";
     } else if (
       paramKey === "assigned_facility" ||
       paramKey === "orgin_facility" ||
       paramKey === "shifting_approving_facility"
     ) {
       localData[`${paramKey}_ref`] = "";
-      params[`${paramKey}_ref`] = "";
+      // params[`${paramKey}_ref`] = "";
     }
-    updatedFilters(params, localData);
+    updateFilter(params, localData);
   };
   const badge = (key: string, value: any, paramKey: any) => {
     return (
@@ -115,7 +113,7 @@ export default function BadgesList(props: any) {
       )}
 
       {badge(
-        "AssigTo",
+        "Assigned To",
         appliedFilters.assigned_user ||
           appliedFilters.assigned_to ||
           local.assigned_user ||

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useQueryParams, navigate } from "raviger";
 import ListFilter from "./ListFilter";
 import ShiftingBoard from "./ShiftingBoard";
+import BadgesList from "./BadgesList";
 import { SHIFTING_CHOICES } from "../../Common/constants";
 import { make as SlideOver } from "../Common/SlideOver.gen";
 import { InputSearchBox } from "../Common/SearchBox";
@@ -34,8 +35,6 @@ export default function BoardView() {
   const [isLoading, setIsLoading] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const local = JSON.parse(localStorage.getItem("shift-filters") || "{}");
-
-  badge;
 
   const updateQuery = (filter: any) => {
     // prevent empty filters from cluttering the url
@@ -77,6 +76,11 @@ export default function BoardView() {
   const onListViewBtnClick = () => {
     navigate("/shifting/list-view", qParams);
     localStorage.setItem("defaultShiftView", "list");
+  };
+
+  const updateFilter = (params: any, local: any) => {
+    updateQuery(params);
+    localStorage.setItem("shift-filters", JSON.stringify(local));
   };
 
   return (
@@ -138,90 +142,12 @@ export default function BoardView() {
           </button>
         </div>
       </div>
-      <div className="flex flex-wrap space-y-1 space-x-2 mt-2 ml-2">
-        {badge(
-          "status",
-          (appliedFilters.status != "--" && appliedFilters.status) ||
-            (local.status !== "--" && local.status)
-        )}
-        {badge(
-          "Emergency",
-          local.emergency === "yes" || appliedFilters.emergency === "true"
-            ? "yes"
-            : local.emergency === "no" || appliedFilters.emergency === "false"
-            ? "no"
-            : undefined
-        )}
-        {badge(
-          "Is KASP",
-          local.is_kasp === "yes" || appliedFilters.is_kasp === "true"
-            ? "yes"
-            : local.is_kasp === "no" || appliedFilters.is_kasp === "false"
-            ? "no"
-            : undefined
-        )}
-        {badge(
-          "Up Shift",
-          local.is_up_shift === "yes" || appliedFilters.is_up_shift === "true"
-            ? "yes"
-            : local.is_up_shift === "no" ||
-              appliedFilters.is_up_shift === "false"
-            ? "no"
-            : undefined
-        )}
-        {badge(
-          "Phone Number",
-          appliedFilters.patient_phone_number || local.patient_phone_number
-        )}
-        {badge(
-          "Patient Name",
-          appliedFilters.patient_name || local.patient_name
-        )}
-        {badge(
-          "Modified After",
-          appliedFilters.modified_date_after || local.modified_date_after
-        )}
-        {badge(
-          "Modified Before",
-          appliedFilters.modified_date_before || local.modified_date_before
-        )}
-        {badge(
-          "Created Before",
-          appliedFilters.created_date_before || local.created_date_before
-        )}
-        {badge(
-          "Created After",
-          appliedFilters.created_date_after || local.created_date_after
-        )}
-        {badge(
-          "Disease Status",
-          appliedFilters.disease_status || local.disease_status
-        )}
-
-        {badge(
-          "Assigned To",
-          appliedFilters.assigned_user ||
-            appliedFilters.assigned_to ||
-            local.assigned_user ||
-            local.assigned_to
-        )}
-        {badge(
-          "Filtered By",
-          (appliedFilters.assigned_facility || local.assigned_facility) &&
-            "Assigned Facility"
-        )}
-        {badge(
-          "Filtered By",
-          (appliedFilters.orgin_facility || local.orgin_facility) &&
-            "Origin Facility"
-        )}
-        {badge(
-          "Filtered By",
-          (appliedFilters.shifting_approving_facility ||
-            local.shifting_approving_facility) &&
-            "Shifting Approving Facility"
-        )}
-      </div>
+      <BadgesList
+        filterParams={qParams}
+        appliedFilters={appliedFilters}
+        local={local}
+        updateFilter={updateFilter}
+      />
       <div className="flex mt-4 pb-2 flex-1 items-start overflow-x-scroll">
         {isLoading ? (
           <Loading />

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -3,6 +3,7 @@ import loadable from "@loadable/component";
 import { InputSearchBox } from "../Common/SearchBox";
 import { navigate, useQueryParams } from "raviger";
 import { useDispatch } from "react-redux";
+import BadgesList from "./BadgesList";
 import moment from "moment";
 import GetAppIcon from "@material-ui/icons/GetApp";
 import { CSVLink } from "react-csv";
@@ -137,6 +138,11 @@ export default function ListView() {
     qParams.disease_status,
     offset,
   ]);
+
+  const updateFilter = (params: any, local: any) => {
+    updateQuery(params);
+    localStorage.setItem("shift-filters", JSON.stringify(local));
+  };
 
   let showShiftingCardList = (data: any) => {
     if (data && !data.length) {
@@ -380,92 +386,13 @@ export default function ListView() {
           </button>
         </div>
       </div>
-
-      <div className="flex flex-wrap space-y-1 space-x-2 mt-2 ml-2">
-        {badge(
-          "status",
-          (appliedFilters.status != "--" && appliedFilters.status) ||
-            (local.status !== "--" && local.status)
-        )}
-        {badge(
-          "Emergency",
-          local.emergency === "yes" || appliedFilters.emergency === "true"
-            ? "yes"
-            : local.emergency === "no" || appliedFilters.emergency === "false"
-            ? "no"
-            : undefined
-        )}
-        {badge(
-          "Is KASP",
-          local.is_kasp === "yes" || appliedFilters.is_kasp === "true"
-            ? "yes"
-            : local.is_kasp === "no" || appliedFilters.is_kasp === "false"
-            ? "no"
-            : undefined
-        )}
-        {badge(
-          "Up Shift",
-          local.is_up_shift === "yes" || appliedFilters.is_up_shift === "true"
-            ? "yes"
-            : local.is_up_shift === "no" ||
-              appliedFilters.is_up_shift === "false"
-            ? "no"
-            : undefined
-        )}
-        {badge(
-          "Phone Number",
-          appliedFilters.patient_phone_number || local.patient_phone_number
-        )}
-        {badge(
-          "Patient Name",
-          appliedFilters.patient_name || local.patient_name
-        )}
-        {badge(
-          "Modified After",
-          appliedFilters.modified_date_after || local.modified_date_after
-        )}
-        {badge(
-          "Modified Before",
-          appliedFilters.modified_date_before || local.modified_date_before
-        )}
-        {badge(
-          "Created Before",
-          appliedFilters.created_date_before || local.created_date_before
-        )}
-        {badge(
-          "Created After",
-          appliedFilters.created_date_after || local.created_date_after
-        )}
-        {badge(
-          "Disease Status",
-          appliedFilters.disease_status || local.disease_status
-        )}
-
-        {badge(
-          "Assigned To",
-          appliedFilters.assigned_user ||
-            appliedFilters.assigned_to ||
-            local.assigned_user ||
-            local.assigned_to
-        )}
-        {badge(
-          "Filtered By",
-          (appliedFilters.assigned_facility || local.assigned_facility) &&
-            "Assigned Facility"
-        )}
-        {badge(
-          "Filtered By",
-          (appliedFilters.orgin_facility || local.orgin_facility) &&
-            "Origin Facility"
-        )}
-        {badge(
-          "Filtered By",
-          (appliedFilters.shifting_approving_facility ||
-            local.shifting_approving_facility) &&
-            "Shifting Approving Facility"
-        )}
-      </div>
-
+      {console.log(qParams)}
+      <BadgesList
+        filterParams={qParams}
+        appliedFilters={appliedFilters}
+        local={local}
+        updateFilter={updateFilter}
+      />
       <div className="px-4">
         {isLoading ? (
           <Loading />

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -386,7 +386,6 @@ export default function ListView() {
           </button>
         </div>
       </div>
-      {console.log(qParams)}
       <BadgesList
         filterParams={qParams}
         appliedFilters={appliedFilters}


### PR DESCRIPTION
Resolves #1418

## Before
The filters applied in the shifting page cannot be removed from the badges itself.

![image](https://user-images.githubusercontent.com/62461536/122386733-c9eba700-cf8b-11eb-9612-e67946b53117.png)

## After

The badges can now be removed from both the board and list view.
![badges](https://user-images.githubusercontent.com/62461536/122387574-a07f4b00-cf8c-11eb-8a92-91a85592732f.gif)
