### PR TITLE
Facility page for read-only users improved

### DIFF
--- a/src/Components/Common/RoleButton.tsx
+++ b/src/Components/Common/RoleButton.tsx
@@ -1,0 +1,54 @@
+import id from "date-fns/esm/locale/id/index.js";
+import React from "react";
+import { useSelector } from "react-redux";
+
+// role types to manage button disable functionality
+// readOnly = all user types with read only access
+export type roleType = "readOnly";
+
+/*
+Component to render button "enable" or "disable" based
+on user role
+*/
+
+// Decide whether to disable button or not
+const getDisableButton: (userType: string, disableFor: roleType) => boolean = (
+  userType,
+  disableFor
+) => {
+  switch (disableFor) {
+    case "readOnly":
+      if (
+        userType === "StaffReadOnly" ||
+        userType === "StateReadOnlyAdmin" ||
+        userType === "DistrictReadOnlyAdmin"
+      )
+        return true;
+      else return false;
+    default:
+      return false;
+  }
+};
+
+export function RoleButton(props: {
+  id?: string;
+  className?: string;
+  handleClickCB: () => void;
+  children: React.ReactNode;
+  disableFor: roleType;
+}) {
+  const state: any = useSelector((state) => state);
+  const { currentUser } = state;
+  const type = currentUser.data.user_type;
+
+  return (
+    <button
+      id={props.id}
+      className={props.className}
+      onClick={props.handleClickCB}
+      disabled={getDisableButton(type, props.disableFor)}
+    >
+      {props.children}
+    </button>
+  );
+}

