### PR TITLE
reposition blood group dropdown

### DIFF
--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1444,6 +1444,27 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                       </AccordionSummary>
                       <AccordionDetails>
                         <div className="grid gap-4 xl:gap-x-20 xl:gap-y-6 grid-cols-1 md:grid-cols-2 w-full">
+                          <div data-testid="blood-group" id="blood_group-div">
+                            <InputLabel
+                              id="blood_group-label"
+                              htmlFor="blood_group"
+                              required
+                            >
+                              Blood Group
+                            </InputLabel>
+                            <SelectField
+                              labelId="blood_group"
+                              name="blood_group"
+                              variant="outlined"
+                              margin="dense"
+                              showEmpty={true}
+                              optionArray={true}
+                              value={state.form.blood_group}
+                              options={bloodGroups}
+                              onChange={handleChange}
+                              errors={state.errors.blood_group}
+                            />
+                          </div>
                           <div id="test_type-div">
                             <InputLabel
                               id="test_type-label"
@@ -1477,6 +1498,29 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                               value={state.form.srf_id}
                               onChange={handleChange}
                               errors={state.errors.srf_id}
+                            />
+                          </div>
+                          <div
+                            data-testid="disease-status"
+                            id="disease_status-div"
+                          >
+                            <InputLabel
+                              htmlFor="disease_status"
+                              id="disease_status-label"
+                              required
+                            >
+                              COVID Disease Status
+                            </InputLabel>
+                            <SelectField
+                              labelId="disease_status"
+                              name="disease_status"
+                              variant="outlined"
+                              margin="dense"
+                              optionArray={true}
+                              value={state.form.disease_status}
+                              options={diseaseStatus}
+                              onChange={handleChange}
+                              errors={state.errors.disease_status}
                             />
                           </div>
                           <div id="is_declared_positive-div">
@@ -1787,29 +1831,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                               </div>
                             </div>
                           </Collapse>
-                          <div
-                            data-testid="disease-status"
-                            id="disease_status-div"
-                          >
-                            <InputLabel
-                              htmlFor="disease_status"
-                              id="disease_status-label"
-                              required
-                            >
-                              COVID Disease Status
-                            </InputLabel>
-                            <SelectField
-                              labelId="disease_status"
-                              name="disease_status"
-                              variant="outlined"
-                              margin="dense"
-                              optionArray={true}
-                              value={state.form.disease_status}
-                              options={diseaseStatus}
-                              onChange={handleChange}
-                              errors={state.errors.disease_status}
-                            />
-                          </div>
+
                           <div id="date_of_test-div">
                             <InputLabel
                               id="date_of_birth-label"
@@ -2008,28 +2030,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             value={state.form.allergies}
                             onChange={handleChange}
                             errors={state.errors.allergies}
-                          />
-                        </div>
-
-                        <div data-testid="blood-group" id="blood_group-div">
-                          <InputLabel
-                            id="blood_group-label"
-                            htmlFor="blood_group"
-                            required
-                          >
-                            Blood Group
-                          </InputLabel>
-                          <SelectField
-                            labelId="blood_group"
-                            name="blood_group"
-                            variant="outlined"
-                            margin="dense"
-                            showEmpty={true}
-                            optionArray={true}
-                            value={state.form.blood_group}
-                            options={bloodGroups}
-                            onChange={handleChange}
-                            errors={state.errors.blood_group}
                           />
                         </div>
                       </div>


### PR DESCRIPTION
## Proposed Changes

- The blood group field with dropdown is moved from "Medical History" section to the "health details" section

<img width="895" alt="image" src="https://user-images.githubusercontent.com/57039447/184535613-8c1e458d-3f5a-49ba-987a-d733e486c0e4.png">

related : #3335 

@coronasafe/reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
