### PR TITLE
fix: Notes breadcrumb link on Patient Notes page

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -201,7 +201,7 @@ export const ConsultationDetails = (props: any) => {
                 Patient Details
               </Link>
               <Link
-                href={`/facility/${patientData.facility}/patient/${patientData.id}/notes/`}
+                href={`/facility/${patientData.facility}/patient/${patientData.id}/notes`}
                 className="btn m-1 btn-primary hover:text-white"
               >
                 Doctor&apos;s Notes

--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -139,7 +139,7 @@ const routes = {
   "/facility/:facilityId/patient/:patientId/sample/:id": ({ id }: any) => (
     <SampleDetails id={id} />
   ),
-  "/facility/:facilityId/patient/:patientId/notes/": ({
+  "/facility/:facilityId/patient/:patientId/notes": ({
     facilityId,
     patientId,
   }: any) => <PatientNotes patientId={patientId} facilityId={facilityId} />,


### PR DESCRIPTION
This PR closes #2331 
Fixed the Notes breadcrumb broken link on Patient Notes page. The issue was caused due to the `src/Components/Common/Breadcrumbs.tsx` component which is creating the href for the `Notes` breadcrumb. It doesn't add a trailing slash at the end, while the actual route defined in the router had a trailing slash causing a mismatch