### PR TITLE
Made the live feed responsive in samsung fold device

### DIFF
--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -24,6 +24,8 @@ import {
   InputLabel,
   Modal,
   Tooltip,
+  useMediaQuery,
+  useTheme,
 } from "@material-ui/core";
 import { FeedCameraPTZHelpButton } from "./Feed";
 import { AxiosError } from "axios";
@@ -55,7 +57,8 @@ const LiveFeed = (props: any) => {
   });
   const [toDelete, setToDelete] = useState<any>(null);
   const [toUpdate, setToUpdate] = useState<any>(null);
-
+  const theme = useTheme();
+  const isExtremeSmallScreen = useMediaQuery(theme.breakpoints.down(320));
   const liveFeedPlayerRef = useRef<any>(null);
 
   const videoEl = liveFeedPlayerRef.current as HTMLVideoElement;
@@ -424,7 +427,11 @@ const LiveFeed = (props: any) => {
                 )}
               </div>
             </div>
-            <div className="md:flex max-w-lg mt-4">
+            <div
+              className={`${
+                isExtremeSmallScreen ? " flex flex-wrap " : " md:flex "
+              } max-w-lg mt-4`}
+            >
               {cameraPTZ.map((option) => {
                 const shortcutKeyDescription =
                   option.shortcutKey &&
@@ -500,7 +507,11 @@ const LiveFeed = (props: any) => {
               </button>
             </nav>
             <div className="w-full space-y-4 my-2">
-              <div className="grid grid-cols-2 my-auto gap-2">
+              <div
+                className={`grid ${
+                  isExtremeSmallScreen ? " sm:grid-cols-2 " : " grid-cols-2 "
+                } my-auto gap-2`}
+              >
                 {showDefaultPresets ? (
                   <>
                     {viewOptions(presetsPage)?.map((option: any, i) => (


### PR DESCRIPTION
## Proposed Changes
Fixes #3589 
Made the live feed responsive in samsung fold device
![image](https://user-images.githubusercontent.com/59426397/192227747-cc29f132-e7ab-4227-8c4f-743f4a8eaf02.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
