### PR TITLE
add not_working_reason to Assets

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -189,6 +189,11 @@ const AssetManage = (props: AssetManageProps) => {
             <Typography>
               Working status : {working_status(asset?.is_working)}
             </Typography>
+            {!asset?.is_working && (
+              <Typography>
+                Not working reason : {asset?.not_working_reason}
+              </Typography>
+            )}
             <Typography>Vendor Name : {asset?.vendor_name}</Typography>
             <Typography>
               Customer Support Name : {asset?.support_name}

--- a/src/Components/Assets/AssetTypes.ts
+++ b/src/Components/Assets/AssetTypes.ts
@@ -16,6 +16,7 @@ export interface AssetData {
   location: string;
   description: string;
   is_working: boolean;
+  not_working_reason: string;
   created_date: string;
   modified_date: string;
   serial_number: string;

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -69,6 +69,7 @@ const AssetCreate = (props: AssetProps) => {
   const [state, dispatch] = useReducer(asset_create_reducer, initialState);
   const [name, setName] = useState<string>("");
   const [asset_type, setAssetType] = useState<string>("");
+  const [not_working_reason, setNotWorkingReason] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [is_working, setIsWorking] = useState<string>();
   const [serial_number, setSerialNumber] = useState<string>("");
@@ -109,6 +110,7 @@ const AssetCreate = (props: AssetProps) => {
       setLocation(asset.location_object.id);
       setAssetType(asset.asset_type);
       setIsWorking(String(asset.is_working));
+      setNotWorkingReason(asset.not_working_reason);
       setSerialNumber(asset.serial_number);
       setWarrantyDetails(asset.warranty_details);
       setVendorName(asset.vendor_name);
@@ -169,6 +171,7 @@ const AssetCreate = (props: AssetProps) => {
         asset_type: asset_type,
         description: description,
         is_working: is_working,
+        not_working_reason: is_working === "true" ? "" : not_working_reason,
         serial_number: serial_number,
         warranty_details: warranty_details,
         location: location,
@@ -315,6 +318,27 @@ const AssetCreate = (props: AssetProps) => {
                 errors={state.errors.is_working}
               />
             </div>
+            {is_working === "false" && (
+              <div>
+                <InputLabel htmlFor="description" id="name=label">
+                  Reason
+                </InputLabel>
+                <MultilineInputField
+                  id="not_working_reason"
+                  rows={3}
+                  fullWidth
+                  name="description"
+                  placeholder=""
+                  variant="outlined"
+                  margin="dense"
+                  value={not_working_reason}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setNotWorkingReason(e.target.value)
+                  }
+                  errors={state.errors.not_working_reason}
+                />
+              </div>
+            )}
             <div>
               <InputLabel htmlFor="description" id="name=label">
                 Description


### PR DESCRIPTION
closes #1704 

This PR adds Not Working Reason field to Assets.

![asset](https://user-images.githubusercontent.com/26682202/137376471-fb035091-a26e-48a5-8ae4-3ceb52c7e145.gif)


Corresponding Backend PR: https://github.com/coronasafe/care/pull/633