### PR TITLE
Renamed button from 'Add COVID Suspect/Patient' to 'Add Patient'

### DIFF
--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -65,7 +65,7 @@ const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const debounce = require("lodash.debounce");
-
+// eslint-disable-next-line
 const placesList = countryList.concat(
   statesList.filter((i: string) => i !== "Kerala")
 );
@@ -103,6 +103,7 @@ const diseaseStatus = [...DISEASE_STATUS];
 const bloodGroups = [...BLOOD_GROUPS];
 
 const testType = [...TEST_TYPE];
+// eslint-disable-next-line
 const designationOfHealthWorkers = [...DESIGNATION_HEALTH_CARE_WORKER];
 const vaccines = ["Select", ...VACCINES];
 
@@ -243,7 +244,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
   const headerText = !id
     ? "Add Details of Covid Suspect / Patient"
     : "Update Covid Suspect / Patient Details";
-  const buttonText = !id ? "Add Covid Suspect / Patient" : "Save Details";
+  const buttonText = !id ? "Add Patient" : "Save Details";
 
   const fetchDistricts = useCallback(
     async (id: string) => {
@@ -509,7 +510,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     const errors = { ...initError };
     let invalidForm = false;
     let error_div = "";
-
+    // eslint-disable-next-line
     Object.keys(state.form).forEach((field, i) => {
       let phoneNumber, emergency_phone_number;
       switch (field) {
@@ -854,7 +855,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
       dispatch({ type: "set_form", form });
     }
   };
-
+  // eslint-disable-next-line
   const handleCheckboxFieldChange = (e: any) => {
     const form = { ...state.form };
     const { checked, name } = e.target;

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -241,9 +241,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     }
   }, [careExtId]);
 
-  const headerText = !id
-    ? "Add Details of Covid Suspect / Patient"
-    : "Update Covid Suspect / Patient Details";
+  const headerText = !id ? "Add Details of Patient" : "Update Patient Details";
   const buttonText = !id ? "Add Patient" : "Save Details";
 
   const fetchDistricts = useCallback(

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -25,11 +25,11 @@ import {
   GENDER_TYPES,
   MEDICAL_HISTORY_CHOICES,
   TEST_TYPE,
-  DESIGNATION_HEALTH_CARE_WORKER,
+  // DESIGNATION_HEALTH_CARE_WORKER,
   VACCINES,
 } from "../../Common/constants";
 import countryList from "../../Common/static/countries.json";
-import statesList from "../../Common/static/states.json";
+// import statesList from "../../Common/static/states.json";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   createPatient,
@@ -65,10 +65,10 @@ const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const debounce = require("lodash.debounce");
-// eslint-disable-next-line
-const placesList = countryList.concat(
-  statesList.filter((i: string) => i !== "Kerala")
-);
+
+// const placesList = countryList.concat(
+//   statesList.filter((i: string) => i !== "Kerala")
+// );
 
 interface PatientRegisterProps extends PatientModel {
   facilityId: number;
@@ -103,8 +103,7 @@ const diseaseStatus = [...DISEASE_STATUS];
 const bloodGroups = [...BLOOD_GROUPS];
 
 const testType = [...TEST_TYPE];
-// eslint-disable-next-line
-const designationOfHealthWorkers = [...DESIGNATION_HEALTH_CARE_WORKER];
+// const designationOfHealthWorkers = [...DESIGNATION_HEALTH_CARE_WORKER];
 const vaccines = ["Select", ...VACCINES];
 
 const initForm: any = {
@@ -508,8 +507,8 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     const errors = { ...initError };
     let invalidForm = false;
     let error_div = "";
-    // eslint-disable-next-line
-    Object.keys(state.form).forEach((field, i) => {
+
+    Object.keys(state.form).forEach((field) => {
       let phoneNumber, emergency_phone_number;
       switch (field) {
         case "address":
@@ -853,13 +852,13 @@ export const PatientRegister = (props: PatientRegisterProps) => {
       dispatch({ type: "set_form", form });
     }
   };
-  // eslint-disable-next-line
-  const handleCheckboxFieldChange = (e: any) => {
-    const form = { ...state.form };
-    const { checked, name } = e.target;
-    form[name] = checked;
-    dispatch({ type: "set_form", form });
-  };
+
+  // const handleCheckboxFieldChange = (e: any) => {
+  //   const form = { ...state.form };
+  //   const { checked, name } = e.target;
+  //   form[name] = checked;
+  //   dispatch({ type: "set_form", form });
+  // };
 
   const handleMedicalCheckboxChange = (e: any, id: number) => {
     const form = { ...state.form };

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -25,11 +25,9 @@ import {
   GENDER_TYPES,
   MEDICAL_HISTORY_CHOICES,
   TEST_TYPE,
-  // DESIGNATION_HEALTH_CARE_WORKER,
   VACCINES,
 } from "../../Common/constants";
 import countryList from "../../Common/static/countries.json";
-// import statesList from "../../Common/static/states.json";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   createPatient,
@@ -66,10 +64,6 @@ const PageTitle = loadable(() => import("../Common/PageTitle"));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const debounce = require("lodash.debounce");
 
-// const placesList = countryList.concat(
-//   statesList.filter((i: string) => i !== "Kerala")
-// );
-
 interface PatientRegisterProps extends PatientModel {
   facilityId: number;
 }
@@ -103,7 +97,6 @@ const diseaseStatus = [...DISEASE_STATUS];
 const bloodGroups = [...BLOOD_GROUPS];
 
 const testType = [...TEST_TYPE];
-// const designationOfHealthWorkers = [...DESIGNATION_HEALTH_CARE_WORKER];
 const vaccines = ["Select", ...VACCINES];
 
 const initForm: any = {
@@ -852,13 +845,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
       dispatch({ type: "set_form", form });
     }
   };
-
-  // const handleCheckboxFieldChange = (e: any) => {
-  //   const form = { ...state.form };
-  //   const { checked, name } = e.target;
-  //   form[name] = checked;
-  //   dispatch({ type: "set_form", form });
-  // };
 
   const handleMedicalCheckboxChange = (e: any, id: number) => {
     const form = { ...state.form };


### PR DESCRIPTION
Fixes #2393 

Renamed the "Add Covid Suspect/Patient" button in the patient registration form to "Add Patient".

Before:
![image](https://user-images.githubusercontent.com/40627011/168851004-1b2946c4-43de-4362-bb40-61849c409586.png)

After:
![image](https://user-images.githubusercontent.com/40627011/168850884-5afbdacf-09e1-4924-9b9c-33be8961fd98.png)
