### PR TITLE
Added spacing on Sample page and Esc key closes delete result popup

### DIFF
--- a/src/Components/Common/AlertDialog.tsx
+++ b/src/Components/Common/AlertDialog.tsx
@@ -32,8 +32,14 @@ const AlertDialog = (props: Props) => {
     primaryButton,
     secondaryButton,
   } = props;
+
+  const handleEscKeyPress = (event: any) => {
+    if (event.key === "Escape") {
+      handleCancel ? handleCancel() : null;
+    }
+  };
   return (
-    <Dialog open={true}>
+    <Dialog open={true} onKeyDown={(e) => handleEscKeyPress(e)}>
       <DialogTitle id="alert-dialog-title">{title || ""}</DialogTitle>
       <DialogContent>
         <DialogContentText id="alert-dialog-description">

--- a/src/Components/Patient/SampleDetails.tsx
+++ b/src/Components/Patient/SampleDetails.tsx
@@ -62,7 +62,7 @@ export const SampleDetails = (props: SampleDetailsProps) => {
     return (
       <div className="border rounded-lg bg-white shadow h-full text-black mt-2 mr-3 md:mr-8 p-4">
         <div className="grid grid-cols-1 md:grid-cols-2">
-          <div className="mt-2">
+          <div className="mt-2 flex flex-col gap-2">
             <div>
               <span className="font-semibold leading-relaxed">Name: </span>
               {patientData?.name}
@@ -135,7 +135,7 @@ export const SampleDetails = (props: SampleDetailsProps) => {
               {patientData?.nationality || "-"}
             </div>
           </div>
-          <div className="mt-2">
+          <div className="mt-2 flex flex-col gap-2">
             <div>
               <span className="font-semibold leading-relaxed">
                 Blood Group:{" "}


### PR DESCRIPTION
Fixes #2960 
- Added spacing on Sample page in Details of Patient card
http://localhost:4000/sample/54a30f22-18b5-48a8-a58d-8f6569538737
![image](https://user-images.githubusercontent.com/70687348/176945176-7cbdfeed-bf77-46f5-b914-af8e024e12f7.png)

- Esc key closes the delete result popup on the External Results page
http://localhost:4000/external_results/6564#
https://www.loom.com/share/f65bd543602245efa39121605e6e0fe8