### PR TITLE
Fix filter for patient list download buttons

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -196,16 +196,13 @@ export const PatientManager = (props: any) => {
 
   let managePatients: any = null;
   const handleDownload = async (isFiltered: boolean) => {
-    const res = await dispatch(
-      getAllPatient(
-        {
-          ...params,
-          csv: true,
-          facility: facilityId,
-        },
-        "downloadPatients"
-      )
-    );
+    const filters = {
+      ...params,
+      csv: true,
+      facility: facilityId,
+    };
+    if (!isFiltered) delete filters.is_active;
+    const res = await dispatch(getAllPatient(filters, "downloadPatients"));
     if (res && res.data && res.status === 200) {
       setDownloadFile(res.data);
       document.getElementById("downloadlink")?.click();


### PR DESCRIPTION
Fixes #3416

This PR fixes the filters applied to download buttons for patient list.

# Before
Download Live List: 23 Patients
Download Discharged List: 1 Patient
Download All: 23 if Live tab is selected, 1 if discharged tab is selected

# After fix
Download Live List: 23 Patients
Download Discharged List: 1 Patient
Download All: 24 Patients

