### PR TITLE
Made The shifting page board responsive

### DIFF
--- a/src/Components/Common/SearchBox.tsx
+++ b/src/Components/Common/SearchBox.tsx
@@ -37,7 +37,7 @@ export const InputSearchBox = (props: TextFieldPropsExtended) => {
   };
 
   return (
-    <div className="md:flex sticky top-0 bg-gray-100">
+    <div className="md:flex top-0 bg-gray-100">
       <div className="relative rounded-md shadow-sm max-w-sm w-full">
         <input
           name="search"

--- a/src/Components/Shifting/ShiftingBoard.tsx
+++ b/src/Components/Shifting/ShiftingBoard.tsx
@@ -349,7 +349,7 @@ export default function ListView({
       ));
   };
   return (
-    <div className="bg-gray-200 mr-2 flex-shrink-0 w-full md:w-1/2 lg:w-1/3 xl:w-1/4 pb-4 h-full overflow-y-auto rounded-md">
+    <div className="bg-gray-200 mr-2 flex-shrink-0 w-full lg:w-1/3 xl:w-1/4 pb-4 h-full overflow-y-auto rounded-md">
       <div className="sticky top-0 pt-2 bg-gray-200 rounded z-10">
         <div className="flex justify-between p-4 mx-2 rounded bg-white shadow items-center">
           <h3 className="text-xs flex items-center h-8">

--- a/src/Components/Shifting/ShiftingBoard.tsx
+++ b/src/Components/Shifting/ShiftingBoard.tsx
@@ -151,12 +151,12 @@ export default function ListView({
             >
               <div>
                 <div className="flex justify-between">
-                  <div className="font-bold text-xl capitalize mb-2">
+                  <div className="font-bold text-xl capitalize mb-2 ">
                     {shift.patient_object.name} - {shift.patient_object.age}
                   </div>
                   <div>
                     {shift.emergency && (
-                      <span className="shrink-0 inline-block px-2 py-0.5 text-red-800 text-xs leading-4 font-medium bg-red-100 rounded-full">
+                      <span className="shrink-0 inline-block px-2 py-0.5 text-red-800 text-xs leading-4 font-medium bg-red-100 rounded-full ">
                         Emergency
                       </span>
                     )}
@@ -169,7 +169,7 @@ export default function ListView({
                       className="text-sm leading-5 font-medium text-gray-500 flex items-center"
                     >
                       <i className="fas fa-mobile mr-2" />
-                      <dd className="font-bold text-sm leading-5 text-gray-900">
+                      <dd className="font-bold text-sm leading-5 text-gray-900 break-normal">
                         {shift.patient_object.phone_number || ""}
                       </dd>
                     </dt>
@@ -180,7 +180,7 @@ export default function ListView({
                       className="text-sm leading-5 font-medium text-gray-500 flex items-center"
                     >
                       <i className="fas fa-plane-departure mr-2"></i>
-                      <dd className="font-bold text-sm leading-5 text-gray-900">
+                      <dd className="font-bold text-sm leading-5 text-gray-900 break-normal">
                         {(shift.orgin_facility_object || {}).name}
                       </dd>
                     </dt>
@@ -191,7 +191,7 @@ export default function ListView({
                       className="text-sm leading-5 font-medium text-gray-500 flex items-center"
                     >
                       <i className="fas fa-user-check mr-2"></i>
-                      <dd className="font-bold text-sm leading-5 text-gray-900">
+                      <dd className="font-bold text-sm leading-5 text-gray-900 break-normal">
                         {(shift.shifting_approving_facility_object || {}).name}
                       </dd>
                     </dt>
@@ -203,7 +203,7 @@ export default function ListView({
                     >
                       <i className="fas fa-plane-arrival mr-2"></i>
 
-                      <dd className="font-bold text-sm leading-5 text-gray-900">
+                      <dd className="font-bold text-sm leading-5 text-gray-900 break-normal">
                         {(shift.assigned_facility_object || {}).name ||
                           "Yet to be decided"}
                       </dd>
@@ -223,7 +223,7 @@ export default function ListView({
                       }
                     >
                       <i className="fas fa-stopwatch mr-2"></i>
-                      <dd className="font-bold text-sm leading-5">
+                      <dd className="font-bold text-sm leading-5 break-normal">
                         {moment(shift.modified_date).format("LLL") || "--"}
                       </dd>
                     </dt>
@@ -235,7 +235,7 @@ export default function ListView({
                       className="text-sm leading-5 font-medium text-gray-500 flex items-center"
                     >
                       <i className="fas fa-home mr-2"></i>
-                      <dd className="font-bold text-sm leading-5 text-gray-900">
+                      <dd className="font-bold text-sm leading-5 text-gray-900 break-normal">
                         {shift.patient_object.address || "--"}
                       </dd>
                     </dt>
@@ -248,7 +248,7 @@ export default function ListView({
                         className="text-sm leading-5 font-medium text-gray-500 flex items-center"
                       >
                         <i className="fas fa-user mr-2"></i>
-                        <dd className="font-bold text-sm leading-5 text-gray-900">
+                        <dd className="font-bold text-sm leading-5 text-gray-900 break-normal">
                           {shift.assigned_to_object.first_name}{" "}
                           {shift.assigned_to_object.last_name} -{" "}
                           {shift.assigned_to_object.user_type}
@@ -263,7 +263,7 @@ export default function ListView({
                       className="text-sm leading-5 font-medium text-gray-500 flex items-center"
                     >
                       <i className="fas fa-thumbtack mr-2"></i>
-                      <dd className="font-bold text-sm leading-5 text-gray-900">
+                      <dd className="font-bold text-sm leading-5 text-gray-900 break-normal">
                         {shift.patient_object.state_object.name || "--"}
                       </dd>
                     </dt>


### PR DESCRIPTION
Fixes #2826 

# Bugs Fixed

## Made The shifting page board responsive in iPad
- iPad Air
![image](https://user-images.githubusercontent.com/59426397/175667026-546d4750-e32e-48f6-80c9-2a9e344f7118.png)
- iPad Mini
![image](https://user-images.githubusercontent.com/59426397/175667148-03bfa26a-52f2-40b7-b9b5-b1d5d92283ad.png)
