### PR TITLE
Renamed 'Message' to 'Notice' in notifications

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -457,7 +457,7 @@ export const DESIGNATION_HEALTH_CARE_WORKER = [
 ];
 
 export const NOTIFICATION_EVENTS = [
-  { id: "MESSAGE", text: "Message", icon: "fa-regular fa-message" },
+  { id: "MESSAGE", text: "Notice", icon: "fa-regular fa-message" },
   {
     id: "PATIENT_CREATED",
     text: "Patient Created",
@@ -739,28 +739,28 @@ export const getCameraPTZ: (precision: number) => CameraPTZ[] = (precision) => [
 
 export const FACILITY_FEATURE_TYPES = [
   {
-    id : 1,
-    name : "CT Scan Facility",
-    icon : "circle-dot"
+    id: 1,
+    name: "CT Scan Facility",
+    icon: "circle-dot",
   },
   {
-    id : 2,
-    name : "Maternity Care",
-    icon : "person-breastfeeding"
+    id: 2,
+    name: "Maternity Care",
+    icon: "person-breastfeeding",
   },
   {
-    id : 3,
-    name : "X-Ray facility",
-    icon : "x-ray"
+    id: 3,
+    name: "X-Ray facility",
+    icon: "x-ray",
   },
   {
-    id : 4,
-    name : "Neonatal care",
-    icon : "baby"
+    id: 4,
+    name: "Neonatal care",
+    icon: "baby",
   },
   {
-    id : 5,
-    name : "Operation theater",
-    icon : "syringe"
-  }
+    id: 5,
+    name: "Operation theater",
+    icon: "syringe",
+  },
 ];

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -462,7 +462,10 @@ export default function NotificationsList({
                   value={eventFilter}
                   options={[
                     { id: "", text: "Show All" },
-                    ...NOTIFICATION_EVENTS,
+                    ...NOTIFICATION_EVENTS.map((i) => {
+                      if (i.id === "MESSAGE") return { ...i, text: "Notices" };
+                      return i;
+                    }),
                   ]}
                   onChange={(e: any) => setEventFilter(e.target.value)}
                 />


### PR DESCRIPTION
Fixes #3188 

- [x] Changed the header in the notification panel to "Notice"
- [x] Changed the item in Filter on notification panel from "Messages" to "Notices"

Preview:

![image](https://user-images.githubusercontent.com/40627011/180467810-066bd7e8-4e32-4456-9d12-1f74c37cf0a0.png)

![image](https://user-images.githubusercontent.com/40627011/180467722-d9d33d36-7e4b-4347-b982-43795a279ae5.png)
