### PR TITLE
Set file as uploaded on a successful upload

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -11,6 +11,7 @@ import {
   retrieveUpload,
   createUpload,
   getPatient,
+  editUpload,
 } from "../../Redux/actions";
 import { FileUploadModel } from "./models";
 import { TextInputField } from "../Common/HelperInputFields";
@@ -270,7 +271,11 @@ export const FileUpload = (props: FileUploadProps) => {
       if (!status.aborted) {
         if (res && res.data) {
           audio_urls(res.data.results);
-          setuploadedFiles(res.data.results);
+          setuploadedFiles(
+            res.data.results.filter(
+              (file: FileUploadModel) => file.upload_completed
+            )
+          );
           setTotalCount(res.data.count);
         }
         setIsLoading(false);
@@ -479,7 +484,7 @@ export const FileUpload = (props: FileUploadProps) => {
             msg: "File Uploaded Successfully",
           });
           setUploadFileNameError("");
-          resolve();
+          resolve(response);
         })
         .catch((e) => {
           Notification.Error({
@@ -504,6 +509,16 @@ export const FileUpload = (props: FileUploadProps) => {
     }
     return true;
   };
+  const markUploadComplete = async (response: any) => {
+    return dispatch(
+      editUpload(
+        { upload_completed: true },
+        response.data.id,
+        type,
+        getAssociatedId()
+      )
+    );
+  };
 
   const handleUpload = async (status: any) => {
     if (!validateFileUpload()) return;
@@ -523,6 +538,7 @@ export const FileUpload = (props: FileUploadProps) => {
     };
     dispatch(createUpload(requestData))
       .then(uploadfile)
+      .then(markUploadComplete)
       .catch(() => {
         setUploadStarted(false);
       })

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -289,6 +289,7 @@ export interface FileUploadModel {
   id?: string;
   name?: string;
   created_date?: string;
+  upload_completed?: boolean;
   uploaded_by?: { username?: string };
   file_category?: string;
 }

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -660,6 +660,19 @@ export const retrieveUploadFilesURL = (params: object, fileId: string) => {
   return fireRequestForFiles("retrieveUpload", [], params, { fileId: fileId });
 };
 
+export const editUpload = (
+  params: object,
+  fileId: string,
+  fileType: string,
+  associatingId: string
+) => {
+  return fireRequest("editUpload", [], params, {
+    fileId,
+    fileType,
+    associatingId,
+  });
+};
+
 // Investigation
 
 export const listInvestigations = (
@@ -721,7 +734,7 @@ export const editInvestigation = (
 // ICD11
 export const listICD11Diagnosis = (params: object, key: string) => {
   return fireRequest("listICD11Diagnosis", [], params, null, key);
-}
+};
 
 // Resource
 export const createResource = (params: object) => {

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -629,6 +629,10 @@ const routes: Routes = {
     path: "/api/v1/files/{fileId}/",
     method: "GET",
   },
+  editUpload: {
+    path: "/api/v1/files/{fileId}/?file_type={fileType}&associating_id={associatingId}",
+    method: "PATCH",
+  },
 
   // Investigation
   listInvestigations: {


### PR DESCRIPTION
Closes: 

Related PR: https://github.com/coronasafe/care/pull/1029

## Proposed Changes

- On file upload, an additional PATCH is sent to mark the file upload as complete
- Only completed file_uploads are shown to the user

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

Before: [All files are shown even if the upload failed for any reason]
![image](https://user-images.githubusercontent.com/3626859/191008712-f4fbd95f-c825-4b01-bafa-6754eb233a1b.png)

> Previewing any such incomplete upload will fail, since the file was never uploaded.
![image](https://user-images.githubusercontent.com/3626859/191008709-1ceac859-53f2-4799-9a16-338d4a924da5.png)


After: [Only files marked with `upload_completed = True` are shown]
![image](https://user-images.githubusercontent.com/3626859/191008481-bb9ad6d9-a880-49db-a6b5-c1213c99ca68.png)