### PR TITLE
Add bots for notifying on merge conflicts and mark inactive issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,18 +1,21 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
-  - leapcode
+  - good to merge
+  - waiting for back end
+  - waiting for related PR
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: waiting for update
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions. Feel free to repopen the issue.
+  This issue has been automatically marked as stale because it has not had recent activity.
+  It will be closed if no further activity occurs. Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: true
+closeComment: >
+  This issue has been automatically closed because it has not had recent activity.
+  Thank you for your contributions. Feel free to repopen the issue.

--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -1,0 +1,21 @@
+name: Auto Label Conflicts
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: prince-chrismc/label-merge-conflicts-action@v2
+        with:
+          conflict_label_name: "merge conflict"
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          max_retries: 5
+          wait_ms: 15000
+          detect_merge_changes: false
+          conflict_comment: |
+            :wave: Hi, @${author},
+            Conflicts have been detected against the base branch. Please rebase your branch against the base branch.


### PR DESCRIPTION
Closes #3629

## Proposed Changes

- Added https://github.com/marketplace/actions/label-merge-conflicts to automatically label merge conflicts and notify the author about it.
- Tweaked and fixed the configuration for https://github.com/marketplace/stale to mark inactive issues as stale and request updates on them.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers