### PR TITLE
Added a global hook to give screen width and height at any component

### DIFF
--- a/src/Common/hooks/useWindowDimensions.ts
+++ b/src/Common/hooks/useWindowDimensions.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowDimensions;
+}
+
+//usage of this hook
+
+/* const Component = () => {
+    const { height, width } = useWindowDimensions();
+  
+    return (
+      <div>
+        width: {width} ~ height: {height}
+      </div>
+    );
+  }
+*/


### PR DESCRIPTION
## Proposed Changes

Fixes #3692 
Added a global hook to give screen width and height at any component.


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
