### PR TITLE
Show dropdown list over mui modal in LinkFacilityDialog

### DIFF
--- a/src/Components/Common/FacilitySelect.tsx
+++ b/src/Components/Common/FacilitySelect.tsx
@@ -13,6 +13,7 @@ interface FacilitySelectProps {
   facilityType?: number;
   district?: string;
   showAll?: boolean;
+  showNOptions?: number;
   selected: FacilityModel | FacilityModel[] | null;
   setSelected: (selected: FacilityModel | FacilityModel[] | null) => void;
 }
@@ -25,6 +26,7 @@ export const FacilitySelect = (props: FacilitySelectProps) => {
     setSelected,
     searchAll,
     showAll = true,
+    showNOptions = 10,
     className = "",
     facilityType,
     district,
@@ -60,6 +62,7 @@ export const FacilitySelect = (props: FacilitySelectProps) => {
       selected={selected}
       onChange={setSelected}
       fetchData={facilitySearch}
+      showNOptions={showNOptions}
       optionLabel={(option: any) =>
         option.name +
         (option.district_object ? `, ${option.district_object.name}` : "")

--- a/src/Components/Users/LinkFacilityDialog.tsx
+++ b/src/Components/Users/LinkFacilityDialog.tsx
@@ -4,12 +4,20 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  withStyles,
-  WithStyles,
 } from "@material-ui/core";
 import React, { useState } from "react";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { FacilityModel } from "../Facility/models";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles({
+  paperFullWidth: {
+    overflowY: "visible",
+  },
+  dialogContentRoot: {
+    overflowY: "visible",
+  },
+});
 
 interface Props {
   username: string;
@@ -20,16 +28,10 @@ interface Props {
   handleCancel: () => void;
 }
 
-const styles = {
-  paper: {
-    "max-width": "600px",
-    "min-width": "400px",
-  },
-};
-
-const LinkFacilityDialog = (props: Props & WithStyles<typeof styles>) => {
+const LinkFacilityDialog = (props: Props) => {
   const { username, handleOk, handleCancel } = props;
   const [facility, setFacility] = useState<any>(null);
+  const classes = useStyles();
 
   const okClicked = () => {
     handleOk(username, facility);
@@ -40,19 +42,31 @@ const LinkFacilityDialog = (props: Props & WithStyles<typeof styles>) => {
   };
 
   return (
-    <Dialog open={true} onClose={cancelClicked}>
+    <Dialog
+      open={true}
+      onClose={cancelClicked}
+      classes={{
+        paper: classes.paperFullWidth,
+      }}
+    >
       <DialogTitle id="alert-dialog-title">
         Link new facility to {username}
       </DialogTitle>
-      <DialogContent>
+      <DialogContent
+        classes={{
+          root: classes.dialogContentRoot,
+        }}
+      >
         <div className="md:min-w-[400px]">
           <FacilitySelect
             multiple={false}
             name="facility"
             showAll={false} // Show only facilities that user has access to link (not all facilities)
+            showNOptions={8}
             selected={facility}
             setSelected={setFacility}
             errors=""
+            className="z-40"
           />
         </div>
       </DialogContent>
@@ -73,4 +87,4 @@ const LinkFacilityDialog = (props: Props & WithStyles<typeof styles>) => {
   );
 };
 
-export default withStyles(styles)(LinkFacilityDialog);
+export default LinkFacilityDialog;


### PR DESCRIPTION
## Proposed Changes

- Show dropdown list over mui modal in LinkFacilityDialog
![image](https://user-images.githubusercontent.com/29787772/199208721-34e3add5-e6f9-4a9b-b391-8389c7404319.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

_This is a mui-specific issue, making our own custom Modal and replacing it instead of mui Dialog should solve this_