### PR TITLE
fixed word wrapping in patient page tabs

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -162,7 +162,7 @@ export const ConsultationDetails = (props: any) => {
   }
 
   const tabButtonClasses = (selected: boolean) =>
-    `capitalize min-w-max-content cursor-pointer border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300 font-bold ${
+    `capitalize min-w-max-content cursor-pointer border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300 font-bold whitespace-nowrap ${
       selected === true ? "border-primary-500 text-primary-600 border-b-2" : ""
     }`;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23238460/171660705-2ecb8afe-e4f7-4f78-ae26-a16e9841e64b.png)
fixes word wrap problem for page tabs, now they are in a single line

closes #2562 