### PR TITLE
Cypress: Satisfy new `.env` file requirement in local compose.

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: satackey/action-docker-layer-caching@v0.0.11
 
       - name: Compose Up Care
-        run: cd care && make build && make up && cd .. && sleep 30s
+        run: cd care && touch .env && make build && make up && cd .. && sleep 30s
         # Voluntarily kept 30 seconds delay to wait for migrations to complete.
 
       - run: docker exec care python manage.py collectstatic


### PR DESCRIPTION
Care BE, local compose required `.env` file due to recent change https://github.com/coronasafe/care/commit/0e74ff4db61636aed27129f38faaa32118ca414a

## Proposed Changes:
- `touch .env` file inside care before composing it up.