### PR TITLE
Remove history of present illness card from medicine tab

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -951,18 +951,6 @@ export const ConsultationDetails = (props: any) => {
         )}
         {tab === "MEDICINES" && (
           <div>
-            {consultationData.history_of_present_illness && (
-              <div className="bg-white overflow-hidden shadow rounded-lg mt-4">
-                <div className="px-4 py-5 sm:p-6">
-                  <h3 className="text-lg font-semibold leading-relaxed text-gray-900">
-                    History of present illness:{" "}
-                  </h3>
-                  <div className="mt-2">
-                    {consultationData.history_of_present_illness}
-                  </div>
-                </div>
-              </div>
-            )}
             {consultationData.discharge_advice && (
               <div className="mt-4">
                 <div className="flex flex-wrap text-lg font-semibold leading-relaxed text-gray-900 mb-2">


### PR DESCRIPTION
- This PR closes #3821
- Remove "History of present illness" card from medicines tab in patient dashboard

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/57039447/197746957-20c8070c-2e44-4444-8b1b-432d6343cacf.png">
