### PR TITLE
changed title to  Treatment Plan / Treatment Summary

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -654,7 +654,7 @@ export const ConsultationForm = (props: any) => {
 
                 <div id="prescribed_medication-div">
                   <InputLabel id="prescribed-medication-label">
-                    Treatment Summary
+                    Treatment Plan / Treatment Summary
                   </InputLabel>
                   <MultilineInputField
                     rows={5}


### PR DESCRIPTION
Fixed [#2289](https://github.com/coronasafe/care_fe/issues/2289)

![image](https://user-images.githubusercontent.com/59426397/167545004-d9536cc8-0d03-41bf-abf8-bfcfeb55d38a.png)

Changed the title from "Treatment Summary" to "Treatment Plan/Treatment Summary" in Consultation page.