### PR TITLE
Fix Bed actions button style

### DIFF
--- a/src/Components/TeleIcu/Patient/InfoCard.tsx
+++ b/src/Components/TeleIcu/Patient/InfoCard.tsx
@@ -61,7 +61,7 @@ export default function TeleICUPatientInfoCard({
           <div className="text-sm flex flex-wrap items-center">
             {!patient.last_consultation?.current_bed ? (
               <button
-                className="text-sm text-primary-600 hover:bg-gray-300 p-2 rounded"
+                className="btn btn-primary text-sm p-2"
                 onClick={() => setOpen(true)}
               >
                 Assign Bed
@@ -72,7 +72,7 @@ export default function TeleICUPatientInfoCard({
                   {patient.last_consultation?.current_bed?.bed_object?.name}
                 </span>
                 <button
-                  className="text-sm text-primary-600 hover:bg-gray-300 p-2 rounded"
+                  className="btn btn-primary text-sm p-2"
                   onClick={() => setOpen(true)}
                 >
                   Switch Bed


### PR DESCRIPTION
Currently the actions for Assigning and Switching a bed are hard to be recognized as buttons because of their styling. To make it more user friendly, make them look and feel like they are call to actions buttons and not just a hyperlink.

Before:
![image](https://user-images.githubusercontent.com/3626859/171426482-ce4ae4b4-bfff-4971-b50a-b31a3a8097a8.png)

After:
![image](https://user-images.githubusercontent.com/3626859/171426407-72af0a1d-2206-45f8-89b6-1e863a5ad0ca.png)
