### PR TITLE
Fix: Dates not visible in graph (consultation page of patient)

### DIFF
--- a/src/Components/Facility/Consultations/components/LinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/LinePlot.tsx
@@ -12,7 +12,7 @@ export const LinePlot = (props: any) => {
   } = props;
   let generalOptions: any = {
     grid: {
-      left: "15px",
+      left: "20px",
       right: "30px",
       containLabel: true,
     },
@@ -56,9 +56,9 @@ export const LinePlot = (props: any) => {
       boundaryGap: false,
       data: xData,
       axisLabel: {
-        width: 85,
+        width: 60,
         overflow: "break",
-        align: "left",
+        align: "center",
       },
     },
     yAxis: {

--- a/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
+++ b/src/Components/Facility/Consultations/components/StackedLinePlot.tsx
@@ -15,7 +15,7 @@ export const StackedLinePlot = (props: any) => {
 
   const generalOptions = {
     grid: {
-      left: "15px",
+      left: "20px",
       right: "30px",
       containLabel: true,
     },
@@ -71,9 +71,9 @@ export const StackedLinePlot = (props: any) => {
       boundaryGap: false,
       data: xData,
       axisLabel: {
-        width: 85,
+        width: 60,
         overflow: "break",
-        align: "left",
+        align: "center",
       },
     },
     yAxis: {


### PR DESCRIPTION
fixes #3809 
## Proposed Changes

- The dates in the graphs are now showing fully on the normal view in the consultation page

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
