### PR TITLE
Fix crash when feature's id is missing from feature_types

### DIFF
--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -303,7 +303,9 @@ export const FacilityHome = (props: any) => {
             </div>
             <div className="flex items-center gap-3 mt-4">
               <div>
-                <h1 className="text-lg font-bold">Features</h1>
+                {facilityData.features?.some((feature) =>
+                  FACILITY_FEATURE_TYPES.some((f) => f.id === feature)
+                ) && <h1 className="text-lg font-bold">Features</h1>}
                 <div className="flex gap-2 flex-wrap mt-2">
                   {facilityData.features?.map(
                     (feature, i) =>

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -305,26 +305,29 @@ export const FacilityHome = (props: any) => {
               <div>
                 <h1 className="text-lg font-bold">Features</h1>
                 <div className="flex gap-2 flex-wrap mt-2">
-                  {facilityData.features?.map((feature, i) => (
-                    <div
-                      key={i}
-                      className="bg-primary-100 text-primary-600 font-semibold px-3 py-1 rounded-full border border-primary-600 text-sm"
-                    >
-                      <i
-                        className={`fas fa-${
-                          FACILITY_FEATURE_TYPES.filter(
-                            (f) => f.id === feature
-                          )[0].icon
-                        }`}
-                      />{" "}
-                      &nbsp;
-                      {
-                        FACILITY_FEATURE_TYPES.filter(
-                          (f) => f.id === feature
-                        )[0].name
-                      }
-                    </div>
-                  ))}
+                  {facilityData.features?.map(
+                    (feature, i) =>
+                      FACILITY_FEATURE_TYPES.some((f) => f.id === feature) && (
+                        <div
+                          key={i}
+                          className="bg-primary-100 text-primary-600 font-semibold px-3 py-1 rounded-full border border-primary-600 text-sm"
+                        >
+                          <i
+                            className={`fas fa-${
+                              FACILITY_FEATURE_TYPES.filter(
+                                (f) => f.id === feature
+                              )[0]?.icon
+                            }`}
+                          />{" "}
+                          &nbsp;
+                          {
+                            FACILITY_FEATURE_TYPES.filter(
+                              (f) => f.id === feature
+                            )[0]?.name
+                          }
+                        </div>
+                      )
+                  )}
                 </div>
               </div>
             </div>

--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -362,31 +362,36 @@ export const HospitalList = (props: any) => {
                       <div className="px-2.5 py-0.5 rounded-md text-sm font-medium leading-5 bg-blue-100 text-blue-800">
                         {facility.facility_type}
                       </div>
-                      {facility.features?.map((feature: number, i: number) => (
-                        <div
-                          key={i}
-                          className="bg-primary-100 text-primary-600 font-semibold px-2.5 py-0.5 rounded-md text-sm leading-5"
-                          title={
-                            FACILITY_FEATURE_TYPES.filter(
-                              (f) => f.id === feature
-                            )[0]?.name
-                          }
-                        >
-                          <i
-                            className={`fas fa-${
-                              FACILITY_FEATURE_TYPES.filter(
-                                (f) => f.id === feature
-                              )[0]?.icon
-                            }`}
-                          />{" "}
-                          &nbsp;
-                          {
-                            FACILITY_FEATURE_TYPES.filter(
-                              (f) => f.id === feature
-                            )[0]?.name
-                          }
-                        </div>
-                      ))}
+                      {facility.features?.map(
+                        (feature: number, i: number) =>
+                          FACILITY_FEATURE_TYPES.some(
+                            (f) => f.id === feature
+                          ) && (
+                            <div
+                              key={i}
+                              className="bg-primary-100 text-primary-600 font-semibold px-2.5 py-0.5 rounded-md text-sm leading-5"
+                              title={
+                                FACILITY_FEATURE_TYPES.filter(
+                                  (f) => f.id === feature
+                                )[0]?.name
+                              }
+                            >
+                              <i
+                                className={`fas fa-${
+                                  FACILITY_FEATURE_TYPES.filter(
+                                    (f) => f.id === feature
+                                  )[0]?.icon
+                                }`}
+                              />{" "}
+                              &nbsp;
+                              {
+                                FACILITY_FEATURE_TYPES.filter(
+                                  (f) => f.id === feature
+                                )[0]?.name
+                              }
+                            </div>
+                          )
+                      )}
                     </div>
 
                     <div className="mt-2 flex justify-between">

--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -369,21 +369,21 @@ export const HospitalList = (props: any) => {
                           title={
                             FACILITY_FEATURE_TYPES.filter(
                               (f) => f.id === feature
-                            )[0].name
+                            )[0]?.name
                           }
                         >
                           <i
                             className={`fas fa-${
                               FACILITY_FEATURE_TYPES.filter(
                                 (f) => f.id === feature
-                              )[0].icon
+                              )[0]?.icon
                             }`}
                           />{" "}
                           &nbsp;
                           {
                             FACILITY_FEATURE_TYPES.filter(
                               (f) => f.id === feature
-                            )[0].name
+                            )[0]?.name
                           }
                         </div>
                       ))}


### PR DESCRIPTION
Fix #3552

The search results page crashes when a facility has a feature whose id is not mapped in the `FACILITY_FEATURE_TYPES`. This PR adds a safe check for existence before accessing the feature's properties. 

![image](https://user-images.githubusercontent.com/3626859/188811437-877eee79-da77-448f-937a-9026b79945d6.png)
