### PR TITLE
Hide extra error message when shifting bed fails

### DIFF
--- a/src/Components/Facility/Consultations/Beds.tsx
+++ b/src/Components/Facility/Consultations/Beds.tsx
@@ -90,10 +90,6 @@ const Beds = (props: BedsProps) => {
         msg: "Bed allocated successfully",
       });
       window.location.reload();
-    } else {
-      Notification.Error({
-        msg: "Something went wrong..!",
-      });
     }
   };
 


### PR DESCRIPTION
Since we already have the logic to display error message on a `4xx` http status, we do not need to separately display another "Something went wrong" message alongside.

Before:
![image](https://user-images.githubusercontent.com/3626859/178098089-6a8e68bf-acf1-42e5-94fb-09a50fc6e0e4.png)

After:
![image](https://user-images.githubusercontent.com/3626859/178098096-fe6d73ed-de60-401b-ae4e-819b90a58b4b.png)
