### PR TITLE
Fixed Now Date of Result cannot be selected before Date of Sample in patient registration Form

### DIFF
--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -95,6 +95,7 @@ interface DateInputFieldProps extends DatePickerProps {
     value?: string | null | undefined
   ) => void;
   label?: string;
+  min?: string;
   errors: string;
   inputVariant?: "standard" | "outlined" | "filled";
   disabled?: boolean;
@@ -234,6 +235,7 @@ export const DateInputField = (props: DateInputFieldProps) => {
     onChange,
     label,
     errors,
+    min,
     // variant,
     disabled,
     margin,
@@ -248,6 +250,7 @@ export const DateInputField = (props: DateInputFieldProps) => {
         format="dd/MM/yyyy"
         value={value}
         onChange={onChange}
+        minDate={min}
         disabled={disabled}
         KeyboardButtonProps={{
           "aria-label": "change date",

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1815,6 +1815,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                               onChange={(date) =>
                                 handleDateChange(date, "date_of_result")
                               }
+                              min={state.form.date_of_test}
                               errors={state.errors.date_of_result}
                               inputVariant="outlined"
                               margin="dense"


### PR DESCRIPTION
Fixes #2692 

# Bugs

## Fixed Date of Result cannot be selected before Date of Sample in patient registration Form

https://user-images.githubusercontent.com/59426397/173266581-159bcea3-5019-489a-8baa-e60b369bf273.mp4

