### PR TITLE
Fix facility create response check

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -457,7 +457,7 @@ export const FacilityCreate = (props: FacilityProps) => {
         facilityId ? updateFacility(facilityId, data) : createFacility(data)
       );
 
-      if (res && res.status === 200 && res.data) {
+      if (res && (res.status === 200 || res.status === 201) && res.data) {
         const id = res.data.id;
         dispatch({ type: "set_form", form: initForm });
         if (!facilityId) {
@@ -471,6 +471,10 @@ export const FacilityCreate = (props: FacilityProps) => {
           });
           navigate(`/facility/${facilityId}`);
         }
+      } else {
+        Notification.Error({
+          msg: "Something went wrong: " + res.data.detail ? res.data.detail : "",
+        });
       }
       setIsLoading(false);
     }

--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -473,7 +473,7 @@ export const FacilityCreate = (props: FacilityProps) => {
         }
       } else {
         Notification.Error({
-          msg: "Something went wrong: " + res.data.detail ? res.data.detail : "",
+          msg: "Something went wrong: " + (res.data.detail || ""),
         });
       }
       setIsLoading(false);


### PR DESCRIPTION
Fixes #3207

Facility creation returns `201`, This change fixes the response status code check to show success or error message as appropriate.

Success:
![image](https://user-images.githubusercontent.com/3626859/180607361-40490d8f-1b04-4c7f-a921-0c9489d37cbb.png)

Failure:
![image](https://user-images.githubusercontent.com/3626859/180607535-771c944a-9ae9-41dd-8d62-743065defef7.png)
