### PR TITLE
Renamed the page heading  from 'Covid Suspect Details' to 'Patient Details'

### DIFF
--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -562,7 +562,7 @@ export const PatientHome = (props: any) => {
 
       <div id="revamp">
         <PageTitle
-          title={"Covid Suspect Details"}
+          title={"Patient Details"}
           backUrl="/patients"
           crumbsReplacements={{
             [facilityId]: { name: patientData?.facility_object?.name },


### PR DESCRIPTION
Fixes #2325 
Changed the page title 'Covid Suspect Details' to 'Patient Details'.

Before:
![image](https://user-images.githubusercontent.com/40627011/168121989-fdf15209-e6d0-4261-a690-edfebf8b8e6f.png)

After:
![image](https://user-images.githubusercontent.com/40627011/168122059-372909ad-9a3d-4e16-b8c1-5403f1cd0b8c.png)
