### PR TITLE
fixed the alignment of filter badges in Patients and Shifting tabs

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -359,7 +359,7 @@ export const PatientManager = (props: any) => {
   const badge = (key: string, value: any, paramKey: string) => {
     return (
       value && (
-        <span className="inline-flex items-center px-3 py-1 mt-2 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+        <span className="inline-flex items-center px-3 py-1 mt-2 ml-2 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
           {key}
           {": "}
           {value}
@@ -376,7 +376,7 @@ export const PatientManager = (props: any) => {
     const badge = (key: string, value: any, id: string) => {
       return (
         value && (
-          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+          <span className="inline-flex items-center px-3 py-1 mt-2 ml-2 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
             {key}
             {": "}
             {value}
@@ -679,7 +679,7 @@ export const PatientManager = (props: any) => {
             />
           </div>
         </div>
-        <div className="flex space-x-2 flex-wrap w-full col-span-3">
+        <div className="flex flex-wrap w-full col-span-3">
           {qParams.phone_number?.trim().split(" ").length - 1
             ? badge("Primary Number", qParams.phone_number, "phone_number")
             : null}

--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -51,7 +51,7 @@ export default function BadgesList(props: any) {
   const badge = (key: string, value: any, paramKey: any) => {
     return (
       value && (
-        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+        <span className="inline-flex items-center px-3 py-1 mt-2 ml-2 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
           {key}
           {": "}
           {value}
@@ -64,7 +64,7 @@ export default function BadgesList(props: any) {
     );
   };
   return (
-    <div className="flex flex-wrap space-x-2 mt-2 ml-2">
+    <div className="flex flex-wrap mt-4 ml-2">
       {badge(
         "status",
         (appliedFilters.status != "--" && appliedFilters.status) ||


### PR DESCRIPTION
Fixes #1851 


- [x] fixed the alignment of filter badges in Patients
![image](https://user-images.githubusercontent.com/29787772/134757432-45b5a7f0-cc3d-485b-ac76-bb2f891a2627.png)

- [x] fixed the alignment of filter badges in Shifting
![image](https://user-images.githubusercontent.com/29787772/134757628-4dc7d593-6ebc-44a3-b521-df86e7ab5d30.png)
