### PR TITLE
Improve re-fetching updated data

### DIFF
--- a/src/Components/Facility/Consultations/Beds.tsx
+++ b/src/Components/Facility/Consultations/Beds.tsx
@@ -88,7 +88,7 @@ const Beds = (props: BedsProps) => {
       Notification.Success({
         msg: "Bed allocated successfully",
       });
-      window.location.reload();
+      fetchData({ aborted: false });
     }
   };
 

--- a/src/Components/Facility/FacilityUsers.tsx
+++ b/src/Components/Facility/FacilityUsers.tsx
@@ -185,7 +185,7 @@ export default function FacilityUsers(props: any) {
     }
 
     setUserData({ show: false, username: "", name: "" });
-    window.location.reload();
+    fetchData({ aborted: false });
   };
 
   const handleDelete = (user: any) => {

--- a/src/Components/Facility/InventoryLog.tsx
+++ b/src/Components/Facility/InventoryLog.tsx
@@ -75,7 +75,7 @@ export default function InventoryLog(props: any) {
       Notification.Success({
         msg: "Updated Successfully",
       });
-      window.location.reload();
+      fetchData({ aborted: false });
     }
     setSaving(false);
   };
@@ -93,7 +93,7 @@ export default function InventoryLog(props: any) {
       Notification.Success({
         msg: "Last entry deleted Successfully",
       });
-      window.location.reload();
+      fetchData({ aborted: false });
     } else {
       Notification.Error({
         msg: "Error while deleting last entry: " + (res?.data?.detail || ""),

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -260,7 +260,7 @@ export default function ManageUsers() {
     }
 
     setUserData({ show: false, username: "", name: "" });
-    window.location.reload();
+    fetchData({ aborted: false });
   };
 
   const handleUnlinkFacilitySubmit = async () => {


### PR DESCRIPTION
Fixes #3614

## Proposed Changes

- This PR improves how data is re-fetched. Instead of using window reload, (which reloads the entire page) we now use proper fetchData functions to refresh and present the new data to the user without reloading the entire page.

Places where this has changed: (Notice how the notifications stay on the page instead of immediately getting lost on a page reload)
1. Allocating a bed
![image](https://user-images.githubusercontent.com/3626859/192108243-826e1763-5c52-4979-be86-eb64900ab1ed.png)

2. Deleting users
![image](https://user-images.githubusercontent.com/3626859/192108298-fe2d0c04-6305-4042-a699-52308316ec0c.png)

3. Inventory Log
![image](https://user-images.githubusercontent.com/3626859/192108371-6221cd0b-7cf0-47de-8d0d-df4131412ad2.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers