### PR TITLE
Added subtext to show current values in critical-care graphs

### DIFF
--- a/src/Components/Facility/Consultations/components/LinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/LinePlot.tsx
@@ -5,6 +5,15 @@ export const LinePlot = (props: any) => {
   let generalOptions = {
     title: {
       text: title,
+      subtext: `current value: {0|${yData[yData.length - 1] || "NA"}}`,
+      padding: [0, 0, 10, 0],
+      subtextStyle: {
+        fontSize: 14,
+        fontWeight: "bold",
+        rich: {
+          0: { color: "#5470C6" },
+        },
+      },
     },
     legend: {
       data: [name],
@@ -93,5 +102,7 @@ export const LinePlot = (props: any) => {
   if (high && low) {
     generalOptions = { ...generalOptions, ...visualMap };
   }
+
+  console.log(title, yData);
   return <ReactECharts option={generalOptions} />;
 };

--- a/src/Components/Facility/Consultations/components/LinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/LinePlot.tsx
@@ -103,6 +103,5 @@ export const LinePlot = (props: any) => {
     generalOptions = { ...generalOptions, ...visualMap };
   }
 
-  console.log(title, yData);
   return <ReactECharts option={generalOptions} />;
 };

--- a/src/Components/Facility/Consultations/components/LinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/LinePlot.tsx
@@ -4,14 +4,16 @@ export const LinePlot = (props: any) => {
   const { title, name, xData, yData, low = null, high = null } = props;
   let generalOptions = {
     title: {
-      text: title,
-      subtext: `current value: {0|${yData[yData.length - 1] || "NA"}}`,
-      padding: [0, 0, 10, 0],
-      subtextStyle: {
-        fontSize: 14,
-        fontWeight: "bold",
+      text: `${title} [ {0|${yData[yData.length - 1] || "NA"}} ]`,
+      textStyle: {
+        fontSize: 20,
         rich: {
-          0: { color: "#5470C6" },
+          0: {
+            fontSize: 14,
+            fontWeight: "bold",
+            padding: [0, 5],
+            color: "#5470C6",
+          },
         },
       },
     },

--- a/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
@@ -16,21 +16,25 @@ export const StackedLinePlot = (props: any) => {
   const generalOptions = {
     color: COLORS,
     title: {
-      text: title,
-      subtext:
-        "current value(s): " +
+      text:
+        title +
+        " [ " +
         yData
           .map(
             (x: any, i: number) => `{${i}|${x.data[x.data.length - 1] ?? "NA"}}`
           )
-          .join(" | "),
-      padding: [0, 0, 10, 0],
-      subtextStyle: {
-        fontSize: 14,
-        fontWeight: "bold",
+          .join(" | ") +
+        " ] ",
+      textStyle: {
+        fontSize: 20,
         rich: Object.assign(
           {},
-          COLORS.map((x: any) => ({ color: x }))
+          COLORS.map((x: any) => ({
+            fontSize: 14,
+            fontWeight: "bold",
+            padding: [0, 5],
+            color: x,
+          }))
         ),
       },
     },

--- a/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
@@ -1,7 +1,11 @@
 import ReactECharts from "echarts-for-react";
 
+const COLORS = ["#B13F3C", "#2F8B35", "#44327A", "#B19D3C"];
+
 export const StackedLinePlot = (props: any) => {
   const { title, xData, yData } = props;
+
+  console.log(yData);
 
   const series = yData.map((x: any) => ({
     name: x.name,
@@ -12,8 +16,25 @@ export const StackedLinePlot = (props: any) => {
   }));
 
   const generalOptions = {
+    color: COLORS,
     title: {
       text: title,
+      subtext:
+        "current value(s): " +
+        yData
+          .map(
+            (x: any, i: number) => `{${i}|${x.data[x.data.length - 1] ?? "NA"}}`
+          )
+          .join(" | "),
+      padding: [0, 0, 10, 0],
+      subtextStyle: {
+        fontSize: 14,
+        fontWeight: "bold",
+        rich: Object.assign(
+          {},
+          COLORS.map((x: any) => ({ color: x }))
+        ),
+      },
     },
 
     legend: {

--- a/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
@@ -5,8 +5,6 @@ const COLORS = ["#B13F3C", "#2F8B35", "#44327A", "#B19D3C"];
 export const StackedLinePlot = (props: any) => {
   const { title, xData, yData } = props;
 
-  console.log(yData);
-
   const series = yData.map((x: any) => ({
     name: x.name,
     type: "line",


### PR DESCRIPTION
Fixes #2149 

UI showing current values in the graphs:
![image](https://user-images.githubusercontent.com/29787772/158015139-d05ec8b3-523b-4a78-991a-9b959b6929f3.png)
