### PR TITLE
Improve filter inputs

### DIFF
--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -16,6 +16,8 @@ import GetAppIcon from "@material-ui/icons/GetApp";
 import FacilitiesSelectDialogue from "./FacilitiesSelectDialogue";
 import { FacilityModel } from "../Facility/models";
 import clsx from "clsx";
+import { PhoneNumberField } from "../Common/HelperInputFields";
+import parsePhoneNumberFromString from "libphonenumber-js";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
@@ -55,7 +57,9 @@ export default function ResultList() {
     const params = {
       page: qParams.page || 1,
       name: qParams.name || "",
-      mobile_number: qParams.mobile_number ? qParams.mobile_number : "",
+      mobile_number: qParams.mobile_number
+        ? parsePhoneNumberFromString(qParams.mobile_number)?.format("E.164")
+        : "",
       wards: qParams.wards || undefined,
       local_bodies: qParams.local_bodies || undefined,
       created_date_before: qParams.created_date_before || undefined,
@@ -382,10 +386,10 @@ export default function ResultList() {
           </div>
           <div className="text-sm font-semibold my-2">Search by number</div>
           <div className="w-full">
-            <InputSearchBox
-              value={qParams.mobile_number || ""}
-              search={searchByPhone}
-              placeholder="Search by Phone Number"
+            <PhoneNumberField
+              value={qParams.mobile_number || "+91"}
+              onChange={(value: string) => searchByPhone(value)}
+              turnOffAutoFormat={false}
               errors=""
             />
           </div>

--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -826,6 +826,7 @@ export default function PatientFilterV2(props: any) {
             <TextInputField
               id="age_min"
               name="age_min"
+              type="number"
               variant="outlined"
               margin="dense"
               errors=""
@@ -837,6 +838,7 @@ export default function PatientFilterV2(props: any) {
             <TextInputField
               id="age_max"
               name="age_max"
+              type="number"
               variant="outlined"
               margin="dense"
               errors=""

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -5,6 +5,7 @@ import {
   SelectField,
   DateInputField,
   TextInputField,
+  PhoneNumberField,
 } from "../Common/HelperInputFields";
 import {
   SHIFTING_FILTER_ORDER,
@@ -20,6 +21,7 @@ import { CircularProgress } from "@material-ui/core";
 import { SHIFTING_CHOICES } from "../../Common/constants";
 import { Link } from "raviger";
 import { DateRangePicker, getDate } from "../Common/DateRangePicker";
+import parsePhoneNumberFromString from "libphonenumber-js";
 
 function useMergeState(initialState: any) {
   const [state, setState] = useState(initialState);
@@ -201,7 +203,9 @@ export default function ListFilter(props: any) {
       assigned_facility: assigned_facility || "",
       emergency: emergency || "",
       is_up_shift: is_up_shift || "",
-      patient_phone_number: patient_phone_number || "",
+      patient_phone_number: patient_phone_number
+        ? parsePhoneNumberFromString(patient_phone_number)?.format("E.164")
+        : "",
       created_date_before:
         created_date_before && moment(created_date_before).isValid()
           ? moment(created_date_before).format("YYYY-MM-DD")
@@ -470,13 +474,12 @@ export default function ListFilter(props: any) {
 
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">Patient Phone Number</span>
-          <TextInputField
+          <PhoneNumberField
             name="patient_phone_number"
-            variant="outlined"
-            margin="dense"
-            errors=""
             value={filterState.patient_phone_number}
-            onChange={handleChange}
+            onChange={(value: string) => {
+              handleChange({ target: { name: "patient_phone_number", value } });
+            }}
           />
         </div>
 

--- a/src/Components/Users/UserFilter.tsx
+++ b/src/Components/Users/UserFilter.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react";
-import { SelectField, TextInputField } from "../Common/HelperInputFields";
+import {
+  PhoneNumberField,
+  SelectField,
+  TextInputField,
+} from "../Common/HelperInputFields";
 import { USER_TYPES } from "../../Common/constants";
 import { navigate } from "raviger";
+import parsePhoneNumberFromString from "libphonenumber-js";
 
 const useMergeState = (initialState: any) => {
   const [state, setState] = useState(initialState);
@@ -54,8 +59,12 @@ export default function UserFilter(props: any) {
     const data = {
       first_name: first_name || "",
       last_name: last_name || "",
-      phone_number: phone_number || "",
-      alt_phone_number: alt_phone_number || "",
+      phone_number: phone_number
+        ? parsePhoneNumberFromString(phone_number)?.format("E.164")
+        : "",
+      alt_phone_number: alt_phone_number
+        ? parsePhoneNumberFromString(alt_phone_number)?.format("E.164")
+        : "",
       user_type: user_type || "",
     };
     onChange(data);
@@ -128,16 +137,12 @@ export default function UserFilter(props: any) {
           <span className="text-sm font-semibold">Phone Number</span>
           <div className="flex justify-between">
             <div className="w-full">
-              <TextInputField
-                id="phone_number"
+              <PhoneNumberField
                 name="phone_number"
-                variant="outlined"
-                margin="dense"
-                errors=""
                 value={filterState.phone_number}
-                onChange={handleChange}
-                label="Phone Number"
-                className="bg-white h-10 shadow-sm md:text-sm md:leading-5 md:h-9 mr-1"
+                onChange={(value: string) => {
+                  handleChange({ target: { name: "phone_number", value } });
+                }}
               />
             </div>
           </div>
@@ -147,16 +152,12 @@ export default function UserFilter(props: any) {
           <span className="text-sm font-semibold">Alt Phone Number</span>
           <div className="flex justify-between">
             <div className="w-full">
-              <TextInputField
-                id="alt_phone_number"
+              <PhoneNumberField
                 name="alt_phone_number"
-                variant="outlined"
-                margin="dense"
-                errors=""
                 value={filterState.alt_phone_number}
-                onChange={handleChange}
-                label="Alt Phone Number"
-                className="bg-white h-10 shadow-sm md:text-sm md:leading-5 md:h-9 mr-1"
+                onChange={(value: string) => {
+                  handleChange({ target: { name: "alt_phone_number", value } });
+                }}
               />
             </div>
           </div>

--- a/src/Components/Users/UserFilter.tsx
+++ b/src/Components/Users/UserFilter.tsx
@@ -1,10 +1,15 @@
 import { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { getDistrict } from "../../Redux/actions";
-import { SelectField, TextInputField } from "../Common/HelperInputFields";
+import {
+  PhoneNumberField,
+  SelectField,
+  TextInputField,
+} from "../Common/HelperInputFields";
 import { USER_TYPES } from "../../Common/constants";
 import { navigate } from "raviger";
 import DistrictSelect from "../Facility/FacilityFilter/DistrictSelect";
+import parsePhoneNumberFromString from "libphonenumber-js";
 
 const useMergeState = (initialState: any) => {
   const [state, setState] = useState(initialState);


### PR DESCRIPTION
Closes #3182 

This PR changes some input types on the filter section. The changes are as follows:

1. Patient Filter
Set Min and Max age input type to `number` so that letters can not be entered there
![image](https://user-images.githubusercontent.com/3626859/180316268-e70ea93f-8a05-406d-9878-cef75db64b8e.png)


3. Set the inputs requiring a phone number as proper phone number input rather than a text input.
a. Shifting filter
![image](https://user-images.githubusercontent.com/3626859/180314500-ac47f2a2-f346-4baa-90ab-7c284e8c01d8.png)
b. User management 
![image](https://user-images.githubusercontent.com/3626859/180314561-49ad8565-6afe-401e-a05f-3866576270a4.png)
c. External Results
![image](https://user-images.githubusercontent.com/3626859/180316035-0fba1958-1af7-4704-9b1d-9cf87f69f10f.png)
