### PR TITLE
Fix left alignment on Resource and Shifting page

### DIFF
--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -125,7 +125,7 @@ export default function BoardView() {
 
       <BadgesList appliedFilters={appliedFilters} updateFilter={updateFilter} />
 
-      <div className="flex mt-4 pb-2 flex-1 items-start overflow-x-scroll">
+      <div className="flex mt-4 pb-2 flex-1 items-start overflow-x-scroll px-4">
         {isLoading ? (
           <Loading />
         ) : (

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -148,7 +148,7 @@ export default function BoardView() {
         local={local}
         updateFilter={updateFilter}
       />
-      <div className="flex mt-4 pb-2 flex-1 items-start overflow-x-scroll">
+      <div className="flex mt-4 pb-2 flex-1 items-start overflow-x-scroll px-4">
         {isLoading ? (
           <Loading />
         ) : (


### PR DESCRIPTION
fixes #1921

This PR fixes alignment issues on Resources and Shifting pages.

![align](https://user-images.githubusercontent.com/26682202/138512505-94dce09d-a23b-414c-a1d6-d60d961288ab.png)
