### PR TITLE
Fix Pagination buttons

### DIFF
--- a/src/Components/Common/Pagination.tsx
+++ b/src/Components/Common/Pagination.tsx
@@ -73,15 +73,19 @@ const Pagination = (props: PaginationProps) => {
     const totalPage = Math.ceil(data.totalCount / rowsPerPage);
 
     switch (action) {
-      case "prev":
+      case "<":
         newPage = currentPage - 1;
         break;
 
-      case "next":
+      case ">":
         newPage = currentPage + 1;
         break;
 
-      case "last":
+      case "<<<":
+        newPage = 1;
+        break;
+
+      case ">>>":
         newPage = totalPage;
         break;
 


### PR DESCRIPTION
Fixes #2661 

The labels for the buttons were updated but the action names were not. This caused them to not work anymore. This change updates the action names to match the button labels accordingly.