### PR TITLE
Changed the name of buttons in Inventory Manager Page

### DIFF
--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -219,7 +219,7 @@ export const AddInventoryForm = (props: any) => {
   return (
     <div className="px-2">
       <PageTitle
-        title="Add Inventory"
+        title="Manage Inventory"
         crumbsReplacements={{ [facilityId]: { name: facilityName } }}
       />
       <div className="mt-4">
@@ -306,7 +306,7 @@ export const AddInventoryForm = (props: any) => {
                   startIcon={<CheckCircleOutlineIcon></CheckCircleOutlineIcon>}
                   onClick={(e) => handleSubmit(e)}
                 >
-                  Add Inventory
+                  Add/Update Inventory
                 </Button>
               </div>
             </CardContent>

--- a/src/Components/Facility/InventoryList.tsx
+++ b/src/Components/Facility/InventoryList.tsx
@@ -176,7 +176,7 @@ export default function InventoryList(props: any) {
                 disableFor="readOnly"
                 buttonType="materialUI"
               >
-                Add Inventory
+                Manage Inventory
               </RoleButton>
             </div>
             <div className="mt-2">


### PR DESCRIPTION
Fixes #3349 

## Changed the button name Add Inventory to Manage Inventory
![image](https://user-images.githubusercontent.com/59426397/183412413-18034b1f-6873-487f-b4c3-ad70acd225a5.png)
## Changed the page title to manage inventory and the button name to Add/Update Inventory
![image](https://user-images.githubusercontent.com/59426397/183412638-f7c9ae15-702b-40d1-88a4-f85fbac81ee8.png)
