### PR TITLE
fixed redirection path of normal round in Daily Rounds

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -315,9 +315,15 @@ export const DailyRounds = (props: any) => {
           Notification.Success({
             msg: "Consultation Updates details updated successfully",
           });
-          navigate(
-            `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/daily_rounds/${res.data.external_id}/update`
-          );
+          if (state.form.rounds_type === "NORMAL") {
+            navigate(
+              `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}`
+            );
+          } else {
+            navigate(
+              `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/daily_rounds/${res.data.external_id}/update`
+            );
+          }
         } else {
           Notification.Success({
             msg: "Consultation Updates details created successfully",


### PR DESCRIPTION
Fixes #2023 

Now when the normal round update is submitted, the user is redirected to the consultation page.