### PR TITLE
Add all WHO approved vaccines

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -333,7 +333,6 @@ export const VACCINES = [
   "CoviShield",
   "Covaxin",
   "Sputnik",
-  "Astrazeneca",
   "Moderna",
   "Pfizer",
   "Janssen",

--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -329,7 +329,16 @@ export const DISEASE_STATUS = [
 
 export const TEST_TYPE = ["UNK", "ANTIGEN", "RTPCR", "CBNAAT", "TRUENAT"];
 
-export const VACCINES = ["CoviShield", "Covaxin"];
+export const VACCINES = [
+  "CoviShield",
+  "Covaxin",
+  "Sputnik",
+  "Astrazeneca",
+  "Moderna",
+  "Pfizer",
+  "Janssen",
+  "Sinovac",
+];
 
 export const BLOOD_GROUPS = [
   "UNK",


### PR DESCRIPTION
This PR adds the following vaccines to Patient Creation Page:

 - Sputnik V
 - Moderna
 - Pfizer
 - Janssen (Johnson & Johnson)
 - Sinovac
 
![Screenshot_20210729_200123](https://user-images.githubusercontent.com/26682202/127510724-b27489c7-9ca0-415b-be31-70e487a556e5.png)


Note: Needs https://github.com/coronasafe/care/pull/602 to be merged in the backend to work.

Closes #1574 
