### PR TITLE
Center aligned buttons on Resource and Shifting page

### DIFF
--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -112,7 +112,7 @@ export default function BoardView() {
           />
         </div>
 
-        <div className="w-full flex items-start justify-center pt-2 lg:space-x-4 lg:items-center flex-col md:flex-row">
+        <div className="w-full flex justify-center pt-2 lg:space-x-4 items-center flex-col md:flex-row">
           <div className="bg-gray-200 text-sm text-gray-500 leading-none border-2 border-gray-200 rounded-full inline-flex mt-1">
             <button
               className={

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -111,7 +111,7 @@ export default function BoardView() {
             breadcrumbs={false}
           />
         </div>
-        <div className="w-full md:w-full flex items-start pt-2 lg:space-x-4 lg:items-center flex-col lg:flex-row">
+        <div className="w-full flex pt-2 lg:space-x-4 items-center flex-col lg:flex-row justify-between">
           <InputSearchBox
             value={qParams.patient_name || ""}
             search={searchByName}


### PR DESCRIPTION
Fixes #3326 

Removed white space
![image](https://user-images.githubusercontent.com/70687348/183026406-4be7e2c8-e0a1-4a9a-8eea-1e1b86eb2ec9.png)

![image](https://user-images.githubusercontent.com/70687348/183026450-3cf9fc95-d27a-4cf8-926f-cdaa3100124e.png)

![image](https://user-images.githubusercontent.com/70687348/183026468-0e48e7b3-c6c1-48f4-a5b1-c4a2c511a95b.png)
