### PR TITLE
Fixed: Limit DistrictAdmin to link facilities for new users

### DIFF
--- a/src/Components/Common/FacilitySelect.tsx
+++ b/src/Components/Common/FacilitySelect.tsx
@@ -12,6 +12,7 @@ interface FacilitySelectProps {
   searchAll?: boolean;
   multiple?: boolean;
   facilityType?: number;
+  district?: string;
   showAll?: boolean;
   selected: FacilityModel | FacilityModel[] | null;
   setSelected: (selected: FacilityModel | FacilityModel[] | null) => void;
@@ -29,6 +30,7 @@ export const FacilitySelect = (props: FacilitySelectProps) => {
     showAll = true,
     className = "",
     facilityType,
+    district,
   } = props;
   const dispatchAction: any = useDispatch();
   const [facilityLoading, isFacilityLoading] = useState(false);
@@ -61,6 +63,7 @@ export const FacilitySelect = (props: FacilitySelectProps) => {
           search_text: text,
           all: searchAll,
           facility_type: facilityType,
+          district,
         };
 
         const res = await dispatchAction(

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -679,6 +679,7 @@ export const UserAdd = (props: UserProps) => {
                     name="facilities"
                     selected={selectedFacility}
                     setSelected={setFacility}
+                    district={currentUser.data.district}
                     errors={state.errors.facilities}
                   />
                 )}

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -40,7 +40,6 @@ import {
 } from "../Common/HelperInputFields";
 import { FacilityModel } from "../Facility/models";
 import HelpToolTip from "../Common/utils/HelpToolTip";
-import { Cancel, CheckCircle } from "@material-ui/icons";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));


### PR DESCRIPTION
# Updates

- [x] Fixes #3308
- [x] Added district as prop to `FacilitySelect` component
- [x] Passed district as query param for searching facilities
- [x] Removed unused import
