### PR TITLE
Fix notification padding when no results are found

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -273,8 +273,8 @@ export default function ResultList({
     );
   } else if (data && data.length === 0) {
     manageResults = (
-      <div>
-        <h5> No Results Found</h5>
+      <div className="px-4 pt-3 lg:px-8">
+        <h5> No Results Found </h5>
       </div>
     );
   }

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -1,5 +1,4 @@
-import loadable from "@loadable/component";
-import { navigate, useQueryParams } from "raviger";
+import { navigate } from "raviger";
 import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import {
@@ -8,10 +7,8 @@ import {
   updateUserPnconfig,
   getPublicKey,
 } from "../../Redux/actions";
-import Pagination from "../Common/Pagination";
 import { make as SlideOver } from "../Common/SlideOver.gen";
 import { SelectField } from "../Common/HelperInputFields";
-import { InputLabel } from "@material-ui/core";
 import moment from "moment";
 import { useSelector } from "react-redux";
 import { Button, CircularProgress } from "@material-ui/core";
@@ -20,13 +17,13 @@ import { Error } from "../../Utils/Notifications.js";
 import clsx from "clsx";
 import { useTranslation } from "react-i18next";
 
-const Loading = loadable(() => import("../Common/Loading"));
-const PageTitle = loadable(() => import("../Common/PageTitle"));
-
 const RESULT_LIMIT = 14;
-const now = moment().format("DD-MM-YYYY:hh:mm:ss");
 
-export default function ResultList({ expanded = false }) {
+export default function ResultList({
+  expanded = false,
+}: {
+  expanded?: boolean;
+}) {
   const rootState: any = useSelector((rootState) => rootState);
   const { currentUser } = rootState;
   const { t } = useTranslation();
@@ -93,34 +90,34 @@ export default function ResultList({ expanded = false }) {
           .then(function (subscription) {
             subscription
               ?.unsubscribe()
-              .then(async function (successful) {
+              .then(async function (_successful) {
                 const data = {
                   pf_endpoint: "",
                   pf_p256dh: "",
                   pf_auth: "",
                 };
-                const res = await dispatch(
+                await dispatch(
                   updateUserPnconfig(data, { username: username })
                 );
 
                 setIsSubscribed("NotSubscribed");
                 setIsSubscribing(false);
               })
-              .catch(function (e) {
+              .catch(function (_e) {
                 Error({
                   msg: "Unsubscribe failed.",
                 });
               });
           })
-          .catch(function (e) {
+          .catch(function (_e) {
             Error({
-              msg: `Subscription Error`,
+              msg: "Subscription Error",
             });
           });
       })
-      .catch(function (e) {
+      .catch(function (_e) {
         Error({
-          msg: `Service Worker Error`,
+          msg: "Service Worker Error",
         });
       });
   };
@@ -190,7 +187,7 @@ export default function ResultList({ expanded = false }) {
   //   updateQuery({ page, limit });
   // };
 
-  let resultUrl = (event: string, data: any) => {
+  const resultUrl = (event: string, data: any) => {
     switch (event) {
       case "PATIENT_CREATED":
         return `/facility/${data.facility}/patient/${data.patient}`;
@@ -207,18 +204,18 @@ export default function ResultList({ expanded = false }) {
       case "INVESTIGATION_SESSION_CREATED":
         return `/facility/${data.facility}/patient/${data.patient}/consultation/${data.consultation}/investigation/${data.session}`;
       case "MESSAGE":
-        return `/notice_board/`;
+        return "/notice_board/";
       default:
         return "#";
     }
   };
 
-  let getNotificationTitle = (id: string) =>
+  const getNotificationTitle = (id: string) =>
     NOTIFICATION_EVENTS.find((notification) => notification.id === id)?.text;
 
   let resultList: any[] = [];
   if (data && data.length) {
-    resultList = data.map((result: any, idx: number) => {
+    resultList = data.map((result: any, _idx: number) => {
       return (
         <div
           key={`usr_${result.id}`}


### PR DESCRIPTION
Fixes the "No results found" message's padding when no notifications are present.

Before:
![image](https://user-images.githubusercontent.com/3626859/169226026-5a56527e-d823-4ce2-9862-ae52bdb7e727.png)

After:
![image](https://user-images.githubusercontent.com/3626859/169226046-4fa94660-7691-4177-a0f3-c3a8249b92ac.png)
