### PR TITLE
Removed Diagnosis section from Notes

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -414,8 +414,7 @@ export const ConsultationDetails = (props: any) => {
                 </div>
               )}
 
-              {(consultationData.diagnosis ||
-                consultationData.operation ||
+              {(consultationData.operation ||
                 consultationData.special_instruction) && (
                 <div className="bg-white overflow-hidden shadow rounded-lg mt-4">
                   <div className="px-4 py-5 sm:p-6">
@@ -423,14 +422,6 @@ export const ConsultationDetails = (props: any) => {
                       Notes
                     </h3>
                     <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
-                      {consultationData.diagnosis && (
-                        <div>
-                          <h5>Diagnosis</h5>
-                          <p className="text-justify break-words">
-                            {consultationData.diagnosis}
-                          </p>
-                        </div>
-                      )}
                       {consultationData.operation && (
                         <div className="mt-4">
                           <h5>Operation</h5>


### PR DESCRIPTION
# Updates

- [x] Fixes #2749
- [x] Removed `Diagnosis` from `Notes` section
![image](https://user-images.githubusercontent.com/77210185/174431851-4e09816a-3b91-460b-b3af-23e49e1fdaa8.png)
