### PR TITLE
Fix slider fill width on ABGA page.

### DIFF
--- a/src/Components/CriticalCareRecording/components/Slider.res
+++ b/src/Components/CriticalCareRecording/components/Slider.res
@@ -110,7 +110,7 @@ let make = (
         style={ReactDOM.Style.unsafeAddStyle(
           ReactDOM.Style.make(),
           {
-            "--min": start,
+            "--min": {value != "" ? start : "0"},
             "--max": end,
             "--fill-color": "#0e9f6e",
             "--primary-color": "#0e9f6e",


### PR DESCRIPTION
Fixes #2257 

This issue happened when the `--start` CSS property of the slider was initially negative. The browser instead rendered the slider pre-filled to that value instead.

This PR adds a hotfix for edge cases where the `--start` could be negative initially, in those cases it would be temporarily set to 0, then to it's intended value when user uses the slider.

![msedge_ObHSRCuECo](https://user-images.githubusercontent.com/3626859/188640987-82d87d31-d010-457d-b87a-ca24a1cf1ef7.gif)
