### PR TITLE
🚑 Fix crash when csv export response status is not 200

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -180,18 +180,29 @@ export const PatientManager = (props: any) => {
     is_antenatal: qParams.is_antenatal || undefined,
   };
 
+  const csvCreatedDateAfter: moment.Moment = !!params.created_date_after
+    ? moment(params.created_date_after)
+    : !!params.created_date_before
+    ? moment(params.created_date_before).subtract(7, "days")
+    : moment().subtract(7, "d");
+
+  const csvCreatedDateBefore: moment.Moment = !!params.created_date_before
+    ? moment(params.created_date_before)
+    : !!params.created_date_after
+    ? moment(params.created_date_after).add(7, "days")
+    : moment();
+
+  const isDownloadAllowed: boolean =
+    csvCreatedDateBefore.diff(csvCreatedDateAfter, "days") <= 7;
+
   let managePatients: any = null;
   const handleDownload = async (isFiltered: boolean) => {
     const res = await dispatch(
       getAllPatient(
         {
           ...params,
-          created_date_after: params.created_date_after
-            ? params.created_date_after
-            : moment().subtract(7, "d").format("YYYY-MM-DD"),
-          created_date_before: params.created_date_before
-            ? params.created_date_before
-            : moment().format("YYYY-MM-DD"),
+          created_date_after: csvCreatedDateAfter.format("YYYY-MM-DD"),
+          created_date_before: csvCreatedDateBefore.format("YYYY-MM-DD"),
           csv: true,
           facility: facilityId,
         },
@@ -590,14 +601,22 @@ export const PatientManager = (props: any) => {
               target="_blank"
             ></CSVLink>
           </div>
-          <Button
-            color="primary"
-            onClick={handleDownloadAll}
-            size="small"
-            startIcon={<ArrowDownwardIcon>download</ArrowDownwardIcon>}
-          >
-            Download All Patients
-          </Button>
+          <div className="flex flex-col gap-2">
+            <Button
+              color="primary"
+              onClick={handleDownloadAll}
+              size="small"
+              startIcon={<ArrowDownwardIcon>download</ArrowDownwardIcon>}
+              disabled={!isDownloadAllowed}
+            >
+              Download All Patients
+            </Button>
+            {!isDownloadAllowed && (
+              <p className="self-end text-sm italic text-red-400">
+                * Select a 7 day period
+              </p>
+            )}
+          </div>
         </div>
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="px-4 py-5 sm:p-6">

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -201,18 +201,20 @@ export const PatientManager = (props: any) => {
     ],
   ];
 
-  const isDownloadAllowed = date_range_fields
-    .map((field: string[]) => {
-      if (field[0] || field[1]) {
-        if (field[0] && field[1]) {
-          return moment(field[0]).diff(moment(field[1]), "days") <= 7;
-        } else {
-          return false;
-        }
-      }
-      return true;
-    })
-    .every((x) => x);
+  const durations = date_range_fields.map((field: string[]) => {
+    // XOR (checks if only one of the dates is set)
+    if (!field[0] !== !field[1]) {
+      return -1;
+    }
+    if (field[0] && field[1]) {
+      return moment(field[0]).diff(moment(field[1]), "days");
+    }
+    return 0;
+  });
+
+  const isDownloadAllowed =
+    durations.every((x) => x >= 0 && x <= 7) &&
+    !durations.every((x) => x === 0);
 
   let managePatients: any = null;
   const handleDownload = async (isFiltered: boolean) => {

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -192,7 +192,7 @@ export const PatientManager = (props: any) => {
         "downloadPatients"
       )
     );
-    if (res && res.data) {
+    if (res && res.data && res.data.status === 200) {
       setDownloadFile(res.data);
       document.getElementById("downloadlink")?.click();
     }

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -186,6 +186,12 @@ export const PatientManager = (props: any) => {
       getAllPatient(
         {
           ...params,
+          created_date_after: params.created_date_after
+            ? params.created_date_after
+            : moment().subtract(7, "d").format("YYYY-MM-DD"),
+          created_date_before: params.created_date_before
+            ? params.created_date_before
+            : moment().format("YYYY-MM-DD"),
           csv: true,
           facility: facilityId,
         },

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -192,7 +192,7 @@ export const PatientManager = (props: any) => {
         "downloadPatients"
       )
     );
-    if (res && res.data && res.data.status === 200) {
+    if (res && res.data && res.status === 200) {
       setDownloadFile(res.data);
       document.getElementById("downloadlink")?.click();
     }


### PR DESCRIPTION
fixes #1948

Prevent Crash when Patient CSV export response status is not 200 from the api.

1. If No filter is set for Creation date : Last 7 days data is downloaded.
2. If `before` filter is set for Creation date : 7 days data preceding the set date is downloaded.
3. If `after` filter is set for Creation date : 7 days data from the set date is downloaded.
4. If both `after` and `before` filters are set :
     - If duration is less than or equal to 7 days : The said duration's data is downloaded.
     - If duration is more than 7 days : Button is disabled and a message to select 7 days' data is shown.
        ![7dp](https://user-images.githubusercontent.com/26682202/140751679-dd266157-ff8e-4dd5-b754-7217b132220b.png)
