### PR TITLE
Fix: Overlapping card headings in Resource Details page

### DIFF
--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -259,7 +259,7 @@ export default function ResourceDetails(props: { id: string }) {
         </div>
       ) : (
         <div className="mx-3 md:mx-8 mb-10">
-          <div className="my-4 flex justify-between items-center">
+          <div className="my-4 flex flex-col items-start md:flex-row md:justify-between md:items-center">
             <PageTitle
               title={"Resource details"}
               crumbsReplacements={{ [props.id]: { name: data.title } }}
@@ -289,7 +289,7 @@ export default function ResourceDetails(props: { id: string }) {
             </div>
           )}
           <div className="border rounded-lg bg-white shadow h-full text-black mt-4 p-4">
-            <div className="flex justify-between">
+            <div className="flex justify-between mb-4">
               <div className="text-xl font-semibold">{data.title || "--"}</div>
               <div>
                 <div className="mt-2">
@@ -450,14 +450,14 @@ export default function ResourceDetails(props: { id: string }) {
               </div>
             </div>
           </div>
-          <div className="grid md:grid-cols-3 gap-4 pb-4">
+          <div className="grid-cols-1 md:grid-cols-3 gap-4 pb-4">
             <div>
               <h4 className="mt-8">Origin Facility</h4>
 
               {showFacilityCard(data.orgin_facility_object)}
             </div>
             <div>
-              <h4 className="mt-8">Resource Approving facility</h4>
+              <h4 className="mt-8">Resource Approving Facility</h4>
 
               {showFacilityCard(data.approving_facility_object)}
             </div>


### PR DESCRIPTION
Fixes #2626
 
Fixed the overlapping card headings issue in mobile view and made the Resource Details page more responsive

![image](https://user-images.githubusercontent.com/57593654/172019864-feffdcb9-c8fb-4221-80c1-3c3ac76970e9.png)
