### PR TITLE
Fix success text when sending a sample

### DIFF
--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -3,7 +3,7 @@ import { navigate } from "raviger";
 import moment from "moment";
 import React, { useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import { GENDER_TYPES } from "../../Common/constants";
+import { GENDER_TYPES, SAMPLE_TEST_STATUS } from "../../Common/constants";
 import loadable from "@loadable/component";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { OnlineUsersSelect } from "../Common/OnlineUsersSelect";
@@ -301,10 +301,7 @@ export const PatientHome = (props: any) => {
       status,
       consultation: sample.consultation,
     };
-    let statusName = "";
-    if (status === 4) {
-      statusName = "SENT_TO_COLLECTON_CENTRE";
-    }
+    const statusName = SAMPLE_TEST_STATUS.find((i) => i.id === status)?.desc;
 
     const res = await dispatch(patchSample(sampleData, { id: sample.id }));
     if (res && (res.status === 201 || res.status === 200)) {


### PR DESCRIPTION
Fixes #2939

This change fixes the text shown in success message box to be derived from `SAMPLE_TEST_STATUS` instead of being hardcoded.

![image](https://user-images.githubusercontent.com/3626859/176180390-a1e6895c-d4c1-4dca-9f38-12cabbc8def6.png)
