### PR TITLE
Fix alignment of badges on Assets page

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -342,7 +342,7 @@ const AssetsList = () => {
                     </p>
                   </div>
                   <div className="md:flex justify-between pt-2">
-                    <div className="md:flex flex-wrap">
+                    <div className="md:flex flex-wrap px-4">
                       {asset.is_working ? (
                         <Badge color="green" startIcon="cog" text="Working" />
                       ) : (


### PR DESCRIPTION
Fixes #3488

![image](https://user-images.githubusercontent.com/3626859/187028916-fd1f05e4-99e2-41d2-9dbb-15a2411f1a85.png)
