### PR TITLE
Fixed alignment issue in Asset List

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -287,7 +287,7 @@ const AssetsList = () => {
             errors=""
           />
         </div>
-        <div className="flex flex-row justify-start items-center gap-2">
+        <div className="flex flex-row lg:px-8 justify-start items-center gap-2">
           <AdvancedFilterButton setShowFilters={setShowFilters} />
           <button
             className="btn btn-primary"

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -287,7 +287,7 @@ const AssetsList = () => {
             errors=""
           />
         </div>
-        <div className="flex flex-row lg:px-8 justify-start items-center gap-2">
+        <div className="flex flex-row lg:ml-2 justify-start items-start gap-2">
           <AdvancedFilterButton setShowFilters={setShowFilters} />
           <button
             className="btn btn-primary"


### PR DESCRIPTION
# Updates

- [x] Fixes #2965
- [x] Fixed alignment issue for `Advanced Filters` and `Scan Asset QR` button in `lg` screen
