### PR TITLE
fix `animate-ping` effect of no consultation filed in patient card

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -623,8 +623,8 @@ export const PatientManager = (props: any) => {
                           startIcon="notes-medical"
                           text="No Consultation Filed"
                         />
-                        <span className="flex absolute h-3 w-3 -top-1 -right-1">
-                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
+                        <span className="flex absolute h-3 w-3 -top-1 -right-1 items-center justify-center">
+                          <span className="animate-ping absolute inline-flex h-4 w-4 center rounded-full bg-red-400"></span>
                           <span className="relative inline-flex rounded-full h-3 w-3 bg-red-600"></span>
                         </span>
                       </span>

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -552,10 +552,8 @@ export const PatientManager = (props: any) => {
                         {" "}
                         {patient.facility_object.name}
                       </p>
-                      <p className="text-base">
-                        <span className="text-sm text-gray-600">
-                          last updated
-                        </span>{" "}
+                      <p className="text-sm">
+                        <span className="text-gray-600">last updated</span>{" "}
                         <span className="font-medium text-gray-900">
                           {" "}
                           {moment(patient.modified_date).fromNow()}


### PR DESCRIPTION
## Proposed Changes

- Improve ping animation of patient card tag: 'No Consultation Filed'

https://user-images.githubusercontent.com/25143503/197340005-6cff576d-7662-4921-8a30-4d97ad0b47ce.mp4

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
