### PR TITLE
fix (LiveFeed): gets preset only when hostname is available

### DIFF
--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -151,17 +151,21 @@ const LiveFeed = (props: any) => {
       onSuccess: () => setLoading(undefined),
     });
   };
+
   useEffect(() => {
-    getPresets({
-      onSuccess: (resp) => setPresets(resp.data),
-      onError: (resp) => {
-        resp instanceof AxiosError &&
-          Notification.Error({
-            msg: "Fetching presets failed",
-          });
-      },
-    });
+    if (cameraAsset?.hostname) {
+      getPresets({
+        onSuccess: (resp) => setPresets(resp.data),
+        onError: (resp) => {
+          resp instanceof AxiosError &&
+            Notification.Error({
+              msg: "Fetching presets failed",
+            });
+        },
+      });
+    }
   }, []);
+
   useEffect(() => {
     setNewPreset(toUpdate?.meta?.preset_name);
     setBed(toUpdate?.bed_object);


### PR DESCRIPTION
Fixes #3597 

## Proposed Changes

- In useeffect getPreset is called only when hostname is available 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

@nihal467 
