### PR TITLE
Fixed UI issues on Assets and External Results page

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -341,18 +341,28 @@ const AssetsList = () => {
                       </span>
                     </p>
                   </div>
-                  <div className="md:flex justify-between pt-2">
-                    <div className="md:flex flex-wrap">
+                  <div className=" px-4 md:flex justify-between pt-2">
+                    <div className="md:flex flex-wrap gap-4">
                       {asset.is_working ? (
-                        <Badge color="green" startIcon="cog" text="Working" />
+                        <div>
+                          <Badge color="green" startIcon="cog" text="Working" />
+                        </div>
                       ) : (
-                        <Badge color="red" startIcon="cog" text="Not Working" />
+                        <div>
+                          <Badge
+                            color="red"
+                            startIcon="cog"
+                            text="Not Working"
+                          />
+                        </div>
                       )}
-                      <Badge
-                        color="blue"
-                        startIcon="location-arrow"
-                        text={asset.status}
-                      />
+                      <div>
+                        <Badge
+                          color="blue"
+                          startIcon="location-arrow"
+                          text={asset.status}
+                        />
+                      </div>
                     </div>
                     <div className="px-2">
                       <div

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -498,8 +498,8 @@ export default function ResultList() {
             {manageResults}
           </tbody>
         </table>
-        <div className="bg-white divide-y divide-gray-200">{pagination}</div>
       </div>
+      <div className="bg-white divide-y divide-gray-200">{pagination}</div>
       <CSVLink
         data={downloadFile}
         filename={`external-result--${now}.csv`}


### PR DESCRIPTION
Fixes #3471 
- Centered Pagination on scroll for mobile view
http://localhost:4000/external_results
![image](https://user-images.githubusercontent.com/70687348/186602516-ec08983b-93c1-4695-96bd-fbf5f0f0308b.png)

- Improved badges styling on the Assets page
http://localhost:4000/assets
![image](https://user-images.githubusercontent.com/70687348/186602677-d404215f-5788-45af-9d86-dd0f879e16ea.png)
