### PR TITLE
Fix breadcrumbs issue in user pages by redirecting.

### DIFF
--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -459,6 +459,7 @@ const menus = [
 const AppRouter = () => {
   useRedirect("/", "/facility");
   useRedirect("/teleicu", "/teleicu/facility");
+  useRedirect("/user", "/users");
   const pages = useRoutes(routes);
   const path = usePath();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);


### PR DESCRIPTION
Fixes #2441 

As we can't change breadcrumbs for individual pages, redirect `/user` to `/users`.