### PR TITLE
Fixed: Bed assign malfunction in consultation form

### DIFF
--- a/src/Components/Common/BedSelect.tsx
+++ b/src/Components/Common/BedSelect.tsx
@@ -15,6 +15,7 @@ interface BedSelectProps {
   facility?: string;
   location?: string;
   showAll?: boolean;
+  disabled?: boolean;
   selected: BedModel | BedModel[] | null;
   setSelected: (selected: BedModel | BedModel[] | null) => void;
 }
@@ -31,6 +32,7 @@ export const BedSelect = (props: BedSelectProps) => {
     className = "",
     facility,
     location,
+    disabled = false,
   } = props;
   const dispatchAction: any = useDispatch();
   const [bedLoading, isBedLoading] = useState(false);
@@ -83,6 +85,7 @@ export const BedSelect = (props: BedSelectProps) => {
       value={selected}
       options={bedList}
       onSearch={handelSearch}
+      disabled={disabled}
       onChange={(e: any, selected: any) => handleValueChange(selected)}
       loading={bedLoading}
       placeholder="Search by beds name"

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -557,6 +557,7 @@ interface AutoCompleteAsyncFieldProps {
   filterOptions?: (options: any) => any;
   name?: string;
   freeSolo?: boolean;
+  disabled?: boolean;
 }
 
 export const AutoCompleteAsyncField = (props: AutoCompleteAsyncFieldProps) => {
@@ -583,6 +584,7 @@ export const AutoCompleteAsyncField = (props: AutoCompleteAsyncFieldProps) => {
     multiple = false,
     autoSelect = true,
     className = "",
+    disabled = false,
   } = props;
   return (
     <>
@@ -595,6 +597,7 @@ export const AutoCompleteAsyncField = (props: AutoCompleteAsyncFieldProps) => {
         onOpen={onOpen}
         onBlur={onBlur}
         options={options}
+        disabled={disabled}
         onChange={onChange}
         value={value}
         defaultValue={defaultValue}

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -275,9 +275,10 @@ export const ConsultationForm = (props: any) => {
             special_instruction: res.data.special_instruction || "",
             weight: res.data.weight ? res.data.weight : "",
             height: res.data.height ? res.data.height : "",
-            bed: res.data?.current_bed?.bed_object?.id || null,
+            bed: res.data?.current_bed?.bed_object || null,
           };
           dispatch({ type: "set_form", form: formData });
+          setBed(formData.bed);
         } else {
           goBack();
         }
@@ -856,6 +857,7 @@ export const ConsultationForm = (props: any) => {
                         errors=""
                         multiple={false}
                         margin="dense"
+                        disabled={true}
                         // location={state.form.}
                         facility={facilityId}
                       />

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -108,7 +108,7 @@ type FormDetails = {
   review_time: number;
   weight: string;
   height: string;
-  bed: string | null;
+  bed: BedModel | null;
 };
 
 type Action =


### PR DESCRIPTION
# Updates

- [x] Fixes #3274
- [x] Updated bed to store `BedModel` instead of storing `bed's id`
- [x] Used state function to set initial bed
