### PR TITLE
Added 'History of present illness' card in consultation details

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -242,7 +242,6 @@ export const ConsultationDetails = (props: any) => {
     setDischargeSummaryForm({ email: currentUser.data.email });
   };
 
-
   const fetchData = useCallback(
     async (status: statusType) => {
       setIsLoading(true);
@@ -457,7 +456,10 @@ export const ConsultationDetails = (props: any) => {
         </nav>
         <div className="flex md:flex-row flex-col w-full mt-2">
           <div className="border rounded-lg bg-white shadow h-full text-black w-full">
-            <TeleICUPatientInfoCard patient={patientData} ip_no ={consultationData.ip_no}/>
+            <TeleICUPatientInfoCard
+              patient={patientData}
+              ip_no={consultationData.ip_no}
+            />
 
             <div className="flex md:flex-row flex-col justify-between border-t px-4 pt-5">
               {consultationData.admitted_to && (
@@ -525,8 +527,7 @@ export const ConsultationDetails = (props: any) => {
               <div className="flex-1 text-right">
                 <button className="btn btn-primary" onClick={handleClickOpen}>
                   <i className="fas fa-clipboard-list"></i>
-                  &nbsp;
-                  Discharge Summary
+                  &nbsp; Discharge Summary
                 </button>
 
                 <button
@@ -538,8 +539,7 @@ export const ConsultationDetails = (props: any) => {
                   }
                 >
                   <i className="fas fa-hospital-user"></i>
-                  &nbsp;
-                  Discharge from CARE
+                  &nbsp; Discharge from CARE
                 </button>
               </div>
             </div>
@@ -634,6 +634,20 @@ export const ConsultationDetails = (props: any) => {
                   </div>
                 </div>
               )}
+
+              {consultationData.existing_medication && (
+                <div className="bg-white overflow-hidden shadow rounded-lg mt-4">
+                  <div className="px-4 py-5 sm:p-6">
+                    <h3 className="text-lg font-semibold leading-relaxed text-gray-900">
+                      History of Present Illness
+                    </h3>
+                    <div className="mt-2">
+                      {consultationData.existing_medication || "-"}
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {consultationData.examination_details && (
                 <div className="bg-white overflow-hidden shadow rounded-lg mt-4">
                   <div className="px-4 py-5 sm:p-6">


### PR DESCRIPTION
Fixes #2742 

The 'History of present illness' card has been added to the consultation details, below the symptoms card.

![image](https://user-images.githubusercontent.com/40627011/174329635-f4018991-6f1e-49a3-90fc-3839b3ff79ab.png)
