### PR TITLE
Add null check for last login

### DIFF
--- a/src/Components/TeleIcu/DoctorVideoSlideover.tsx
+++ b/src/Components/TeleIcu/DoctorVideoSlideover.tsx
@@ -134,7 +134,9 @@ function UserListItem(props: { user: UserModel }) {
             </p>
             <p className="text-sm text-gray-500 flex gap-2 divide-gray-800">
               <span>{user.alt_phone_number}</span>
-              <span>{moment(user.last_login).fromNow()}</span>
+              {user.last_login && (
+                <span>{moment(user.last_login).fromNow()}</span>
+              )}
             </p>
           </div>
         </a>


### PR DESCRIPTION
Fixes #3616

## Proposed Changes

- Last login is now only shown when `user.last_login` is not null.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

Before:
![image](https://user-images.githubusercontent.com/3626859/191194892-d35ba525-a5b9-4697-b984-3f20529d6403.png)

Now:
![image](https://user-images.githubusercontent.com/3626859/191194950-a3d2cd3d-0ab9-4cc5-9835-b42112000c60.png)

