### PR TITLE
move consultation tabs to constants

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -518,3 +518,17 @@ export const MOTOR_RESPONSE_SCALE = [
   { value: 2, text: "Abnormal Extension(decerebrate)" },
   { value: 1, text: "No Response" },
 ];
+export const CONSULTATION_TABS: Array<OptionsType> = [
+  { id: 1, text: "UPDATES", desc: "Updates" },
+  { id: 2, text: "SUMMARY", desc: "Summary" },
+  { id: 3, text: "MEDICINES", desc: "Medicines" },
+  { id: 4, text: "FILES", desc: "Files" },
+  { id: 5, text: "INVESTIGATIONS", desc: "Investigations" },
+  { id: 6, text: "ABG", desc: "ABG" },
+  { id: 7, text: "NURSING", desc: "Nursing" },
+  { id: 8, text: "NEUROLOGICAL_MONITORING", desc: "Neurological Monitoring" },
+  { id: 9, text: "VENTILATOR", desc: "Ventilator" },
+  { id: 10, text: "NUTRITION", desc: "Nutrition" },
+  { id: 11, text: "PRESSURE_SORE", desc: "Pressure Sore" },
+  { id: 12, text: "DIALYSIS", desc: "Dialysis" },
+];

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -305,7 +305,6 @@ export const ConsultationDetails = (props: any) => {
                       className={tabButtonClasses(tab === p)}
                       href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.toLocaleLowerCase()}`}
                     >
-                      {/* {p.replaceAll("_", " ").toLocaleLowerCase()} */}
                       {CONSULTATION_TABS.find((x) => x.text === p)?.desc}
                     </Link>
                   ))}

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -6,7 +6,11 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getConsultation } from "../../Redux/actions";
 import loadable from "@loadable/component";
 import { ConsultationModel } from "./models";
-import { PATIENT_CATEGORY, SYMPTOM_CHOICES } from "../../Common/constants";
+import {
+  PATIENT_CATEGORY,
+  SYMPTOM_CHOICES,
+  CONSULTATION_TABS,
+} from "../../Common/constants";
 import { FileUpload } from "../Patient/FileUpload";
 import TreatmentSummary from "./TreatmentSummary";
 import { PrimaryParametersPlot } from "./Consultations/PrimaryParametersPlot";
@@ -301,7 +305,8 @@ export const ConsultationDetails = (props: any) => {
                       className={tabButtonClasses(tab === p)}
                       href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.toLocaleLowerCase()}`}
                     >
-                      {p.replaceAll("_", " ").toLocaleLowerCase()}
+                      {/* {p.replaceAll("_", " ").toLocaleLowerCase()} */}
+                      {CONSULTATION_TABS.find((x) => x.text === p)?.desc}
                     </Link>
                   ))}
                 </nav>

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -10,6 +10,7 @@ import {
   PATIENT_CATEGORY,
   SYMPTOM_CHOICES,
   CONSULTATION_TABS,
+  OptionsType,
 } from "../../Common/constants";
 import { FileUpload } from "../Patient/FileUpload";
 import TreatmentSummary from "./TreatmentSummary";
@@ -286,26 +287,13 @@ export const ConsultationDetails = (props: any) => {
             <div className="sm:flex sm:items-baseline overflow-x-auto">
               <div className="mt-4 sm:mt-0">
                 <nav className="pl-2 flex space-x-6 overflow-x-auto pb-2 ">
-                  {[
-                    "UPDATES",
-                    "SUMMARY",
-                    "MEDICINES",
-                    "FILES",
-                    "INVESTIGATIONS",
-                    "ABG",
-                    "NURSING",
-                    "NEUROLOGICAL_MONITORING",
-                    "VENTILATOR",
-                    "NUTRITION",
-                    "PRESSURE_SORE",
-                    "DIALYSIS",
-                  ].map((p: string) => (
+                  {CONSULTATION_TABS.map((p: OptionsType) => (
                     <Link
-                      key={p}
-                      className={tabButtonClasses(tab === p)}
-                      href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.toLocaleLowerCase()}`}
+                      key={p.text}
+                      className={tabButtonClasses(tab === p.text)}
+                      href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.text.toLocaleLowerCase()}`}
                     >
-                      {CONSULTATION_TABS.find((x) => x.text === p)?.desc}
+                      {p.desc}
                     </Link>
                   ))}
                 </nav>


### PR DESCRIPTION
Closes #1745
removing `replaceAll` and moving the consultation tabs to `constants.tsx`.