### PR TITLE
Added is antenatal as filtering option in Shifting

### DIFF
--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -78,6 +78,16 @@ export default function BadgesList(props: any) {
         "is_up_shift"
       )}
       {badge(
+        "Is Antenatal",
+        local.is_antenatal === "yes" || appliedFilters.is_antenatal === "true"
+          ? "yes"
+          : local.is_antenatal === "no" ||
+            appliedFilters.is_antenatal === "false"
+          ? "no"
+          : undefined,
+        "is_antenatal"
+      )}
+      {badge(
         "Phone Number",
         appliedFilters.patient_phone_number || local.patient_phone_number,
         "patient_phone_number"

--- a/src/Components/Shifting/Commons.tsx
+++ b/src/Components/Shifting/Commons.tsx
@@ -23,6 +23,7 @@ export const initialFilterData = {
   assigned_user: "",
   assigned_to: "",
   disease_status: "",
+  is_antenatal: "--",
 };
 
 export const formatFilter = (params: any) => {
@@ -62,6 +63,12 @@ export const formatFilter = (params: any) => {
       (filter.is_kasp && filter.is_kasp) === "--"
         ? ""
         : filter.is_kasp === "yes"
+        ? "true"
+        : "false",
+    is_antenatal:
+      (filter.is_antenatal && filter.is_antenatal) === "--"
+        ? ""
+        : filter.is_antenatal === "yes"
         ? "true"
         : "false",
   };

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -65,6 +65,7 @@ export default function ListFilter(props: any) {
     assigned_user_ref: null,
     assigned_to: filter.assigned_to || local.assigned_to || "",
     disease_status: filter.disease_status || local.disease_status || "",
+    is_antenatal: filter.is_antenatal || local.is_antenatal || "--",
   });
   const dispatch: any = useDispatch();
 
@@ -198,6 +199,7 @@ export default function ListFilter(props: any) {
       assigned_user,
       assigned_to,
       disease_status,
+      is_antenatal,
     } = filterState;
     const data = {
       orgin_facility: orgin_facility || "",
@@ -228,6 +230,7 @@ export default function ListFilter(props: any) {
       assigned_user: assigned_user || "",
       assigned_to: assigned_to || "",
       disease_status: disease_status || "",
+      is_antenatal: is_antenatal || "",
     };
     localStorage.setItem(
       "shift-filters",
@@ -439,6 +442,20 @@ export default function ListFilter(props: any) {
             optionArray={true}
             value={filterState.disease_status}
             options={["--", ...DISEASE_STATUS]}
+            onChange={handleChange}
+            className="bg-white h-10 shadow-sm md:text-sm md:leading-5 md:h-9"
+          />
+        </div>
+
+        <div className="w-64 flex-none">
+          <span className="text-sm font-semibold">Is Antenatal</span>
+          <SelectField
+            name="is_antenatal"
+            variant="outlined"
+            margin="dense"
+            optionArray={true}
+            value={filterState.is_antenatal}
+            options={["--", "yes", "no"]}
             onChange={handleChange}
             className="bg-white h-10 shadow-sm md:text-sm md:leading-5 md:h-9"
           />

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -136,6 +136,7 @@ export default function ListView() {
     qParams.assigned_user,
     qParams.assigned_to,
     qParams.disease_status,
+    qParams.is_antenatal,
     offset,
   ]);
 

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -188,6 +188,14 @@ export default function ShiftDetails(props: { id: string }) {
               {patientData?.age}
             </div>
           )}
+          {patientData?.is_antenatal && (
+            <div>
+              <span className="font-semibold leading-relaxed">
+                Is antenatal:{" "}
+              </span>
+              <span className="badge badge-pill badge-warning">Yes</span>
+            </div>
+          )}
           <div>
             <span className="font-semibold leading-relaxed">Gender: </span>
             {patientGender}

--- a/src/Components/Shifting/ShiftingBoard.tsx
+++ b/src/Components/Shifting/ShiftingBoard.tsx
@@ -98,6 +98,7 @@ export default function ListView({
     filterProp.assigned_user,
     filterProp.assigned_to,
     filterProp.disease_status,
+    filterProp.is_antenatal,
   ]);
 
   const handlePagination = (page: number, limit: number) => {


### PR DESCRIPTION
- Filter Shifting requests using the is_antenatal parameter.
- Added the is_antenatal badge to Patient Details in Shifting Details.

https://www.loom.com/share/f0676b4145f045b3a8dc6f71897fe945

fixes #1798 