### PR TITLE
Allow only image files for facility cover file input

### DIFF
--- a/src/Components/Facility/CoverImageEditModal.tsx
+++ b/src/Components/Facility/CoverImageEditModal.tsx
@@ -123,6 +123,7 @@ const CoverImageEditModal = ({
                 <input
                   title="changeFile"
                   type="file"
+                  accept="image/*"
                   className="hidden"
                   onChange={onSelectFile}
                 />


### PR DESCRIPTION
Fixes #3913

![image](https://user-images.githubusercontent.com/3626859/199927346-f25b4497-1436-42f8-8bbc-b7aafde0e680.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
