### PR TITLE
Fix Patient Summary

### DIFF
--- a/src/Components/Facility/Consultations/PrimaryParametersPlot.tsx
+++ b/src/Components/Facility/Consultations/PrimaryParametersPlot.tsx
@@ -35,7 +35,7 @@ export const PrimaryParametersPlot = (props: any) => {
               "rhythm_detail",
             ],
           },
-          props.consultationId
+          { consultationId: props.consultationId }
         )
       );
       if (!status.aborted) {


### PR DESCRIPTION
This change fixes the Summary section on Patient page.

![image](https://user-images.githubusercontent.com/3626859/173639780-0c7e98b4-cacb-4fcf-b019-55fa23dcb43d.png)

Currently it throws an error because consultationId is not placed in the URL. 

![image](https://user-images.githubusercontent.com/3626859/173640024-017c06c7-ac31-448a-b2fb-492f6da17b85.png)
