### PR TITLE
Fix check for required fields on Update Patient Details page

### DIFF
--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -835,9 +835,22 @@ export const PatientRegister = (props: PatientRegisterProps) => {
 
   const handleChange = (e: any) => {
     const form = { ...state.form };
-    if (e.target.name === "local_body") form["ward"] = "0";
-    if (e.target.name === "district") form["local_body"] = "0";
-    if (e.target.name === "state") form["district"] = "0";
+    switch (e.target.name) {
+      case "state":
+        form["district"] = "0";
+        form["local_body"] = "0";
+        form["ward"] = "0";
+        break;
+
+      case "district":
+        form["local_body"] = "0";
+        form["ward"] = "0";
+        break;
+
+      case "local_body":
+        form["ward"] = "0";
+        break;
+    }
     form[e.target.name] = e.target.value;
     dispatch({ type: "set_form", form });
   };

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -529,21 +529,30 @@ export const PatientRegister = (props: PatientRegisterProps) => {
           }
           return;
         case "local_body":
-          if (state.form.nationality === "India" && !state.form[field]) {
+          if (
+            state.form.nationality === "India" &&
+            !Number(state.form[field])
+          ) {
             errors[field] = "Please select local body";
             if (!error_div) error_div = field;
             invalidForm = true;
           }
           return;
         case "ward":
-          if (state.form.nationality === "India" && !state.form[field]) {
+          if (
+            state.form.nationality === "India" &&
+            !Number(state.form[field])
+          ) {
             errors[field] = "Please select ward";
             if (!error_div) error_div = field;
             invalidForm = true;
           }
           return;
         case "district":
-          if (state.form.nationality === "India" && !state.form[field]) {
+          if (
+            state.form.nationality === "India" &&
+            !Number(state.form[field])
+          ) {
             errors[field] = "Please select district";
             if (!error_div) error_div = field;
             invalidForm = true;
@@ -826,6 +835,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
 
   const handleChange = (e: any) => {
     const form = { ...state.form };
+    if (e.target.name === "local_body") form["ward"] = "0";
+    if (e.target.name === "district") form["local_body"] = "0";
+    if (e.target.name === "state") form["district"] = "0";
     form[e.target.name] = e.target.value;
     dispatch({ type: "set_form", form });
   };


### PR DESCRIPTION
Fixes #3181 

When a parent selection changes, the dependent option is reset to the "Unselected" choice. This PR also fixes the check for blank selection, by casting it to a number first as they are stored as string.

![image](https://user-images.githubusercontent.com/3626859/180590346-8302efaf-61fd-4a99-8f45-1d63a0081fca.png)
