### PR TITLE
Fix API calls on Safari

### DIFF
--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -61,6 +61,10 @@ export const fireRequest = (
     if (path.length > 0) {
       request.path += "/" + path.join("/");
     }
+    // add trailing slash to path before query paramaters
+    if (request.path.slice(-1) !== "/" && request.path.indexOf("?") === -1) {
+      request.path += "/";
+    }
     if (request.method === undefined || request.method === "GET") {
       request.method = "GET";
       const qs = querystring.stringify(params);
@@ -160,8 +164,8 @@ export const fireRequestV2 = (
   key: string,
   path: any = [],
   params: any = {},
-  successCallback: any = () => {},
-  errorCallback: any = () => {},
+  successCallback: any = () => undefined,
+  errorCallback: any = () => undefined,
   pathParam?: any,
   altKey?: string
 ) => {


### PR DESCRIPTION
Fixes #1060 

Safari does not persist the Authorization header on redirect. This can cause some API calls to fail when they are redirected for any reason, like when the trailing slash is missing from the request URL.

To prevent this from happening, this change adds a check for trailing slash to avoid any unnecessary API redirect which would lead to dropping of the header.

This PR also remedies 2 ESLint errors: `no-empty-function`
