### PR TITLE
Added notice board to sidebar

### DIFF
--- a/src/Components/Notifications/NoticeBoard.tsx
+++ b/src/Components/Notifications/NoticeBoard.tsx
@@ -41,6 +41,16 @@ export const NoticeBoard: any = () => {
         </CardContent>
       </Card>
     ));
+  } else {
+    notices.push(
+      <Card className="my-4 mx-8 rounded-lg">
+        <CardContent>
+          <div className="text-xl text-center semibold">
+            No notices for you.
+          </div>
+        </CardContent>
+      </Card>
+    );
   }
 
   return (

--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -365,6 +365,11 @@ let menus = [
     link: "/user/profile",
     icon: "fas fa-user-secret",
   },
+  {
+    title: "Notice Board",
+    link: "/notice_board/",
+    icon: "fas fa-comment-alt",
+  },
 ];
 
 const AppRouter = (props: any) => {


### PR DESCRIPTION
- Added a link to notice board in the desktop and mobile navbar (sidebar)
- Added empty state for notice board

<img width="960" alt="desktop_empty_state" src="https://user-images.githubusercontent.com/8392802/125027047-3b0e0e00-e0a3-11eb-83e5-2389438b1b71.PNG">

fixes #1525 