### PR TITLE
fix TeleICU Switch

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -144,6 +144,9 @@ export const DailyRounds = (props: any) => {
             admitted_to: res.data.admitted_to ? res.data.admitted_to : "Select",
           };
           dispatch({ type: "set_form", form: data });
+          if (res.data.bed) {
+            setIsTeleicu("true");
+          }
         }
         setIsLoading(false);
       }


### PR DESCRIPTION
setting TeleICU as true if the bed was selected previously

if no bed was selected:
![teleicu-switch-no-bed](https://user-images.githubusercontent.com/42417893/153166489-e1fabd9a-e3ae-496a-b312-d9bd3a657e4d.gif)

If a bed was selected previously:
![teleicu-switch](https://user-images.githubusercontent.com/42417893/153166895-19376c2a-7978-4ac6-bec0-c6c8b628487a.gif)

