### PR TITLE
Prevented overlapping of content in user card in extreme small devices

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -29,26 +29,13 @@ import { make as SlideOver } from "../Common/SlideOver.gen";
 import UserDetails from "../Common/UserDetails";
 import clsx from "clsx";
 import UnlinkFacilityDialog from "./UnlinkFacilityDialog";
+import useWindowDimensions from "../../Common/hooks/useWindowDimensions";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
-const getScreenSize = () => {
-  const { innerWidth, innerHeight } = window;
-  return { innerWidth, innerHeight };
-};
-
 export default function ManageUsers() {
-  const [screenSize, setScreenSize] = useState(getScreenSize());
-  useEffect(() => {
-    const handleWindowResize = () => {
-      setScreenSize(getScreenSize());
-    };
-    window.addEventListener("resize", handleWindowResize);
-    return () => {
-      window.removeEventListener("resize", handleWindowResize);
-    };
-  }, []);
+  const { width } = useWindowDimensions();
 
   const [qParams, setQueryParams] = useQueryParams();
   const dispatch: any = useDispatch();
@@ -90,9 +77,10 @@ export default function ManageUsers() {
   }>({ show: false, userName: "", facility: undefined });
 
   const limit =
-    screenSize.innerWidth >= 1280
-      ? RESULTS_PER_PAGE_LIMIT + 1
-      : RESULTS_PER_PAGE_LIMIT;
+    width >= 1280 ? RESULTS_PER_PAGE_LIMIT + 1 : RESULTS_PER_PAGE_LIMIT;
+  const extremeSmallScreenBreakpoint: number = 320;
+  const isExtremeSmallScreen =
+    width <= extremeSmallScreenBreakpoint ? true : false;
 
   const applyFilter = (data: any) => {
     const filter = { ...qParams, ...data };
@@ -461,7 +449,13 @@ export default function ManageUsers() {
                   )}
                 </div>
 
-                <div className="flex flex-row md:grid md:grid-cols-4 gap-2 justify-between">
+                <div
+                  className={`flex ${
+                    isExtremeSmallScreen
+                      ? " flex-wrap "
+                      : " flex-row justify-between "
+                  } md:grid md:grid-cols-4 gap-2`}
+                >
                   {user.user_type && (
                     <div className="col-span-2">
                       <UserDetails title="Role">
@@ -486,7 +480,13 @@ export default function ManageUsers() {
                     </div>
                   </UserDetails>
                 )}
-                <div className="grid grid-cols-4">
+                <div
+                  className={`${
+                    isExtremeSmallScreen
+                      ? "flex flex-wrap "
+                      : "grid grid-cols-4 "
+                  }`}
+                >
                   {user.created_by && (
                     <div className="col-span-2">
                       <UserDetails title="Created by">


### PR DESCRIPTION
## Proposed Changes

Fixes #3715 

Prevented overlapping of content in user card in extreme small devices

![image](https://user-images.githubusercontent.com/59426397/194982664-d7ec6f7e-fd95-410f-8de2-f369dbee502c.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
