### PR TITLE
Make KASP a constant in constants.tsx

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -9,6 +9,9 @@ export interface OptionsType {
   disabled?: boolean;
 }
 
+export const KASP_STRING = "KASP";
+export const KASP_FULL_STRING = "Karunya Arogya Suraksha Padhathi";
+
 export const USER_TYPES: Array<String> = [
   "Volunteer",
   "Pharmacist",
@@ -142,10 +145,10 @@ export const BED_TYPES: Array<OptionsType> = [
   { id: 120, text: "Covid Oxygen beds" },
   { id: 110, text: "Covid ICU (ICU without ventilator)" },
   { id: 100, text: "Covid Ventilators (ICU with ventilator)" },
-  { id: 40, text: "KASP Ordinary Beds" },
-  { id: 60, text: "KASP Oxygen beds" },
-  { id: 50, text: "KASP ICU (ICU without ventilator)" },
-  { id: 70, text: "KASP ICU (ICU with ventilator)" },
+  { id: 40, text: KASP_STRING + " Ordinary Beds" },
+  { id: 60, text: KASP_STRING + " Oxygen beds" },
+  { id: 50, text: KASP_STRING + " ICU (ICU without ventilator)" },
+  { id: 70, text: KASP_STRING + " ICU (ICU with ventilator)" },
   { id: 2, text: "Hostel" },
   { id: 3, text: "Single Room with Attached Bathroom" },
 ];

--- a/src/Components/Facility/ConsultationCard.tsx
+++ b/src/Components/Facility/ConsultationCard.tsx
@@ -3,6 +3,7 @@ import { navigate } from "raviger";
 import moment from "moment";
 import React from "react";
 import { ConsultationModel } from "./models";
+import { KASP_STRING } from "../../Common/constants";
 
 interface ConsultationProps {
   itemData: ConsultationModel;
@@ -15,7 +16,7 @@ export const ConsultationCard = (props: ConsultationProps) => {
     <div className="block border rounded-lg bg-white shadow h-full cursor-pointer hover:border-primary-500 text-black mt-4">
       {itemData.is_kasp && (
         <div className="ml-3 mt-2 inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium leading-5 bg-yellow-100 text-yellow-800">
-          KASP
+          {KASP_STRING}
         </div>
       )}
 
@@ -46,7 +47,9 @@ export const ConsultationCard = (props: ConsultationProps) => {
             {itemData.kasp_enabled_date && (
               <Grid item xs={7}>
                 <Typography>
-                  <span className="text-gray-700">Kasp Enabled date: </span>
+                  <span className="text-gray-700">
+                    {KASP_STRING} Enabled date:{" "}
+                  </span>
                   {itemData.kasp_enabled_date
                     ? moment(itemData.kasp_enabled_date).format("lll")
                     : "-"}

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -22,6 +22,7 @@ import {
   SYMPTOM_CHOICES,
   TELEMEDICINE_ACTIONS,
   REVIEW_AT_CHOICES,
+  KASP_STRING,
 } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
@@ -282,7 +283,9 @@ export const ConsultationForm = (props: any) => {
           return;
         case "is_kasp":
           if (!state.form[field]) {
-            errors[field] = "Please select an option, Kasp is mandatory";
+            errors[
+              field
+            ] = `Please select an option, ${KASP_STRING} is mandatory`;
             if (!error_div) error_div = field;
             invalidForm = true;
           }
@@ -742,7 +745,7 @@ export const ConsultationForm = (props: any) => {
               </div>
 
               <div className="flex-1" id="is_kasp-div">
-                <InputLabel id="admitted-label">Kasp*</InputLabel>
+                <InputLabel id="admitted-label">{KASP_STRING}*</InputLabel>
                 <RadioGroup
                   aria-label="covid"
                   name="is_kasp"

--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -19,7 +19,7 @@ import loadable from "@loadable/component";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
 import React, { useCallback, useReducer, useState } from "react";
 import { useDispatch } from "react-redux";
-import { FACILITY_TYPES } from "../../Common/constants";
+import { FACILITY_TYPES, KASP_STRING } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   validateLocationCoordinates,
@@ -781,7 +781,7 @@ export const FacilityCreate = (props: FacilityProps) => {
                   htmlFor="facility-kasp-empanelled"
                   id="kasp_empanelled"
                 >
-                  Is this facility KASP empanelled?
+                  Is this facility {KASP_STRING} empanelled?
                 </InputLabel>
                 <RadioGroup
                   aria-label="kasp_empanelled"

--- a/src/Components/Facility/FacilityFilter/index.tsx
+++ b/src/Components/Facility/FacilityFilter/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { navigate } from "raviger";
 import { SelectField } from "../../Common/HelperInputFields";
 import { CircularProgress } from "@material-ui/core";
-import { FACILITY_TYPES } from "../../../Common/constants";
+import { FACILITY_TYPES, KASP_STRING } from "../../../Common/constants";
 import {
   getStates,
   getDistrictByState,
@@ -239,7 +239,9 @@ function FacillityFilter(props: any) {
         </div>
 
         <div className="w-64 flex-none">
-          <span className="text-sm font-semibold">KASP Empanelled</span>
+          <span className="text-sm font-semibold">
+            {KASP_STRING} Empanelled
+          </span>
           <SelectField
             name="kasp_empanelled"
             variant="outlined"

--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -2,7 +2,11 @@ import { navigate, useQueryParams } from "raviger";
 import React, { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import { statusType, useAbortableEffect } from "../../Common/utils";
-import { DOWNLOAD_TYPES, FACILITY_TYPES } from "../../Common/constants";
+import {
+  DOWNLOAD_TYPES,
+  FACILITY_TYPES,
+  KASP_STRING,
+} from "../../Common/constants";
 import {
   getFacilities,
   downloadFacility,
@@ -320,7 +324,7 @@ const HospitalListPage = (props: any) => {
               <div className="px-6 py-4">
                 {facility.kasp_empanelled && (
                   <div className="mt-2 inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium leading-5 bg-yellow-100 text-yellow-800">
-                    KASP
+                    {KASP_STRING}
                   </div>
                 )}
                 <div className="inline-flex float-right items-center px-2.5 py-0.5 mt-2 rounded-md text-sm font-medium leading-5 bg-blue-100 text-blue-800">
@@ -655,8 +659,10 @@ const HospitalListPage = (props: any) => {
         )}
         {qParams.kasp_empanelled &&
           badge(
-            "KASP Empanelled",
-            qParams.kasp_empanelled === "true" ? "KASP" : "Non KASP",
+            `${KASP_STRING} Empanelled`,
+            qParams.kasp_empanelled === "true"
+              ? KASP_STRING
+              : `Non ${KASP_STRING}`,
             "kasp_empanelled"
           )}
       </div>

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -27,6 +27,7 @@ import {
   GENDER_TYPES,
   TELEMEDICINE_ACTIONS,
   PATIENT_FILTER_ADMITTED_TO,
+  KASP_STRING,
 } from "../../Common/constants";
 import { make as SlideOver } from "../Common/SlideOver.gen";
 import PatientFilterV2 from "./PatientFilterV2";
@@ -738,8 +739,8 @@ export const PatientManager = (props: any) => {
             )}
           {qParams.is_kasp &&
             badge(
-              "KASP",
-              qParams.is_kasp === "true" ? "KASP" : "Non KASP",
+              KASP_STRING,
+              qParams.is_kasp === "true" ? KASP_STRING : `Non ${KASP_STRING}`,
               "is_kasp"
             )}
           {badge("COWIN ID", qParams.covin_id, "covin_id")}

--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -12,6 +12,7 @@ import {
   DISEASE_STATUS,
   PATIENT_FILTER_CATEGORY,
   PATIENT_FILTER_ADMITTED_TO,
+  KASP_STRING,
 } from "../../Common/constants";
 import moment from "moment";
 import { getAllLocalBody, getFacility, getDistrict } from "../../Redux/actions";
@@ -502,7 +503,7 @@ export default function PatientFilterV2(props: any) {
         </div>
 
         <div className="w-64 flex-none">
-          <span className="text-sm font-semibold">KASP</span>
+          <span className="text-sm font-semibold">{KASP_STRING}</span>
           <SelectField
             name="is_kasp"
             variant="outlined"
@@ -510,8 +511,8 @@ export default function PatientFilterV2(props: any) {
             value={filterState.is_kasp}
             options={[
               { id: "", text: "Show All" },
-              { id: "true", text: "Show KASP" },
-              { id: "false", text: "Show Non KASP" },
+              { id: "true", text: `Show ${KASP_STRING}` },
+              { id: "false", text: `Show Non ${KASP_STRING}` },
             ]}
             onChange={handleChange}
             className="bg-white h-10 shadow-sm md:text-sm md:leading-5 md:h-9"

--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { KASP_STRING } from "../../Common/constants";
 
 export default function BadgesList(props: any) {
   const { filterParams, appliedFilters, local, updateFilter } = props;
@@ -59,7 +60,7 @@ export default function BadgesList(props: any) {
         "emergency"
       )}
       {badge(
-        "Is KASP",
+        `Is ${KASP_STRING}`,
         local.is_kasp === "yes" || appliedFilters.is_kasp === "true"
           ? "yes"
           : local.is_kasp === "no" || appliedFilters.is_kasp === "false"

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -6,7 +6,11 @@ import {
   DateInputField,
   TextInputField,
 } from "../Common/HelperInputFields";
-import { SHIFTING_FILTER_ORDER, DISEASE_STATUS } from "../../Common/constants";
+import {
+  SHIFTING_FILTER_ORDER,
+  DISEASE_STATUS,
+  KASP_STRING,
+} from "../../Common/constants";
 import moment from "moment";
 import { getFacility, getUserList } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
@@ -399,7 +403,7 @@ export default function ListFilter(props: any) {
         </div>
 
         <div className="w-64 flex-none">
-          <span className="text-sm font-semibold">Is KASP</span>
+          <span className="text-sm font-semibold">Is {KASP_STRING}</span>
           <SelectField
             name="is_kasp"
             variant="outlined"

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -6,7 +6,11 @@ import { getShiftDetails, deleteShiftRecord } from "../../Redux/actions";
 import { navigate, Link } from "raviger";
 import Button from "@material-ui/core/Button";
 import QRCode from "qrcode.react";
-import { GENDER_TYPES, TEST_TYPE_CHOICES } from "../../Common/constants";
+import {
+  GENDER_TYPES,
+  KASP_FULL_STRING,
+  TEST_TYPE_CHOICES,
+} from "../../Common/constants";
 import moment from "moment";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -683,7 +687,7 @@ export default function ShiftDetails(props: { id: string }) {
               </div>
               <div>
                 <span className="font-semibold leading-relaxed">
-                  Karunya Arogya Suraksha Padhathi:{" "}
+                  {KASP_FULL_STRING}:{" "}
                 </span>
                 <span className="badge badge-pill badge-warning py-1 px-2">
                   {" "}

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -20,6 +20,7 @@ import {
   FACILITY_TYPES,
   SHIFTING_VEHICLE_CHOICES,
   BREATHLESSNESS_LEVEL,
+  KASP_FULL_STRING,
 } from "../../Common/constants";
 import { UserSelect } from "../Common/UserSelect";
 
@@ -300,7 +301,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
               </div>
 
               <div>
-                <InputLabel>Is Karunya Arogya Suraksha Padhathi?</InputLabel>
+                <InputLabel>Is {KASP_FULL_STRING}?</InputLabel>
                 <RadioGroup
                   aria-label="is_kasp"
                   name="is_kasp"


### PR DESCRIPTION
This PR makes "KASP" a constant in constants.tsx and replaces hard coded KASP with constant to enable customization for different deployments.

closes #1731 