### PR TITLE
Hide config button if asset_class=null

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -260,14 +260,16 @@ const AssetManage = (props: AssetManageProps) => {
               <i className="fas fa-pencil-alt text-white mr-2"></i>
               Update Asset
             </button>
-            <button
-              onClick={() => navigate(`/assets/${asset?.id}/configure`)}
-              id="update-asset"
-              className="btn-primary btn"
-            >
-              <i className="fas fa-cog text-white mr-2"></i>
-              Configure Asset
-            </button>
+            {asset?.asset_class && (
+              <button
+                onClick={() => navigate(`/assets/${asset?.id}/configure`)}
+                id="update-asset"
+                className="btn-primary btn"
+              >
+                <i className="fas fa-cog text-white mr-2"></i>
+                Configure Asset
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/Components/Assets/AssetTypes.ts
+++ b/src/Components/Assets/AssetTypes.ts
@@ -21,6 +21,7 @@ export interface AssetData {
   modified_date: string;
   serial_number: string;
   warranty_details: string;
+  asset_class: "ONVIF" | "HL7MONITOR";
   asset_type: "INTERNAL" | "EXTERNAL";
   location_object: AssetLocationObject;
   status: "ACTIVE" | "TRANSFER_IN_PROGRESS";


### PR DESCRIPTION
# Updates

- [x] Fixes #2809
- [x] Added `asset_class` property to `AssetData` interface
- [x] Added logic to hide config button on `asset_class=null`
- [x] Tested on asset with `asset_class!=null` (`assetId=f6f2eeb5-16f7-4892-a579-2f8e054b8216`)
- [x] Tested on asset with `asset_class=null` (`assetId=86c5fc30-98c7-45ad-855f-2c59cc7d2fd2`)
