### PR TITLE
Removed empty space in Update Section

### DIFF
--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -76,7 +76,7 @@ export const DailyRoundsList = (props: any) => {
           <div
             className={`block border rounded-lg ${
               telemedicine_doctor_update ? "bg-purple-200" : "bg-white"
-            }  shadow h-full cursor-pointer`}
+            } shadow cursor-pointer`}
           >
             <div className="p-2">
               <Grid container justify="space-between" alignItems="center">


### PR DESCRIPTION
Resolves #1898 

The extra empty space below the update section has been removed.
![image](https://user-images.githubusercontent.com/62461536/137526719-bcf0c612-c0ed-4ada-8c49-e1b76ee4f24b.png)
