### PR TITLE
fix: UserAdd component responsive layout

### DIFF
--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -553,7 +553,7 @@ export const UserAdd = (props: UserProps) => {
                 />
               </div>
 
-              <div className="col-span-2">
+              <div className="md:col-span-2">
                 <InputLabel>Facilities</InputLabel>
                 {userType === "Staff" || userType === "StaffReadOnly" ? (
                   <MultiSelectField


### PR DESCRIPTION
col span of Facilities input was causing the grid to glitch when the grid had 1 column

fixes #2275 

#### Preview: 
<img src="https://user-images.githubusercontent.com/46787056/167296298-b385f6f6-128a-4516-a50a-29edd425a4ea.png" width="50%">