### PR TITLE
Fixes working status's dropdown causing page layout to jump

### DIFF
--- a/src/Components/Common/components/SelectMenu.tsx
+++ b/src/Components/Common/components/SelectMenu.tsx
@@ -60,7 +60,7 @@ export default function SelectMenu<T>(props: Props<T>) {
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
             >
-              <Listbox.Options className="origin-top-right absolute z-10 left-0 mt-2 w-72 rounded-md shadow-lg overflow-hidden bg-white divide-y divide-gray-200 ring-1 ring-black ring-opacity-5 focus:outline-none">
+              <Listbox.Options className="origin-top-right absolute z-10 left-0 mt-2 rounded-md shadow-lg overflow-hidden bg-white divide-y divide-gray-200 ring-1 ring-black ring-opacity-5 focus:outline-none">
                 {options.map((option) => (
                   <Listbox.Option
                     key={option.title}

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -11,16 +11,7 @@ import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import CancelOutlineIcon from "@material-ui/icons/CancelOutlined";
 import CropFreeIcon from "@material-ui/icons/CropFree";
 import PageTitle from "../Common/PageTitle";
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  FormControlLabel,
-  InputLabel,
-  Radio,
-  RadioGroup,
-} from "@material-ui/core";
+import { Button, Card, CardContent, InputLabel } from "@material-ui/core";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { validateEmailAddress } from "../../Common/validation";
 import {


### PR DESCRIPTION
Closes #3424 

Changes: 
- Tailwind component: SelectMenu's options width setting is removed, so width automatically adjusts based on selected item's text.

![image](https://user-images.githubusercontent.com/25143503/185621208-d899fe50-b80b-4f09-9c1b-842605541a1a.png)
