### PR TITLE
Added new UI to log additional details in PressureSore

### DIFF
--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -19,6 +19,8 @@ type scrollIntoView = {
 }
 
 type state = {
+  modalPosition: CriticalCare__PressureSoreInputModal.position,
+  selectedRegion: PressureSore.region,
   parts: array<PressureSore.part>,
   saving: bool,
   dirty: bool,
@@ -28,8 +30,12 @@ type state = {
 type action =
   | AutoManageScale(PressureSore.part)
   | AddPressureSore(PressureSore.region)
+  | AddSelectedPart(PressureSore.region)
+  | UpdateSelectedPart(PressureSore.part)
   | RemoveFromSelectedParts(PressureSore.part)
   | Update(array<PressureSore.part>)
+  | SetSelectedRegion(PressureSore.region)
+  | SetModalPosition(CriticalCare__PressureSoreInputModal.position)
   | SetPreviewMode
   | ClearPreviewMode
   | SetSaving
@@ -62,6 +68,35 @@ let reducer = (state, action) => {
       parts: Js.Array.concat(state.parts, [PressureSore.makeDefault(region)]),
       dirty: true,
     }
+  | AddSelectedPart(region) => {
+      ...state,
+      parts: Js.Array.concat(
+        Js.Array.filter(p => PressureSore.region(p) !== region, state.parts), 
+        [
+          Belt.Option.getWithDefault(
+            Js.Array.find(p => PressureSore.region(p) === region, state.parts), 
+            PressureSore.makeDefault(region)
+          )
+        ]
+      ),
+      dirty: true,
+    }
+  | UpdateSelectedPart(part) => {
+      ...state,
+      parts: Js.Array.concat(
+        Js.Array.filter((item: PressureSore.part) => item.region != part.region, state.parts), 
+        [part],
+      ),
+      dirty: true,
+    }
+  | SetSelectedRegion(region) => {
+      ...state,
+      selectedRegion: region,
+    }
+  | SetModalPosition(position) => {
+      ...state,
+      modalPosition: position,
+    }
   | SetSaving => {...state, saving: true}
   | ClearSaving => {...state, saving: false}
   | Update(parts) => {
@@ -77,6 +112,11 @@ let makeField = p => {
   let payload = Js.Dict.empty()
   Js.Dict.set(payload, "region", Js.Json.string(PressureSore.endcodeRegion(p)))
   Js.Dict.set(payload, "scale", Js.Json.number(float_of_int(PressureSore.scale(p))))
+  Js.Dict.set(payload, "width", Js.Json.number(p.width))
+  Js.Dict.set(payload, "length", Js.Json.number(p.length))
+  Js.Dict.set(payload, "tissue_type", Js.Json.string(PressureSore.tissueTypeToString(p.tissue_type)))
+  Js.Dict.set(payload, "exudate_amount", Js.Json.string(PressureSore.extrudateAmountToString(p.exudate_amount)))
+  Js.Dict.set(payload, "description", Js.Json.string(p.description))
   payload
 }
 
@@ -107,6 +147,8 @@ let saveData = (id, consultationId, state, send, updateCB) => {
 let initialState = (psp, previewMode) => {
   {
     parts: psp,
+    modalPosition: {"x": 0, "y": 0},
+    selectedRegion: PressureSore.Other,
     saving: false,
     dirty: false,
     previewMode: previewMode,
@@ -190,6 +232,7 @@ let getIntoView = (region: string, isPart: bool) => {
 }
 
 let renderBody = (state, send, title, partPaths, substr) => {
+  Js.log(state)
   <div className=" w-full text-center mx-2">
     <div className="text-2xl font-bold mt-8"> {str(title)} </div>
     <div className="text-left font-bold mx-auto mt-5">
@@ -241,6 +284,18 @@ let renderBody = (state, send, title, partPaths, substr) => {
     </div>
     // Diagram
     <div className="flex justify-center mx-auto border-2">
+      <CriticalCare__PressureSoreInputModal
+        show={state.selectedRegion !== PressureSore.Other}
+        hideModal={_ => send(SetSelectedRegion(PressureSore.Other))}
+        position={state.modalPosition}
+        part={
+          Belt.Option.getWithDefault(
+            Js.Array.find(p => PressureSore.region(p) === state.selectedRegion, state.parts), 
+            PressureSore.makeDefault(state.selectedRegion)
+          )
+        }
+        updatePart={part => send(UpdateSelectedPart(part))}
+      />
       <svg className="h-screen py-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 344.7 932.661">
         {Js.Array.mapi((part, renderIndex) => {
           let regionType = PressureSore.regionForPath(part)
@@ -254,11 +309,9 @@ let renderBody = (state, send, title, partPaths, substr) => {
             id={"part" ++ PressureSore.regionToString(regionType)}
             onClick={state.previewMode
               ? _ => getIntoView(PressureSore.regionToString(regionType), true)
-              : _ => {
-                  switch selectedPart {
-                  | Some(p) => send(AutoManageScale(p))
-                  | None => send(AddPressureSore(regionType))
-                  }
+              : e => {
+                  send(SetSelectedRegion(part.region))
+                  send(SetModalPosition({"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
                 }}>
             <title className=""> {str(PressureSore.regionToString(regionType))} </title>
           </path>
@@ -310,7 +363,7 @@ let make = (~pressureSoreParameter, ~updateCB, ~id, ~consultationId, ~previewMod
         : React.null}
     </div>
     <div className="flex md:flex-row flex-col justify-between">
-      {renderBody(state, send, "Front", PressureSore.anteriorParts, 8)}
+      {renderBody(state, send, "Front", PressureSore.anteriorParts, 8, )}
       {renderBody(state, send, "Back", PressureSore.posteriorParts, 9)}
     </div>
     {!previewMode

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -32,10 +32,11 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
     let tissueScore = tissueTypes->Belt.Array.getIndexBy(tissue => tissue == state.tissue_type->PressureSore.tissueTypeToString)->Belt.Option.getWithDefault(0)->float_of_int
 
     let score = areaScore +. exudateScore +. tissueScore
-    Js.log4(area, areaScore, exudateScore, tissueScore)
     setPushScore(_ => score)
     None
   }, [state])
+
+  Js.log(PressureSore.regionToString(part.region))
 
   let ref = React.useRef(Js.Nullable.null)
   let handleClickOutside = %raw(`
@@ -52,26 +53,29 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
     className="fixed w-full inset-0 z-40 overflow-y-auto"
   >
     <div
-      className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+      hidden={!show} 
+      className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
+    >
       <div
-          ref={ReactDOM.Ref.domRef(ref)}
-          style={ReactDOMStyle.make(
-            ~position={innerWidth >= 640 ? "absolute" : ""},
-            ~left= `${position["x"]->Belt.Int.toString}px`,
-            ~top=`${position["y"]->Belt.Int.toString}px`,
-            ()
-          )}
-          className="transform overflow-hidden w-4/5 rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
-        <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        ref={ReactDOM.Ref.domRef(ref)}
+        style={ReactDOMStyle.make(
+          ~position={innerWidth >= 640 ? "absolute" : ""},
+          ~left= `${position["x"]->Belt.Int.toString}px`,
+          ~top=`${position["y"]->Belt.Int.toString}px`,
+          ()
+        )}
+        className="transform w-4/5 rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit"
+      >
+        <div className="bg-white px-4 pt-2 pb-4 sm:p-6 sm:pb-4">
           <div className="sm:flex sm:items-start">
             <div className="mt-3 text-center sm:mt-0 sm:text-left">
-              <div className="flex gap-2">
+              <div className="flex gap-2 justify-center">
                 <span>{str("Region: ")}</span>
                 <span className="text-black">{str(PressureSore.regionToString(state.region))}</span>
               </div>
-              <div className="sm:flex gap-2 mt-2">
+              <div className="flex flex-col sm:flex-row gap-2 mt-2">
                 <div>
-                  <label className="block font-medium text-black">{str("Width")}</label>
+                  <label className="block font-medium text-black text-left">{str("Width")}</label>
                   <input
                     type_="number"
                     value={state.width->Belt.Float.toString}
@@ -88,7 +92,7 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
                   />
                 </div>
                 <div>
-                  <label className="block font-medium text-black">{str("Height")}</label>
+                  <label className="block font-medium text-black text-left">{str("Height")}</label>
                   <input
                     type_="number"
                     value={state.length->Belt.Float.toString}
@@ -105,7 +109,7 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
                   />
                 </div>
               </div>
-              <div className="sm:flex gap-2 mt-2">
+              <div className="flex flex-col sm:flex-row gap-2 mt-2">
                   <CriticalCare__Dropdown
                     id="exudate-amount"
                     label="Exudate amount"
@@ -125,7 +129,7 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
               </div>
               
               <div className="mt-2">
-                <label className="block font-medium text-black">{str("Description")}</label>
+                <label className="block font-medium text-black text-left">{str("Description")}</label>
                 <textarea
                   placeholder="Description"
                   value={state.description}
@@ -139,12 +143,12 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
             </div>
           </div>
         </div>
-        <div className="bg-gray-50 px-4 py-3 sm:px-6 flex items-center justify-between">
-          <div className="flex gap-2">
+        <div className="bg-gray-50 px-4 py-3 sm:px-6 flex flex-col sm:flex-row items-center justify-between gap-2">
+          <div className="flex gap-2 w-full justify-center sm:justify-start items-center">
             <span>{str("Push Score: ")}</span>
             <span className="text-black">{str(pushScore->Belt.Float.toString)}</span>
           </div>
-          <div className="sm:flex sm:flex-row-reverse">
+          <div className="flex flex-col-reverse sm:flex-row-reverse w-full gap-2">
             <button
               type_="button"
               onClick=(e => {

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -1,0 +1,169 @@
+@val external innerWidth: int = "window.innerWidth"
+
+let str = React.string
+open CriticalCare__Types
+
+type position = {
+  "x": int,
+  "y": int,
+}
+
+type part = PressureSore.part
+
+@react.component
+let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: position, ~part: part, ~updatePart: part => unit) => {
+
+  let (state, setState) = React.useState(_ => part)
+  let (pushScore, setPushScore) = React.useState(_ => 0.0)
+
+  React.useEffect2(() => {
+    setState(_ => part)
+    None
+  }, (part, show))
+
+  React.useEffect1(() => {
+    let areaIntervalPoints = [0.0, 0.3, 0.6, 1.0, 2.2, 3.0, 4.0, 8.0, 12.0, 24.0]
+    let exudateAmounts = ["None", "Light", "Moderate", "Heavy"]
+    let tissueTypes = ["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
+
+    let area = state.length *. state.width
+    let areaScore = areaIntervalPoints->Belt.Array.getIndexBy(interval => interval >= area)->Belt.Option.getWithDefault(10)->float_of_int
+    let exudateScore = exudateAmounts->Belt.Array.getIndexBy(amount => amount == state.exudate_amount->PressureSore.extrudateAmountToString)->Belt.Option.getWithDefault(0)->float_of_int
+    let tissueScore = tissueTypes->Belt.Array.getIndexBy(tissue => tissue == state.tissue_type->PressureSore.tissueTypeToString)->Belt.Option.getWithDefault(0)->float_of_int
+
+    let score = areaScore +. exudateScore +. tissueScore
+    Js.log4(area, areaScore, exudateScore, tissueScore)
+    setPushScore(_ => score)
+    None
+  }, [state])
+
+  let ref = React.useRef(Js.Nullable.null)
+  let handleClickOutside = %raw(`
+    function (event, ref, hideModal) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        hideModal(event)
+      }
+    }
+  `)
+
+  <div 
+    hidden={!show} 
+    onClick={e => handleClickOutside(e, ref, hideModal)} 
+    className="fixed w-full inset-0 z-40 overflow-y-auto"
+  >
+    <div
+      className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+      <div
+          ref={ReactDOM.Ref.domRef(ref)}
+          style={ReactDOMStyle.make(
+            ~position={innerWidth >= 640 ? "absolute" : ""},
+            ~left= `${position["x"]->Belt.Int.toString}px`,
+            ~top=`${position["y"]->Belt.Int.toString}px`,
+            ()
+          )}
+          className="transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
+        <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div className="sm:flex sm:items-start">
+            <div className="mt-3 text-center sm:mt-0 sm:text-left">
+              <div className="flex gap-2">
+                <span>{str("Region: ")}</span>
+                <span className="text-black">{str(PressureSore.regionToString(state.region))}</span>
+              </div>
+              <div className="sm:flex gap-2 mt-2">
+                <div>
+                  <label className="block font-medium text-black">{str("Width")}</label>
+                  <input
+                    type_="number"
+                    value={state.width->Belt.Float.toString}
+                    step={0.1}
+                    placeholder="Width (cm)"
+                    className="border border-gray-300 rounded-md w-full px-2 py-1"
+                    onChange={e => {
+                      let value = ReactEvent.Form.target(e)["value"]->Belt.Float.fromString
+                      switch value {
+                      | Some(value) => setState(prev => {...prev, width: value})
+                      | None => setState(prev => {...prev, width: 0.0})
+                      }
+                    }}
+                  />
+                </div>
+                <div>
+                  <label className="block font-medium text-black">{str("Height")}</label>
+                  <input
+                    type_="number"
+                    value={state.length->Belt.Float.toString}
+                    step={0.1}
+                    placeholder="Length (cm)"
+                    className="border border-gray-300 rounded-md w-full px-2 py-1"
+                    onChange={e => {
+                      let value = ReactEvent.Form.target(e)["value"]->Belt.Float.fromString
+                      switch value {
+                      | Some(value) => setState(prev => {...prev, length: value})
+                      | None => setState(prev => {...prev, length: 0.0})
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="sm:flex gap-2 mt-2">
+                  <CriticalCare__Dropdown
+                    id="exudate-amount"
+                    label="Exudate amount"
+                    value={state.exudate_amount->PressureSore.encodeExudateAmount}
+                    updateCB=(value => setState(prev => {...prev, exudate_amount: value->PressureSore.decodeExtrudateAmount}))
+                    placeholder="Exudate amount"
+                    selectables=["None", "Light", "Moderate", "Heavy"]
+                  />
+                  <CriticalCare__Dropdown
+                    id="tissue-type"
+                    label="Tissue type"
+                    value={state.tissue_type->PressureSore.encodeTissueType}
+                    updateCB=(value => setState(prev => {...prev, tissue_type: value->PressureSore.decodeTissueType}))
+                    placeholder="Tissue type"
+                    selectables=["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
+                  />
+              </div>
+              
+              <div className="mt-2">
+                <label className="block font-medium text-black">{str("Description")}</label>
+                <textarea
+                  placeholder="Description"
+                  value={state.description}
+                  onChange={e => {
+                    let value = ReactEvent.Form.target(e)["value"]
+                    setState(prev => {...prev, description: value})
+                  }}
+                  className="border border-gray-300 rounded-md px-2 py-1 w-full"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="bg-gray-50 px-4 py-3 sm:px-6 flex items-center justify-between">
+          <div className="flex gap-2">
+            <span>{str("Push Score: ")}</span>
+            <span className="text-black">{str(pushScore->Belt.Float.toString)}</span>
+          </div>
+          <div className="sm:flex sm:flex-row-reverse">
+            <button
+              type_="button"
+              onClick=(e => {
+                updatePart(state)
+                hideModal(e)
+              })
+              className="inline-flex w-full justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:ml-3 sm:w-auto sm:text-sm">
+              {str("Apply")}
+            </button>
+            <button
+              type_="button"
+              onClick={hideModal}
+              className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+              {str("Cancel")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+}

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -36,8 +36,6 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
     None
   }, [state])
 
-  Js.log(PressureSore.regionToString(part.region))
-
   let ref = React.useRef(Js.Nullable.null)
   let handleClickOutside = %raw(`
     function (event, ref, hideModal) {

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -61,7 +61,7 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
             ~top=`${position["y"]->Belt.Int.toString}px`,
             ()
           )}
-          className="transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
+          className="transform overflow-hidden w-4/5 rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
         <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <div className="sm:flex sm:items-start">
             <div className="mt-3 text-center sm:mt-0 sm:text-left">

--- a/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
+++ b/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
@@ -1,0 +1,96 @@
+let str = React.string
+
+open Webapi.Dom
+
+let onWindowClick = (showDropdown, setShowDropdown, _event) =>
+  if showDropdown {
+    setShowDropdown(_ => false)
+  } else {
+    ()
+  }
+
+let toggleDropdown = (setShowDropdown, event) => {
+  event |> ReactEvent.Mouse.stopPropagation
+  setShowDropdown(showDropdown => !showDropdown)
+}
+
+let search = (searchString, selectables) =>
+  (selectables |> Js.Array.filter(selection =>
+    selection
+    |> String.lowercase_ascii
+    |> Js.String.includes(searchString |> String.lowercase_ascii) && selection != searchString
+  ))->Belt.SortArray.stableSortBy((x, y) => String.compare(x, y))
+
+let renderSelectables = (selections, updateCB) =>
+  selections |> Array.mapi((index, selection) =>
+    <button
+      type_="button"
+      key={index |> string_of_int}
+      onClick={_ => updateCB(selection)}
+      className="w-full block px-4 py-2 text-sm leading-5 text-left text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900">
+      {selection |> str}
+    </button>
+  )
+
+let searchResult = (searchInput, updateCB, selectables) => {
+  // Remove all excess space characters from the user input.
+  let normalizedString =
+    searchInput
+    |> Js.String.trim
+    |> Js.String.replaceByRe(Js.Re.fromStringWithFlags("\\s+", ~flags="g"), " ")
+  switch normalizedString {
+  | "" => []
+  | searchString =>
+    let matchingSelections = search(searchString, selectables)
+    renderSelectables(matchingSelections, updateCB)
+  }
+}
+
+let renderDropdown = results =>
+  <div className="origin-top-left absolute z-40 left-0 mt-2 w-full rounded-md shadow-lg ">
+    <div className="rounded-md bg-white ring-1 ring-black ring-opacity-5">
+      <div className="py-1 max-height-dropdown"> {results |> React.array} </div>
+    </div>
+  </div>
+
+@react.component
+let make = (~id, ~value, ~updateCB, ~placeholder, ~selectables, ~label="") => {
+  let results = searchResult(value, updateCB, selectables)
+  let (showDropdown, setShowDropdown) = React.useState(_ => false)
+  React.useEffect1(() => {
+    let curriedFunction = onWindowClick(showDropdown, setShowDropdown)
+
+    let removeEventListener = () => Window.removeEventListener(window, "click", curriedFunction)
+
+    if showDropdown {
+      Window.addEventListener(window, "click", curriedFunction)
+      Some(removeEventListener)
+    } else {
+      removeEventListener()
+      None
+    }
+  }, [showDropdown])
+
+  <div className="relative inline-block text-left w-full">
+    <label className="block font-medium text-black" hidden={label == ""}>{str(label)}</label>
+    <input
+      id
+      value
+      autoComplete="off"
+      onClick={_ => setShowDropdown(_ => !showDropdown)}
+      onChange={e => updateCB(ReactEvent.Form.target(e)["value"])}
+      className="appearance-none h-10 mt-1 block w-full border border-gray-400 rounded py-2 px-4 text-sm bg-gray-100 hover:bg-gray-200 focus:outline-none focus:bg-white focus:ring-primary-500"
+      placeholder
+      required=true
+    />
+    {results |> Array.length == 0
+      ? switch showDropdown {
+        | true => renderDropdown(renderSelectables(selectables, updateCB))
+        | false => React.null
+        }
+      : switch showDropdown {
+        | true => renderDropdown(results)
+        | false => React.null
+        }}
+  </div>
+}

--- a/src/Components/CriticalCareRecording/types/CriticalCare__PressureSore.res
+++ b/src/Components/CriticalCareRecording/types/CriticalCare__PressureSore.res
@@ -41,17 +41,37 @@ type region =
   | PosteriorRightFoot
   | Other
 
+type extrudateAmount = 
+  | None
+  | Light
+  | Moderate
+  | Heavy
+
+type tissueType = 
+  | Closed
+  | Epithelial 
+  | Granulation 
+  | Slough 
+  | Necrotic
+
 type path = {d: string, transform: string, region: region}
 let d = path => path.d
 let transform = path => path.transform
 let regionForPath = path => path.region
 
-type part = {region: region, scale: int}
+type part = {
+  region: region, 
+  scale: int, 
+  length: float, 
+  width: float,
+  exudate_amount: extrudateAmount,
+  tissue_type: tissueType,
+  description: string,
+}
 
 export type t = array<part>
 
-let makePart = p => {
-  let region = switch p["region"] {
+let decodeRegion = region => switch region {
   | "anterior_head" => AnteriorHead
   | "anterior_neck" => AnteriorNeck
   | "anterior_right_shoulder" => AnteriorRightShoulder
@@ -95,8 +115,71 @@ let makePart = p => {
   | _ => Other
   }
 
-  {region: region, scale: p["scale"]}
+  let decodeExtrudateAmount = extrudateAmount => switch extrudateAmount {
+  | "None" => None
+  | "Light" => Light
+  | "Moderate" => Moderate
+  | "Heavy" => Heavy
+  | _ => None
+  }
+
+  let decodeTissueType = tissueType => switch tissueType {
+  | "Closed" => Closed
+  | "Epithelial" => Epithelial
+  | "Granulation" => Granulation
+  | "Slough" => Slough
+  | "Necrotic" => Necrotic
+  | _ => Closed
+  }
+
+let makePart = p => {
+  {
+    region: decodeRegion(p["region"]),
+    scale: p["scale"],
+    length: p["length"],
+    width: p["width"],
+    exudate_amount: decodeExtrudateAmount(p["exudate_amount"]),
+    tissue_type: decodeTissueType(p["tissue_type"]),
+    description: p["description"],
+  }
 }
+
+let encodeExudateAmount = extrudateAmount => {
+  switch extrudateAmount {
+  | None => "None"
+  | Light => "Light"
+  | Moderate => "Moderate"
+  | Heavy => "Heavy"
+  }
+}
+
+let extrudateAmountToString = extrudateAmount => {
+  switch extrudateAmount {
+  | None => "None"
+  | Light => "Light"
+  | Moderate => "Moderate"
+  | Heavy => "Heavy"
+  }
+}
+
+let encodeTissueType = tissueType => {
+  switch tissueType {
+    | Closed => "Closed"
+    | Epithelial => "Epithelial"
+    | Granulation => "Granulation"
+    | Slough => "Slough"
+    | Necrotic => "Necrotic"
+  }
+}
+
+let tissueTypeToString = tissueType => switch tissueType {
+  | Closed => "Closed"
+  | Epithelial => "Epithelial"
+  | Granulation => "Granulation"
+  | Slough => "Slough"
+  | Necrotic => "Necrotic"
+}
+
 
 let endcodeRegion = part => {
   switch part.region {
@@ -192,7 +275,15 @@ let regionToString = region => {
 
 let region = part => part.region
 let scale = part => part.scale
-let makeDefault = region => {region: region, scale: 1}
+let makeDefault = (region) => {
+  region: region, 
+  scale: 1, 
+  length: 0.0, 
+  width: 0.0, 
+  exudate_amount: None, 
+  tissue_type: Closed, 
+  description: ""
+}
 
 let autoScale = part => {
   {...part, scale: mod(part.scale + 1, 6)}


### PR DESCRIPTION
Fixes #3432 

## Proposed Changes

- Added new UI to log additional details in PressureSore 

![image](https://user-images.githubusercontent.com/29787772/197191012-f48d98d3-79fd-4488-aa9a-a82d956d3c15.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
