### PR TITLE
Make error messages more user friendly

### DIFF
--- a/src/Utils/Notifications.js
+++ b/src/Utils/Notifications.js
@@ -46,13 +46,14 @@ const notifyError = (error) => {
     errorMsg = error.detail;
   } else {
     for (let [key, value] of Object.entries(error)) {
+      let keyName = key.replace(/_/g, " ");
       if (Array.isArray(value)) {
         const uniques = [...new Set(value)];
-        errorMsg += `${key} - ${uniques.splice(0, 5).join(", ")}`;
+        errorMsg += `${keyName} - ${uniques.splice(0, 5).join(", ")}`;
       } else if (typeof value === "string") {
-        errorMsg += `${key} - ${value}`;
+        errorMsg += `${keyName} - ${value}`;
       } else {
-        errorMsg += `${key} - Bad Request`;
+        errorMsg += `${keyName} - Bad Request`;
       }
       errorMsg += "\n";
     }

--- a/src/Utils/Notifications.js
+++ b/src/Utils/Notifications.js
@@ -1,6 +1,7 @@
 import { alert, Stack } from "@pnotify/core";
 import "@pnotify/core/dist/PNotify.css";
 import "@pnotify/core/dist/BrightTheme.css";
+import _ from "lodash";
 
 const notifyStack = new Stack({
   dir1: "down",
@@ -46,7 +47,7 @@ const notifyError = (error) => {
     errorMsg = error.detail;
   } else {
     for (let [key, value] of Object.entries(error)) {
-      let keyName = key.replace(/_/g, " ");
+      let keyName = _.startCase(_.camelCase(key));
       if (Array.isArray(value)) {
         const uniques = [...new Set(value)];
         errorMsg += `${keyName} - ${uniques.splice(0, 5).join(", ")}`;


### PR DESCRIPTION
Fixes #2251 

The error keys returned from the backend often have a `_` instead of a space. Instead of editing it out everywhere in the backend, we can make a small change here on how Error messages are parsed and displayed. This change will replace the `_` with a space to make it more user friendly.

The above linked issue also accompanies a backend change which is linked below.

Related Backend PR: https://github.com/coronasafe/care/pull/734