### PR TITLE
Close option list after selection (multi select AutoCompleteAsync)

### DIFF
--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useMemo } from "react";
 import { Combobox } from "@headlessui/react";
 import Spinner from "../Common/Spinner";
 import { debounce } from "lodash";
-import { DropdownTransition } from "../Common/components/HelperComponents";
 
 interface Props {
   name?: string;
@@ -35,10 +34,13 @@ const AutoCompleteAsync = (props: Props) => {
   const [data, setData] = useState([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const queryInputRef = React.useRef<HTMLInputElement>(null);
 
   const getPlaceholder = () => {
     if (!multiple && selected) return optionLabel(selected);
-    if (multiple && selected?.length > 0) return `${selected.length} selected`;
+    if (!visible && multiple && selected?.length > 0)
+      return `${selected.length} selected`;
     return placeholder || "Start typing to search...";
   };
 
@@ -70,6 +72,11 @@ const AutoCompleteAsync = (props: Props) => {
               as="div"
             >
               <Combobox.Input
+                ref={queryInputRef}
+                onFocus={() => {
+                  setQuery("");
+                  setVisible(true);
+                }}
                 name={name}
                 className={`w-full border-none text-sm leading-5 text-gray-900 ${
                   hasSelection
@@ -79,14 +86,22 @@ const AutoCompleteAsync = (props: Props) => {
                 placeholder={getPlaceholder()}
                 onChange={(event) => setQuery(event.target.value)}
               />
-              <div className="absolute inset-y-0 right-0 flex items-center pr-2">
+              <div className="absolute top-2 right-0 flex items-center pr-2">
                 {loading && <Spinner path={{ fill: "black" }} />}
                 <i className="p-2 mr-2 text-sm fa-solid fa-chevron-down" />
               </div>
             </Combobox.Button>
           </div>
-          <DropdownTransition afterLeave={() => setQuery("")}>
-            <Combobox.Options className="top-12 absolute z-10 mt-2 w-full rounded-md xl:rounded-lg shadow-lg overflow-auto max-h-96 bg-gray-100 divide-y divide-gray-300 ring-1 ring-gray-400 focus:outline-none text-sm">
+          <div className={visible ? "visible" : "hidden"}>
+            <Combobox.Options
+              static
+              onClick={() => {
+                setQuery("");
+                setVisible(false);
+                if (queryInputRef.current) queryInputRef.current.value = "";
+              }}
+              className="top-12 absolute z-10 mt-2 w-full rounded-md xl:rounded-lg shadow-lg overflow-auto max-h-96 bg-gray-100 divide-y divide-gray-300 ring-1 ring-gray-400 focus:outline-none text-sm"
+            >
               {data?.length === 0 ? (
                 <div className="relative cursor-default select-none py-2 px-4 text-gray-700">
                   {query !== ""
@@ -103,6 +118,9 @@ const AutoCompleteAsync = (props: Props) => {
                       }`
                     }
                     value={item}
+                    onClick={() => {
+                      setVisible(false);
+                    }}
                   >
                     {({ selected, active }) => (
                       <>
@@ -128,7 +146,7 @@ const AutoCompleteAsync = (props: Props) => {
                 ))
               )}
             </Combobox.Options>
-          </DropdownTransition>
+          </div>
           {multiple && selected?.length > 0 && (
             <div className="p-2 flex flex-wrap gap-2">
               {selected?.map((option: any) => (


### PR DESCRIPTION
Fixes #3871

- Fixed alignment of the dropdown arrow icon on the right
- Selecting an option, now closes the dropdown and clears the search, so the user is then ready to search for the next facility.
- When focused on the search box, the placeholder will now show "Start typing to search..."

![msedge_qnXqGmPsdA](https://user-images.githubusercontent.com/3626859/198854636-96d5beaa-1061-4ba2-8cdf-021fcf124aa5.gif)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
