### PR TITLE
Fixed camera feed issue in the Patient Dashboard for new assets

### DIFF
--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -53,7 +53,7 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
       setIpAddress_error("");
       const data = {
         meta: {
-          asset_type: assetType,
+          asset_type: "CAMERA",
           middleware_hostname: middlewareHostname,
           local_ip_address: cameraAddress,
           camera_access_key: cameraAccessKey,


### PR DESCRIPTION
Initially, In ONVIF camera the `meta.asset_type` was set to `"ONVIF"` which had to be `"CAMERA"`

Fixes #3566 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


@nihal467 while testing this create a new asset and test it, this won't work for assets created in this week