### PR TITLE
Keep loading spinner during a page redirect on login page

### DIFF
--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -99,11 +99,10 @@ export const Login = () => {
             window.location.pathname === "/" ||
             window.location.pathname === "/login"
           ) {
-            navigate("/facility");
+            window.location.href = "/facility";
           } else {
-            navigate(window.location.pathname.toString());
+            window.location.href = window.location.pathname.toString();
           }
-          window.location.reload();
         } else {
           // error from server set back to login button
           setLoading(false);


### PR DESCRIPTION
Resolves #3751 

## Proposed Changes

- Using the `navigate` function resets all the state variables to their default values, including the loading state. This causes the spinner to disappear while the redirected page is loading.
- Instead of setting the window location then calling `window.reload` to perform the redirect. It's better to do both in a single step by setting `window.location.href` property.

![login page loading](https://user-images.githubusercontent.com/3626859/195636540-14151031-ce8d-40a8-a198-409108a82c86.gif)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers