### PR TITLE
Display error message on 429 status code

### DIFF
--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -134,9 +134,7 @@ export const fireRequest = (
 
           // 4xx Errors
           if (error.response.status > 400 && error.response.status < 500) {
-            if (error.response.status === 429) {
-              return error.response;
-            } else if (error.response.data && error.response.data.detail) {
+            if (error.response.data && error.response.data.detail) {
               Notification.Error({
                 msg: error.response.data.detail,
               });
@@ -144,6 +142,9 @@ export const fireRequest = (
               Notification.Error({
                 msg: "Something went wrong...!",
               });
+            }
+            if (error.response.status === 429) {
+              return error.response;
             }
             return;
           }
@@ -243,9 +244,7 @@ export const fireRequestV2 = (
 
         // 4xx Errors
         if (error.response.status > 400 && error.response.status < 500) {
-          if (error.response.status === 429) {
-            return error.response;
-          } else if (error.response.data && error.response.data.detail) {
+          if (error.response.data && error.response.data.detail) {
             Notification.Error({
               msg: error.response.data.detail,
             });
@@ -254,6 +253,10 @@ export const fireRequestV2 = (
               msg: "Something went wrong...!",
             });
           }
+          if (error.response.status === 429) {
+            return error.response;
+          }
+          return;
         }
 
         // 5xx Errors


### PR DESCRIPTION
Fixes #2938
This change displays the error message before returning the error response.

![image](https://user-images.githubusercontent.com/3626859/176626566-06918069-1950-49bb-b17d-5fc6ecd69f3e.png)
