### PR TITLE
Revamped buttons in Add corona triage form in mobile view

### DIFF
--- a/src/Components/Facility/ConsultationCard.tsx
+++ b/src/Components/Facility/ConsultationCard.tsx
@@ -100,7 +100,7 @@ export const ConsultationCard = (props: ConsultationProps) => {
 
           <div className="mt-4 flex flex-col gap-2 md:flex-row justify-between w-full">
             <button
-              className="w-full md:w-auto px-4 py-2 shadow border bg-white rounded-md border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
+              className="w-full md:w-auto px-4 py-2 shadow border bg-white rounded-md border-grey-500 text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
               onClick={() =>
                 navigate(
                   `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}`
@@ -110,7 +110,7 @@ export const ConsultationCard = (props: ConsultationProps) => {
               View Consultation / Consultation Updates
             </button>
             <button
-              className="w-full md:w-auto px-4 py-2 shadow bg-white rounded-md border border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
+              className="w-full md:w-auto px-4 py-2 shadow bg-white rounded-md border border-grey-500 text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
               onClick={() =>
                 navigate(
                   `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}/files/`
@@ -121,7 +121,7 @@ export const ConsultationCard = (props: ConsultationProps) => {
             </button>
             {isLastConsultation && (
               <RoleButton
-                className="w-full md:w-auto mr-4 px-4 py-2 shadow border bg-white rounded-md border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
+                className="w-full md:w-auto mr-4 px-4 py-2 shadow border bg-white rounded-md border-grey-500 text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
                 handleClickCB={() =>
                   navigate(
                     `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}/daily-rounds`

--- a/src/Components/Facility/ConsultationCard.tsx
+++ b/src/Components/Facility/ConsultationCard.tsx
@@ -98,9 +98,9 @@ export const ConsultationCard = (props: ConsultationProps) => {
             </div>
           </div>
 
-          <div className="mt-4 flex flex-wrap justify-between w-full">
+          <div className="mt-4 flex flex-col gap-2 md:flex-row justify-between w-full">
             <button
-              className="px-4 py-2 shadow border bg-white rounded-md border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
+              className="w-full md:w-auto px-4 py-2 shadow border bg-white rounded-md border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
               onClick={() =>
                 navigate(
                   `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}`
@@ -110,7 +110,7 @@ export const ConsultationCard = (props: ConsultationProps) => {
               View Consultation / Consultation Updates
             </button>
             <button
-              className="px-4 py-2 shadow border bg-white rounded-md border border-grey-500 whitespace-nowrap text-sm font-semibold rounded cursor-pointer hover:bg-gray-300 text-center"
+              className="w-full md:w-auto px-4 py-2 shadow bg-white rounded-md border border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
               onClick={() =>
                 navigate(
                   `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}/files/`
@@ -121,7 +121,7 @@ export const ConsultationCard = (props: ConsultationProps) => {
             </button>
             {isLastConsultation && (
               <RoleButton
-                className="mr-4 px-4 py-2 shadow border bg-white rounded-md border border-grey-500 whitespace-nowrap text-sm font-semibold rounded cursor-pointer hover:bg-gray-300 text-center"
+                className="w-full md:w-auto mr-4 px-4 py-2 shadow border bg-white rounded-md border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
                 handleClickCB={() =>
                   navigate(
                     `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}/daily-rounds`

--- a/src/Components/Facility/TriageForm.tsx
+++ b/src/Components/Facility/TriageForm.tsx
@@ -306,10 +306,12 @@ export const TriageForm = (props: triageFormProps) => {
                   />
                 </div>
               </div>
-              <div className="flex justify-between mt-4">
+              <div className="flex flex-col md:flex-row gap-2 justify-between mt-4">
                 <Button
                   color="default"
                   variant="contained"
+                  fullWidth
+                  className="w-full md:w-auto"
                   type="button"
                   onClick={goBack}
                 >
@@ -319,6 +321,8 @@ export const TriageForm = (props: triageFormProps) => {
                   color="primary"
                   variant="contained"
                   type="submit"
+                  fullWidth
+                  className="w-full md:w-auto"
                   style={{ marginLeft: "auto" }}
                   startIcon={
                     <CheckCircleOutlineIcon>save</CheckCircleOutlineIcon>

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -343,7 +343,7 @@ export const PatientHome = (props: any) => {
             <div className="text-sm leading-5 font-medium text-gray-500">
               {item.disease}
             </div>
-            <div className="mt-1 text-sm leading-5 text-gray-900 whitespace-pre-wrap">
+            <div className="mt-1 text-sm leading-5 text-gray-900 overflow-x-scroll">
               {item.details}
             </div>
           </>
@@ -398,7 +398,7 @@ export const PatientHome = (props: any) => {
     ));
   }
 
-  const isPatientInactive = (patientData: PatientModel, facilityId : number) => {
+  const isPatientInactive = (patientData: PatientModel, facilityId: number) => {
     return (
       !patientData.is_active ||
       !(patientData?.last_consultation?.facility === facilityId)

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -147,7 +147,7 @@ export const PatientHome = (props: any) => {
   function Badge(props: { color: string; icon: string; text: string }) {
     return (
       <span
-        className="inline-flex items-center py-1 rounded-full text-xs font-medium leading-4 bg-gray-100 text-gray-700"
+        className="inline-flex m-2 items-center py-1 rounded-full text-xs font-medium leading-4 bg-gray-100 text-gray-700"
         title={props.text}
       >
         <i
@@ -1059,7 +1059,7 @@ export const PatientHome = (props: any) => {
               {!patientData.present_health &&
                 !patientData.allergies &&
                 !patientData.ongoing_medication &&
-                patientData.gender === 2 &&
+                // patientData.gender === 2 &&
                 !patientData.is_antenatal && (
                   <div className="text-gray-500 w-full font-bold flex justify-center items-center text-xl">
                     No Medical History Available

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1059,7 +1059,7 @@ export const PatientHome = (props: any) => {
               {!patientData.present_health &&
                 !patientData.allergies &&
                 !patientData.ongoing_medication &&
-                // patientData.gender === 2 &&
+                patientData.gender === 2 &&
                 !patientData.is_antenatal && (
                   <div className="text-gray-500 w-full font-bold flex justify-center items-center text-xl">
                     No Medical History Available

--- a/src/Components/Patient/SampleTestCard.tsx
+++ b/src/Components/Patient/SampleTestCard.tsx
@@ -155,16 +155,16 @@ export const SampleTestCard = (props: SampleDetailsProps) => {
             )}
           </div>
         </div>
-        <div className="mt-4 flex flex-wrap justify-between w-full">
+        <div className="mt-4 flex flex-col md:flex-row gap-2 justify-between w-full">
           <button
             onClick={(e) => navigate(`/sample/${itemData.id}`)}
-            className="px-4 py-2 shadow border bg-white rounded-md border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
+            className="px-4 py-2 shadow border bg-white rounded-md border-grey-500 text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
           >
             Sample Report
           </button>
           <button
             onClick={(e) => showUpdateStatus(itemData)}
-            className="px-4 py-2 shadow border bg-white rounded-md border-grey-500 whitespace-nowrap text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
+            className="px-4 py-2 shadow border bg-white rounded-md border-grey-500 text-sm font-semibold cursor-pointer hover:bg-gray-300 text-center"
           >
             UPDATE SAMPLE TEST STATUS
           </button>


### PR DESCRIPTION
Fixes #3421 
http://localhost:4000/facility/497fd4fc-c5c1-4ed3-9b57-64cc881087fe/triage

Placed the buttons in a column in the mobile view
![image](https://user-images.githubusercontent.com/70687348/185339485-242bd94e-6349-4d53-8da5-06cb286ed7ac.png)
