### PR TITLE
Use GITHUB_TOKEN for merge conflict workflow

### DIFF
--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -1,4 +1,9 @@
 name: Auto Label Conflicts
+
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   push:
     branches: [develop]
@@ -12,7 +17,7 @@ jobs:
       - uses: prince-chrismc/label-merge-conflicts-action@v2
         with:
           conflict_label_name: "merge conflict"
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           max_retries: 5
           wait_ms: 15000
           detect_merge_changes: false


### PR DESCRIPTION
## Proposed Changes

- Instead of using the personal access token, it's better to use the `GITHUB_TOKEN` which is provided by default for all Github Action Workflows. The token is temporarily generated and destroyed after the workflow is over. 
- This should also make all the comments appear to be made by the "Github actions" bot, instead of @mathew-alex .
- More about it here: [https://docs.github.com/en/actions/security-guides/automatic-token-authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers