### PR TITLE
Resolved blank systolic error

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -265,7 +265,7 @@ export const DailyRounds = (props: any) => {
           data = {
             ...data,
             bp:
-              state.form.bp.systolic && state.form.bp.diastolic
+              state.form.bp && state.form.bp.systolic && state.form.bp.diastolic
                 ? {
                     systolic: Number(state.form.bp.systolic),
                     diastolic: Number(state.form.bp.diastolic),


### PR DESCRIPTION
Logging a daily round update without a systolic value no more throws an error
closes [https://github.com/coronasafe/care_fe/issues/2329](https://github.com/coronasafe/care_fe/issues/2329)