### PR TITLE
Update files list after upload

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -514,13 +514,13 @@ export const FileUpload = (props: FileUploadProps) => {
       associating_id: getAssociatedId(),
       file_category: category,
     };
-    dispatch(createUpload(requestData))
+    await dispatch(createUpload(requestData))
       .then(uploadfile)
       .catch(() => {
         setUploadStarted(false);
-      })
-      .then(fetchData(status).then(() => {}));
+      });
 
+    fetchData(status);
     // setting the value of file name to empty
     setUploadFileNameError("");
     setUploadFileName("");


### PR DESCRIPTION
Partially Fixes #3579

This PR changes when the file list is refreshed and makes it happen only after the upload is fully processed. This makes sure that the new file list contains information about the last upload action regardless of the success.