### PR TITLE
Improved UI on assets page

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -167,13 +167,14 @@ const AssetManage = (props: AssetManageProps) => {
       />
       <div className="bg-white rounded-lg md:rounded-xl md:p-8 p-6">
         <div className="mb-4 flex flex-col gap-1">
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 justify-between w-full">
             <span className="text-2xl md:text-3xl font-semibold break-words">
               {asset?.name}
             </span>
-            <div className="flex-1" />
-            {status(asset?.status)}
-            {workingStatus(asset?.is_working)}
+            <div className=" flex flex-wrap gap-2">
+              {status(asset?.status)}
+              {workingStatus(asset?.is_working)}
+            </div>
           </div>
           <span className="text-gray-700">{asset?.description}</span>
         </div>

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -352,7 +352,7 @@ const AssetsList = () => {
                               ""
                             )}
                           </span>
-                          {asset.name}
+                          <p className="truncate w-1/2">{asset.name}</p>
                         </p>
                       </div>
                       <p className="font-normal text-sm">


### PR DESCRIPTION
Fixes #3703 
- Added truncate on long assets name
http://localhost:4000/assets
![image](https://user-images.githubusercontent.com/70687348/193755542-bfd756d1-c513-450a-9331-3e8424920593.png)

- Improved placing of badges on the assets page
http://localhost:4000/assets/cd151e76-6d4e-4876-9bc2-57d7d221cbd3
![image](https://user-images.githubusercontent.com/70687348/193754288-05008118-ea13-4785-b30f-a3e56534f22e.png)
