### PR TITLE
Added category validations in VentilatorParameters

### DIFF
--- a/src/Components/Common/utils/DictUtils.res
+++ b/src/Components/Common/utils/DictUtils.res
@@ -7,20 +7,20 @@ let setOptionalString = (key, value, payload) => {
 let setOptionalNumber = (key, value, payload) => {
   switch value {
   | Some(v) => Js.Dict.set(payload, key, Js.Json.number(float_of_int(v)))
-  | None => ()
+  | None => Js.Dict.set(payload, key, Js.Json.null)
   }
 }
 
 let setOptionalFloat = (key, value, payload) => {
   switch value {
   | Some(v) => Js.Dict.set(payload, key, Js.Json.number(v))
-  | None => ()
+  | None => Js.Dict.set(payload, key, Js.Json.null)
   }
 }
 
 let setOptionalBool = (key, value, payload) => {
   switch value {
   | Some(v) => Js.Dict.set(payload, key, Js.Json.boolean(v))
-  | None => ()
+  | None => Js.Dict.set(payload, key, Js.Json.null)
   }
 }

--- a/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
+++ b/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
@@ -101,27 +101,34 @@ let makePayload = (state: VentilatorParameters.state) => {
   DictUtils.setOptionalNumber("ventilator_tidal_volume", state.ventilator_tidal_volume, payload)
   DictUtils.setOptionalNumber(
     "ventilator_oxygen_modality_oxygen_rate",
-    state.ventilator_oxygen_modality_oxygen_rate,
+    state.ventilator_interface === UNKNOWN &&
+      state.ventilator_oxygen_modality !== HIGH_FLOW_NASAL_CANNULA
+      ? state.ventilator_oxygen_modality_oxygen_rate
+      : None,
     payload,
   )
   DictUtils.setOptionalNumber(
     "ventilator_oxygen_modality_flow_rate",
-    state.ventilator_oxygen_modality_flow_rate,
+    state.ventilator_oxygen_modality === HIGH_FLOW_NASAL_CANNULA
+      ? state.ventilator_oxygen_modality_flow_rate
+      : None,
     payload,
   )
   DictUtils.setOptionalNumber(
-    "ventilator_fi02", 
-    state.ventilator_oxygen_modality === HIGH_FLOW_NASAL_CANNULA || 
-    state.ventilator_interface === INVASIVE || 
-    state.ventilator_interface === NON_INVASIVE ? state.ventilator_fi02 : None, 
-    payload
+    "ventilator_fi02",
+    state.ventilator_oxygen_modality === HIGH_FLOW_NASAL_CANNULA ||
+    state.ventilator_interface === INVASIVE ||
+    state.ventilator_interface === NON_INVASIVE
+      ? state.ventilator_fi02
+      : None,
+    payload,
   )
   DictUtils.setOptionalNumber("ventilator_spo2", state.ventilator_spo2, payload)
 
   payload
 }
 
-let successCB = (send, updateCB, data) => {
+let successCB = (_send, updateCB, data) => {
   updateCB(CriticalCare__DailyRound.makeFromJs(data))
 }
 


### PR DESCRIPTION
Fixes #2256 

added category validations for oxygen_rate, flow_rate, and fio2, checks if either of these inputs belongs to the correct category and sets their value, if not value is set to null.