### PR TITLE
ops: updated stale bot configurations

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 7
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
@@ -10,12 +10,20 @@ exemptLabels:
   - waiting for back end
   - waiting for related PR
 # Label to use when marking an issue as stale
-staleLabel: waiting for update
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had recent activity.
-  It will be closed if no further activity occurs. Thank you for your contributions.
+  Hi, @${author},
+  This pr/issue has been automatically marked as stale because it has not had recent activity.
+  It will be closed if no further activity occurs for 7 more days. Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  This issue has been automatically closed because it has not had recent activity.
-  Thank you for your contributions. Feel free to repopen the issue.
+  Hi, @${author}, @gigincg, @nihal467, @khavinshankar, @mathew-alex 
+  This pr/issue has been automatically closed because it has not had recent activity.
+  Thank you for your contributions. Feel free to repopen the pr/issue.
+# Issue specific properties
+issue:
+  # Inactivity time for issue to be considered stale
+  daysUntilStale: 14
+  # No auto closing the issues
+  daysUntilClose: false


### PR DESCRIPTION
## Proposed Changes

- Changed label to `stale`
- Changed inactivity time for pr as 7 days and issue as 14 days
- Issues are not auto-closed by the stale bot
- Added mentions

@nihal467 @gigincg can you guys give it check
@mathew-alex Can you please check this and merge it

