### PR TITLE
removed dotnet install step from OSSAR workflow

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -27,13 +27,7 @@ jobs:
       - run: git checkout HEAD^2
         if: ${{ github.event_name == 'pull_request' }}
 
-        # Install dotnet, used by OSSAR
-      - name: Install .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "3.1.201"
-
-        # Run open source static analysis tools
+      # Run open source static analysis tools
       - name: Run OSSAR
         uses: github/ossar-action@v1
         id: ossar


### PR DESCRIPTION
removed dotnet install step as it is not required for github runners this will fix the failing workflows

ref: https://github.com/github/ossar-action/commit/60d95d399a4b3dba3933d7e0d36bb6ed2435162b

