### PR TITLE
Improve Login Redirect, issue #2222

### DIFF
--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -80,7 +80,12 @@ const LoginPage = (props: any) => {
         } else if (res && statusCode === 200) {
           localStorage.setItem("care_access_token", res.access);
           localStorage.setItem("care_refresh_token", res.refresh);
-          navigate("/facility");
+
+          if (window.location.pathname === '/' || window.location.pathname === '/login') {
+            navigate('/facility');
+          } else {
+            navigate(window.location.pathname.toString());
+          }
           window.location.reload();
         }
       });


### PR DESCRIPTION
On successful login, only redirects to '/facility' if the current URL path is '/' or '/login' - otherwise it reloads the page that the user tried to initially open.

fixes #2222 