### PR TITLE
Fix inventory notification

### DIFF
--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -7,8 +7,8 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getItems, postInventory } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
 import { SelectField, TextInputField } from "../Common/HelperInputFields";
-const Loading = loadable(() => import("../Common/Loading"));
 import { InventoryItemsModel } from "./models";
+const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 const initForm = {
@@ -103,7 +103,8 @@ export const AddInventoryForm = (props: any) => {
 
     const res = await dispatchAction(postInventory(data, { facilityId }));
     setIsLoading(false);
-    if (res && res.data) {
+    console.log("result : ", res);
+    if (res && res.data && (res.status === 200 || res.status === 201)) {
       Notification.Success({
         msg: "Inventory created successfully",
       });


### PR DESCRIPTION
closes #1442 

`Inventory added successfully` notification will now only be shown when it is successfull. For that I am checking status code of request output.

https://www.loom.com/share/5ca33a8d1f62461d87911878670f91f9