### PR TITLE
Remove Download all patients Button from patients page

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -191,9 +191,6 @@ export const PatientManager = (props: any) => {
       document.getElementById("downloadlink")?.click();
     }
   };
-  const handleDownloadAll = async () => {
-    await handleDownload(false);
-  };
   const handleDownloadFiltered = async () => {
     await handleDownload(true);
   };
@@ -574,14 +571,6 @@ export const PatientManager = (props: any) => {
               target="_blank"
             ></CSVLink>
           </div>
-          <Button
-            color="primary"
-            onClick={handleDownloadAll}
-            size="small"
-            startIcon={<ArrowDownwardIcon>download</ArrowDownwardIcon>}
-          >
-            Download All Patients
-          </Button>
         </div>
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="px-4 py-5 sm:p-6">


### PR DESCRIPTION
This PR removes "Download All Patients" Button . It was not working as intended and is going to deprecated.

closes #1616 
![Screenshot_20210727_200215](https://user-images.githubusercontent.com/26682202/127172787-91228b11-c1de-447d-be62-b1bbc0cf152c.png)
