### PR TITLE
Fix lag in search 

### DIFF
--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -14,7 +14,7 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
   const handler = useCallback(debounce(search, 500), [search]);
 
   const handleKeyDown = (event: any) => {
-    if (event.key === "Enter") {
+    if (event.key == "Enter") {
       const value = event.target.value;
       setSearchValue(value);
       handler(value);

--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -11,14 +11,12 @@ type TextFieldPropsExtended = TextFieldProps & {
 export const InputSearchBox = (props: TextFieldPropsExtended) => {
   const { search, placeholder, value } = props;
   const [searchValue, setSearchValue] = useState(value);
-  const handler = useCallback(debounce(search, 500), [search]);
+  const handler = useCallback(debounce(search, 700), [search]);
 
   const handleKeyDown = (event: any) => {
     const value = event.target.value;
     setSearchValue(value);
-    if (value.length === 0 || value.length > 2) {
-      handler(value);
-    }
+    handler(value);
   };
 
   useEffect(() => {

--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -14,10 +14,12 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
   const handler = useCallback(debounce(search, 500), [search]);
 
   const handleKeyDown = (event: any) => {
-    const value = event.target.value;
-    setSearchValue(value);
-    if (value.length === 0 || value.length > 2) {
-      handler(value);
+    if (event.key == "Enter") {
+      const value = event.target.value;
+      setSearchValue(value);
+      if (value.length === 0 || value.length > 2) {
+        handler(value);
+      }
     }
   };
 
@@ -32,8 +34,7 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
 
   const inputProps = {
     placeholder,
-    onChange: handleKeyDown,
-    value: searchValue,
+    onKeyDown: handleKeyDown,
   };
 
   return (

--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -17,9 +17,7 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
     if (event.key == "Enter") {
       const value = event.target.value;
       setSearchValue(value);
-      if (value.length === 0 || value.length > 2) {
-        handler(value);
-      }
+      handler(value);
     }
   };
 

--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -14,12 +14,10 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
   const handler = useCallback(debounce(search, 500), [search]);
 
   const handleKeyDown = (event: any) => {
-    if (event.key == "Enter") {
-      const value = event.target.value;
-      setSearchValue(value);
-      if (value.length === 0 || value.length > 2) {
-        handler(value);
-      }
+    const value = event.target.value;
+    setSearchValue(value);
+    if (value.length === 0 || value.length > 2) {
+      handler(value);
     }
   };
 
@@ -34,7 +32,8 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
 
   const inputProps = {
     placeholder,
-    onKeyDown: handleKeyDown,
+    onChange: handleKeyDown,
+    value: searchValue,
   };
 
   return (

--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -17,7 +17,9 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
     if (event.key == "Enter") {
       const value = event.target.value;
       setSearchValue(value);
-      handler(value);
+      if (value.length === 0 || value.length > 2) {
+        handler(value);
+      }
     }
   };
 

--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -14,7 +14,7 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
   const handler = useCallback(debounce(search, 500), [search]);
 
   const handleKeyDown = (event: any) => {
-    if (event.key == "Enter") {
+    if (event.key === "Enter") {
       const value = event.target.value;
       setSearchValue(value);
       handler(value);


### PR DESCRIPTION
## Issue: #1539 
onChange function was called everytime value of input field is changed. This results in frequent search query and hence lag while searching. 

## Solution Applied 
1. Changed from `onChange` handler to `onKeyDown` handler with checking if key pressed is `Enter` key or not
Hence, this time only after pressing key, search query will execute. 1d6e9159f25aecc131f97f28e262fc95bf9d551f
2. Remove restriction of search query(query was only executed when `query length > 2` 9c3b4508a2c3411b9d36abac43b3aeb7f525bec8

![357a02d0-2db7-424b-b08c-1f3439357434](https://user-images.githubusercontent.com/52771399/125138951-3a21be80-e12d-11eb-8166-d5db33ba84ca.gif)

## Instruction to search
1. Enter the search query you want to search
2. Press `Enter` Key to get search result

closes #1539 