### PR TITLE
External Results Filters not removed when changing pages

### DIFF
--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -179,6 +179,12 @@ export default function ListFilter(props: any) {
     return selectedwards;
   };
 
+  const clearFilters = () => {
+    localStorage.removeItem("external-filters");
+    localStorage.removeItem("lsg-ward-data");
+    closeFilter();
+  };
+
   return (
     <div>
       <div className="flex justify-between">
@@ -189,6 +195,7 @@ export default function ListFilter(props: any) {
         <Link
           href="/external_results"
           className="btn btn-default hover:text-gray-900"
+          onClick={clearFilters}
         >
           <i className="fas fa-times mr-2" />
           Clear Filters

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -14,7 +14,7 @@ function useMergeState(initialState: any) {
 }
 
 export default function ListFilter(props: any) {
-  let { filter, onChange, closeFilter, dataList } = props;
+  let { filter, onChange, closeFilter, dataList, local } = props;
   const [wardList, setWardList] = useState<any[]>([]);
   const [lsgList, setLsgList] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -25,12 +25,22 @@ export default function ListFilter(props: any) {
   const state: any = useSelector((state) => state);
   const { currentUser } = state;
   const [filterState, setFilterState] = useMergeState({
-    created_date_before: filter.created_date_before || null,
-    created_date_after: filter.created_date_after || null,
-    result_date_before: filter.result_date_before || null,
-    result_date_after: filter.result_date_after || null,
-    sample_collection_date_before: filter.sample_collection_date_before || null,
-    sample_collection_date_after: filter.sample_collection_date_after || null,
+    created_date_before:
+      filter.created_date_before || local.created_date_before || null,
+    created_date_after:
+      filter.created_date_after || local.created_date_after || null,
+    result_date_before:
+      filter.result_date_before || local.result_date_before || null,
+    result_date_after:
+      filter.result_date_after || local.result_date_after || null,
+    sample_collection_date_before:
+      filter.sample_collection_date_before ||
+      local.sample_collection_date_before ||
+      null,
+    sample_collection_date_after:
+      filter.sample_collection_date_after ||
+      local.sample_collection_date_after ||
+      null,
   });
 
   const handleDateRangeChange = (
@@ -77,8 +87,8 @@ export default function ListFilter(props: any) {
     } = filterState;
 
     const data = {
-      wards: selectedWardIds.length ? selectedWardIds : undefined,
-      local_bodies: selectedLsgIds.length ? selectedLsgIds : undefined,
+      wards: selectedWardIds.length ? selectedWardIds : "",
+      local_bodies: selectedLsgIds.length ? selectedLsgIds : "",
       created_date_before: formatDateTime(created_date_before),
       created_date_after: formatDateTime(created_date_after),
       result_date_before: formatDateTime(result_date_before),
@@ -90,6 +100,11 @@ export default function ListFilter(props: any) {
         sample_collection_date_before
       ),
     };
+    localStorage.setItem("external-filters", JSON.stringify(data));
+    localStorage.setItem(
+      "lsg-ward-data",
+      JSON.stringify({ lsgList: selectedLsgs, wardList: wards })
+    );
     onChange(data);
     dataList(selectedLsgs, wards);
   };

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -61,7 +61,7 @@ export default function ResultList() {
   let manageResults: any = null;
   const local = JSON.parse(localStorage.getItem("external-filters") || "{}");
   const localLsgWard = JSON.parse(
-    localStorage.getItem("lsg-ward-data") || "{}"
+    localStorage.getItem("lsg-ward-data") || '{"lsgList": [], "wardList": []}'
   );
 
   useEffect(() => {

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -59,6 +59,10 @@ export default function ResultList() {
   });
 
   let manageResults: any = null;
+  const local = JSON.parse(localStorage.getItem("external-filters") || "{}");
+  const localLsgWard = JSON.parse(
+    localStorage.getItem("lsg-ward-data") || "{}"
+  );
 
   useEffect(() => {
     setIsLoading(true);
@@ -139,35 +143,65 @@ export default function ResultList() {
     setShowFilters(false);
   };
 
+  useEffect(() => {
+    applyFilter(local);
+    setDataList({ ...localLsgWard });
+  }, []);
+
   const removeFilter = (paramKey: any) => {
+    const localData: any = { ...local };
+
     updateQuery({
       ...qParams,
       [paramKey]: "",
     });
+    localData[paramKey] = "";
+
+    localStorage.setItem("external-filters", JSON.stringify(localData));
   };
 
   const removeLSGFilter = (paramKey: any, id: any) => {
     const updatedLsgList = dataList.lsgList.filter((x: any) => x.id !== id);
     const lsgParams = updatedLsgList.map((x: any) => x.id);
+    const localData: any = { ...local };
+
     const updatedWardList = dataList.wardList.filter(
       (x: any) => x.local_body_id !== id
     );
     const wardParams = updatedWardList.map((x: any) => x.id);
+
     updateQuery({
       ...qParams,
       [paramKey]: lsgParams,
       ["wards"]: wardParams,
     });
+    localData[paramKey] = lsgParams.length ? lsgParams : "";
+    localData["wards"] = wardParams.length ? wardParams : "";
+
+    localStorage.setItem("external-filters", JSON.stringify(localData));
+    localStorage.setItem(
+      "lsg-ward-data",
+      JSON.stringify({ lsgList: updatedLsgList, wardList: updatedWardList })
+    );
     setDataList({ lsgList: updatedLsgList, wardList: updatedWardList });
   };
 
   const removeWardFilter = (paramKey: any, id: any) => {
     const updatedList = dataList.wardList.filter((x: any) => x.id !== id);
     const params = updatedList.map((x: any) => x.id);
+    const localData: any = { ...local };
+
     updateQuery({
       ...qParams,
       [paramKey]: params,
     });
+    localData[paramKey] = params.length ? params : "";
+
+    localStorage.setItem("external-filters", JSON.stringify(localData));
+    localStorage.setItem(
+      "lsg-ward-data",
+      JSON.stringify({ ...dataList, wardList: updatedList })
+    );
     setDataList({ ...dataList, wardList: updatedList });
   };
 
@@ -392,28 +426,34 @@ export default function ResultList() {
       <div className="flex space-x-2 my-2 flex-wrap w-full col-span-3 space-y-1">
         {badge(
           "Created before",
-          qParams.created_date_before,
+          qParams.created_date_before || local.created_date_before,
           "created_date_before"
         )}
         {badge(
           "Created after",
-          qParams.created_date_after,
+          qParams.created_date_after || local.created_date_after,
           "created_date_after"
         )}
         {badge(
           "Result before",
-          qParams.result_date_before,
+          qParams.result_date_before || local.result_date_before,
           "result_date_before"
         )}
-        {badge("Result after", qParams.result_date_after, "result_date_after")}
+        {badge(
+          "Result after",
+          qParams.result_date_after || local.result_date_after,
+          "result_date_after"
+        )}
         {badge(
           "Sample created before",
-          qParams.sample_collection_date_before,
+          qParams.sample_collection_date_before ||
+            local.sample_collection_date_before,
           "sample_collection_date_before"
         )}
         {badge(
           "Sample created after",
-          qParams.sample_collection_date_after,
+          qParams.sample_collection_date_after ||
+            local.sample_collection_date_after,
           "sample_collection_date_after"
         )}
       </div>
@@ -457,6 +497,7 @@ export default function ResultList() {
             onChange={applyFilter}
             closeFilter={() => setShowFilters(false)}
             dataList={lsgWardData}
+            local={local}
           />
         </div>
       </SlideOver>

--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -471,6 +471,8 @@ const AppRouter = (props: any) => {
                           localStorage.removeItem("care_access_token");
                           localStorage.removeItem("care_refresh_token");
                           localStorage.removeItem("shift-filters");
+                          localStorage.removeItem("external-filters");
+                          localStorage.removeItem("lsg-ward-data");
                           navigate("/login");
                           window.location.reload();
                         }}
@@ -551,6 +553,8 @@ const AppRouter = (props: any) => {
                       localStorage.removeItem("care_access_token");
                       localStorage.removeItem("care_refresh_token");
                       localStorage.removeItem("shift-filters");
+                      localStorage.removeItem("external-filters");
+                      localStorage.removeItem("lsg-ward-data");
                       navigate("/login");
                       window.location.reload();
                     }}


### PR DESCRIPTION
Resolves #1494

The filters applied in external results page will not removed when the user changes pages. The applied filters will be still present when the user comes back to the page. So, the filters need to be re-applied.

![ext](https://user-images.githubusercontent.com/62461536/123665359-d6a6af80-d855-11eb-8c1a-50c4fd455dd7.gif)