### PR TITLE
Change Patient homepage back button to go back in history

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -100,13 +100,15 @@ export const ConsultationDetails = (props: any) => {
         />
       ) : (
         <div className="px-2 pb-2">
-          <Link
+          <div
             className="btn btn-default bg-white mt-2"
-            href={`/facility/${facilityId}/patient/${patientId}`}
+            onClick={() => {
+              window.history.go(-1);
+            }}
           >
             <i className="fas fa-chevron-left  rounded-md p-2 hover:bg-gray-200 mr-1"></i>
             {"Go back to Patient Page"}
-          </Link>
+          </div>
           <div className="flex md:flex-row flex-col w-full mt-2">
             <div className="border rounded-lg bg-white shadow h-full text-black p-4 w-full">
               <div className="flex md:flex-row flex-col justify-between">

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -599,7 +599,7 @@ export const PatientHome = (props: any) => {
       )}
 
       <div id="revamp">
-        <PageTitle title={`Covid Suspect Details`} backUrl="/patients" />
+        <PageTitle title={`Covid Suspect Details`} />
         <div className="relative mt-2">
           <div className="max-w-screen-xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
             <div className="md:flex">


### PR DESCRIPTION
Change Patient homepage back button to go back in history instead of hard-coded "/patients"

Fixes #1865, Fixes #1866

![patienthomeback](https://user-images.githubusercontent.com/26682202/135055944-7ce0e8c4-9ea8-418c-8340-51c8556d4fb8.gif)
