### PR TITLE
specify eslint version for codeclimate scans

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+plugins:
+  eslint:
+    enabled: true
+    channel: "eslint-7"


### PR DESCRIPTION
this will use use ESLint ^7.8.0 instead of ESLint v3.19.0 

ref:https://docs.codeclimate.com/docs/eslint#eslint-versions