### PR TITLE
Improved shifting detail comment section

### DIFF
--- a/src/Components/Shifting/CommentsSection.tsx
+++ b/src/Components/Shifting/CommentsSection.tsx
@@ -55,6 +55,22 @@ const CommentSection = (props: CommentSectionProps) => {
 
   return (
     <div className="w-full flex flex-col">
+      <textarea
+        rows={3}
+        value={commentBox}
+        minLength={3}
+        placeholder="Type your comment"
+        className="mt-4 border border-gray-500 rounded-lg p-4 focus:ring-primary-500"
+        onChange={(e) => setCommentBox(e.target.value)}
+      />
+      <div className="flex w-full justify-end">
+        <Button
+          onClick={onSubmitComment}
+          className="border border-solid border-primary-600 hover:border-primary-700 text-primary-600 hover:bg-white capitalize my-2 text-sm"
+        >
+          Post Your Comment
+        </Button>
+      </div>
       <div className=" w-full">
         {isLoading ? (
           <CircularProgress />
@@ -84,22 +100,6 @@ const CommentSection = (props: CommentSectionProps) => {
             </div>
           ))
         )}
-      </div>
-      <textarea
-        rows={3}
-        value={commentBox}
-        minLength={3}
-        placeholder="Type your comment"
-        className="mt-4 border border-gray-500 rounded-lg p-4"
-        onChange={(e) => setCommentBox(e.target.value)}
-      />
-      <div className="flex w-full justify-end">
-        <Button
-          onClick={onSubmitComment}
-          className="border border-solid border-primary-600 hover:border-primary-700 text-primary-600 hover:bg-white capitalize my-2 text-sm"
-        >
-          Post Your Comment
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #3062 

- [x] keep the text box on the top of the comments
- [x] when we click the box, change the blue border to green border

Preview:

![image](https://user-images.githubusercontent.com/40627011/178025856-b700020a-fcc2-4a78-b366-6a192c0439f6.png)
