### PR TITLE
Fix check on Update Sample Test Status

### DIFF
--- a/src/Components/Patient/UpdateStatusDialog.tsx
+++ b/src/Components/Patient/UpdateStatusDialog.tsx
@@ -93,7 +93,7 @@ const UpdateStatusDialog = (props: Props & WithStyles<typeof styles>) => {
 
   useEffect(() => {
     const form = { ...state.form };
-    form.status = currentStatus?.id;
+    form.status = 0;
     dispatch({ type: "set_form", form });
   }, []);
 


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/3180

The checks are already in place but the issue is that `form.status` (New status) is initially set to the current status rather than "0 (Not selected)" which causes a bug where the user can update the status without selecting a new value.

Now, update status button will be disabled until both the fields (New status and agree checkbox) are filled.

![image](https://user-images.githubusercontent.com/3626859/180367450-6c7a11e3-29fb-4430-8a75-c923e5306984.png)
![image](https://user-images.githubusercontent.com/3626859/180367438-5d4c78b3-a072-4bbd-8649-bf038ab66aff.png)
![image](https://user-images.githubusercontent.com/3626859/180367468-086f1783-414f-4f81-8698-20d9dae5eff7.png)

Also, works with special case `7` (Test completed).

![image](https://user-images.githubusercontent.com/3626859/180367544-c9547206-806d-4393-912c-bfbe50019830.png)
