### PR TITLE
Show bed field while creation in ConsultationForm

### DIFF
--- a/src/Components/Common/BedSelect.tsx
+++ b/src/Components/Common/BedSelect.tsx
@@ -11,6 +11,7 @@ interface BedSelectProps {
   errors: string;
   className?: string;
   searchAll?: boolean;
+  unoccupiedOnly?: boolean;
   multiple?: boolean;
   facility?: string;
   location?: string;
@@ -29,6 +30,7 @@ export const BedSelect = (props: BedSelectProps) => {
     margin,
     errors,
     searchAll,
+    unoccupiedOnly,
     className = "",
     facility,
     location,
@@ -64,8 +66,12 @@ export const BedSelect = (props: BedSelectProps) => {
 
       const res = await dispatchAction(listFacilityBeds(params));
       if (res && res.data) {
-        setBedList(res.data.results);
-        console.log(res.data.results);
+        let beds = res.data.results;
+        if (unoccupiedOnly) {
+          beds = beds.filter((bed: BedModel) => bed?.is_occupied === false);
+        }
+
+        setBedList(beds);
       }
       isBedLoading(false);
     }, 300),
@@ -99,7 +105,7 @@ export const BedSelect = (props: BedSelectProps) => {
           | {option?.location_object?.name}
         </div>
       )}
-      getOptionSelected={(option: any, value: any) => option.id === value.id}
+      getOptionSelected={(option: any, value: any) => option?.id === value?.id}
       getOptionLabel={(option: any) => option?.name || ""}
       filterOptions={(options: BedModel[]) => options}
       errors={errors}

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -871,6 +871,12 @@ export const ConsultationForm = (props: any) => {
                         // location={state.form.}
                         facility={facilityId}
                       />
+                      {!!id && (
+                        <p className="text-gray-500 text-sm -mt-5 mb-1">
+                          Can't be edited while Consultation update. To change
+                          bed use the form bellow
+                        </p>
+                      )}
                     </div>
                   </>
                 )}

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -866,7 +866,8 @@ export const ConsultationForm = (props: any) => {
                         errors=""
                         multiple={false}
                         margin="dense"
-                        disabled={true}
+                        unoccupiedOnly={true}
+                        disabled={!!id} // disabled while editing
                         // location={state.form.}
                         facility={facilityId}
                       />

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -186,6 +186,7 @@ export interface BedModel {
     name: string;
   };
   location?: string;
+  is_occupied?: boolean;
 }
 
 export interface CurrentBed {


### PR DESCRIPTION
Fixes #3842 
depends on https://github.com/coronasafe/care/pull/1083

## Proposed Changes

- show bed field while consultation creation
- added filter by is_occupied property in BedSelect 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