--- a/src/Components/Common/RoleButton.tsx
+++ b/src/Components/Common/RoleButton.tsx
@@ -36,6 +36,7 @@ export function RoleButton(props: {
   handleClickCB: () => void;
   children: React.ReactNode;
   disableFor: roleType;
+  disabled?: boolean;
 }) {
   const state: any = useSelector((state) => state);
   const { currentUser } = state;
@@ -46,7 +47,7 @@ export function RoleButton(props: {
       id={props.id}
       className={props.className}
       onClick={props.handleClickCB}
-      disabled={getDisableButton(type, props.disableFor)}
+      disabled={getDisableButton(type, props.disableFor) || props.disabled}
     >
       {props.children}
     </button>

--- a/src/Components/Common/RoleButton.tsx
+++ b/src/Components/Common/RoleButton.tsx
@@ -1,10 +1,14 @@
-import id from "date-fns/esm/locale/id/index.js";
 import React from "react";
 import { useSelector } from "react-redux";
+import Button from "@material-ui/core/Button";
+import { ButtonProps } from "@material-ui/core/Button";
 
 // role types to manage button disable functionality
 // readOnly = all user types with read only access
 export type roleType = "readOnly";
+
+// render different buttons
+export type buttonType = "html" | "materialUI";
 
 /*
 Component to render button "enable" or "disable" based
@@ -37,19 +41,44 @@ export function RoleButton(props: {
   children: React.ReactNode;
   disableFor: roleType;
   disabled?: boolean;
+  materialButtonProps?: ButtonProps;
+  buttonType: buttonType;
 }) {
   const state: any = useSelector((state) => state);
   const { currentUser } = state;
   const type = currentUser.data.user_type;
 
-  return (
-    <button
-      id={props.id}
-      className={props.className}
-      onClick={props.handleClickCB}
-      disabled={getDisableButton(type, props.disableFor) || props.disabled}
-    >
-      {props.children}
-    </button>
-  );
+  const renderHtmlButton = () => {
+    return (
+      <button
+        id={props.id}
+        className={props.className}
+        onClick={props.handleClickCB}
+        disabled={getDisableButton(type, props.disableFor) || props.disabled}
+      >
+        {props.children}
+      </button>
+    );
+  };
+
+  const renderMaterialUIButton = () => {
+    return (
+      <Button
+        id={props.id}
+        className={props.className}
+        {...props.materialButtonProps}
+        onClick={props.handleClickCB}
+        disabled={getDisableButton(type, props.disableFor) || props.disabled}
+      >
+        {props.children}
+      </Button>
+    );
+  };
+
+  switch (props.buttonType) {
+    case "html":
+      return renderHtmlButton();
+    case "materialUI":
+      return renderMaterialUIButton();
+  }
 }

--- a/src/Components/Facility/BedTypeCard.tsx
+++ b/src/Components/Facility/BedTypeCard.tsx
@@ -28,6 +28,7 @@ const BedTypeCard = (props: BedTypeProps) => {
             navigate(`/facility/${props.facilityId}/bed/${props.room_type}`)
           }
           disableFor="readOnly"
+          buttonType="html"
         >
           Edit
         </RoleButton>

--- a/src/Components/Facility/BedTypeCard.tsx
+++ b/src/Components/Facility/BedTypeCard.tsx
@@ -3,6 +3,7 @@ import { CapacityModal } from "./models";
 import { navigate } from "raviger";
 import { BED_TYPES } from "../../Common/constants";
 import moment from "moment";
+import { RoleButton } from "../Common/RoleButton";
 
 interface BedTypeProps extends CapacityModal {
   facilityId: number;
@@ -21,14 +22,15 @@ const BedTypeCard = (props: BedTypeProps) => {
         <div className="font-bold text-xs mt-2 text-center">
           Currently Occupied / Total Capacity
         </div>
-        <div
+        <RoleButton
           className="btn btn-default"
-          onClick={() =>
+          handleClickCB={() =>
             navigate(`/facility/${props.facilityId}/bed/${props.room_type}`)
           }
+          disableFor="readOnly"
         >
           Edit
-        </div>
+        </RoleButton>
         <div className="text-xs text-gray-600 mt-2">
           <i className="fas fa-history text-sm pr-2"></i>
           {props.modified_date && moment(props.modified_date).fromNow()}

--- a/src/Components/Facility/DoctorsCountCard.tsx
+++ b/src/Components/Facility/DoctorsCountCard.tsx
@@ -22,6 +22,7 @@ const DoctorsCountCard = (props: DoctorsCountProps) => {
             navigate(`/facility/${props.facilityId}/doctor/${props.area}`)
           }
           disableFor="readOnly"
+          buttonType="html"
         >
           Edit
         </RoleButton>

--- a/src/Components/Facility/DoctorsCountCard.tsx
+++ b/src/Components/Facility/DoctorsCountCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { navigate } from "raviger";
 import { DoctorModal } from "./models";
 import { DOCTOR_SPECIALIZATION } from "../../Common/constants";
+import { RoleButton } from "../Common/RoleButton";
 
 interface DoctorsCountProps extends DoctorModal {
   facilityId: number;
@@ -15,14 +16,15 @@ const DoctorsCountCard = (props: DoctorsCountProps) => {
       <div className="flex flex-col items-center shadow rounded-lg p-4 h-full justify-between">
         <div className="text-bold text-3xl mt-2">{props.count}</div>
         <div className="font-semibold text-md mt-2">{area} Doctors</div>
-        <div
+        <RoleButton
           className="btn btn-default"
-          onClick={() =>
+          handleClickCB={() =>
             navigate(`/facility/${props.facilityId}/doctor/${props.area}`)
           }
+          disableFor="readOnly"
         >
           Edit
-        </div>
+        </RoleButton>
       </div>
     </div>
   );

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -26,6 +26,7 @@ import {
   PatientStatsModel,
 } from "./models";
 import moment from "moment";
+import { RoleButton, roleType } from "../Common/RoleButton";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
@@ -161,14 +162,15 @@ export const FacilityHome = (props: any) => {
           {data.num_patient_confirmed_positive || "0"}
         </td>
         <td className="border px-4 py-2">
-          <button
+          <RoleButton
             className="btn btn-default"
-            onClick={() =>
+            handleClickCB={() =>
               navigate(`/facility/${facilityId}/triage/${data.id}`)
             }
+            disableFor="readOnly"
           >
             Edit
-          </button>
+          </RoleButton>
         </td>
       </tr>
     );
@@ -270,14 +272,17 @@ export const FacilityHome = (props: any) => {
               </div>
             </div>
             <div className="mt-2">
-              <button
+              <RoleButton
                 className="btn-primary btn mt-2 mr-2 w-full md:w-auto"
-                onClick={() => navigate(`/facility/${facilityId}/patient`)}
+                handleClickCB={() =>
+                  navigate(`/facility/${facilityId}/patient`)
+                }
                 data-testid="add-patient-button"
+                disableFor="readOnly"
               >
                 <i className="fas fa-plus text-white mr-2"></i>
                 Add Details of a Patient
-              </button>
+              </RoleButton>
 
               <button
                 className="btn-primary btn mt-2 mr-2 w-full md:w-auto"
@@ -289,14 +294,15 @@ export const FacilityHome = (props: any) => {
             </div>
           </div>
           <div className="flex flex-col mt-2 md:mt-4">
-            <button
+            <RoleButton
               id="update-facility"
               className="btn-primary btn"
-              onClick={() => navigate(`/facility/${facilityId}/update`)}
+              handleClickCB={() => navigate(`/facility/${facilityId}/update`)}
+              disableFor="readOnly"
             >
               <i className="fas fa-pencil-alt text-white mr-2"></i>
               Update Facility
-            </button>
+            </RoleButton>
             <button
               className="btn-primary btn mt-2"
               onClick={() => navigate(`/facility/${facilityId}/inventory`)}
@@ -311,20 +317,26 @@ export const FacilityHome = (props: any) => {
               <i className="fas fa-map-marker-alt text-white mr-2"></i>
               Location Management
             </button>
-            <button
+            <RoleButton
               className="btn-primary btn mt-2"
-              onClick={() => navigate(`/facility/${facilityId}/resource/new`)}
+              handleClickCB={() =>
+                navigate(`/facility/${facilityId}/resource/new`)
+              }
+              disableFor="readOnly"
             >
               <i className="fas fa-dolly-flatbed text-white mr-2"></i>
               Resource Request
-            </button>
-            <button
+            </RoleButton>
+            <RoleButton
               className="btn-primary btn mt-2"
-              onClick={() => navigate(`/facility/${facilityId}/assets/new`)}
+              handleClickCB={() =>
+                navigate(`/facility/${facilityId}/assets/new`)
+              }
+              disableFor="readOnly"
             >
               <i className="fas fa-plus-circle text-white mr-2"></i>
               Create Asset
-            </button>
+            </RoleButton>
             <button
               className="btn-primary btn mt-2"
               onClick={() => navigate(`/assets?facility=${facilityId}`)}
@@ -389,40 +401,43 @@ export const FacilityHome = (props: any) => {
         <div className="mt-4">
           <div className="md:flex justify-between  md:border-b md:pb-2">
             <div className="font-semibold text-xl">Bed Capacity</div>
-            <button
+            <RoleButton
               className="btn-primary btn w-full md:w-auto"
-              onClick={() => navigate(`/facility/${facilityId}/bed`)}
+              handleClickCB={() => navigate(`/facility/${facilityId}/bed`)}
+              disableFor="readOnly"
             >
               <i className="fas fa-bed text-white mr-2"></i>
               Add More Bed Types
-            </button>
+            </RoleButton>
           </div>
           <div className="mt-4 flex flex-wrap">{capacityList}</div>
         </div>
         <div className="mt-4">
           <div className="md:flex justify-between  md:border-b md:pb-2">
             <div className="font-semibold text-xl">Doctors List</div>
-            <button
+            <RoleButton
               className="btn-primary btn w-full md:w-auto"
-              onClick={() => navigate(`/facility/${facilityId}/doctor`)}
+              handleClickCB={() => navigate(`/facility/${facilityId}/doctor`)}
               disabled={doctorList.length === DOCTOR_SPECIALIZATION.length}
+              disableFor="readOnly"
             >
               <i className="fas fa-user-md text-white mr-2"></i>
               Add Doctor Types
-            </button>
+            </RoleButton>
           </div>
           <div className="mt-4 flex flex-wrap">{doctorList}</div>
         </div>
         <div className="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8 mt-4">
           <div className="md:flex justify-between  md:border-b md:pb-2">
             <div className="font-semibold text-xl">Corona Triage</div>
-            <button
+            <RoleButton
               className="btn-primary btn w-full md:w-auto"
-              onClick={() => navigate(`/facility/${facilityId}/triage`)}
+              handleClickCB={() => navigate(`/facility/${facilityId}/triage`)}
+              disableFor="readOnly"
             >
               <i className="fas fa-notes-medical text-white mr-2"></i>
               Add Triage
-            </button>
+            </RoleButton>
           </div>
           <div className="align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200 mt-4">
             <table className="min-w-full border-2 rounded overflow-hidden">

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -168,6 +168,7 @@ export const FacilityHome = (props: any) => {
               navigate(`/facility/${facilityId}/triage/${data.id}`)
             }
             disableFor="readOnly"
+            buttonType="html"
           >
             Edit
           </RoleButton>
@@ -279,6 +280,7 @@ export const FacilityHome = (props: any) => {
                 }
                 data-testid="add-patient-button"
                 disableFor="readOnly"
+                buttonType="html"
               >
                 <i className="fas fa-plus text-white mr-2"></i>
                 Add Details of a Patient
@@ -299,6 +301,7 @@ export const FacilityHome = (props: any) => {
               className="btn-primary btn"
               handleClickCB={() => navigate(`/facility/${facilityId}/update`)}
               disableFor="readOnly"
+              buttonType="html"
             >
               <i className="fas fa-pencil-alt text-white mr-2"></i>
               Update Facility
@@ -323,6 +326,7 @@ export const FacilityHome = (props: any) => {
                 navigate(`/facility/${facilityId}/resource/new`)
               }
               disableFor="readOnly"
+              buttonType="html"
             >
               <i className="fas fa-dolly-flatbed text-white mr-2"></i>
               Resource Request
@@ -333,6 +337,7 @@ export const FacilityHome = (props: any) => {
                 navigate(`/facility/${facilityId}/assets/new`)
               }
               disableFor="readOnly"
+              buttonType="html"
             >
               <i className="fas fa-plus-circle text-white mr-2"></i>
               Create Asset
@@ -405,6 +410,7 @@ export const FacilityHome = (props: any) => {
               className="btn-primary btn w-full md:w-auto"
               handleClickCB={() => navigate(`/facility/${facilityId}/bed`)}
               disableFor="readOnly"
+              buttonType="html"
             >
               <i className="fas fa-bed text-white mr-2"></i>
               Add More Bed Types
@@ -420,6 +426,7 @@ export const FacilityHome = (props: any) => {
               handleClickCB={() => navigate(`/facility/${facilityId}/doctor`)}
               disabled={doctorList.length === DOCTOR_SPECIALIZATION.length}
               disableFor="readOnly"
+              buttonType="html"
             >
               <i className="fas fa-user-md text-white mr-2"></i>
               Add Doctor Types
@@ -434,6 +441,7 @@ export const FacilityHome = (props: any) => {
               className="btn-primary btn w-full md:w-auto"
               handleClickCB={() => navigate(`/facility/${facilityId}/triage`)}
               disableFor="readOnly"
+              buttonType="html"
             >
               <i className="fas fa-notes-medical text-white mr-2"></i>
               Add Triage

--- a/src/Components/Facility/InventoryList.tsx
+++ b/src/Components/Facility/InventoryList.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from "react-redux";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getInventorySummary, getAnyFacility } from "../../Redux/actions";
 import Pagination from "../Common/Pagination";
+import { RoleButton } from "../Common/RoleButton";
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -166,16 +167,20 @@ export default function InventoryList(props: any) {
         <div className="py-4 md:py-8">
           <div className="flex flex-col md:flex-row items-center">
             <div className="mt-2">
-              <Button
-                variant="contained"
-                color="primary"
-                size="small"
-                onClick={() =>
+              <RoleButton
+                materialButtonProps={{
+                  variant: "contained",
+                  color: "primary",
+                  size: "small",
+                }}
+                handleClickCB={() =>
                   navigate(`/facility/${facilityId}/inventory/add`)
                 }
+                disableFor="readOnly"
+                buttonType="materialUI"
               >
                 Add Inventory
-              </Button>
+              </RoleButton>
             </div>
             <div className="mt-2">
               <Button

--- a/src/Components/Facility/MinQuantityList.tsx
+++ b/src/Components/Facility/MinQuantityList.tsx
@@ -6,6 +6,7 @@ import { getMinQuantity, getAnyFacility } from "../../Redux/actions";
 import Pagination from "../Common/Pagination";
 import { Button, ButtonBase } from "@material-ui/core";
 import { navigate } from "raviger";
+import { RoleButton } from "../Common/RoleButton";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
@@ -85,16 +86,18 @@ export default function MinQuantityList(props: any) {
           </p>
         </td>
         <td className="px-5 py-5 border-b border-gray-200 text-sm ">
-          <Button
+          <RoleButton
             className="ml-2 bg-primary-400 hover:bg-primary-600"
-            onClick={() =>
+            handleClickCB={() =>
               navigate(
                 `/facility/${facilityId}/inventory/${inventoryItem.id}/update/${inventoryItem.item_object?.id}`
               )
             }
+            disableFor="readOnly"
+            buttonType="materialUI"
           >
             UPDATE
-          </Button>
+          </RoleButton>
         </td>
       </tr>
     ));
@@ -169,17 +172,21 @@ export default function MinQuantityList(props: any) {
       />
       <div className="container mx-auto px-4 sm:px-8">
         <div className="py-8">
-          <Button
+          <RoleButton
             className="ml-2"
-            variant="contained"
-            color="primary"
-            size="small"
-            onClick={() =>
+            materialButtonProps={{
+              variant: "contained",
+              color: "primary",
+              size: "small",
+            }}
+            handleClickCB={() =>
               navigate(`/facility/${facilityId}/inventory/min_quantity/set`)
             }
+            disableFor="readOnly"
+            buttonType="materialUI"
           >
             Set Min Quantity
-          </Button>
+          </RoleButton>
           {inventoryItem}
         </div>
       </div>


### PR DESCRIPTION
### Issue Fixed
fixes #2509 

### Updates

-  Created RoleButton component to render buttons according to role it supports both materalUI and html button.
- [X] Remove/Disable "Add More Bed Types", "Add Doctor Types", "Add Triage" buttons 
- [X] Remove/Disable "Add Details of a Patient" button
- [X] Remove/Disable "Update Facility" button
- [X] Remove/Disable "Create Assets" button
- [X] Remove/Disable add and update options in "Inventory Management"
- [X] Remove/Disable "Resource Request" button
- [X] Remove/Disable all edits option in "Bed Capacity", "Doctors List", "Corona Triage"

**Task Pending**
- [ ] Remove/Disable add and update options in "Location Management". In this case backend is allowing readOnly user to add location and edit it.

### Demo

https://user-images.githubusercontent.com/39593226/170842929-c98b9ebc-0991-4fa9-818b-18b071e64bf4.mp4


