### PR TITLE
Fix Notification suppression logic

### DIFF
--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -522,8 +522,15 @@ export const dischargePatient = (params: object, pathParams: object) => {
 };
 
 //Profile
-export const getUserDetails = (username: string, suppress? : true) => {
-  return fireRequest("getUserDetails", [], {}, { username: username }, undefined, suppress);
+export const getUserDetails = (username: string, suppress = true) => {
+  return fireRequest(
+    "getUserDetails",
+    [],
+    {},
+    { username: username },
+    undefined,
+    suppress
+  );
 };
 export const updateUserDetails = (username: string, data: object) => {
   return fireRequest("updateUserDetails", [username], data);

--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -49,7 +49,7 @@ export const fireRequest = (
   params: any = {},
   pathParam?: any,
   altKey?: string,
-  suppressNotif? : true,
+  suppressNotif = false
 ) => {
   return (dispatch: any) => {
     // cancel previous api call
@@ -102,7 +102,7 @@ export const fireRequest = (
       .catch((error: any) => {
         dispatch(fetchDataRequestError(key, error));
 
-        if (suppressNotif && error.response) {
+        if (!suppressNotif && error.response) {
           // temporarily don't show invalid phone number error on duplicate patient check
           if (error.response.status === 400 && key === "searchPatient") {
             return;
@@ -157,7 +157,7 @@ export const fireRequest = (
             });
             return;
           }
-        }else{
+        } else {
           return error.response;
         }
       });


### PR DESCRIPTION
There are minor issues in the way `fireRequest` decides when to suppress error notifications.
It was recently changed in https://github.com/coronasafe/care_fe/commit/da40a71f9a86d2707e610e735e839a39c196525a


1. `suppressNotif? : true,`
This defines an optional parameter `suppressNotif` which has a type of `true | undefined`. This is not the intended behavior. It should rather be a parameter named `suppressNotif` of type `Boolean` which defaults to `false`. `false` because the old behavior of the CARE platform was not to suppress these errors unless explicitly specified. It seems that the below logic does keep that old behavior but the variable usage is confusing. 

     Changed to `suppressNotif = false`


2. `if (suppressNotif && error.response) {`
This is a confusing use of the variable `suppressNotif`. In this case, if `suppressNotif` is true (We want to suppress error messages), it will actually end up showing the error messages, and if it is false (we want to show the error messages), it actually hides all the error messages. 

     Changed to `if (!suppressNotif && error.response) {`

3. `export const getUserDetails = (username: string, suppress? : true) => {`
This again defines an optional parameter `suppress` which has a type of `undefined | true`, instead it should be a Boolean parameter with default value of `true`
    Changed to `export const getUserDetails = (username: string, suppress = true) => {`