### PR TITLE
Fix alignment in COVID Disease Status

### DIFF
--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -859,7 +859,7 @@ export const PatientHome = (props: any) => {
                   <div className="flex justify-between">
                     <div className="w-1/2 border-r-2 truncate">
                       <div className="text-sm leading-5 font-medium text-gray-500">
-                        COVID <br /> Disease Status
+                        COVID Status
                       </div>
                       <div className="mt-1 text-xl font-semibold leading-5 text-gray-900">
                         {patientData.disease_status}


### PR DESCRIPTION
closes #1922

This PR renames COVID Disease Status to "COVID Status" on Patient Home page.

![cds](https://user-images.githubusercontent.com/26682202/139054404-3e9af0ae-d857-40c4-b53c-da903b6b3e62.png)
