### PR TITLE
fixed queueData overflow issue in Waveform

### DIFF
--- a/src/Components/TeleIcu/Patient/Waveform.tsx
+++ b/src/Components/TeleIcu/Patient/Waveform.tsx
@@ -26,7 +26,7 @@ export default function Waveform(props: {
 }) {
   const wave = props.wave;
   const data = wave.data.split(" ").map(Number);
-  const [queueData, setQueueData] = useState<number[]>([]);
+  const [queueData, setQueueData] = useState<number[]>(Array(200).fill(0));
   const [xData, setXData] = useState<number[]>([]);
   const [lastStream, setLastStream] = useState(0);
 
@@ -44,7 +44,7 @@ export default function Waveform(props: {
       seconds++;
     }, 1000);
     return () => clearInterval(timer);
-  }, [props]);
+  }, [props.wave.data]);
 
   useEffect(() => {
     const timeout = setTimeout(() => {


### PR DESCRIPTION
Fixes #3808 

## Proposed Changes

- The issue was that the useEffect was triggered twice and the data was added to queueData twice but removed only once which eventually led to overflow 
- When we add data only once, there is some initial visual issue with the waveform, so added default initial dummy data to fix that

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
