### PR TITLE
Added appropriate message when no data is found

### DIFF
--- a/src/Components/Facility/Consultations/MedicineTables.tsx
+++ b/src/Components/Facility/Consultations/MedicineTables.tsx
@@ -46,19 +46,30 @@ export const MedicineTables = (props: any) => {
     },
     [currentPage]
   );
-  // eslint-disable-next-line
-  const handlePagination = (page: number, limit: number) => {
+
+  const handlePagination = (page: number) => {
     setCurrentPage(page);
   };
 
-  //
+  const areFieldsEmpty = () => {
+    let emptyFieldCount = 0;
+    Object.keys(results).forEach((k: any) => {
+      if (Object.keys(results[k].medication_given).length === 0) {
+        emptyFieldCount++;
+      }
+    });
+    if (emptyFieldCount === Object.keys(results).length) return true;
+    else return false;
+  };
+
+  const noDataFound = Object.keys(results).length === 0 || areFieldsEmpty();
 
   return (
     <div>
       {results && (
         <div>
           <div className="mt-4 text-lg font-bold">Consultation Updates</div>
-          {Object.keys(results).length === 0 && (
+          {noDataFound && (
             <div className="text-md h-full text-center mt-5">
               No Consultation Updates Found
             </div>

--- a/src/Components/Facility/Consultations/MedicineTables.tsx
+++ b/src/Components/Facility/Consultations/MedicineTables.tsx
@@ -1,17 +1,14 @@
 import moment from "moment";
 import { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
-// import { NURSING_CARE_FIELDS } from "../../../Common/constants";
 import { statusType, useAbortableEffect } from "../../../Common/utils";
 import { dailyRoundsAnalyse } from "../../../Redux/actions";
 import Pagination from "../../Common/Pagination";
 import { PAGINATION_LIMIT } from "../../../Common/constants";
 
 export const MedicineTables = (props: any) => {
-  // eslint-disable-next-line
   const { facilityId, patientId, consultationId } = props;
   const dispatch: any = useDispatch();
-  // eslint-disable-next-line
   const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState<any>({});
   const [currentPage, setCurrentPage] = useState(1);
@@ -103,13 +100,13 @@ export const MedicineTables = (props: any) => {
                               {results[k].medication_given.map(
                                 (med: any, index: number) => (
                                   <tr className="bg-white" key={index}>
-                                    <td className="px-6 py-4 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm leading-5 font-medium text-gray-900">
                                       {med.medicine}
                                     </td>
-                                    <td className="px-6 py-4 whitespace-no-wrap text-sm leading-5 text-gray-500">
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm leading-5 text-gray-500">
                                       {med.dosage}
                                     </td>
-                                    <td className="px-6 py-4 whitespace-no-wrap text-sm leading-5 text-gray-500">
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm leading-5 text-gray-500">
                                       {med.days}
                                     </td>
                                   </tr>

--- a/src/Components/Facility/Consultations/MedicineTables.tsx
+++ b/src/Components/Facility/Consultations/MedicineTables.tsx
@@ -1,15 +1,17 @@
 import moment from "moment";
 import { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
-import { NURSING_CARE_FIELDS } from "../../../Common/constants";
+// import { NURSING_CARE_FIELDS } from "../../../Common/constants";
 import { statusType, useAbortableEffect } from "../../../Common/utils";
 import { dailyRoundsAnalyse } from "../../../Redux/actions";
 import Pagination from "../../Common/Pagination";
 import { PAGINATION_LIMIT } from "../../../Common/constants";
 
 export const MedicineTables = (props: any) => {
+  // eslint-disable-next-line
   const { facilityId, patientId, consultationId } = props;
   const dispatch: any = useDispatch();
+  // eslint-disable-next-line
   const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState<any>({});
   const [currentPage, setCurrentPage] = useState(1);
@@ -44,7 +46,7 @@ export const MedicineTables = (props: any) => {
     },
     [currentPage]
   );
-
+  // eslint-disable-next-line
   const handlePagination = (page: number, limit: number) => {
     setCurrentPage(page);
   };
@@ -56,8 +58,13 @@ export const MedicineTables = (props: any) => {
       {results && (
         <div>
           <div className="mt-4 text-lg font-bold">Consultation Updates</div>
-          {Object.keys(results).map((k: any) => (
-            <div>
+          {Object.keys(results).length === 0 && (
+            <div className="text-md h-full text-center mt-5">
+              No Consultation Updates Found
+            </div>
+          )}
+          {Object.keys(results).map((k: any, indx: number) => (
+            <div key={indx}>
               {Object.keys(results[k].medication_given).length !== 0 && (
                 <div className="grid md:grid-cols-full gap-4">
                   <div className="mt-4">

--- a/src/Components/Facility/Consultations/NursingPlot.tsx
+++ b/src/Components/Facility/Consultations/NursingPlot.tsx
@@ -8,10 +8,8 @@ import Pagination from "../../Common/Pagination";
 import { PAGINATION_LIMIT } from "../../../Common/constants";
 
 export const NursingPlot = (props: any) => {
-  // eslint-disable-next-line
   const { facilityId, patientId, consultationId } = props;
   const dispatch: any = useDispatch();
-  // eslint-disable-next-line
   const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState<any>({});
   const [currentPage, setCurrentPage] = useState(1);
@@ -46,8 +44,8 @@ export const NursingPlot = (props: any) => {
     },
     [currentPage]
   );
-  // eslint-disable-next-line
-  const handlePagination = (page: number, limit: number) => {
+
+  const handlePagination = (page: number) => {
     setCurrentPage(page);
   };
 

--- a/src/Components/Facility/Consultations/NursingPlot.tsx
+++ b/src/Components/Facility/Consultations/NursingPlot.tsx
@@ -8,8 +8,10 @@ import Pagination from "../../Common/Pagination";
 import { PAGINATION_LIMIT } from "../../../Common/constants";
 
 export const NursingPlot = (props: any) => {
+  // eslint-disable-next-line
   const { facilityId, patientId, consultationId } = props;
   const dispatch: any = useDispatch();
+  // eslint-disable-next-line
   const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState<any>({});
   const [currentPage, setCurrentPage] = useState(1);
@@ -44,7 +46,7 @@ export const NursingPlot = (props: any) => {
     },
     [currentPage]
   );
-
+  // eslint-disable-next-line
   const handlePagination = (page: number, limit: number) => {
     setCurrentPage(page);
   };
@@ -56,7 +58,7 @@ export const NursingPlot = (props: any) => {
     };
   });
 
-  let dataToDisplay = data
+  const dataToDisplay = data
     .map((x) =>
       x.nursing.map((f: any) => {
         f["date"] = x.date;
@@ -72,11 +74,25 @@ export const NursingPlot = (props: any) => {
     return filtered.length > 0;
   };
 
+  const areFieldsEmpty = () => {
+    let emptyFieldCount = 0;
+    for (let i = 0; i < NURSING_CARE_FIELDS.length; i++) {
+      if (!filterEmpty(NURSING_CARE_FIELDS[i])) emptyFieldCount++;
+    }
+    if (emptyFieldCount === NURSING_CARE_FIELDS.length) return true;
+    else return false;
+  };
+
   return (
     <div>
       <div className="">
         <div>
           <div className="flex flex-row overflow-x-scroll">
+            {areFieldsEmpty() && (
+              <div className="text-center text-lg mt-5 w-full">
+                No data available
+              </div>
+            )}
             {NURSING_CARE_FIELDS.map(
               (f: any) =>
                 filterEmpty(f) && (

--- a/src/Components/Facility/Investigations/ViewInvestigations.tsx
+++ b/src/Components/Facility/Investigations/ViewInvestigations.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import { statusType, useAbortableEffect } from "../../../Common/utils";
 import { getInvestigationSessions } from "../../../Redux/actions";
-import PageTitle from "../../Common/PageTitle";
+// import PageTitle from "../../Common/PageTitle";
 import moment from "moment";
 import { navigate } from "raviger";
 import loadable from "@loadable/component";
@@ -47,9 +47,17 @@ export default function ViewInvestigations(props: any) {
         <Loading />
       ) : (
         <div className="mt-4 space-y-2 ">
-          {investigationData.map((data: InvestigationType) => {
+          {investigationData.length === 0 && (
+            <div className="text-lg h-full text-center mt-5">
+              No Investigation Reports Found
+            </div>
+          )}
+          {investigationData.map((data: InvestigationType, indx: number) => {
             return (
-              <div className="flex justify-between items-center bg-white hover:bg-gray-200 cursor-pointer p-4 border rounded-lg shadow">
+              <div
+                key={indx}
+                className="flex justify-between items-center bg-white hover:bg-gray-200 cursor-pointer p-4 border rounded-lg shadow"
+              >
                 <div>{moment(data.session_created_date).format("lll")}</div>
                 <button
                   onClick={() =>

--- a/src/Components/Facility/Investigations/ViewInvestigations.tsx
+++ b/src/Components/Facility/Investigations/ViewInvestigations.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import { statusType, useAbortableEffect } from "../../../Common/utils";
 import { getInvestigationSessions } from "../../../Redux/actions";
-// import PageTitle from "../../Common/PageTitle";
 import moment from "moment";
 import { navigate } from "raviger";
 import loadable from "@loadable/component";
@@ -31,7 +30,7 @@ export default function ViewInvestigations(props: any) {
         setIsLoading(false);
       }
     },
-    [dispatchAction]
+    [dispatchAction, consultationId]
   );
 
   useAbortableEffect(


### PR DESCRIPTION
Fixes #2403 

When no data is found, an appropriate message stating that no data is available is displayed.

![image](https://user-images.githubusercontent.com/40627011/169661232-e963c355-6552-42fd-b597-c98de5c0a23f.png)

![image](https://user-images.githubusercontent.com/40627011/169661245-c7302a1b-c0ae-4b58-8d79-f29d3ab873e0.png)

![image](https://user-images.githubusercontent.com/40627011/169661257-b1c67cbe-0898-4ee9-b7f2-9634b806db37.png)
