### PR TITLE
Adjusted download button size in HospitalList

### DIFF
--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -557,8 +557,8 @@ export const HospitalList = (props: any) => {
         <div className="flex md:justify-end w-full md:mt-4">
           <div className="w-full md:w-auto">
             <AccordionV2
-              title={<p className="font-medium text-lg">Downloads</p>}
-              className="lg:mt-0 md:mt-0 sm:mt-0 bg-white shadow-md rounded-lg p-3 relative"
+              title={<p className="pl-2 text-lg">Downloads</p>}
+              className="lg:mt-0 md:mt-0 sm:mt-0 bg-white shadow-md rounded-lg p-2 relative"
               expandIcon={<ExpandMoreIcon />}
             >
               <div className="mt-3">


### PR DESCRIPTION
## Proposed Changes

- Reduced the padding of the download button size in HospitalList

cc: @nihal467 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
