### PR TITLE
prevent showing feed tab unnecessarily

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -363,15 +363,20 @@ export const ConsultationDetails = (props: any) => {
             <div className="sm:flex sm:items-baseline overflow-x-auto">
               <div className="mt-4 sm:mt-0">
                 <nav className="pl-2 flex space-x-6 overflow-x-auto pb-2 ">
-                  {CONSULTATION_TABS.map((p: OptionsType) => (
-                    <Link
-                      key={p.text}
-                      className={tabButtonClasses(tab === p.text)}
-                      href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.text.toLocaleLowerCase()}`}
-                    >
-                      {p.desc}
-                    </Link>
-                  ))}
+                  {CONSULTATION_TABS.map((p: OptionsType) => {
+                    if (p.text === "FEED") {
+                      if (!consultationData?.last_daily_round?.bed) return null;
+                    }
+                    return (
+                      <Link
+                        key={p.text}
+                        className={tabButtonClasses(tab === p.text)}
+                        href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.text.toLocaleLowerCase()}`}
+                      >
+                        {p.desc}
+                      </Link>
+                    );
+                  })}
                 </nav>
               </div>
             </div>

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -109,6 +109,7 @@ export interface ConsultationModel {
   ett_tt?: number;
   cuff_pressure?: number;
   lines?: any;
+  last_daily_round?: any;
 }
 export interface PatientStatsModel {
   id?: number;


### PR DESCRIPTION
fixes #2087 
now the `feed` tab will only be shown if the patient is using a bed:

If they have a bed:
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/42417893/153462910-75d0f9b8-10f2-43c4-a934-28b63912962b.png">

If they don't have a bed:
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/42417893/153463178-b046a893-e4ab-41c9-bfb2-1925072b84fb.png">
