### PR TITLE
AutoCompleteAsync: make button and input as peers instead of parent children

### DIFF
--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useMemo } from "react";
 import { Combobox } from "@headlessui/react";
 import Spinner from "../Common/Spinner";
 import { debounce } from "lodash";
+import { DropdownTransition } from "../Common/components/HelperComponents";
 
 interface Props {
   name?: string;
@@ -37,7 +38,6 @@ const AutoCompleteAsync = (props: Props) => {
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [visible, setVisible] = useState(false);
-  const queryInputRef = React.useRef<HTMLInputElement>(null);
 
   const getPlaceholder = () => {
     if (!multiple && selected) {
@@ -77,110 +77,94 @@ const AutoCompleteAsync = (props: Props) => {
         by={compareBy}
         multiple={multiple as any}
       >
-        {({ open }) => (
-          <div className="relative mt-1">
-            <div className="w-full flex rounded bg-gray-200 focus:border-primary-400 border-2 outline-none ring-0 transition-all duration-200 ease-in-out">
-              <Combobox.Input
-                ref={queryInputRef}
-                onFocus={() => {
-                  setQuery("");
-                  setVisible(true);
-                }}
-                name={name}
-                className={`w-full border-none text-sm leading-5 text-gray-900 ${
-                  hasSelection
-                    ? "placeholder:text-gray-900 font-medium"
-                    : "placeholder:text-gray-500"
-                } focus:ring-0 bg-inherit shadow-none`}
-                placeholder={getPlaceholder()}
-                onChange={(event) => setQuery(event.target.value)}
-              />
-              <Combobox.Button className="block w-full pl-3 pr-10 py-1 focus:outline-none focus:ring-0 sm:text-sm">
-                <div className="absolute top-1 right-0 flex items-center pr-2">
-                  {loading && <Spinner path={{ fill: "black" }} />}
-                  <i className="p-2 mr-2 text-sm fa-solid fa-chevron-down" />
+        <div className="relative mt-1">
+          <div className="w-full flex rounded bg-gray-200 focus:border-primary-400 border-2 outline-none ring-0 transition-all duration-200 ease-in-out">
+            <Combobox.Input
+              name={name}
+              className={`w-full border-none text-sm leading-5 text-gray-900 ${
+                hasSelection
+                  ? "placeholder:text-gray-900 font-medium"
+                  : "placeholder:text-gray-500"
+              } focus:ring-0 bg-inherit shadow-none`}
+              placeholder={getPlaceholder()}
+              displayValue={() => (hasSelection ? getPlaceholder() : undefined)}
+              onChange={({ target }) => setQuery(target.value)}
+            />
+            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+              <div className="absolute top-1 right-0 flex items-center pr-2">
+                {loading && <Spinner path={{ fill: "black" }} />}
+                <i className="p-2 mr-2 text-sm fa-solid fa-chevron-down" />
+              </div>
+            </Combobox.Button>
+          </div>
+          <DropdownTransition>
+            <Combobox.Options className="top-12 absolute z-10 mt-2 w-full rounded-md xl:rounded-lg shadow-lg overflow-auto max-h-96 bg-gray-100 divide-y divide-gray-300 ring-1 ring-gray-400 focus:outline-none text-sm">
+              {data?.length === 0 ? (
+                <div className="relative cursor-default select-none py-2 px-4 text-gray-700">
+                  {query !== ""
+                    ? "Nothing found."
+                    : "Start typing to search..."}
                 </div>
-              </Combobox.Button>
-            </div>
-            <div className={visible && open ? "visible" : "hidden"}>
-              <Combobox.Options
-                static
-                onClick={() => {
-                  setQuery("");
-                  setVisible(false);
-                  if (queryInputRef.current) queryInputRef.current.value = "";
-                }}
-                className="top-12 absolute z-10 mt-2 w-full rounded-md xl:rounded-lg shadow-lg overflow-auto max-h-96 bg-gray-100 divide-y divide-gray-300 ring-1 ring-gray-400 focus:outline-none text-sm"
-              >
-                {data?.length === 0 ? (
-                  <div className="relative cursor-default select-none py-2 px-4 text-gray-700">
-                    {query !== ""
-                      ? "Nothing found."
-                      : "Start typing to search..."}
-                  </div>
-                ) : (
-                  data?.map((item: any) => (
-                    <Combobox.Option
-                      key={item.id}
-                      className={({ active }) =>
-                        `relative cursor-default select-none py-2 pl-10 pr-4 ${
-                          active ? "text-white bg-primary-500" : "text-gray-900"
-                        }`
-                      }
-                      value={item}
-                      onClick={() => {
-                        setVisible(false);
-                      }}
-                    >
-                      {({ selected, active }) => (
-                        <>
+              ) : (
+                data?.map((item: any) => (
+                  <Combobox.Option
+                    key={item.id}
+                    className={({ active }) =>
+                      `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                        active ? "text-white bg-primary-500" : "text-gray-900"
+                      }`
+                    }
+                    value={item}
+                    onClick={() => {
+                      setVisible(false);
+                    }}
+                  >
+                    {({ selected, active }) => (
+                      <>
+                        <span
+                          className={`block truncate ${
+                            selected ? "font-medium" : "font-normal"
+                          }`}
+                        >
+                          {optionLabel(item)}
+                        </span>
+                        {selected ? (
                           <span
-                            className={`block truncate ${
-                              selected ? "font-medium" : "font-normal"
+                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                              active ? "text-white" : "text-primary-500"
                             }`}
                           >
-                            {optionLabel(item)}
+                            <i className="fa-solid fa-check" />
                           </span>
-                          {selected ? (
-                            <span
-                              className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
-                                active ? "text-white" : "text-primary-500"
-                              }`}
-                            >
-                              <i className="fa-solid fa-check" />
-                            </span>
-                          ) : null}
-                        </>
-                      )}
-                    </Combobox.Option>
-                  ))
-                )}
-              </Combobox.Options>
+                        ) : null}
+                      </>
+                    )}
+                  </Combobox.Option>
+                ))
+              )}
+            </Combobox.Options>
+          </DropdownTransition>
+          {multiple && selected?.length > 0 && (
+            <div className="p-2 flex flex-wrap gap-2">
+              {selected?.map((option: any) => (
+                <span className="bg-gray-200 border border-gray-400 text-gray-800 rounded-full text-xs px-2 py-1">
+                  {optionLabel(option)}
+                  <i
+                    className="fa-solid fa-x h-3 w-3 ml-1 text-gray-700 cursor-pointer"
+                    onClick={() => {
+                      onChange(
+                        selected.filter((item: any) => item.id !== option.id)
+                      );
+                    }}
+                  />
+                </span>
+              ))}
             </div>
-            {multiple && selected?.length > 0 && (
-              <div className="p-2 flex flex-wrap gap-2">
-                {selected?.map((option: any) => (
-                  <span className="bg-gray-200 border border-gray-400 text-gray-800 rounded-full text-xs px-2 py-1">
-                    {optionLabel(option)}
-                    <i
-                      className="fa-solid fa-x h-3 w-3 ml-1 text-gray-700 cursor-pointer"
-                      onClick={() => {
-                        onChange(
-                          selected.filter((item: any) => item.id !== option.id)
-                        );
-                      }}
-                    />
-                  </span>
-                ))}
-              </div>
-            )}
-            {error && (
-              <div className="text-red-500 text-sm font-medium mt-1">
-                {error}
-              </div>
-            )}
-          </div>
-        )}
+          )}
+          {error && (
+            <div className="text-red-500 text-sm font-medium mt-1">{error}</div>
+          )}
+        </div>
       </Combobox>
     </div>
   );

--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -68,14 +68,16 @@ const AutoCompleteAsync = (props: Props) => {
           <div className="w-full flex rounded bg-gray-200 focus:border-primary-400 border-2 outline-none ring-0 transition-all duration-200 ease-in-out">
             <Combobox.Input
               name={name}
-              className="w-full border-none text-sm leading-5 text-gray-900 placeholder:text-gray-500 font-medium placeholder:font-normal focus:ring-0 bg-inherit shadow-none pr-16 truncate"
+              className="w-full border-none text-sm leading-5 text-gray-900 placeholder:text-gray-600 font-medium focus:ring-0 bg-inherit shadow-none pr-16 truncate"
               placeholder={
                 multiple && hasSelection
                   ? `${selected.length} selected`
                   : placeholder || "Start typing to search..."
               }
               displayValue={() =>
-                hasSelection ? optionLabel && optionLabel(selected) : undefined
+                hasSelection && !multiple
+                  ? optionLabel && optionLabel(selected)
+                  : ""
               }
               onChange={({ target }) => setQuery(target.value)}
             />

--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -37,19 +37,6 @@ const AutoCompleteAsync = (props: Props) => {
   const [data, setData] = useState([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
-  const [visible, setVisible] = useState(false);
-
-  const getPlaceholder = () => {
-    if (!multiple && selected) {
-      const option_label = optionLabel(selected);
-      if (option_label) {
-        return option_label;
-      }
-    }
-    if (!visible && multiple && selected?.length > 0)
-      return `${selected.length} selected`;
-    return placeholder || "Start typing to search...";
-  };
 
   const hasSelection =
     (!multiple && selected) || (multiple && selected?.length > 0);
@@ -82,8 +69,14 @@ const AutoCompleteAsync = (props: Props) => {
             <Combobox.Input
               name={name}
               className="w-full border-none text-sm leading-5 text-gray-900 placeholder:text-gray-500 font-medium placeholder:font-normal focus:ring-0 bg-inherit shadow-none pr-16 truncate"
-              placeholder={getPlaceholder()}
-              displayValue={() => (hasSelection ? getPlaceholder() : undefined)}
+              placeholder={
+                multiple && hasSelection
+                  ? `${selected.length} selected`
+                  : placeholder || "Start typing to search..."
+              }
+              displayValue={() =>
+                hasSelection ? optionLabel && optionLabel(selected) : undefined
+              }
               onChange={({ target }) => setQuery(target.value)}
             />
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
@@ -111,9 +104,6 @@ const AutoCompleteAsync = (props: Props) => {
                       }`
                     }
                     value={item}
-                    onClick={() => {
-                      setVisible(false);
-                    }}
                   >
                     {({ selected, active }) => (
                       <>

--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -81,11 +81,7 @@ const AutoCompleteAsync = (props: Props) => {
           <div className="w-full flex rounded bg-gray-200 focus:border-primary-400 border-2 outline-none ring-0 transition-all duration-200 ease-in-out">
             <Combobox.Input
               name={name}
-              className={`w-full border-none text-sm leading-5 text-gray-900 ${
-                hasSelection
-                  ? "placeholder:text-gray-900 font-medium"
-                  : "placeholder:text-gray-500"
-              } focus:ring-0 bg-inherit shadow-none`}
+              className="w-full border-none text-sm leading-5 text-gray-900 placeholder:text-gray-500 font-medium placeholder:font-normal focus:ring-0 bg-inherit shadow-none pr-16 truncate"
               placeholder={getPlaceholder()}
               displayValue={() => (hasSelection ? getPlaceholder() : undefined)}
               onChange={({ target }) => setQuery(target.value)}

--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -80,26 +80,23 @@ const AutoCompleteAsync = (props: Props) => {
         {({ open }) => (
           <div className="relative mt-1">
             <div className="w-full flex rounded bg-gray-200 focus:border-primary-400 border-2 outline-none ring-0 transition-all duration-200 ease-in-out">
-              <Combobox.Button
-                className="block w-full pl-3 pr-10 py-1 focus:outline-none focus:ring-0 sm:text-sm"
-                as="div"
-              >
-                <Combobox.Input
-                  ref={queryInputRef}
-                  onFocus={() => {
-                    setQuery("");
-                    setVisible(true);
-                  }}
-                  name={name}
-                  className={`w-full border-none text-sm leading-5 text-gray-900 ${
-                    hasSelection
-                      ? "placeholder:text-gray-900 font-medium"
-                      : "placeholder:text-gray-500"
-                  } focus:ring-0 bg-inherit shadow-none`}
-                  placeholder={getPlaceholder()}
-                  onChange={(event) => setQuery(event.target.value)}
-                />
-                <div className="absolute top-2 right-0 flex items-center pr-2">
+              <Combobox.Input
+                ref={queryInputRef}
+                onFocus={() => {
+                  setQuery("");
+                  setVisible(true);
+                }}
+                name={name}
+                className={`w-full border-none text-sm leading-5 text-gray-900 ${
+                  hasSelection
+                    ? "placeholder:text-gray-900 font-medium"
+                    : "placeholder:text-gray-500"
+                } focus:ring-0 bg-inherit shadow-none`}
+                placeholder={getPlaceholder()}
+                onChange={(event) => setQuery(event.target.value)}
+              />
+              <Combobox.Button className="block w-full pl-3 pr-10 py-1 focus:outline-none focus:ring-0 sm:text-sm">
+                <div className="absolute top-1 right-0 flex items-center pr-2">
                   {loading && <Spinner path={{ fill: "black" }} />}
                   <i className="p-2 mr-2 text-sm fa-solid fa-chevron-down" />
                 </div>


### PR DESCRIPTION
## Proposed Changes

- Resolves #3937 

https://user-images.githubusercontent.com/25143503/199979463-c1095719-5ba6-4e2c-8e3d-7b9c2bb14a68.mp4

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
