### PR TITLE
Fix: wrong request id for listAssetBeds

### DIFF
--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -122,7 +122,7 @@ export const partialUpdateFacilityAssetLocation = (
 
 // asset bed
 export const listAssetBeds = (params: object) =>
-  fireRequest("listFacilityBeds", [], params, {});
+  fireRequest("listAssetBeds", [], params, {});
 export const createAssetBed = (
   params: object,
   asset_id: string,


### PR DESCRIPTION
Wrong key was passed to fireRequest in listAssetBeds function