### PR TITLE
Fix Profile Tab not showing active in sidebar

### DIFF
--- a/src/Components/Common/SideBar.tsx
+++ b/src/Components/Common/SideBar.tsx
@@ -82,7 +82,7 @@ export const SideBar: React.FC<SideBarProps> = ({ isOpen, setIsOpen }) => {
     ""
   )}`;
   const path = usePath();
-  const url = path.split("/");
+  const url = path.replaceAll("/", "");
 
   const active = menus.reduce((acc, menu) => {
     const tag = menu.link.replaceAll("/", "");


### PR DESCRIPTION
Fixes #2267

- Profile tab will now show as active when selected.
- This change works fine with all other tabs too on the sidebar.

Preview:
![image](https://user-images.githubusercontent.com/3626859/167703316-eb580466-71b7-4d4f-afcb-8e0e08ee0c48.png)
