### PR TITLE
added backUrl in PatientHome page title

### DIFF
--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -599,7 +599,7 @@ export const PatientHome = (props: any) => {
       )}
 
       <div id="revamp">
-        <PageTitle title={`Covid Suspect Details`} />
+        <PageTitle title={`Covid Suspect Details`} backUrl="/patients" />
         <div className="relative mt-2">
           <div className="max-w-screen-xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
             <div className="md:flex">


### PR DESCRIPTION
Closes #1769 
Added static backUrl, so it goes to patient list rather than back to consultation page.