### PR TITLE
Revamped buttons on External results page in mobile view

### DIFF
--- a/src/Components/ExternalResult/ResultItem.tsx
+++ b/src/Components/ExternalResult/ResultItem.tsx
@@ -69,16 +69,16 @@ export default function ResultItem(props: any) {
       )}
 
       <div className="mx-3 md:mx-8 mb-10 mt-4">
-        <div className="flex justify-end">
+        <div className="flex flex-col md:flex-row gap-2 justify-end">
           <button
-            className="btn-primary btn mr-2"
+            className="btn-primary btn mr-2 w-full md:w-auto"
             onClick={() => navigate(`/external_results/${data.id}/update`)}
           >
             <i className="fas fa-pencil-alt text-white mr-2"></i>
             Update Record
           </button>
           <button
-            className="btn btn-danger"
+            className="btn btn-danger w-full md:w-auto"
             onClick={() => setShowDeleteAlert(true)}
           >
             <i className="fas fa-trash text-white mr-2"></i>

--- a/src/Components/ExternalResult/ResultUpdate.tsx
+++ b/src/Components/ExternalResult/ResultUpdate.tsx
@@ -331,27 +331,26 @@ export default function UpdateResult(props: any) {
               </RadioGroup>
             </div>
           </div>
-          <div className="flex justify-end mt-4">
+          <div className="flex flex-col md:flex-row gap-2 justify-end mt-4">
             <Button
               color="default"
               variant="contained"
               type="button"
+              className="w-full md:w-auto"
               onClick={goBack}
             >
-              {" "}
-              Cancel{" "}
+              Cancel
             </Button>
             <Button
               color="primary"
               variant="contained"
               type="submit"
-              style={{ marginLeft: "10px" }}
               startIcon={<CheckCircleOutlineIcon>save</CheckCircleOutlineIcon>}
               onClick={(e) => handleSubmit(e)}
               data-testid="submit-button"
+              className="w-full md:w-auto"
             >
-              {" "}
-              Submit{" "}
+              Submit
             </Button>
           </div>
         </form>


### PR DESCRIPTION
Fixes #3231 

External result details page updated view:
![image](https://user-images.githubusercontent.com/70687348/180974683-defabb58-7d25-4c74-9013-fbb8409dd9af.png)

Update External results page updated view:
![image](https://user-images.githubusercontent.com/70687348/180974621-d36b4cbe-5bff-4df5-80bc-00a2beef3e93.png)
