### PR TITLE
Resource: Filters can be removed from the badges itself

### DIFF
--- a/src/Components/Resource/Commons.tsx
+++ b/src/Components/Resource/Commons.tsx
@@ -42,14 +42,14 @@ export const formatFilter = (params: any) => {
   };
 };
 
-export const badge = (key: string, value: any) => {
-  return (
-    value && (
-      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
-        {key}
-        {": "}
-        {value}
-      </span>
-    )
-  );
-};
+// export const badge = (key: string, value: any) => {
+//   return (
+//     value && (
+//       <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+//         {key}
+//         {": "}
+//         {value}
+//       </span>
+//     )
+//   );
+// };

--- a/src/Components/Resource/ListView.tsx
+++ b/src/Components/Resource/ListView.tsx
@@ -15,7 +15,7 @@ import ListFilter from "./ListFilter";
 import Pagination from "../Common/Pagination";
 import { Modal, Button } from "@material-ui/core";
 
-import { limit, formatFilter, badge } from "./Commons";
+import { limit, formatFilter } from "./Commons";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -112,6 +112,29 @@ export default function ListView() {
     qParams.ordering,
     offset,
   ]);
+
+  const removeFilter = (paramKey: any) => {
+    const params = { ...qParams };
+    console.log(params);
+    params[paramKey] = "";
+    updateQuery(params);
+  };
+
+  const badge = (key: string, value: any, paramKey: string) => {
+    return (
+      value && (
+        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+          {key}
+          {": "}
+          {value}
+          <i
+            className="fas fa-times ml-2 rounded-full cursor-pointer hover:bg-gray-500 px-1 py-0.5"
+            onClick={(e) => removeFilter(paramKey)}
+          ></i>
+        </span>
+      )
+    );
+  };
 
   let showResourceCardList = (data: any) => {
     if (data && !data.length) {
@@ -258,10 +281,11 @@ export default function ListView() {
         </div>
       </div>
 
-      <div className="flex space-x-2 mt-2 ml-2">
+      <div className="flex flex-wrap space-x-2 mt-2 ml-2 space-y-1">
         {badge(
           "status",
-          appliedFilters.status != "--" && appliedFilters.status
+          appliedFilters.status != "--" && appliedFilters.status,
+          "status"
         )}
         {badge(
           "Emergency",
@@ -269,23 +293,43 @@ export default function ListView() {
             ? "yes"
             : appliedFilters.emergency === "false"
             ? "no"
-            : undefined
-        )}
-        {badge("Modified After", appliedFilters.modified_date_after)}
-        {badge("Modified Before", appliedFilters.modified_date_before)}
-        {badge("Created Before", appliedFilters.created_date_before)}
-        {badge("Created After", appliedFilters.created_date_after)}
-        {badge(
-          "Filtered By",
-          appliedFilters.assigned_facility && "Assigned Facility"
+            : undefined,
+          "emergency"
         )}
         {badge(
-          "Filtered By",
-          appliedFilters.orgin_facility && "Origin Facility"
+          "Modified After",
+          appliedFilters.modified_date_after,
+          "modified_date_after"
+        )}
+        {badge(
+          "Modified Before",
+          appliedFilters.modified_date_before,
+          "modified_date_before"
+        )}
+        {badge(
+          "Created Before",
+          appliedFilters.created_date_before,
+          "created_date_before"
+        )}
+        {badge(
+          "Created After",
+          appliedFilters.created_date_after,
+          "created_date_after"
         )}
         {badge(
           "Filtered By",
-          appliedFilters.approving_facility && "Resource Approving Facility"
+          appliedFilters.assigned_facility && "Assigned Facility",
+          "assigned_facility"
+        )}
+        {badge(
+          "Filtered By",
+          appliedFilters.orgin_facility && "Origin Facility",
+          "orgin_facility"
+        )}
+        {badge(
+          "Filtered By",
+          appliedFilters.approving_facility && "Resource Approving Facility",
+          "approving_facility"
         )}
       </div>
 

--- a/src/Components/Resource/ListView.tsx
+++ b/src/Components/Resource/ListView.tsx
@@ -282,6 +282,7 @@ export default function ListView() {
       </div>
 
       <div className="flex flex-wrap space-x-2 mt-2 ml-2 space-y-1">
+        {badge("Ordering", appliedFilters.ordering, "ordering")}
         {badge(
           "status",
           appliedFilters.status != "--" && appliedFilters.status,

--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -142,6 +142,7 @@ export default function BoardView() {
         </div>
       </div>
       <div className="flex flex-wrap space-x-2 mt-2 ml-2 space-y-1">
+        {badge("Ordering", appliedFilters.ordering, "ordering")}
         {badge(
           "Emergency",
           appliedFilters.emergency === "true"

--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -12,7 +12,7 @@ import { useDispatch } from "react-redux";
 import moment from "moment";
 import GetAppIcon from "@material-ui/icons/GetApp";
 
-import { formatFilter, badge } from "./Commons";
+import { formatFilter } from "./Commons";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -67,6 +67,29 @@ export default function BoardView() {
     localStorage.setItem("defaultResourceView", "list");
   };
 
+  const removeFilter = (paramKey: any) => {
+    const params = { ...qParams };
+    console.log(params);
+    params[paramKey] = "";
+    updateQuery(params);
+  };
+
+  const badge = (key: string, value: any, paramKey: any = "") => {
+    return (
+      value && (
+        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+          {key}
+          {": "}
+          {value}
+          <i
+            className="fas fa-times ml-2 rounded-full cursor-pointer hover:bg-gray-500 px-1 py-0.5"
+            onClick={(e) => removeFilter(paramKey)}
+          ></i>
+        </span>
+      )
+    );
+  };
+
   return (
     <div className="flex flex-col h-screen px-2 pb-2">
       <div className="flex items-end justify-between px-4">
@@ -118,30 +141,50 @@ export default function BoardView() {
           </button>
         </div>
       </div>
-      <div className="flex space-x-2 mt-2 ml-2">
+      <div className="flex flex-wrap space-x-2 mt-2 ml-2 space-y-1">
         {badge(
           "Emergency",
           appliedFilters.emergency === "true"
             ? "yes"
             : appliedFilters.emergency === "false"
             ? "no"
-            : undefined
-        )}
-        {badge("Modified After", appliedFilters.modified_date_after)}
-        {badge("Modified Before", appliedFilters.modified_date_before)}
-        {badge("Created Before", appliedFilters.created_date_before)}
-        {badge("Created After", appliedFilters.created_date_after)}
-        {badge(
-          "Filtered By",
-          appliedFilters.assigned_facility && "Assigned Facility"
+            : undefined,
+          "emergency"
         )}
         {badge(
-          "Filtered By",
-          appliedFilters.orgin_facility && "Origin Facility"
+          "Modified After",
+          appliedFilters.modified_date_after,
+          "modified_date_after"
+        )}
+        {badge(
+          "Modified Before",
+          appliedFilters.modified_date_before,
+          "modified_date_before"
+        )}
+        {badge(
+          "Created Before",
+          appliedFilters.created_date_before,
+          "created_date_before"
+        )}
+        {badge(
+          "Created After",
+          appliedFilters.created_date_after,
+          "created_date_after"
         )}
         {badge(
           "Filtered By",
-          appliedFilters.approving_facility && "Resource Approving Facility"
+          appliedFilters.assigned_facility && "Assigned Facility",
+          "assigned_facility"
+        )}
+        {badge(
+          "Filtered By",
+          appliedFilters.orgin_facility && "Origin Facility",
+          "orgin_facility"
+        )}
+        {badge(
+          "Filtered By",
+          appliedFilters.approving_facility && "Resource Approving Facility",
+          "approving_facility"
         )}
       </div>
       <div className="flex mt-4 pb-2 flex-1 items-start overflow-x-scroll">


### PR DESCRIPTION
Resolves #1558 

The applied filters can now be removed from the badges itself in the resource page. 

Also, badge for filtering based on ordering has also been added.

![res](https://user-images.githubusercontent.com/62461536/125786177-3971122d-141f-4107-8d34-fe8fb1fda933.gif)
