### PR TITLE
Fix validation when updating facility

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -350,7 +350,7 @@ export const FacilityCreate = (props: FacilityProps) => {
         case "state":
         case "local_body":
         case "ward":
-          if (!state.form[field]) {
+          if (!Number(state.form[field])) {
             errors[field] = "Field is required";
             invalidForm = true;
           }


### PR DESCRIPTION
Fixes #3014 

Since the fields, "district", "state", "local_body" and "ward" are numerical values with the default (non selected) value being 0, it should be casted as a number before the validation check is done.


![image](https://user-images.githubusercontent.com/3626859/177423969-41d9d600-3805-4fe9-8651-0e1efa3d5f2b.png)

![image](https://user-images.githubusercontent.com/3626859/177423989-430dff6c-6e66-4afe-b52d-20fa703e7c4d.png)

![image](https://user-images.githubusercontent.com/3626859/177424001-70174164-37a0-439f-ada7-e791424e091d.png)
