### PR TITLE
Add Title Element

### DIFF
--- a/src/Components/Common/PageHeadTitle.tsx
+++ b/src/Components/Common/PageHeadTitle.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+export interface IPageTitleProps {
+  title: string;
+}
+
+export default function PageTitle({ title }: IPageTitleProps) {
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = title + " | Corona Care";
+    return () => {
+      document.title = prevTitle;
+    };
+  }, [title]);
+
+  return <></>;
+}

--- a/src/Components/Common/PageTitle.tsx
+++ b/src/Components/Common/PageTitle.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { navigate } from "raviger";
 import Breadcrumbs from "./Breadcrumbs";
+import PageHeadTitle from "./PageHeadTitle";
 
 interface PageTitleProps {
   title: string;
@@ -34,6 +35,7 @@ export default function PageTitle(props: PageTitleProps) {
   // 'px-3 md:px-8'
   return (
     <div className={`pt-4 mb-4 ${className}`}>
+      <PageHeadTitle title={title} />
       <div className="flex items-center">
         {!hideBack && (
           <button onClick={goBack}>

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1793,7 +1793,7 @@ export const PatientHome = (props: any) => {
 
       <div>
         <PageTitle
-          title="Sample Test History"
+          title="Patient Details"
           hideBack={true}
           breadcrumbs={false}
         />


### PR DESCRIPTION
## Changes 💪

Instead of adding Page Title (#2177) to all the pages, added it to the Breadcrumbs Element. This is to avoid any breaking if we update in all pages. 

## Screenshot

![image](https://user-images.githubusercontent.com/57325503/159211777-95998e86-afac-48a6-8f92-eb14f5c99f54.png)

(Titles on the browser will be changed when change the pages)


Resolves #2177 🔨

