### PR TITLE
Added User info in Consulation Update card

### DIFF
--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -94,6 +94,34 @@ export const DailyRoundsList = (props: any) => {
                       </Typography>
                     </Grid>
                   ) : null}
+
+                  {!telemedicine_doctor_update ? (
+                    <Grid item xs={12}>
+                      <Typography>
+                        <span className="text-gray-700">Updated by:</span>{" "}
+                        {itemData?.last_edited_by &&
+                          itemData.last_edited_by.first_name +
+                            " " +
+                            itemData.last_edited_by.last_name +
+                            " - " +
+                            itemData.last_edited_by.user_type}
+                      </Typography>
+                    </Grid>
+                  ) : null}
+
+                  {!telemedicine_doctor_update && itemData?.created_by ? (
+                    <Grid item xs={12}>
+                      <Typography>
+                        <span className="text-gray-700">Created by:</span>{" "}
+                        {itemData.created_by.first_name +
+                          " " +
+                          itemData.created_by.last_name +
+                          " - " +
+                          itemData.created_by.user_type}
+                      </Typography>
+                    </Grid>
+                  ) : null}
+
                   {itemData.patient_category && (
                     <Grid item xs={12}>
                       <Typography>

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -95,16 +95,15 @@ export const DailyRoundsList = (props: any) => {
                     </Grid>
                   ) : null}
 
-                  {!telemedicine_doctor_update ? (
+                  {!telemedicine_doctor_update && itemData?.last_edited_by ? (
                     <Grid item xs={12}>
                       <Typography>
                         <span className="text-gray-700">Updated by:</span>{" "}
-                        {itemData?.last_edited_by &&
-                          itemData.last_edited_by.first_name +
-                            " " +
-                            itemData.last_edited_by.last_name +
-                            " - " +
-                            itemData.last_edited_by.user_type}
+                        {itemData.last_edited_by.first_name +
+                          " " +
+                          itemData.last_edited_by.last_name +
+                          " - " +
+                          itemData.last_edited_by.user_type}
                       </Typography>
                     </Grid>
                   ) : null}

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -255,6 +255,16 @@ export interface DailyRoundsModel {
   rounds_type?: string;
   last_updated_by_telemedicine?: boolean;
   created_by_telemedicine?: boolean;
+  created_by?: {
+    first_name?: string;
+    last_name?: string;
+    user_type?: string;
+  };
+  last_edited_by?: {
+    first_name?: string;
+    last_name?: string;
+    user_type?: string;
+  };
 }
 export interface FacilityNameModel {
   id?: string;


### PR DESCRIPTION
Adds user created by and updated by information to Update cards visible on the View Consultation page.

![image](https://user-images.githubusercontent.com/8392802/130410312-ec8db651-edb0-49e2-b8e0-8dc457ea6b7b.png)

fixes #1712 