### PR TITLE
Fix log update back link

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -930,22 +930,12 @@ export const DailyRounds = (props: any) => {
               )}
 
               <div className="mt-4 flex justify-between">
-                {id && (
-                  <Link
-                    className="btn btn-default bg-white mt-2"
-                    href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/daily_rounds/${id}/update`}
-                  >
-                    Back
-                  </Link>
-                )}
-                {!id && (
-                  <Link
-                    className="btn btn-default bg-white mt-2"
-                    href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/updates`}
-                  >
-                    Back
-                  </Link>
-                )}
+                <Link
+                  className="btn btn-default bg-white mt-2"
+                  href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}`}
+                >
+                  Back
+                </Link>
                 <button
                   type="submit"
                   className="btn btn-primary ml-auto text-base"


### PR DESCRIPTION
Fixes #3304 

Fixed the link for back button on the Log update page.

![msedge_6ONOIGy8be](https://user-images.githubusercontent.com/3626859/184355483-f658f6a6-3476-4e2e-a3ca-45b52831f097.gif)

