### PR TITLE
Delete endpoint for beds

### DIFF
--- a/src/Components/Facility/BedDeleteDialog.tsx
+++ b/src/Components/Facility/BedDeleteDialog.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@material-ui/core";
+import { WithStyles, withStyles } from "@material-ui/styles";
+
+interface ConfirmDialogProps {
+  name: string;
+  handleCancel: () => void;
+  handleOk: () => void;
+}
+
+const styles = {
+  paper: {
+    "max-width": "650px",
+    "min-width": "400px",
+  },
+};
+
+const BedDeleteDialog = (
+  props: ConfirmDialogProps & WithStyles<typeof styles>
+) => {
+  const { name, handleCancel, handleOk, classes } = props;
+
+  const [disable, setDisable] = useState(false);
+
+  const handleSubmit = () => {
+    handleOk();
+    setDisable(true);
+  };
+  return (
+    <Dialog
+      open={true}
+      classes={{
+        paper: classes.paper,
+      }}
+      onClose={handleCancel}
+    >
+      <DialogContent>
+        <DialogContentText
+          id="alert-dialog-description"
+          className="flex text-gray-800 leading-relaxed"
+        >
+          <div className="flex">
+            Are you sure you want to delete bed{" "}
+            <p className="mx-1 font-semibold capitalize">{name}</p> ?
+          </div>
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} color="primary">
+          Cancel
+        </Button>
+        <button
+          onClick={handleSubmit}
+          className="font-medium btn btn-danger"
+          disabled={disable}
+        >
+          Delete
+        </button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default withStyles(styles)(BedDeleteDialog);

--- a/src/Components/Facility/BedManagement.tsx
+++ b/src/Components/Facility/BedManagement.tsx
@@ -9,6 +9,7 @@ import {
   getAnyFacility,
   listFacilityBeds,
   updateFacilityBed,
+  deleteFacilityBed,
 } from "../../Redux/actions";
 import { navigate } from "raviger";
 import Pagination from "../Common/Pagination";
@@ -22,6 +23,8 @@ import {
 import * as Notification from "../../Utils/Notifications.js";
 import classNames from "classnames";
 import { LOCATION_BED_TYPES } from "../../Common/constants";
+import BedDeleteDialog from "./BedDeleteDialog";
+
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -41,7 +44,7 @@ interface BedRowProps {
 }
 
 const BedRow = (props: BedRowProps) => {
-  let {
+  const {
     id,
     facilityId,
     name,
@@ -57,6 +60,34 @@ const BedRow = (props: BedRowProps) => {
   const [descField, setDescField] = useState(description);
   const [bedTypeField, setBedTypeField] = useState(bedType);
   const [isLoading, setIsLoading] = useState(false);
+  const [bedData, setBedData] = useState<{
+    show: boolean;
+    id: string;
+    name: string;
+  }>({ show: false, id: "", name: "" });
+
+  const handleDelete = (name: string, id: string) => {
+    setBedData({
+      show: true,
+      id,
+      name,
+    });
+  };
+
+  const handleDeleteConfirm = async () => {
+    const res = await dispatchAction(deleteFacilityBed(id));
+    if (res && res.status == 204) {
+      Notification.Success({
+        msg: "Bed deleted successfully",
+      });
+    }
+    setBedData({ show: false, id: "", name: "" });
+    window.location.reload();
+  };
+
+  const handleDeleteCancel = () => {
+    setBedData({ show: false, id: "", name: "" });
+  };
 
   const handleSave = async () => {
     setIsLoading(true);
@@ -176,22 +207,38 @@ const BedRow = (props: BedRowProps) => {
             </Button>
           </div>
         ) : (
-          <Button
-            color="inherit"
-            variant="contained"
-            type="submit"
-            size="small"
-            style={{
-              marginLeft: "auto",
-              backgroundColor: "#24a0ed",
-              color: "white",
-            }}
-            onClick={() => setIsEditable(true)}
-          >
-            EDIT
-          </Button>
+          <div>
+            <Button
+              color="inherit"
+              variant="contained"
+              type="submit"
+              size="small"
+              className="fml-auto bg-[#24a0ed] text-white mx-2"
+              onClick={() => setIsEditable(true)}
+            >
+              <i className="fas fa-pencil-alt text-white mr-2"></i>
+              EDIT
+            </Button>
+            <Button
+              id="bed-delete"
+              className="btn-danger btn ml-auto text-white mx-2 px-2"
+              type="submit"
+              size="small"
+              onClick={() => handleDelete(name, id)}
+            >
+              <i className="fas fa-trash text-white mr-2"></i>
+              Delete
+            </Button>
+          </div>
         )}
       </td>
+      {bedData.show && (
+        <BedDeleteDialog
+          name={bedData.name}
+          handleCancel={handleDeleteCancel}
+          handleOk={handleDeleteConfirm}
+        />
+      )}
     </tr>
   );
 };

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -211,6 +211,9 @@ export const updateFacilityBed = (
       external_id,
     }
   );
+export const deleteFacilityBed = (external_id: string) => {
+  return fireRequest("deleteFacilityBed", [], {}, { external_id });
+};
 
 // Consultation Beds
 export const listConsultationBeds = (params: object) =>

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -198,6 +198,10 @@ const routes: Routes = {
     path: "/api/v1/bed/{external_id}/",
     method: "PUT",
   },
+  deleteFacilityBed: {
+    path: "/api/v1/bed/{external_id}/",
+    method: "DELETE",
+  },
 
   // Consultation beds
 


### PR DESCRIPTION
Closes #2643 

This adds a delete button for the beds, allowing them to be removed.

This also follows the convention and asks for user confirmation before performing the delete request.

![uiqs1IpmEb](https://user-images.githubusercontent.com/3626859/171871357-187bf021-de1b-4db6-a479-66a6a2cf8843.gif)
