### PR TITLE
Redesign patient dashboard navbar ui

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -271,8 +271,10 @@ export const ConsultationDetails = (props: any) => {
   }
 
   const tabButtonClasses = (selected: boolean) =>
-    `capitalize min-w-max-content cursor-pointer border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300 font-bold whitespace-nowrap ${
-      selected === true ? "border-primary-500 text-primary-600 border-b-2" : ""
+    `capitalize min-w-max-content cursor-pointer rounded-md py-1 px-2 mb-1 sm:px-4 border-transparent font-bold whitespace-nowrap text-xs sm:text-base md:text-sm ${
+      selected === true
+        ? "bg-primary-500 sm:hover:bg-primary-700 text-white"
+        : "text-gray-700"
     }`;
 
   const ShowDiagnosis = ({
@@ -625,27 +627,25 @@ export const ConsultationDetails = (props: any) => {
           </div>
         </div>
 
-        <div className="border-b-2 border-gray-200 mt-4 w-full">
-          <div className="sm:flex sm:items-baseline overflow-x-auto">
-            <div className="mt-4 sm:mt-0">
-              <nav className="pl-2 flex space-x-6 overflow-x-auto pb-2 ">
-                {CONSULTATION_TABS.map((p: OptionsType) => {
-                  if (p.text === "FEED") {
-                    if (!consultationData?.current_bed?.bed_object?.id)
-                      return null;
-                  }
-                  return (
-                    <Link
-                      key={p.text}
-                      className={tabButtonClasses(tab === p.text)}
-                      href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.text.toLocaleLowerCase()}`}
-                    >
-                      {p.desc}
-                    </Link>
-                  );
-                })}
-              </nav>
-            </div>
+        <div className="border-b-2 bg-white rounded-md shadow-sm border-gray-200 mt-4 px-4 py-2 w-full">
+          <div className="sm:flex sm:items-baseline flex-wrap">
+            <nav className="flex flex-wrap justify-start">
+              {CONSULTATION_TABS.map((p: OptionsType) => {
+                if (p.text === "FEED") {
+                  if (!consultationData?.current_bed?.bed_object?.id)
+                    return null;
+                }
+                return (
+                  <Link
+                    key={p.text}
+                    className={tabButtonClasses(tab === p.text)}
+                    href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/${p.text.toLocaleLowerCase()}`}
+                  >
+                    {p.desc}
+                  </Link>
+                );
+              })}
+            </nav>
           </div>
         </div>
         {tab === "UPDATES" && (


### PR DESCRIPTION
## Proposed Changes

FIXED #3943 

The improved UI looks like

mobile screens:

Extremely small mobile screens
<img width="348" alt="image" src="https://user-images.githubusercontent.com/61267953/199873968-73dc2743-d038-4b6a-9a40-dbfcb5fa5f35.png">

Normal mobile screens
<img width="399" alt="image" src="https://user-images.githubusercontent.com/61267953/199874023-55052c4a-ac85-43c2-9df8-0ca5ad5b0a39.png">

Mid Size screens view
<img width="389" alt="image" src="https://user-images.githubusercontent.com/61267953/199874115-53cfa8ac-cc05-492e-80fe-0b67e4f70147.png">

Desktop view
<img width="1306" alt="image" src="https://user-images.githubusercontent.com/61267953/199874159-77f09da4-d576-4bd9-88e8-f11691522b2a.png">



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

