### PR TITLE
Hide "copy logs from previous logs" if first consultation update

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -168,6 +168,10 @@ export const DailyRounds = (props: any) => {
           getDailyReport({ limit: 1, offset: 0 }, { consultationId })
         );
         setHasPreviousLog(res.data.count > 0);
+        dispatch({
+          type: "set_form",
+          form: { ...state.form, clone_last: "false" },
+        });
       }
     }
     fetchHasPreviousLog();

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -170,7 +170,10 @@ export const DailyRounds = (props: any) => {
         setHasPreviousLog(res.data.count > 0);
         dispatch({
           type: "set_form",
-          form: { ...state.form, clone_last: "false" },
+          form: {
+            ...state.form,
+            clone_last: res.data.count > 0 ? "true" : "false",
+          },
         });
       }
     }

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -33,6 +33,7 @@ import {
 import {
   createDailyReport,
   getConsultationDailyRoundsDetails,
+  getDailyReport,
   updateDailyReport,
   getPatient,
 } from "../../Redux/actions";
@@ -108,6 +109,7 @@ export const DailyRounds = (props: any) => {
   const [isLoading, setIsLoading] = useState(false);
   const [facilityName, setFacilityName] = useState("");
   const [patientName, setPatientName] = useState("");
+  const [hasPreviousLog, setHasPreviousLog] = useState(false);
   const headerText = !id ? "Add Consultation Update" : "Info";
   const buttonText = !id ? "Save" : "Continue";
 
@@ -158,6 +160,18 @@ export const DailyRounds = (props: any) => {
     }
     fetchPatientName();
   }, [dispatchAction, patientId]);
+
+  useEffect(() => {
+    async function fetchHasPreviousLog() {
+      if (consultationId) {
+        const res = await dispatchAction(
+          getDailyReport({ limit: 1, offset: 0 }, { consultationId })
+        );
+        setHasPreviousLog(res.data.count > 0);
+      }
+    }
+    fetchHasPreviousLog();
+  }, [dispatchAction, consultationId]);
 
   const validateForm = () => {
     const errors = { ...initError };
@@ -507,7 +521,7 @@ export const DailyRounds = (props: any) => {
                   />
                 </div>
               </div>
-              {!id && (
+              {!id && hasPreviousLog && (
                 <div id="clone_last-div" className="mt-4">
                   <InputLabel id="clone_last">
                     Do you want to copy Values from Previous Log?


### PR DESCRIPTION
Fixes #2597 

Defaults to `false` for `clone_last` if no last log update present and shows the entire log update form.

## When no previous log update present

![image](https://user-images.githubusercontent.com/25143503/171848533-89d079d6-8e7a-4590-8481-cc78706d8556.png)

## Defaults to Yes if previous log present

![image](https://user-images.githubusercontent.com/25143503/171848965-f36ffb8c-b843-4c3c-b6c8-b21bd62ecb57.png)

