### PR TITLE
Fixed User Management Pagination

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import loadable from "@loadable/component";
 import { useDispatch, useSelector } from "react-redux";
 import moment from "moment";
@@ -33,7 +33,23 @@ import UnlinkFacilityDialog from "./UnlinkFacilityDialog";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
+const getScreenSize = () => {
+  const { innerWidth, innerHeight } = window;
+  return { innerWidth, innerHeight };
+};
+
 export default function ManageUsers() {
+  const [screenSize, setScreenSize] = useState(getScreenSize());
+  useEffect(() => {
+    const handleWindowResize = () => {
+      setScreenSize(getScreenSize());
+    };
+    window.addEventListener("resize", handleWindowResize);
+    return () => {
+      window.removeEventListener("resize", handleWindowResize);
+    };
+  }, []);
+
   const [qParams, setQueryParams] = useQueryParams();
   const dispatch: any = useDispatch();
   const initialData: any[] = [];
@@ -73,7 +89,10 @@ export default function ManageUsers() {
     facility?: FacilityModel;
   }>({ show: false, userName: "", facility: undefined });
 
-  const limit = RESULTS_PER_PAGE_LIMIT;
+  const limit =
+    screenSize.innerWidth >= 1280
+      ? RESULTS_PER_PAGE_LIMIT + 1
+      : RESULTS_PER_PAGE_LIMIT;
 
   const applyFilter = (data: any) => {
     const filter = { ...qParams, ...data };


### PR DESCRIPTION
Fixes #3596 
## Proposed Changes

- Now the User Management page will display all the users cards that can fit in a page

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/40627011/191015340-dd71d058-fdd6-40ef-8184-af8b47fe054e.png)

### After:
![image](https://user-images.githubusercontent.com/40627011/191015461-fce8d59d-6d7d-4cd3-98d3-27e0aab04f93.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
