### PR TITLE
Fix facility creation error handling

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -472,9 +472,10 @@ export const FacilityCreate = (props: FacilityProps) => {
           navigate(`/facility/${facilityId}`);
         }
       } else {
-        Notification.Error({
-          msg: "Something went wrong: " + (res.data.detail || ""),
-        });
+        if (res?.data)
+          Notification.Error({
+            msg: "Something went wrong: " + (res.data.detail || ""),
+          });
       }
       setIsLoading(false);
     }


### PR DESCRIPTION
Fixes #3390 

This PR adds a check for `res.data` existence before accessing it, this fixes the infinite loading crash when the said property was accessed even though it did not exist.

![image](https://user-images.githubusercontent.com/3626859/186931554-2eaef3d6-823a-4734-8f8e-ed6ea09ac109.png)
