### PR TITLE
changed the placeholder of advice in Consultation Form

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -621,7 +621,7 @@ export const ConsultationForm = (props: any) => {
                   />
                 </div>
                 <div className="flex-1" id="category-div">
-                  <InputLabel id="category-label">Category *</InputLabel>
+                  <InputLabel id="category-label">Category*</InputLabel>
                   <SelectField
                     name="category"
                     variant="standard"
@@ -731,7 +731,7 @@ export const ConsultationForm = (props: any) => {
                   variant="outlined"
                   margin="dense"
                   type="text"
-                  placeholder="Information optional"
+                  placeholder="Consultation Notes..."
                   InputLabelProps={{
                     shrink: !!state.form.consultation_notes,
                   }}


### PR DESCRIPTION
Fixes #1864 


changed the placeholder of advice form input from *Information Optional* to *Consultation Notes...* in the consultation form.

![image](https://user-images.githubusercontent.com/29787772/135209357-f3267519-9ace-4a4f-a54f-17cf3f3b917e.png)
