### PR TITLE
Added date & time to requests in Sample Test

### DIFF
--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -179,6 +179,7 @@ export const SampleTest = (props: any) => {
     if (validForm) {
       setIsLoading(true);
       const data: SampleTestModel = {
+        date_of_sample: new Date().toISOString(),
         fast_track: state.form.isFastTrack ? state.form.fast_track : undefined,
         icmr_label: state.form.icmr_label ? state.form.icmr_label : undefined,
         facility: facilityId,

--- a/src/Components/Patient/SampleTestCard.tsx
+++ b/src/Components/Patient/SampleTestCard.tsx
@@ -98,10 +98,10 @@ export const SampleTestCard = (props: SampleDetailsProps) => {
               {itemData.fast_track}
             </div>
           )}
-          {itemData.date_of_result && (
+          {itemData.date_of_sample && (
             <div>
               <span className="text-gray-700">Tested on :</span>{" "}
-              {moment(itemData.date_of_result).format("lll")}
+              {moment(itemData.date_of_sample).format("lll")}
             </div>
           )}
           {itemData.date_of_result && (

--- a/src/Components/Patient/SampleTestCard.tsx
+++ b/src/Components/Patient/SampleTestCard.tsx
@@ -41,6 +41,7 @@ export const SampleTestCard = (props: SampleDetailsProps) => {
     };
     if (status === 7) {
       sampleData.result = result;
+      sampleData.date_of_result = new Date().toISOString();
     }
     const statusName = SAMPLE_TEST_STATUS.find((i) => i.id === status)?.desc;
 

--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -231,10 +231,14 @@ export default function SampleViewAdmin(props: any) {
                 )}
                 {item.date_of_sample && (
                   <div>
-                    <span className="font-semibold leading-relaxed">
-                      Date of Sample:{" "}
-                    </span>
+                    <span className="text-gray-700">Tested on :</span>{" "}
                     {moment(item.date_of_sample).format("lll")}
+                  </div>
+                )}
+                {item.date_of_result && (
+                  <div>
+                    <span className="text-gray-700">Result on:</span>{" "}
+                    {moment(item.date_of_result).format("lll")}
                   </div>
                 )}
                 {item.patient_has_confirmed_contact && (

--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -145,6 +145,7 @@ export default function SampleViewAdmin(props: any) {
     };
     if (status === 7) {
       sampleData.result = result;
+      sampleData.date_of_result = new Date().toISOString();
     }
     const statusName = SAMPLE_TEST_STATUS.find((i) => i.id === status)?.desc;
     const res = await dispatch(patchSample(sampleData, { id: sample.id }));


### PR DESCRIPTION
Fixes #1829 

- [x] added date_of_sample and date_of_result to Sample Test card
- [x] setting date_of_result to new Date() when the result is entered in Sample Test
- [x] setting date_of_sample to new Date() when the Sample Test request is created

**Note:  _The date and time of Test and Result will be shown on cards that are created from now on because all previous cards have null values for date_of_sample and date_of_result._**

![image](https://user-images.githubusercontent.com/29787772/134310464-514718f4-c8be-4fe3-8aa0-ec281ee2c460.png)
