### PR TITLE
Prevent the api call without extId

### DIFF
--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -298,6 +298,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
   const fetchExtResultData = async (e: any) => {
     if (e) e.preventDefault();
     setIsLoading(true);
+    if (!careExtId) return;
     const res = await dispatchAction(externalResult({ id: careExtId }));
 
     if (res && res.data) {


### PR DESCRIPTION
External result api was being called twice, once without the ext_id and then again with an id. Prevented the first call.
before:
![image](https://user-images.githubusercontent.com/42417893/122641868-7ca33d00-d125-11eb-92a3-df2c3cf87fd9.png)
after:
![image](https://user-images.githubusercontent.com/42417893/122641891-9c3a6580-d125-11eb-80a1-4a8f3fe296e4.png)
