### PR TITLE
Fix formatting of exported CSV files

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "raviger": "^4.1.0",
     "react": "18.1.0",
     "react-copy-to-clipboard": "^5.0.3",
-    "react-csv": "^2.0.3",
+    "react-csv": "2.1.9",
     "react-csv-reader": "^3.3.1",
     "react-dates": "^21.8.0",
     "react-dom": "18.1.0",


### PR DESCRIPTION
Fixes #2979

`react-csv` is the culprit here. For string data inputs, it replaces `"` with `""` which messes up the output file.

The `render_to_csv_response` function on the backend already handles all processing for the csv file, Like adding quotes to preserve newlines, properly encoding commas wherever necessary, and escaping quotes with double quotes.

This unnecessary extra step by the `react-csv` breaks the already processed good csv output.

`react-csv`
![image](https://user-images.githubusercontent.com/3626859/182652506-cd0abc7d-fb8b-4acd-a22a-385ade990b42.png)

This PR reverts to a previous version of `react-csv` (2.1.9) which does not have this unneeded processing (bug?).

Before: (File broken on newlines)
![image](https://user-images.githubusercontent.com/3626859/182686462-551211d6-faa5-444d-be2e-3f5ab43cabca.png)


After: (File is correctly formatted)
![image](https://user-images.githubusercontent.com/3626859/182683347-e9202346-e682-4d7f-abaa-69e97027bff7.png)

All newlines and commas are handled properly:

![image](https://user-images.githubusercontent.com/3626859/182691288-443943b6-0682-42d4-af73-d3ed5fdda56a.png)


