### PR TITLE
Fix phone number clear button on Profile page

### DIFF
--- a/src/Components/Users/UserProfile.tsx
+++ b/src/Components/Users/UserProfile.tsx
@@ -230,10 +230,8 @@ export default function UserProfile() {
   };
 
   const handleValueChange = (phoneNo: string, name: string) => {
-    if (phoneNo && parsePhoneNumberFromString(phoneNo)?.isPossible()) {
-      const form: EditForm = { ...states.form, [name]: phoneNo };
-      dispatch({ type: "set_form", form });
-    }
+    const form: EditForm = { ...states.form, [name]: phoneNo };
+    dispatch({ type: "set_form", form });
   };
 
   const handleWhatsappNumChange = (phoneNo: string, name: string) => {


### PR DESCRIPTION
Fixes #3164 

This change fixes the clear option for the phone number input field. The final check for a valid phone number is still performed before submission.

> Clicking the X
![image](https://user-images.githubusercontent.com/3626859/179684211-0a48ecd1-dcc9-4c7b-b48e-778f2a02dd1c.png)

> Submitting Invalid number
![image](https://user-images.githubusercontent.com/3626859/179684438-6240a2fd-c8a8-47a3-93fe-e9091acc1a0b.png)

> Submitting blank number
![image](https://user-images.githubusercontent.com/3626859/179684364-b722f110-8345-4a78-a01f-4b19cc7c997f.png)

> Submitting valid number
![image](https://user-images.githubusercontent.com/3626859/179684318-f319ced2-ada0-4a97-acd9-9ff6f5e7ebf9.png)
