### PR TITLE
Fix sentry error: TypeError:  Cannot read property 'focus' of null

### DIFF
--- a/src/Components/Common/OnlineUsersSelect.tsx
+++ b/src/Components/Common/OnlineUsersSelect.tsx
@@ -64,7 +64,7 @@ export const OnlineUsersSelect = (props: Props) => {
   );
 
   useEffect(() => {
-    if (isExpanded) {
+    if (isExpanded && searchFieldRef.current) {
       searchFieldRef.current.focus();
     }
   }, [isExpanded]);

--- a/src/Components/Common/OnlineUsersSelect.tsx
+++ b/src/Components/Common/OnlineUsersSelect.tsx
@@ -1,12 +1,5 @@
-import loadable from "@loadable/component";
 import { CircularProgress } from "@material-ui/core";
-import React, {
-  useCallback,
-  useReducer,
-  useState,
-  useEffect,
-  useRef,
-} from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import moment from "moment";
@@ -16,12 +9,12 @@ import classNames from "classnames";
 export const OnlineUsersSelect = (props: any) => {
   const dispatchAction: any = useDispatch();
   const { selectedUser, userId, onSelect, user_type } = props;
-  const initalState = {
+  const initialState = {
     loading: false,
     users: new Array<any>(),
     searchTerm: "",
   };
-  const [state, setState] = useState(initalState);
+  const [state, setState] = useState(initialState);
   const [isExpanded, setIsExpanded] = useState(false);
   const searchFieldRef = useRef<any>(null);
 

--- a/src/Components/Common/OnlineUsersSelect.tsx
+++ b/src/Components/Common/OnlineUsersSelect.tsx
@@ -5,25 +5,25 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import moment from "moment";
 import { getUserList } from "../../Redux/actions";
 import classNames from "classnames";
-import { UserModal } from "../Users/models";
+import { UserModel } from "../Users/models";
 
 type UserFetchState = {
   loading: boolean;
-  users: Array<UserModal>;
+  users: Array<UserModel>;
   searchTerm: string;
   searchFieldRef: React.RefObject<HTMLInputElement>;
 };
 
 type Props = {
-  selectedUser: UserModal;
+  selectedUser: UserModel;
   userId: string;
-  onSelect: (user: string) => void;
+  onSelect: (user: UserModel | null) => void;
   user_type: string;
 };
 
 const initialState: UserFetchState = {
   loading: false,
-  users: new Array<any>(),
+  users: new Array<UserModel>(),
   searchTerm: "",
   searchFieldRef: React.createRef<HTMLInputElement>(),
 };
@@ -131,9 +131,7 @@ export const OnlineUsersSelect = (props: Props) => {
                 </div>
                 <div
                   className="btn btn-default"
-                  onClick={(_) => {
-                    onSelect("");
-                  }}
+                  onClick={(_) => onSelect(null)}
                 >
                   {" "}
                   Clear
@@ -164,7 +162,7 @@ export const OnlineUsersSelect = (props: Props) => {
               className="multiselect-dropdown__search-dropdown w-full border border-gray-400 bg-white mt-1 rounded-lg shadow-lg px-4 py-2 z-50"
             >
               {!loading ? (
-                users.map((user: any) => {
+                users.map((user: UserModel) => {
                   return (
                     <button
                       key={user.id}
@@ -196,7 +194,7 @@ export const OnlineUsersSelect = (props: Props) => {
                           {user.first_name} {user.last_name}
                         </span>
                       </div>
-                      {user.id == userId && (
+                      {user.id?.toString() == userId && (
                         <span className="flex items-center">
                           <svg
                             className="h-5 w-5"

--- a/src/Components/Common/OnlineUsersSelect.tsx
+++ b/src/Components/Common/OnlineUsersSelect.tsx
@@ -6,9 +6,8 @@ import moment from "moment";
 import { getUserList } from "../../Redux/actions";
 import classNames from "classnames";
 
-type State = {
+type UserFetchState = {
   loading: boolean;
-  isExpanded: boolean;
   users: Array<any>;
   searchTerm: string;
   searchFieldRef: React.RefObject<HTMLInputElement>;
@@ -21,9 +20,8 @@ type Props = {
   user_type: string;
 };
 
-const initialState: State = {
+const initialState: UserFetchState = {
   loading: false,
-  isExpanded: false,
   users: new Array<any>(),
   searchTerm: "",
   searchFieldRef: React.createRef<HTMLInputElement>(),
@@ -33,7 +31,8 @@ export const OnlineUsersSelect = (props: Props) => {
   const dispatchAction: any = useDispatch();
   const { selectedUser, userId, onSelect, user_type } = props;
   const [state, setState] = useState(initialState);
-  const { loading, isExpanded, users, searchTerm, searchFieldRef } = state;
+  const { loading, users, searchTerm, searchFieldRef } = state;
+  const [isDropdownExpanded, setDropdownExpand] = useState(false);
 
   const fetchUsers = useCallback(
     async (status: statusType) => {
@@ -64,10 +63,10 @@ export const OnlineUsersSelect = (props: Props) => {
   );
 
   useEffect(() => {
-    if (isExpanded && searchFieldRef.current) {
+    if (isDropdownExpanded && searchFieldRef.current) {
       searchFieldRef.current.focus();
     }
-  }, [isExpanded]);
+  }, [isDropdownExpanded]);
 
   const handleSearchTermChange = (e: any) => {
     const { value } = e.target;
@@ -86,7 +85,7 @@ export const OnlineUsersSelect = (props: Props) => {
         <div className="relative">
           <span className="inline-block w-full rounded-md shadow-sm">
             <button
-              onClick={(_) => setState({ ...state, isExpanded: true })}
+              onClick={(_) => setDropdownExpand(true)}
               type="button"
               aria-haspopup="listbox"
               aria-expanded="true"
@@ -99,7 +98,7 @@ export const OnlineUsersSelect = (props: Props) => {
                 type="text"
                 placeholder="Search by name or username"
                 className={classNames("py-2 pl-3 w-full outline-none", {
-                  hidden: !isExpanded,
+                  hidden: !isDropdownExpanded,
                 })}
                 value={searchTerm}
                 onChange={handleSearchTermChange}
@@ -107,7 +106,7 @@ export const OnlineUsersSelect = (props: Props) => {
               />
               <div
                 className={classNames("flex items-center justify-between", {
-                  hidden: isExpanded,
+                  hidden: isDropdownExpanded,
                 })}
               >
                 <div className="space-x-3 flex items-center">
@@ -159,7 +158,7 @@ export const OnlineUsersSelect = (props: Props) => {
               </span>
             </button>
           </span>
-          {isExpanded && (
+          {isDropdownExpanded && (
             <div
               role="listbox"
               aria-labelledby="listbox-label"
@@ -172,11 +171,11 @@ export const OnlineUsersSelect = (props: Props) => {
                     <button
                       key={user.id}
                       onClick={(_) => {
+                        setDropdownExpand(false);
                         onSelect(user);
                         setState({
                           ...state,
                           searchTerm: "",
-                          isExpanded: false,
                         });
                       }}
                       id="listbox-item-0"

--- a/src/Components/Common/OnlineUsersSelect.tsx
+++ b/src/Components/Common/OnlineUsersSelect.tsx
@@ -146,9 +146,9 @@ export const OnlineUsersSelect = (props: Props) => {
                 >
                   <path
                     d="M7 7l3-3 3 3m0 6l-3 3-3-3"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                   />
                 </svg>
               </span>
@@ -205,7 +205,7 @@ export const OnlineUsersSelect = (props: Props) => {
                             <path
                               fillRule="evenodd"
                               d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clip-rule="evenodd"
+                              clipRule="evenodd"
                             />
                           </svg>
                         </span>

--- a/src/Components/Common/OnlineUsersSelect.tsx
+++ b/src/Components/Common/OnlineUsersSelect.tsx
@@ -5,18 +5,19 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import moment from "moment";
 import { getUserList } from "../../Redux/actions";
 import classNames from "classnames";
+import { UserModal } from "../Users/models";
 
 type UserFetchState = {
   loading: boolean;
-  users: Array<any>;
+  users: Array<UserModal>;
   searchTerm: string;
   searchFieldRef: React.RefObject<HTMLInputElement>;
 };
 
 type Props = {
-  selectedUser: any;
+  selectedUser: UserModal;
   userId: string;
-  onSelect: any;
+  onSelect: (user: string) => void;
   user_type: string;
 };
 
@@ -68,11 +69,6 @@ export const OnlineUsersSelect = (props: Props) => {
     }
   }, [isDropdownExpanded]);
 
-  const handleSearchTermChange = (e: any) => {
-    const { value } = e.target;
-    setState({ ...state, searchTerm: value });
-  };
-
   return (
     <div className="pb-2">
       <div className="space-y-1">
@@ -101,7 +97,9 @@ export const OnlineUsersSelect = (props: Props) => {
                   hidden: !isDropdownExpanded,
                 })}
                 value={searchTerm}
-                onChange={handleSearchTermChange}
+                onChange={(e) =>
+                  setState({ ...state, searchTerm: e.target.value })
+                }
                 onKeyUp={(e) => e.preventDefault()}
               />
               <div

--- a/src/Components/Common/UserSelect2.tsx
+++ b/src/Components/Common/UserSelect2.tsx
@@ -2,15 +2,15 @@ import React, { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import { getUserList } from "../../Redux/actions";
 import { AutoCompleteAsyncField } from "../Common/HelperInputFields";
-import { UserModal } from "../Users/models";
+import { UserModel } from "../Users/models";
 const debounce = require("lodash.debounce");
 interface UserSelectProps {
   margin?: string;
   errors: string;
   className?: string;
   multiple?: boolean;
-  selected: UserModal | UserModal[] | null;
-  setSelected: (selected: UserModal | UserModal[] | null) => void;
+  selected: UserModel | UserModel[] | null;
+  setSelected: (selected: UserModel | UserModel[] | null) => void;
 }
 
 export const UserSelect = (props: UserSelectProps) => {
@@ -25,7 +25,7 @@ export const UserSelect = (props: UserSelectProps) => {
   const dispatchAction: any = useDispatch();
   const [userLoading, isUserLoading] = useState(false);
   const [hasSearchText, setHasSearchText] = useState(false);
-  const [UserList, setUserList] = useState<Array<UserModal>>([]);
+  const [UserList, setUserList] = useState<Array<UserModel>>([]);
 
   const getPersonName = (user: any) => {
     let personName = user.first_name + " " + user.last_name;
@@ -33,7 +33,7 @@ export const UserSelect = (props: UserSelectProps) => {
     return personName.trim().length > 0 ? personName : user.username;
   };
 
-  const handleValueChange = (current: UserModal | UserModal[] | null) => {
+  const handleValueChange = (current: UserModel | UserModel[] | null) => {
     if (!current) {
       setUserList([]);
       isUserLoading(false);
@@ -98,7 +98,7 @@ export const UserSelect = (props: UserSelectProps) => {
       getOptionLabel={(option: any) =>
         `${getPersonName(option)} - (${option.user_type})`
       }
-      filterOptions={(options: UserModal[]) => options}
+      filterOptions={(options: UserModel[]) => options}
       errors={errors}
       className={className}
     />

--- a/src/Components/Users/models.tsx
+++ b/src/Components/Users/models.tsx
@@ -3,6 +3,7 @@ export interface UserModel {
   username?: string;
   first_name?: string;
   last_name?: string;
+  email?: string;
   user_type?: number;
   local_body?: number;
   district?: number;

--- a/src/Components/Users/models.tsx
+++ b/src/Components/Users/models.tsx
@@ -3,10 +3,15 @@ export interface UserModal {
   username?: string;
   first_name?: string;
   last_name?: string;
-  email?: string;
-  user_type?: string;
+  user_type?: number;
+  local_body?: number;
   district?: number;
+  state?: number;
   phone_number?: string;
-  gender?: string;
+  alt_phone_number?: string;
+  gender?: number;
   age?: number;
+  is_superuser?: boolean;
+  verified?: boolean;
+  last_login?: Date;
 }

--- a/src/Components/Users/models.tsx
+++ b/src/Components/Users/models.tsx
@@ -1,4 +1,4 @@
-export interface UserModal {
+export interface UserModel {
   id?: number;
   username?: string;
   first_name?: string;


### PR DESCRIPTION
## About the error
- Sentry Link : [link](https://sentry.io/organizations/coronasafe-network/issues/2555823736/?project=5183632&query=is%3Aunresolved)
- **Page** : `/facility/<facility_id>/patient/<patient_id>`, Eg: [Staging Link](https://care.coronasafe.in/facility/fdad4400-bd11-49dd-9da1-5be0e79fa14e/patient/9f688106-0764-4a0a-a269-58577b6908e2)
- **Suspected component generating issue:** `Assign volunteer component`: `src/Components/Common/OnlineUsersSelect.tsx`
- **Reason for the suspected component:** 
  - `focus` method is only called in this component without check for null. 
  - After refactoring by adding types, now typescript show error of possible null pointer error.

## Changes done
- [x] Remove unused imports. 51e45258aa54c35bfb0ff9bc24a7d0578e209b1e
- [x] Added types for `State` and `Props`. 224a7ce1c79872c526987f0d4fd141b8b85f05da
- [x] Remove console warning for `OnlineUserSelect` Component only for now. cb7436c30ede2195fa14d21507095d4a02b2c255
- [x] Correct spelling from `UserModal` to `UserModel` in whole codebase. 56f5a1c020e023f20207a3d42bd6fd11535ae45f
- [x] Fix sentry issue [`TypeError:  Cannot read property 'focus' of null`](https://sentry.io/organizations/coronasafe-network/issues/2555823736/?project=5183632&query=is%3Aunresolved)


closes #1738 