### PR TITLE
Fix: audit log alignment on shifting details page

### DIFF
--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -826,8 +826,8 @@ export default function ShiftDetails(props: { id: string }) {
             <div className="col-span-2">
               <h4 className="mt-8">Audit Log</h4>
 
-              <div className="p-2 bg-white rounded-lg shadow text-center px-4 mt-2 flex flex-col md:flex-row gap-4 justify-center">
-                <div className="border-r-2">
+              <div className="p-2 bg-white rounded-lg shadow text-center px-4 mt-2 grid lg:grid-cols-2">
+                <div className="lg:border-r-2 border-b-2 lg:border-b-0 pb-2 lg:pb-0">
                   <div className="text-sm leading-5 font-medium text-gray-500">
                     Created
                   </div>
@@ -842,7 +842,7 @@ export default function ShiftDetails(props: { id: string }) {
                     </div>
                   </div>
                 </div>
-                <div className="">
+                <div className="mt-2 lg:mt-0">
                   <div className="text-sm leading-5 font-medium text-gray-500">
                     Last Edited
                   </div>


### PR DESCRIPTION
fixes #3705 
## Proposed Changes

- Made the aligment of the created date in the audit log section of the shifting details page

## Screenshot
![image](https://user-images.githubusercontent.com/40627011/193786067-0b68091a-7d6d-4f80-81ed-09d7753efb4d.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
