### PR TITLE
Made first_name and last_name mandatory in UserAdd

### DIFF
--- a/src/Common/validation.tsx
+++ b/src/Common/validation.tsx
@@ -1,5 +1,5 @@
 export const phonePreg = (phone: string) => {
-  const pattern = /^((\+91|91|0)[\- ]{0,1})?[123456789]\d{9}$/;
+  const pattern = /^((\+91|91|0)[- ]{0,1})?[123456789]\d{9}$/;
   return pattern.test(phone);
 };
 
@@ -10,7 +10,7 @@ export const validateLocationCoordinates = (location: string) => {
 
 export const validateEmailAddress = (email: string) => {
   const pattern =
-    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   return pattern.test(email);
 };
 
@@ -29,6 +29,11 @@ export const getArrayValueByKey = (
 
 export const getRandomNumbers = (min: number, max: number) => {
   return Math.floor(Math.random() * max) + min;
+};
+
+export const validateName = (name: string) => {
+  const pattern = /^([a-zA-Z]+ [a-zA-Z]*)+$/;
+  return pattern.test(name);
 };
 
 export const validateUsername = (username: string) => {

--- a/src/Common/validation.tsx
+++ b/src/Common/validation.tsx
@@ -32,7 +32,7 @@ export const getRandomNumbers = (min: number, max: number) => {
 };
 
 export const validateName = (name: string) => {
-  const pattern = /^([a-zA-Z]+ [a-zA-Z]*)+$/;
+  const pattern = /^([a-zA-Z]*( [a-zA-Z])?)+$/;
   return pattern.test(name);
 };
 

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -16,6 +16,7 @@ import { GENDER_TYPES, USER_TYPES } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   validateEmailAddress,
+  validateName,
   validatePassword,
   validateUsername,
 } from "../../Common/validation";
@@ -340,6 +341,19 @@ export const UserAdd = (props: UserProps) => {
             invalidForm = true;
           }
           return;
+        case "first_name":
+        case "last_name":
+          if (!state.form[field]) {
+            errors[field] = `${field
+              .split("_")
+              .map((word) => word[0].toUpperCase() + word.slice(1))
+              .join(" ")} is required`;
+            invalidForm = true;
+          } else if (!validateName(state.form[field])) {
+            errors[field] = "Please enter a valid name";
+            invalidForm = true;
+          }
+          return;
         case "gender":
           if (!state.form[field]) {
             errors[field] = "Please select the Gender";
@@ -610,7 +624,7 @@ export const UserAdd = (props: UserProps) => {
                       ) : (
                         <CheckCircle fontSize="inherit" color="primary" />
                       )}{" "}
-                      username can't end with ^ . @ + _ -
+                      {"username can't end with ^ . @ + _ -"}
                     </div>
                   </div>
                 )}
@@ -661,7 +675,7 @@ export const UserAdd = (props: UserProps) => {
               </div>
 
               <div>
-                <InputLabel>First name</InputLabel>
+                <InputLabel>First name*</InputLabel>
                 <TextInputField
                   fullWidth
                   name="first_name"
@@ -674,7 +688,7 @@ export const UserAdd = (props: UserProps) => {
               </div>
 
               <div>
-                <InputLabel>Last name</InputLabel>
+                <InputLabel>Last name*</InputLabel>
                 <TextInputField
                   fullWidth
                   name="last_name"


### PR DESCRIPTION
Fixes #2362 

Made first name and last name fields mandatory and also added validations to first name and last name fields in user creation form.

first name and last name fields can only contain letters from a-z, A-Z and space.

![image](https://user-images.githubusercontent.com/29787772/169444047-95e66f28-5347-4dd6-8ca1-518a9cb0ece9.png)
![image](https://user-images.githubusercontent.com/29787772/169444090-d97ae67c-b8aa-4920-a291-bfc49706fc49.png)


_Note: first name and last name fields are only made mandatory in the frontend and it is still optional in the backend_ 