### PR TITLE
added padding to notification card

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -237,8 +237,8 @@ export default function ResultList({ expanded = false, onClickCB }: Props) {
           <div className="text-lg font-bold">
             {getNotificationTitle(result.event)}
           </div>
-          <div className="text-sm">{result.message}</div>
-          <div className="text-xs">
+          <div className="text-sm py-1">{result.message}</div>
+          <div className="text-xs py-1">
             {moment(result.created_date).format("lll")}
           </div>
           <a className="inline-flex items-center font-semibold p-2 md:py-1 bg-white hover:bg-gray-300 border rounded text-xs shrink-0">


### PR DESCRIPTION
fixes #2618 

**Before:**  
<img width="354" alt="image" src="https://user-images.githubusercontent.com/44599895/171451109-9d703bcb-871f-4fc7-968f-b737fce1d9a1.png">

**After:**  
<img width="361" alt="image" src="https://user-images.githubusercontent.com/44599895/171451169-92e972d0-6cdc-406f-99fc-061f1c628e4f.png">
