### PR TITLE
Add Time to Date Range Picker in Patient Filter Page

### DIFF
--- a/src/Components/Common/DateTimeRangePicker.tsx
+++ b/src/Components/Common/DateTimeRangePicker.tsx
@@ -33,14 +33,14 @@ export const DateTimeRangePicker: React.FC<IDateTimeRangePickerProps> = ({
     <Box className="my-2">
       <div className="flex">
         {label && <span className="text-sm font-semibold">{label}</span>}
-        <button
+        {(startDate || endDate) && <button
           className="text-xs font-semibold px-2 bg-red-200 hover:bg-red-300 rounded uppercase float-right mr-1 ml-auto"
           onClick={() => {
             onChange({ startDate: null, endDate: null });
           }}
         >
           X Clear
-        </button>
+        </button>}
       </div>
       <MuiPickersUtilsProvider utils={DateFnsUtils}>
         <div className="flex">

--- a/src/Components/Common/DateTimeRangePicker.tsx
+++ b/src/Components/Common/DateTimeRangePicker.tsx
@@ -29,7 +29,6 @@ export const DateTimeRangePicker: React.FC<IDateTimeRangePickerProps> = ({
   startDateId = "start_date",
   size = "regular",
 }) => {
-  const [focusInput, setFocusInput] = React.useState<any>(null);
   return (
     <Box className="my-2">
       <div className="flex">

--- a/src/Components/Common/DateTimeRangePicker.tsx
+++ b/src/Components/Common/DateTimeRangePicker.tsx
@@ -1,0 +1,75 @@
+import { DateTimePicker, MuiPickersUtilsProvider } from "@material-ui/pickers";
+import { Box, Typography } from "@material-ui/core";
+import DateFnsUtils from "@date-io/date-fns";
+import moment from "moment";
+import React from "react";
+
+interface IDateTimeRangePickerProps {
+  label?: string;
+  onChange: (args: {
+    startDate: moment.Moment | null;
+    endDate: moment.Moment | null;
+  }) => void;
+  startDate: moment.Moment | null;
+  endDate: moment.Moment | null;
+  startDateId?: string;
+  endDateId?: string;
+  size?: "regular" | "small";
+}
+
+export const getDate = (value: any) =>
+  value && moment(value).isValid() ? moment(value) : null;
+
+export const DateTimeRangePicker: React.FC<IDateTimeRangePickerProps> = ({
+  label,
+  endDateId = "end_date",
+  endDate,
+  startDate,
+  onChange,
+  startDateId = "start_date",
+  size = "regular",
+}) => {
+  const [focusInput, setFocusInput] = React.useState<any>(null);
+  return (
+    <Box className="my-2">
+      <div className="flex">
+        {label && <span className="text-sm font-semibold">{label}</span>}
+        <button
+          className="text-xs font-semibold px-2 bg-red-200 hover:bg-red-300 rounded uppercase float-right mr-1 ml-auto"
+          onClick={() => {
+            onChange({ startDate: null, endDate: null });
+          }}
+        >
+          X Clear
+        </button>
+      </div>
+      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+        <div className="flex">
+          <DateTimePicker
+            onChange={(p) =>
+              p && onChange({ startDate: moment(p), endDate: endDate })
+            }
+            value={startDate}
+            label={"Start Date"}
+            autoOk={true}
+            className="text-xs mr-1"
+            clearable={true}
+            maxDate={endDate}
+          />
+
+          <DateTimePicker
+            onChange={(p) =>
+              p && onChange({ startDate: startDate, endDate: moment(p) })
+            }
+            value={endDate}
+            label={"End Date"}
+            autoOk={true}
+            className="text-xs ml-1"
+            clearable={true}
+            minDate={startDate}
+          />
+        </div>
+      </MuiPickersUtilsProvider>
+    </Box>
+  );
+};

--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -19,7 +19,7 @@ import { getAllLocalBody, getFacility, getDistrict } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
 import { CircularProgress } from "@material-ui/core";
 import { navigate } from "raviger";
-import { DateRangePicker, getDate } from "../Common/DateRangePicker";
+import { DateTimeRangePicker, getDate } from "../Common/DateTimeRangePicker";
 import DistrictSelect from "../Facility/FacilityFilter/DistrictSelect";
 
 const debounce = require("lodash.debounce");
@@ -595,7 +595,7 @@ export default function PatientFilterV2(props: any) {
           />
         </div>
         <div className="w-64 flex-none">
-          <DateRangePicker
+          <DateTimeRangePicker
             startDate={getDate(filterState.date_of_result_after)}
             endDate={getDate(filterState.date_of_result_before)}
             onChange={(e) =>
@@ -610,7 +610,7 @@ export default function PatientFilterV2(props: any) {
             label={"Date of result"}
             size="small"
           />
-          <DateRangePicker
+          <DateTimeRangePicker
             startDate={getDate(filterState.date_declared_positive_after)}
             endDate={getDate(filterState.date_declared_positive_before)}
             onChange={(e) =>
@@ -626,7 +626,7 @@ export default function PatientFilterV2(props: any) {
             size="small"
           />
 
-          <DateRangePicker
+          <DateTimeRangePicker
             startDate={getDate(filterState.created_date_after)}
             endDate={getDate(filterState.created_date_before)}
             onChange={(e) =>
@@ -641,7 +641,7 @@ export default function PatientFilterV2(props: any) {
             label={"Created Date"}
             size="small"
           />
-          <DateRangePicker
+          <DateTimeRangePicker
             startDate={getDate(filterState.modified_date_after)}
             endDate={getDate(filterState.modified_date_before)}
             onChange={(e) =>
@@ -656,7 +656,7 @@ export default function PatientFilterV2(props: any) {
             label={"Modified Date"}
             size="small"
           />
-          <DateRangePicker
+          <DateTimeRangePicker
             startDate={getDate(
               filterState.last_consultation_admission_date_after
             )}
@@ -675,7 +675,7 @@ export default function PatientFilterV2(props: any) {
             label={"Admit Date"}
             size="small"
           />
-          <DateRangePicker
+          <DateTimeRangePicker
             startDate={getDate(
               filterState.last_consultation_discharge_date_after
             )}
@@ -694,7 +694,7 @@ export default function PatientFilterV2(props: any) {
             label={"Discharge Date"}
             size="small"
           />
-          <DateRangePicker
+          <DateTimeRangePicker
             startDate={getDate(
               filterState.last_consultation_symptoms_onset_date_after
             )}


### PR DESCRIPTION
## Issue: #1076 

## Proposed Changes
1. Added `src/Components/Common/DateTimeRangePicker.tsx` which is custom material ui based date time range picker. 
    - **Reason**: Couldn't use another because other don't have corresponding `@types` available and gives many errors with jsx.
2. Updated Patient Filter page to use above component 

## Merge Checklist
- [ ] Filter correctly working
- [ ] UI/UX Improved

![bdfd9f95-3074-4929-b752-6b4f404f2042](https://user-images.githubusercontent.com/52771399/123266427-89d87700-d4eb-11eb-9293-2f865eddc722.gif)



closes #1076 