### PR TITLE
Partially improved patients details section for read-only users

### DIFF
--- a/src/Components/Facility/ConsultationCard.tsx
+++ b/src/Components/Facility/ConsultationCard.tsx
@@ -4,6 +4,7 @@ import moment from "moment";
 import React from "react";
 import { ConsultationModel } from "./models";
 import { KASP_STRING } from "../../Common/constants";
+import { RoleButton } from "../Common/RoleButton";
 
 interface ConsultationProps {
   itemData: ConsultationModel;
@@ -119,16 +120,18 @@ export const ConsultationCard = (props: ConsultationProps) => {
               View / Upload Consultation Files
             </button>
             {isLastConsultation && (
-              <button
+              <RoleButton
                 className="mr-4 px-4 py-2 shadow border bg-white rounded-md border border-grey-500 whitespace-nowrap text-sm font-semibold rounded cursor-pointer hover:bg-gray-300 text-center"
-                onClick={() =>
+                handleClickCB={() =>
                   navigate(
                     `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}/daily-rounds`
                   )
                 }
+                disableFor="readOnly"
+                buttonType="html"
               >
                 Add Consultation Updates
-              </button>
+              </RoleButton>
             )}
           </div>
         </Grid>

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1497,12 +1497,14 @@ export const PatientHome = (props: any) => {
                   </button>
                 </div>
                 <div>
-                  <button
+                  <RoleButton
                     className="btn btn-primary w-full"
-                    onClick={handleClickOpen}
+                    handleClickCB={handleClickOpen}
+                    disableFor="readOnly"
+                    buttonType="html"
                   >
                     Discharge Summary
-                  </button>
+                  </RoleButton>
                 </div>
                 <div>
                   <button

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1507,16 +1507,18 @@ export const PatientHome = (props: any) => {
                   </RoleButton>
                 </div>
                 <div>
-                  <button
+                  <RoleButton
                     className="btn btn-primary w-full"
-                    onClick={handleDischageClickOpen}
+                    handleClickCB={handleDischageClickOpen}
                     disabled={
                       !patientData.is_active ||
                       !(patientData?.last_consultation?.facility == facilityId)
                     }
+                    disableFor="readOnly"
+                    buttonType="html"
                   >
                     Discharge from CARE
-                  </button>
+                  </RoleButton>
                 </div>
                 <div>
                   <button

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -35,6 +35,7 @@ import { validateEmailAddress } from "../../Common/validation";
 import Modal from "@material-ui/core/Modal";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
+import { RoleButton } from "../Common/RoleButton";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -900,18 +901,20 @@ export const PatientHome = (props: any) => {
                   </div>
                 )}
                 <div>
-                  <button
+                  <RoleButton
                     className="btn btn-primary w-full"
                     disabled={!patientData.is_active}
-                    onClick={() =>
+                    handleClickCB={() =>
                       navigate(
                         `/facility/${patientData?.facility}/patient/${id}/update`
                       )
                     }
+                    disableFor="readOnly"
+                    buttonType="html"
                   >
                     <i className="fas fa-pencil-alt mr-2" />
                     Update Details
-                  </button>
+                  </RoleButton>
                 </div>
                 <div>
                   <button

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -917,22 +917,24 @@ export const PatientHome = (props: any) => {
                   </RoleButton>
                 </div>
                 <div>
-                  <button
+                  <RoleButton
                     className="btn btn-primary w-full"
                     disabled={
                       !consultationListData ||
                       !consultationListData.length ||
                       !patientData.is_active
                     }
-                    onClick={() =>
+                    handleClickCB={() =>
                       handlePatientTransfer(!patientData.allow_transfer)
                     }
+                    disableFor="readOnly"
+                    buttonType="html"
                   >
                     <i className="fas fa-lock mr-2" />
                     {patientData.allow_transfer
                       ? "Disable Transfer"
                       : "Allow Transfer"}
-                  </button>
+                  </RoleButton>
                 </div>
               </div>
             </div>

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1521,13 +1521,14 @@ export const PatientHome = (props: any) => {
                   </RoleButton>
                 </div>
                 <div>
-                  <button
+                  <RoleButton
                     className="btn btn-primary w-full"
-                    onClick={() => setOpenAssignVolunteerDialog(true)}
-                    disabled={false}
+                    handleClickCB={() => setOpenAssignVolunteerDialog(true)}
+                    disableFor="readOnly"
+                    buttonType="html"
                   >
                     Assign to a volunteer
-                  </button>
+                  </RoleButton>
                 </div>
               </div>
             </div>

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1449,20 +1449,22 @@ export const PatientHome = (props: any) => {
                   </button>
                 </div>
                 <div>
-                  <button
+                  <RoleButton
                     className="btn btn-primary w-full"
                     disabled={
                       !patientData.is_active ||
                       !(patientData?.last_consultation?.facility == facilityId)
                     }
-                    onClick={() =>
+                    handleClickCB={() =>
                       navigate(
                         `/facility/${facilityId}/patient/${id}/shift/new`
                       )
                     }
+                    disableFor="readOnly"
+                    buttonType="html"
                   >
                     SHIFT PATIENT
-                  </button>
+                  </RoleButton>
                 </div>
                 <div>
                   <button

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1467,20 +1467,22 @@ export const PatientHome = (props: any) => {
                   </RoleButton>
                 </div>
                 <div>
-                  <button
+                  <RoleButton
                     className="btn btn-primary w-full"
                     disabled={
                       !patientData.is_active ||
                       !(patientData?.last_consultation?.facility == facilityId)
                     }
-                    onClick={() =>
+                    handleClickCB={() =>
                       navigate(
                         `/facility/${patientData?.facility}/patient/${id}/sample-test`
                       )
                     }
+                    disableFor="readOnly"
+                    buttonType="html"
                   >
                     Request Sample Test
-                  </button>
+                  </RoleButton>
                 </div>
                 <div>
                   <button


### PR DESCRIPTION
### Issue Addressed
partially fixes #2636 

### Updates
**For read-only user type**
**In Pateint details section**

- Disabled "Update Details" Button
- Disabled "Allow Transfer" Button
- Disabled "Add Consultation Updates" Button
- Disabled "Shift Patient" Button
- Disabled "Request Sample Test"
- Disabled "Discharge Summary" Button
- Disabled "Discharge from care" Button
- Disabled "Assign to a volunteer"

### Demo
![Screenshot from 2022-06-02 19-02-33](https://user-images.githubusercontent.com/39593226/171641856-2471b71c-a3e0-40c9-8e6d-e6085c7f06d1.png)
