### PR TITLE
Add error messages when deletion fails

### DIFF
--- a/src/Components/ExternalResult/ResultItem.tsx
+++ b/src/Components/ExternalResult/ResultItem.tsx
@@ -32,10 +32,16 @@ export default function ResultItem(props: any) {
   );
 
   const handleDelete = async () => {
-    let res = await dispatch(deleteExternalResult(props.id));
-    if (res.status >= 200) {
+    const res = await dispatch(deleteExternalResult(props.id));
+    if (res && res.status === 204) {
       Notification.Success({
         msg: "Record has been deleted successfully.",
+      });
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting record: " +
+          ((res.data && res.data.detail) || ""),
       });
     }
 

--- a/src/Components/ExternalResult/ResultItem.tsx
+++ b/src/Components/ExternalResult/ResultItem.tsx
@@ -33,20 +33,18 @@ export default function ResultItem(props: any) {
 
   const handleDelete = async () => {
     const res = await dispatch(deleteExternalResult(props.id));
-    if (res && res.status === 204) {
+    if (res?.status === 204) {
       Notification.Success({
         msg: "Record has been deleted successfully.",
       });
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting record: " +
-          ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting record: " + (res?.data?.detail || ""),
       });
     }
 
     setShowDeleteAlert(false);
-    navigate(`/external_results`);
+    navigate("/external_results");
   };
 
   useAbortableEffect(

--- a/src/Components/Facility/BedManagement.tsx
+++ b/src/Components/Facility/BedManagement.tsx
@@ -60,9 +60,14 @@ const BedRow = (props: BedRowProps) => {
 
   const handleDeleteConfirm = async () => {
     const res = await dispatchAction(deleteFacilityBed(id));
-    if (res && res.status == 204) {
+    if (res && res.status === 204) {
       Notification.Success({
         msg: "Bed deleted successfully",
+      });
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting Bed: " + ((res.data && res.data.detail) || ""),
       });
     }
     setBedData({ show: false, name: "" });

--- a/src/Components/Facility/BedManagement.tsx
+++ b/src/Components/Facility/BedManagement.tsx
@@ -60,14 +60,13 @@ const BedRow = (props: BedRowProps) => {
 
   const handleDeleteConfirm = async () => {
     const res = await dispatchAction(deleteFacilityBed(id));
-    if (res && res.status === 204) {
+    if (res?.status === 204) {
       Notification.Success({
         msg: "Bed deleted successfully",
       });
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting Bed: " + ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting Bed: " + (res?.data?.detail || ""),
       });
     }
     setBedData({ show: false, name: "" });

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -93,11 +93,15 @@ const LiveFeed = (props: any) => {
 
   const deletePreset = async (id: any) => {
     const res = await dispatch(deleteAssetBed(id));
-    if (res?.status === 204) {
+    if (res && res.status === 204) {
       Notification.Success({ msg: "Preset deleted successfully" });
       getBedPresets(cameraAsset.id);
     } else {
-      Notification.Error({ msg: "Failed to delete preset" });
+      Notification.Error({
+        msg:
+          "Error while deleting Preset: " +
+          ((res.data && res.data.detail) || ""),
+      });
     }
     setToDelete(null);
   };

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -93,14 +93,12 @@ const LiveFeed = (props: any) => {
 
   const deletePreset = async (id: any) => {
     const res = await dispatch(deleteAssetBed(id));
-    if (res && res.status === 204) {
+    if (res?.status === 204) {
       Notification.Success({ msg: "Preset deleted successfully" });
       getBedPresets(cameraAsset.id);
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting Preset: " +
-          ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting Preset: " + (res?.data?.detail || ""),
       });
     }
     setToDelete(null);

--- a/src/Components/Facility/DoctorsCountCard.tsx
+++ b/src/Components/Facility/DoctorsCountCard.tsx
@@ -29,11 +29,17 @@ const DoctorsCountCard = (props: DoctorsCountProps) => {
       const res = await dispatchAction(
         deleteDoctor(props.area, { facilityId: props.facilityId })
       );
-      if (res && res.status == 204) {
+      if (res && res.status === 204) {
         Notification.Success({
           msg: "Doctor specialization type deleted successfully",
         });
         props.removeDoctor(props.id);
+      } else {
+        Notification.Error({
+          msg:
+            "Error while deleting Doctor specialization: " +
+            ((res.data && res.data.detail) || ""),
+        });
       }
     }
   };

--- a/src/Components/Facility/DoctorsCountCard.tsx
+++ b/src/Components/Facility/DoctorsCountCard.tsx
@@ -29,7 +29,7 @@ const DoctorsCountCard = (props: DoctorsCountProps) => {
       const res = await dispatchAction(
         deleteDoctor(props.area, { facilityId: props.facilityId })
       );
-      if (res && res.status === 204) {
+      if (res?.status === 204) {
         Notification.Success({
           msg: "Doctor specialization type deleted successfully",
         });
@@ -38,7 +38,7 @@ const DoctorsCountCard = (props: DoctorsCountProps) => {
         Notification.Error({
           msg:
             "Error while deleting Doctor specialization: " +
-            ((res.data && res.data.detail) || ""),
+            (res?.data?.detail || ""),
         });
       }
     }

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -98,9 +98,15 @@ export const FacilityHome = (props: any) => {
 
   const handleDeleteSubmit = async () => {
     const res = await dispatch(deleteFacility(facilityId));
-    if (res && res.status == 204) {
+    if (res && res.status === 204) {
       Notification.Success({
         msg: "Facility deleted successfully",
+      });
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting Facility: " +
+          ((res.data && res.data.detail) || ""),
       });
     }
     navigate("/facility");

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -98,15 +98,13 @@ export const FacilityHome = (props: any) => {
 
   const handleDeleteSubmit = async () => {
     const res = await dispatch(deleteFacility(facilityId));
-    if (res && res.status === 204) {
+    if (res?.status === 204) {
       Notification.Success({
         msg: "Facility deleted successfully",
       });
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting Facility: " +
-          ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting Facility: " + (res?.data?.detail || ""),
       });
     }
     navigate("/facility");

--- a/src/Components/Facility/FacilityUsers.tsx
+++ b/src/Components/Facility/FacilityUsers.tsx
@@ -150,9 +150,14 @@ export default function FacilityUsers(props: any) {
   const handleSubmit = async () => {
     const username = userData.username;
     const res = await dispatch(deleteUser(username));
-    if (res.status >= 200) {
+    if (res && res.status === 204) {
       Notification.Success({
         msg: "User deleted successfully",
+      });
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting User: " + ((res.data && res.data.detail) || ""),
       });
     }
 
@@ -231,6 +236,7 @@ export default function FacilityUsers(props: any) {
   };
 
   const showDelete = (user: any) => {
+    return true;
     const STATE_ADMIN_LEVEL = USER_TYPES.indexOf("StateLabAdmin");
     const STATE_READ_ONLY_ADMIN_LEVEL =
       USER_TYPES.indexOf("StateReadOnlyAdmin");

--- a/src/Components/Facility/FacilityUsers.tsx
+++ b/src/Components/Facility/FacilityUsers.tsx
@@ -150,14 +150,13 @@ export default function FacilityUsers(props: any) {
   const handleSubmit = async () => {
     const username = userData.username;
     const res = await dispatch(deleteUser(username));
-    if (res && res.status === 204) {
+    if (res?.status === 204) {
       Notification.Success({
         msg: "User deleted successfully",
       });
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting User: " + ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting User: " + (res?.data?.detail || ""),
       });
     }
 
@@ -236,7 +235,6 @@ export default function FacilityUsers(props: any) {
   };
 
   const showDelete = (user: any) => {
-    return true;
     const STATE_ADMIN_LEVEL = USER_TYPES.indexOf("StateLabAdmin");
     const STATE_READ_ONLY_ADMIN_LEVEL =
       USER_TYPES.indexOf("StateReadOnlyAdmin");

--- a/src/Components/Facility/InventoryLog.tsx
+++ b/src/Components/Facility/InventoryLog.tsx
@@ -91,9 +91,15 @@ export default function InventoryLog(props: any) {
 
     if (res && res.status === 201) {
       Notification.Success({
-        msg: "Deleted Successfully",
+        msg: "Last entry deleted Successfully",
       });
       window.location.reload();
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting last entry: " +
+          ((res.data && res.data.detail) || ""),
+      });
     }
     setSaving(false);
   };

--- a/src/Components/Facility/InventoryLog.tsx
+++ b/src/Components/Facility/InventoryLog.tsx
@@ -89,16 +89,14 @@ export default function InventoryLog(props: any) {
       })
     );
 
-    if (res && res.status === 201) {
+    if (res?.status === 201) {
       Notification.Success({
         msg: "Last entry deleted Successfully",
       });
       window.location.reload();
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting last entry: " +
-          ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting last entry: " + (res?.data?.detail || ""),
       });
     }
     setSaving(false);

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -25,7 +25,7 @@ const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export default function ResourceDetails(props: { id: string }) {
   const dispatch: any = useDispatch();
-  const initialData: any = {};
+  let initialData: any = {};
   const [data, setData] = useState(initialData);
   const [isLoading, setIsLoading] = useState(true);
   const [isPrintMode, setIsPrintMode] = useState(false);
@@ -58,15 +58,13 @@ export default function ResourceDetails(props: { id: string }) {
     setOpenDeleteResourceDialog(true);
 
     const res = await dispatch(deleteResourceRecord(props.id));
-    if (res && res.status === 204) {
+    if (res?.status === 204) {
       Notification.Success({
         msg: "Resource record has been deleted successfully.",
       });
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting Resource: " +
-          ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting Resource: " + (res?.data?.detail || ""),
       });
     }
 

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -25,7 +25,7 @@ const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export default function ResourceDetails(props: { id: string }) {
   const dispatch: any = useDispatch();
-  let initialData: any = {};
+  const initialData: any = {};
   const [data, setData] = useState(initialData);
   const [isLoading, setIsLoading] = useState(true);
   const [isPrintMode, setIsPrintMode] = useState(false);
@@ -57,14 +57,20 @@ export default function ResourceDetails(props: { id: string }) {
   const handleResourceDelete = async () => {
     setOpenDeleteResourceDialog(true);
 
-    let res = await dispatch(deleteResourceRecord(props.id));
-    if (res.status >= 200) {
+    const res = await dispatch(deleteResourceRecord(props.id));
+    if (res && res.status === 204) {
       Notification.Success({
         msg: "Resource record has been deleted successfully.",
       });
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting Resource: " +
+          ((res.data && res.data.detail) || ""),
+      });
     }
 
-    navigate(`/resource`);
+    navigate("/resource");
   };
 
   const showFacilityCard = (facilityData: any) => {
@@ -453,8 +459,10 @@ export default function ResourceDetails(props: { id: string }) {
           </div>
           <div
             className={clsx(
-                "grid grid-cols-1 mt-8 gap-x-6 gap-y-12", 
-                data.assigned_facility_object ? "lg:grid-cols-3" : "lg:grid-cols-2"
+              "grid grid-cols-1 mt-8 gap-x-6 gap-y-12",
+              data.assigned_facility_object
+                ? "lg:grid-cols-3"
+                : "lg:grid-cols-2"
             )}
           >
             <div>

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -27,7 +27,7 @@ const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export default function ShiftDetails(props: { id: string }) {
   const dispatch: any = useDispatch();
-  let initialData: any = {};
+  const initialData: any = {};
   const [data, setData] = useState(initialData);
   const [isLoading, setIsLoading] = useState(true);
   const [isPrintMode, setIsPrintMode] = useState(false);
@@ -59,14 +59,20 @@ export default function ShiftDetails(props: { id: string }) {
   const handleShiftDelete = async () => {
     setOpenDeleteShiftDialog(true);
 
-    let res = await dispatch(deleteShiftRecord(props.id));
-    if (res.status >= 200) {
+    const res = await dispatch(deleteShiftRecord(props.id));
+    if (res && res.status == 204) {
       Notification.Success({
         msg: "Shifting record has been deleted successfully.",
       });
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting Shifting record: " +
+          ((res.data && res.data.detail) || ""),
+      });
     }
 
-    navigate(`/shifting`);
+    navigate("/shifting");
   };
 
   const showCopyToclipBoard = (data: any) => {

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -27,7 +27,7 @@ const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export default function ShiftDetails(props: { id: string }) {
   const dispatch: any = useDispatch();
-  const initialData: any = {};
+  let initialData: any = {};
   const [data, setData] = useState(initialData);
   const [isLoading, setIsLoading] = useState(true);
   const [isPrintMode, setIsPrintMode] = useState(false);
@@ -60,15 +60,14 @@ export default function ShiftDetails(props: { id: string }) {
     setOpenDeleteShiftDialog(true);
 
     const res = await dispatch(deleteShiftRecord(props.id));
-    if (res && res.status == 204) {
+    if (res?.status == 204) {
       Notification.Success({
         msg: "Shifting record has been deleted successfully.",
       });
     } else {
       Notification.Error({
         msg:
-          "Error while deleting Shifting record: " +
-          ((res.data && res.data.detail) || ""),
+          "Error while deleting Shifting record: " + (res?.data?.detail || ""),
       });
     }
 

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -207,9 +207,14 @@ export default function ManageUsers() {
   const handleSubmit = async () => {
     const username = userData.username;
     const res = await dispatch(deleteUser(username));
-    if (res.status >= 200) {
+    if (res && res.status === 204) {
       Notification.Success({
         msg: "User deleted successfully",
+      });
+    } else {
+      Notification.Error({
+        msg:
+          "Error while deleting User: " + ((res.data && res.data.detail) || ""),
       });
     }
 

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -207,14 +207,13 @@ export default function ManageUsers() {
   const handleSubmit = async () => {
     const username = userData.username;
     const res = await dispatch(deleteUser(username));
-    if (res && res.status === 204) {
+    if (res?.status === 204) {
       Notification.Success({
         msg: "User deleted successfully",
       });
     } else {
       Notification.Error({
-        msg:
-          "Error while deleting User: " + ((res.data && res.data.detail) || ""),
+        msg: "Error while deleting User: " + (res?.data?.detail || ""),
       });
     }
 


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/3212

Some deletion endpoints have no feedback if the deletion fails. This PR fixes it.

![image](https://user-images.githubusercontent.com/3626859/180611735-74586897-bcb1-4229-923d-80bf6c4878da.png)
