### PR TITLE
fix(asset): droplist is stretching the asset page

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -141,7 +141,7 @@ const AssetManage = (props: AssetManageProps) => {
 
   const assetClassProp =
     (asset?.asset_class && assetClassProps[asset.asset_class]) ||
-    assetClassProps.None;
+    assetClassProps.NONE;
 
   const detailBlock = (item: any) =>
     item.hide ? null : (

--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -17,7 +17,7 @@ export enum AssetType {
 }
 
 export enum AssetClass {
-  NONE = "",
+  NONE = "NONE",
   ONVIF = "ONVIF",
   HL7MONITOR = "HL7MONITOR",
 }

--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -10,8 +10,15 @@ export interface AssetLocationObject {
   };
 }
 
-export type AssetType = "INTERNAL" | "EXTERNAL";
-export type AssetClass = "ONVIF" | "HL7MONITOR";
+export enum AssetType {
+  internal = "INTERNAL",
+  external = "EXTERNAL",
+}
+
+export enum AssetClass {
+  onvif = "ONVIF",
+  hl7monitor = "HL7MONITOR",
+}
 
 export const assetClassProps = {
   ONVIF: {

--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -11,13 +11,15 @@ export interface AssetLocationObject {
 }
 
 export enum AssetType {
-  internal = "INTERNAL",
-  external = "EXTERNAL",
+  NONE = "NONE",
+  INTERNAL = "INTERNAL",
+  EXTERNAL = "EXTERNAL",
 }
 
 export enum AssetClass {
-  onvif = "ONVIF",
-  hl7monitor = "HL7MONITOR",
+  NONE = "",
+  ONVIF = "ONVIF",
+  HL7MONITOR = "HL7MONITOR",
 }
 
 export const assetClassProps = {
@@ -33,7 +35,7 @@ export const assetClassProps = {
     icon: "tv",
     uicon: "tv-retro",
   },
-  None: {
+  NONE: {
     name: "N/A",
     icon: "cart-plus",
     uicon: "shopping-cart",

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -274,7 +274,7 @@ const AssetsList = () => {
                       (
                         (asset.asset_class &&
                           assetClassProps[asset.asset_class]) ||
-                        assetClassProps.None
+                        assetClassProps.NONE
                       ).icon
                     }`}
                   />

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -216,7 +216,7 @@ const AssetCreate = (props: AssetProps) => {
           }
           return;
         case "asset_type":
-          if (!asset_type) {
+          if (!asset_type || asset_type == "NONE") {
             errors[field] = "Select an asset type";
             invalidForm = true;
           }
@@ -480,11 +480,16 @@ const AssetCreate = (props: AssetProps) => {
                   <div className="col-span-6 flex flex-col lg:flex-row gap-x-12 xl:gap-x-16 transition-all">
                     {/* Location */}
                     <div>
-                      <label htmlFor="asset-location">Location * </label>
+                      <label htmlFor="asset-location">Location *</label>
                       <div className="mt-2">
                         <SelectMenuV2
                           required
                           options={[
+                            {
+                              title: "Select",
+                              description: "Select the location",
+                              value: "0",
+                            },
                             ...locations.map((location: any) => ({
                               title: location.name,
                               description: location.facility.name,
@@ -502,11 +507,16 @@ const AssetCreate = (props: AssetProps) => {
 
                     {/* Asset Type */}
                     <div>
-                      <label htmlFor="asset-type">Asset Type * </label>
+                      <label htmlFor="asset-type">Asset Type *</label>
                       <div className="mt-2">
                         <SelectMenuV2
                           required
                           options={[
+                            {
+                              title: "Select",
+                              description: "Select the asset type",
+                              value: "NONE",
+                            },
                             {
                               title: "Internal",
                               description:
@@ -523,9 +533,11 @@ const AssetCreate = (props: AssetProps) => {
                           value={asset_type}
                           optionLabel={(o) => o.title}
                           optionValue={(o) =>
-                            o.value === "INTERNAL"
-                              ? AssetType.internal
-                              : AssetType.external
+                            o.value == "NONE"
+                              ? AssetType.NONE
+                              : o.value === "INTERNAL"
+                              ? AssetType.INTERNAL
+                              : AssetType.EXTERNAL
                           }
                           onChange={(e) => setAssetType(e)}
                         />
@@ -540,6 +552,7 @@ const AssetCreate = (props: AssetProps) => {
                         <SelectMenuV2
                           required
                           options={[
+                            { title: "Select", value: "NONE" },
                             { title: "ONVIF Camera", value: "ONVIF" },
                             {
                               title: "HL7 Vitals Monitor",
@@ -549,9 +562,11 @@ const AssetCreate = (props: AssetProps) => {
                           value={asset_class}
                           optionLabel={(o) => o.title}
                           optionValue={(o) =>
-                            o.value === "ONVIF"
-                              ? AssetClass.onvif
-                              : AssetClass.hl7monitor
+                            o.value == "NONE"
+                              ? AssetClass.NONE
+                              : o.value === "ONVIF"
+                              ? AssetClass.ONVIF
+                              : AssetClass.HL7MONITOR
                           }
                           onChange={(e) => setAssetClass(e)}
                         />

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -25,12 +25,12 @@ import { LocationOnOutlined } from "@material-ui/icons";
 import { navigate } from "raviger";
 import QrReader from "react-qr-reader";
 import { parseQueryParams } from "../../Utils/primitives";
-import SelectMenu from "../Common/components/SelectMenu";
 import moment from "moment";
 import TextInputFieldV2 from "../Common/components/TextInputFieldV2";
 import SwitchV2 from "../Common/components/Switch";
 import useVisibility from "../../Utils/useVisibility";
 import { goBack } from "../../Utils/utils";
+import SelectMenuV2 from "../Form/SelectMenuV2";
 const Loading = loadable(() => import("../Common/Loading"));
 
 const initError = {
@@ -164,7 +164,7 @@ const AssetCreate = (props: AssetProps) => {
         setIsLoading(false);
       });
     }
-  }, [assetId]);
+  }, [assetId, dispatchAction, facilityId]);
 
   useEffect(() => {
     if (asset) {
@@ -482,22 +482,19 @@ const AssetCreate = (props: AssetProps) => {
                     <div>
                       <label htmlFor="asset-location">Location * </label>
                       <div className="mt-2">
-                        <SelectMenu
+                        <SelectMenuV2
+                          required
                           options={[
-                            {
-                              title: "Select",
-                              description:
-                                "Select an Asset Location from the following",
-                              value: "",
-                            },
                             ...locations.map((location: any) => ({
                               title: location.name,
                               description: location.facility.name,
                               value: location.id,
                             })),
                           ]}
-                          selected={location}
-                          onSelect={setLocation}
+                          optionLabel={(o) => o.title}
+                          optionValue={(o) => o.value}
+                          value={location}
+                          onChange={(e) => setLocation(e)}
                         />
                       </div>
                       <ErrorHelperText error={state.errors.location} />
@@ -507,14 +504,9 @@ const AssetCreate = (props: AssetProps) => {
                     <div>
                       <label htmlFor="asset-type">Asset Type * </label>
                       <div className="mt-2">
-                        <SelectMenu
+                        <SelectMenuV2
+                          required
                           options={[
-                            {
-                              title: "Select",
-                              description:
-                                "Select an Asset Type from the following",
-                              value: undefined,
-                            },
                             {
                               title: "Internal",
                               description:
@@ -528,8 +520,14 @@ const AssetCreate = (props: AssetProps) => {
                               value: "EXTERNAL",
                             },
                           ]}
-                          selected={asset_type}
-                          onSelect={setAssetType}
+                          value={asset_type}
+                          optionLabel={(o) => o.title}
+                          optionValue={(o) =>
+                            o.value === "INTERNAL"
+                              ? AssetType.internal
+                              : AssetType.external
+                          }
+                          onChange={(e) => setAssetType(e)}
                         />
                       </div>
                       <ErrorHelperText error={state.errors.asset_type} />
@@ -539,17 +537,23 @@ const AssetCreate = (props: AssetProps) => {
                     <div>
                       <label htmlFor="asset-class">Asset Class</label>
                       <div className="mt-2">
-                        <SelectMenu
+                        <SelectMenuV2
+                          required
                           options={[
-                            { title: "Not Applicable", value: undefined },
                             { title: "ONVIF Camera", value: "ONVIF" },
                             {
                               title: "HL7 Vitals Monitor",
                               value: "HL7MONITOR",
                             },
                           ]}
-                          selected={asset_class}
-                          onSelect={setAssetClass}
+                          value={asset_class}
+                          optionLabel={(o) => o.title}
+                          optionValue={(o) =>
+                            o.value === "ONVIF"
+                              ? AssetClass.onvif
+                              : AssetClass.hl7monitor
+                          }
+                          onChange={(e) => setAssetClass(e)}
                         />
                       </div>
                       <ErrorHelperText error={state.errors.asset_class} />

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -513,11 +513,6 @@ const AssetCreate = (props: AssetProps) => {
                           required
                           options={[
                             {
-                              title: "Select",
-                              description: "Select the asset type",
-                              value: "NONE",
-                            },
-                            {
                               title: "Internal",
                               description:
                                 "Asset is inside the facility premises.",
@@ -531,11 +526,10 @@ const AssetCreate = (props: AssetProps) => {
                             },
                           ]}
                           value={asset_type}
+                          placeholder="Select"
                           optionLabel={(o) => o.title}
                           optionValue={(o) =>
-                            o.value == "NONE"
-                              ? AssetType.NONE
-                              : o.value === "INTERNAL"
+                            o.value === "INTERNAL"
                               ? AssetType.INTERNAL
                               : AssetType.EXTERNAL
                           }
@@ -550,9 +544,7 @@ const AssetCreate = (props: AssetProps) => {
                       <label htmlFor="asset-class">Asset Class</label>
                       <div className="mt-2">
                         <SelectMenuV2
-                          required
                           options={[
-                            { title: "Select", value: "NONE" },
                             { title: "ONVIF Camera", value: "ONVIF" },
                             {
                               title: "HL7 Vitals Monitor",
@@ -560,11 +552,10 @@ const AssetCreate = (props: AssetProps) => {
                             },
                           ]}
                           value={asset_class}
+                          placeholder="Select"
                           optionLabel={(o) => o.title}
                           optionValue={(o) =>
-                            o.value == "NONE"
-                              ? AssetClass.NONE
-                              : o.value === "ONVIF"
+                            o.value === "ONVIF"
                               ? AssetClass.ONVIF
                               : AssetClass.HL7MONITOR
                           }


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Fixed stretching of the page during option select
- Replaced `SelectMenu` with `SelectMenuV2`

## Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/3805

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
