### PR TITLE
Resolved loader not working on External Results page

### DIFF
--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -78,8 +78,8 @@ export default function ResultList() {
         if (res && res.data) {
           setData(res.data.results);
           setTotalCount(res.data.count);
+          setIsLoading(false);
         }
-        setIsLoading(false);
       })
       .catch(() => {
         setIsLoading(false);


### PR DESCRIPTION
Fixes #3661 

Loader is visible to the user until the data has been fetched rather than "No data found"
https://www.loom.com/share/e93cda2420504e0eb47648867c65f3fb