### PR TITLE
Change field labels in Patient Form

### DIFF
--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1093,7 +1093,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
 
                   <div>
                     <InputLabel id="is_vaccinated">
-                      Is patient Vaccinated for COVID?
+                      Is patient Vaccinated against COVID?
                     </InputLabel>
                     <RadioGroup
                       aria-label="is_vaccinated"
@@ -1199,7 +1199,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   )}
 
                   <div>
-                    <InputLabel id="test_type-label">Test Type</InputLabel>
+                    <InputLabel id="test_type-label">
+                      COVID Test Type
+                    </InputLabel>
                     <SelectField
                       name="test_type"
                       variant="outlined"
@@ -1212,7 +1214,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                     />
                   </div>
                   <div>
-                    <InputLabel id="srf_id-label">SRF Id</InputLabel>
+                    <InputLabel id="srf_id-label">
+                      SRF Id for COVID Test
+                    </InputLabel>
                     <TextInputField
                       name="srf_id"
                       variant="outlined"
@@ -1225,7 +1229,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   </div>
                   <div>
                     <InputLabel id="date_of_birth-label">
-                      Date of Sample given
+                      Date of Sample given for COVID Test
                     </InputLabel>
                     <DateInputField
                       fullWidth={true}
@@ -1241,7 +1245,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   </div>
                   <div>
                     <InputLabel id="date_of_result-label">
-                      Date of Result
+                      Date of Result for COVID Test
                     </InputLabel>
                     <DateInputField
                       fullWidth={true}
@@ -1751,7 +1755,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   )}
                   <div>
                     <InputLabel id="number_of_primary_contacts-label">
-                      Number Of Primary Contacts
+                      Number Of Primary Contacts for COVID
                     </InputLabel>
                     <TextInputField
                       name="number_of_primary_contacts"
@@ -1765,7 +1769,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   </div>
                   <div>
                     <InputLabel id="number_of_secondary_contacts-label">
-                      Number Of Secondary Contacts
+                      Number Of Secondary Contacts for COVID
                     </InputLabel>
                     <TextInputField
                       name="number_of_secondary_contacts"

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1034,7 +1034,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
 
                   <div data-testid="disease-status">
                     <InputLabel id="disease_status-label">
-                      Disease Status*
+                      COVID Disease Status*
                     </InputLabel>
                     <SelectField
                       name="disease_status"

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1075,7 +1075,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   {state.form.is_declared_positive === "true" && (
                     <div>
                       <InputLabel id="date_declared_positive-label">
-                        Date Patient is Declared Positive
+                        Date Patient is Declared Positive for COVID
                       </InputLabel>
                       <DateInputField
                         fullWidth={true}

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1093,7 +1093,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
 
                   <div>
                     <InputLabel id="is_vaccinated">
-                      Is patient Vaccinated?
+                      Is patient Vaccinated for COVID?
                     </InputLabel>
                     <RadioGroup
                       aria-label="is_vaccinated"


### PR DESCRIPTION
## Issue : #1497 

## Proposed Changes
- Rename following field labels in Patient form
   - [x] `Disease Status` to `COVID Disease Status`
   - [x] `Is patient Vaccinated?` to `Is patient Vaccinated against COVID?`
   - [x] `Date Patient is Declared Positive` to `Date Patient is Declared Positive for COVID`
   - [x] `Test Type` to `COVID Test Type`
   - [x] `SRF Id` to `SRF Id for COVID Test`
   - [x] `Date of Sample given` to `Date of Sample given for COVID Test`
   - [x] `Date of Result` to `Date of Result for COVID Test`
   - [x] `Number Of Primary Contacts` to `Number Of Primary Contacts for COVID`
   - [x] `Number Of Secondary Contacts` to `Number Of Secondary Contacts for COVID`
  
![image](https://user-images.githubusercontent.com/52771399/123653356-af96b080-d84a-11eb-998b-912a8564aa6a.png)


closes #1497 