### PR TITLE
Fix navbar translations

### DIFF
--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -11,5 +11,8 @@
   "District": "District",
   "Local Body": "Local Body",
   "Location": "Location",
-  "Ward": "Ward"
+  "Ward": "Ward",
+  "Notice Board": "Notice Board",
+  "Assets": "Assets",
+  "Notifications": "Notifications"
 }

--- a/src/Locale/ml/Common.json
+++ b/src/Locale/ml/Common.json
@@ -11,5 +11,8 @@
   "District": "ജില്ല",
   "Local Body": "തദ്ദേശസ്ഥാപനം",
   "Location": "സ്ഥാനം",
-  "Ward": "വാര്‍ഡ്‌"
+  "Ward": "വാര്‍ഡ്‌",
+  "Notice Board": "നോട്ടീസ് ബോർഡ്",
+  "Assets": "ആസ്തികൾ",
+  "Notifications": "അറിയിപ്പുകൾ"
 }

--- a/src/Locale/mr/Common.json
+++ b/src/Locale/mr/Common.json
@@ -11,5 +11,8 @@
   "District": "जिल्हा",
   "Local Body": "स्थानिक संस्था",
   "Location": "स्थान",
-  "Ward": "वॉर्ड"
+  "Ward": "वॉर्ड",
+  "Notice Board": "सूचना फलक",
+  "Assets": "मालमत्ता",
+  "Notifications": "अधिसूचना"
 }

--- a/src/Locale/ta/Common.json
+++ b/src/Locale/ta/Common.json
@@ -11,5 +11,8 @@
   "District": "மாவட்டம்",
   "Local Body": "உள்ளாட்சி மன்றம்",
   "Location": "இடம்",
-  "Ward": "தொகுதி"
+  "Ward": "தொகுதி",
+  "Notice Board": "அறிவிப்பு பலகை",
+  "Assets": "சொத்துக்கள்",
+  "Notifications": "அறிவிப்புகள்"
 }


### PR DESCRIPTION
Fixes #2438 

Resolves issue where translations for some text in navbar were not found.

Before: 
![image](https://user-images.githubusercontent.com/63334479/169295023-f4c13ffc-61d3-477a-a096-c19548ad3a32.png)

After: 
![image](https://user-images.githubusercontent.com/63334479/169295197-32537d36-ba18-448c-b294-54f694cdb4c1.png)

The issue has been fixed across all existing languages (Malayalam, Marathi and Tamil)
