### PR TITLE
Adds Patient Category in Daily Rounds and Consultation

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -271,19 +271,14 @@ export const PATIENT_FILTER_ADMITTED_TO = [
   { id: "2", text: "ICU" },
 ];
 
-export const PATIENT_CATEGORY = [
-  { id: "ASYMPTOMATIC", text: "ASYM (ASYMPTOMATIC) " },
-  { id: "Category-A", text: "Mild (Category A)" },
-  { id: "Category-B", text: "Moderate (Category B)" },
-  { id: "Category-C", text: "Severe (Category C)" },
+export const PATIENT_CATEGORIES = [
+  "Comfort Care",
+  "Stable",
+  "Slightly Abnormal",
+  "Critical",
 ];
 
-export const PATIENT_FILTER_CATEGORY = [
-  { id: "ASYM", text: "ASYM (ASYMPTOMATIC) " },
-  { id: "Mild", text: "Mild (Category A)" },
-  { id: "Moderate", text: "Moderate (Category B)" },
-  { id: "Severe", text: "Severe (Category C)" },
-];
+export const PATIENT_FILTER_CATEGORIES = PATIENT_CATEGORIES;
 
 export const CURRENT_HEALTH_CHANGE = [
   { id: 0, text: "NO DATA", desc: "" },

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -10,7 +10,6 @@ import loadable from "@loadable/component";
 import { ConsultationModel } from "./models";
 import { PatientModel } from "../Patient/models";
 import {
-  PATIENT_CATEGORY,
   SYMPTOM_CHOICES,
   CONSULTATION_TABS,
   OptionsType,
@@ -57,7 +56,6 @@ interface PreDischargeFormInterface {
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const symptomChoices = [...SYMPTOM_CHOICES];
-const patientCategoryChoices = [...PATIENT_CATEGORY];
 
 export const ConsultationDetails = (props: any) => {
   const { facilityId, patientId, consultationId } = props;
@@ -216,9 +214,6 @@ export const ConsultationDetails = (props: any) => {
           const data: ConsultationModel = {
             ...res.data,
             symptoms_text: "",
-            category:
-              patientCategoryChoices.find((i) => i.id === res.data.category)
-                ?.text || res.data.category,
           };
           if (res.data.symptoms && res.data.symptoms.length) {
             const symptoms = res.data.symptoms
@@ -1221,9 +1216,7 @@ export const ConsultationDetails = (props: any) => {
               facilityId={facilityId}
               patientId={patientId}
             />
-            <ViewInvestigationSuggestions
-              consultationId={consultationId}
-            />
+            <ViewInvestigationSuggestions consultationId={consultationId} />
           </div>
         )}
       </div>

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -21,7 +21,7 @@ import React, {
 import { useDispatch } from "react-redux";
 import {
   CONSULTATION_SUGGESTION,
-  PATIENT_CATEGORY,
+  PATIENT_CATEGORIES,
   SYMPTOM_CHOICES,
   TELEMEDICINE_ACTIONS,
   REVIEW_AT_CHOICES,
@@ -52,10 +52,16 @@ import { UserModel } from "../Users/models";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
 import { BedSelect } from "../Common/BedSelect";
 import Beds from "./Consultations/Beds";
-import PrescriptionBuilder, { PrescriptionType } from "../Common/prescription-builder/PrescriptionBuilder";
-import PRNPrescriptionBuilder, { PRNPrescriptionType } from "../Common/prescription-builder/PRNPrescriptionBuilder";
+import PrescriptionBuilder, {
+  PrescriptionType,
+} from "../Common/prescription-builder/PrescriptionBuilder";
+import PRNPrescriptionBuilder, {
+  PRNPrescriptionType,
+} from "../Common/prescription-builder/PRNPrescriptionBuilder";
 import { DiagnosisSelect } from "../Common/DiagnosisSelect";
-import InvestigationBuilder, { InvestigationType } from "../Common/prescription-builder/InvestigationBuilder";
+import InvestigationBuilder, {
+  InvestigationType,
+} from "../Common/prescription-builder/InvestigationBuilder";
 import { ICD11DiagnosisModel } from "./models";
 
 const Loading = loadable(() => import("../Common/Loading"));
@@ -89,7 +95,7 @@ type FormDetails = {
   consultation_notes: string;
   ip_no: string;
   discharge_advice: PrescriptionType[];
-  prn_prescription : PRNPrescriptionType[],
+  prn_prescription: PRNPrescriptionType[];
   investigation: InvestigationType[];
   is_telemedicine: BooleanStrings;
   action: string;
@@ -132,7 +138,7 @@ const initForm: FormDetails = {
   consultation_notes: "",
   ip_no: "",
   discharge_advice: [],
-  prn_prescription : [],
+  prn_prescription: [],
   investigation: [],
   is_telemedicine: "false",
   action: "PENDING",
@@ -182,15 +188,6 @@ const suggestionTypes = [
 
 const symptomChoices = [...SYMPTOM_CHOICES];
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const categoryChoices = [
-  {
-    id: 0,
-    text: "Select suspect category",
-  },
-  ...PATIENT_CATEGORY,
-];
-
 const goBack = () => {
   window.history.go(-1);
 };
@@ -209,7 +206,9 @@ export const ConsultationForm = (props: any) => {
     []
   );
   const [PRNAdvice, setPRNAdvice] = useState<PRNPrescriptionType[]>([]);
-  const [InvestigationAdvice, setInvestigationAdvice] = useState<InvestigationType[]>([]);
+  const [InvestigationAdvice, setInvestigationAdvice] = useState<
+    InvestigationType[]
+  >([]);
 
   const [selectedFacility, setSelectedFacility] =
     useState<FacilityModel | null>(null);
@@ -241,8 +240,14 @@ export const ConsultationForm = (props: any) => {
       setIsLoading(true);
       const res = await dispatchAction(getConsultation(id));
       setDischargeAdvice(res && res.data && res.data.discharge_advice);
-      setPRNAdvice(!Array.isArray(res.data.prn_prescription) ? [] : res.data.prn_prescription);
-      setInvestigationAdvice(!Array.isArray(res.data.investigation) ? [] : res.data.investigation);
+      setPRNAdvice(
+        !Array.isArray(res.data.prn_prescription)
+          ? []
+          : res.data.prn_prescription
+      );
+      setInvestigationAdvice(
+        !Array.isArray(res.data.investigation) ? [] : res.data.investigation
+      );
 
       if (!status.aborted) {
         if (res && res.data) {
@@ -300,6 +305,16 @@ export const ConsultationForm = (props: any) => {
         case "symptoms":
           if (!state.form[field] || !state.form[field].length) {
             errors[field] = "Please select the symptoms";
+            if (!error_div) error_div = field;
+            invalidForm = true;
+          }
+          return;
+        case "category":
+          if (
+            !state.form[field] ||
+            !PATIENT_CATEGORIES.includes(state.form[field])
+          ) {
+            errors[field] = "Please select a category";
             if (!error_div) error_div = field;
             invalidForm = true;
           }
@@ -421,12 +436,14 @@ export const ConsultationForm = (props: any) => {
           return;
         }
 
-        case "investigation":{
+        case "investigation": {
           let invalid = false;
-          for (let f of InvestigationAdvice) {
+          for (const f of InvestigationAdvice) {
             if (
               f.type?.length === 0 ||
-              (f.repetitive ? !f.frequency?.replace(/\s/g, "").length : !f.time?.replace(/\s/g, "").length)
+              (f.repetitive
+                ? !f.frequency?.replace(/\s/g, "").length
+                : !f.time?.replace(/\s/g, "").length)
             ) {
               invalid = true;
               break;
@@ -481,7 +498,7 @@ export const ConsultationForm = (props: any) => {
         icd11_diagnoses: state.form.icd11_diagnoses,
         verified_by: state.form.verified_by,
         discharge_advice: dischargeAdvice,
-        prn_prescription : PRNAdvice,
+        prn_prescription: PRNAdvice,
         investigation: InvestigationAdvice,
         patient: patientId,
         facility: facilityId,
@@ -746,17 +763,24 @@ export const ConsultationForm = (props: any) => {
                     errors={state.errors.prescribed_medication}
                   />
                 </div>
-                {/* <div className="flex-1" id="category-div">
-                  <InputLabel id="category-label">Category*</InputLabel>
+                <div className="flex-1" id="category-div">
+                  <InputLabel id="category-label" required>
+                    Category
+                  </InputLabel>
                   <SelectField
                     name="category"
                     variant="standard"
                     value={state.form.category}
-                    options={categoryChoices}
+                    options={PATIENT_CATEGORIES.map((c) => {
+                      return {
+                        id: c,
+                        text: c,
+                      };
+                    })}
                     onChange={handleChange}
                     errors={state.errors.category}
                   />
-                </div> */}
+                </div>
 
                 <div id="suggestion-div">
                   <InputLabel

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -8,12 +8,9 @@ import { getDailyReport } from "../../../Redux/actions";
 import loadable from "@loadable/component";
 import Pagination from "../../Common/Pagination";
 import { DailyRoundsModel } from "../../Patient/models";
-import { PATIENT_CATEGORY } from "../../../Common/constants";
 import { smallCard } from "../../Common/components/SkeletonLoading.gen";
 
 const PageTitle = loadable(() => import("../../Common/PageTitle"));
-
-const patientCategoryChoices = [...PATIENT_CATEGORY];
 
 export const DailyRoundsList = (props: any) => {
   const { facilityId, patientId, consultationId, consultationData } = props;
@@ -126,9 +123,7 @@ export const DailyRoundsList = (props: any) => {
                       <Typography>
                         <span className="text-gray-700">Category: </span>
                         <span className="badge badge-pill badge-warning">
-                          {patientCategoryChoices.find(
-                            (i) => i.id === itemData.patient_category
-                          )?.text || "-"}
+                          {itemData.patient_category || "-"}
                         </span>
                       </Typography>
                     </Grid>

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -71,12 +71,18 @@ export interface OptionsType {
   disabled?: boolean;
 }
 
+export type PatientCategory =
+  | "Comfort Care"
+  | "Stable"
+  | "Slightly Abnormal"
+  | "Critical";
+
 export interface ConsultationModel {
   admission_date?: string;
   admitted?: boolean;
   test_id?: string;
   admitted_to?: string;
-  category?: string;
+  category?: PatientCategory;
   created_date?: string;
   discharge_date?: string;
   examination_details?: string;

--- a/src/Components/Patient/DailyRoundListDetails.tsx
+++ b/src/Components/Patient/DailyRoundListDetails.tsx
@@ -4,11 +4,7 @@ import loadable from "@loadable/component";
 import moment from "moment";
 import React, { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
-import {
-  CURRENT_HEALTH_CHANGE,
-  PATIENT_CATEGORY,
-  SYMPTOM_CHOICES,
-} from "../../Common/constants";
+import { CURRENT_HEALTH_CHANGE, SYMPTOM_CHOICES } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getConsultationDailyRoundsDetails } from "../../Redux/actions";
 import { DailyRoundsModel } from "./models";
@@ -16,7 +12,6 @@ const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const symptomChoices = [...SYMPTOM_CHOICES];
 const currentHealthChoices = [...CURRENT_HEALTH_CHANGE];
-const patientCategoryChoices = [...PATIENT_CATEGORY];
 
 export const DailyRoundListDetails = (props: any) => {
   const { facilityId, patientId, consultationId, id } = props;
@@ -47,10 +42,6 @@ export const DailyRoundListDetails = (props: any) => {
               Object.keys(res.data.medication_given).length === 0
                 ? []
                 : res.data.medication_given,
-            patient_category:
-              patientCategoryChoices.find(
-                (i) => i.id === res.data.patient_category
-              )?.text || res.data.patient_category,
             current_health: currentHealth
               ? currentHealth.desc
               : res.data.current_health,

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   CardContent,
   InputLabel,
   RadioGroup,
@@ -7,7 +6,6 @@ import {
   FormControlLabel,
   Radio,
 } from "@material-ui/core";
-import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import { navigate } from "raviger";
 import moment from "moment";
 import loadable from "@loadable/component";
@@ -18,6 +16,7 @@ import {
   TELEMEDICINE_ACTIONS,
   REVIEW_AT_CHOICES,
   RHYTHM_CHOICES,
+  PATIENT_CATEGORIES,
 } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
@@ -48,7 +47,7 @@ const initForm: any = {
   other_symptoms: "",
   physical_examination_info: "",
   other_details: "",
-  category: "",
+  patient_category: "",
   current_health: 0,
   recommend_discharge: false,
   actions: null,
@@ -241,6 +240,7 @@ export const DailyRounds = (props: any) => {
       const baseData = {
         clone_last: state.form.clone_last === "true" ? true : false,
         rounds_type: state.form.rounds_type,
+        patient_category: state.form.patient_category,
         taken_at: state.form.taken_at
           ? state.form.taken_at
           : new Date().toISOString(),
@@ -262,7 +262,6 @@ export const DailyRounds = (props: any) => {
           physical_examination_info: state.form.physical_examination_info,
           other_details: state.form.other_details,
           consultation: consultationId,
-          patient_category: state.form.category,
           recommend_discharge: JSON.parse(state.form.recommend_discharge),
           action: state.form.action,
           review_time: state.form.review_time,
@@ -491,7 +490,7 @@ export const DailyRounds = (props: any) => {
           <form onSubmit={(e) => handleSubmit(e)}>
             <CardContent>
               <div className="flex flex-col md:flex-row gap-4">
-                <div className="w-full md:w-1/2">
+                <div className="w-full md:w-1/3">
                   <DateTimeFiled
                     label="Measured At"
                     margin="dense"
@@ -503,7 +502,7 @@ export const DailyRounds = (props: any) => {
                     errors={state.errors.taken_at}
                   />
                 </div>
-                <div className="w-full md:w-1/2">
+                <div className="w-full md:w-1/3">
                   <InputLabel id="rounds_type">Round Type</InputLabel>
                   <SelectField
                     className=""
@@ -524,6 +523,21 @@ export const DailyRounds = (props: any) => {
                     value={state.form.rounds_type}
                     onChange={handleChange}
                     errors={state.errors.rounds_type}
+                  />
+                </div>
+                <div className="w-full md:w-1/3">
+                  <InputLabel id="category-label" required>
+                    Category
+                  </InputLabel>
+                  <SelectField
+                    name="patient_category"
+                    variant="standard"
+                    value={state.form.patient_category}
+                    options={PATIENT_CATEGORIES.map((c) => {
+                      return { id: c, text: c };
+                    })}
+                    onChange={handleChange}
+                    errors={state.errors.patient_category}
                   />
                 </div>
               </div>
@@ -629,6 +643,7 @@ export const DailyRounds = (props: any) => {
                         />
                       </div>
                     )}
+
                     <div className="flex-1">
                       <InputLabel id="action-label">Action </InputLabel>
                       <NativeSelectField

--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -11,7 +11,7 @@ import {
   GENDER_TYPES,
   FACILITY_TYPES,
   DISEASE_STATUS,
-  PATIENT_FILTER_CATEGORY,
+  PATIENT_FILTER_CATEGORIES,
   PATIENT_FILTER_ADMITTED_TO,
   KASP_STRING,
   KASP_ENABLED,
@@ -584,7 +584,12 @@ export default function PatientFilterV2(props: any) {
             variant="outlined"
             margin="dense"
             value={filterState.category}
-            options={[{ id: "", text: "Show All" }, ...PATIENT_FILTER_CATEGORY]}
+            options={[
+              { id: "", text: "Show All" },
+              ...PATIENT_FILTER_CATEGORIES.map((o) => {
+                return { id: o, text: o };
+              }),
+            ]}
             onChange={handleChange}
             className="bg-white h-10 shadow-sm md:text-sm md:leading-5 md:h-9"
           />

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -1,4 +1,4 @@
-import { ConsultationModel } from "../Facility/models";
+import { ConsultationModel, PatientCategory } from "../Facility/models";
 
 export interface FlowModel {
   id?: number;
@@ -258,7 +258,7 @@ export interface DailyRoundsModel {
   id?: any;
   other_symptoms?: string;
   admitted_to?: string;
-  patient_category?: string;
+  patient_category?: PatientCategory;
   recommend_discharge?: boolean;
   created_date?: string;
   modified_date?: string;


### PR DESCRIPTION
Functional changes as per #2210 
Colors and styling updates will be made once #3458 is merged.

## Proposed Changes

- Adds mandatory patient category field in Patient Consultation form.
![image](https://user-images.githubusercontent.com/25143503/189366217-a9f2053a-3fd7-45a2-b458-dda4edbbda23.png)


- Adds mandatory patient category field in Daily Rounds form.
![image](https://user-images.githubusercontent.com/25143503/189366088-ca053eb9-8406-400f-b5fa-d96c3e26cfb3.png)



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
