### PR TITLE
changed redirection link to consultationDetails in ConsultationForm

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -341,7 +341,9 @@ export const ConsultationForm = (props: any) => {
             msg: "Consultation created successfully",
           });
         }
-        navigate(`/facility/${facilityId}/patient/${patientId}`);
+        navigate(
+          `/facility/${facilityId}/patient/${patientId}/consultation/${id}`
+        );
       }
     }
   };
@@ -826,7 +828,9 @@ export const ConsultationForm = (props: any) => {
                   variant="contained"
                   type="button"
                   onClick={(_) =>
-                    navigate(`/facility/${facilityId}/patient/${patientId}`)
+                    navigate(
+                      `/facility/${facilityId}/patient/${patientId}/consultation/${id}`
+                    )
                   }
                 >
                   Cancel{" "}


### PR DESCRIPTION
Fixes #1662 

Now in the `Consultation Form`, if the `cancel` or `update` button is pressed, the user is redirected to the `Consultation Details` page.