### PR TITLE
Send raw pulse and spo2 data

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -277,14 +277,14 @@ export const DailyRounds = (props: any) => {
                     ),
                   }
                 : undefined,
-            pulse: Number(state.form.pulse),
+            pulse: state.form.pulse,
             resp: Number(state.form.resp),
             temperature: state.form.tempInCelcius
               ? celciusToFahrenheit(state.form.temperature)
               : state.form.temperature,
             rhythm: Number(state.form.rhythm) || 0,
             rhythm_detail: state.form.rhythm_detail,
-            ventilator_spo2: Number(state.form.ventilator_spo2),
+            ventilator_spo2: state.form.ventilator_spo2,
           };
         }
       } else {


### PR DESCRIPTION
Closes #2141 

`pulse` and `ventilator_spo2` are casted to `Number`. This means that in cases where they are left blank, they are actually forced to be stored as 0, rather than null. ( `Number(null) -> 0` ) Which causes the above issue. Removing this cast resolves it. `null` values displayed properly as `-` in the charts and not as 0s.

![image](https://user-images.githubusercontent.com/3626859/168914088-7f585a51-961c-4b67-ac45-15e796143126.png)

![image](https://user-images.githubusercontent.com/3626859/168914095-8ea3b546-12ae-4c7b-9077-856973a81b4f.png)
