### PR TITLE
Increase input width for Patient Investigation

### DIFF
--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -57,7 +57,7 @@ const TestRow = ({ data, value, onChange }: any) => {
           />
         ) : (
           <input
-            className="w-full px-4 h-12 text-right text-sm border-l border-r focus:ring-primary-500 focus:border-primary-500"
+            className="h-12 text-right text-sm border-l border-r focus:ring-primary-500 focus:border-primary-500"
             value={value}
             onChange={onChange}
             type={inputType}


### PR DESCRIPTION
Fixes #3535

Input fields are now big enough for the user to enter and review the data.

![msedge_txzHeA9XZA](https://user-images.githubusercontent.com/3626859/188372645-3d76e9b1-19f2-4dda-928d-8101866eadfe.gif)