### PR TITLE
Added show details modal in preview mode for PressureSore

### DIFF
--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -307,14 +307,17 @@ let renderBody = (state, send, title, partPaths, substr) => {
             fill="currentColor"
             id={"part" ++ PressureSore.regionToString(regionType)}
             onClick={e => {
+              Js.log("clicked")
               send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
             }}
-            onMouseEnter={e => {
+            onMouseOver={e => {
+              Js.log("enter")
               if state.previewMode {
                 send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
               }
             }}
             onMouseLeave={_ => {
+              Js.log("left")
               if state.previewMode {
                 send(SetSelectedRegion(PressureSore.Other))
               }

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -164,37 +164,34 @@ let initialState = (psp, previewMode) => {
   }
 }
 
-let selectedClass = part => {
+let selectedClass = (part: option<PressureSore.part>) => {
   switch part {
   | Some(p) =>
-    switch PressureSore.scale(p) {
-    | 1 => "text-red-200 hover:bg-red-400 tooltip"
-    | 2 => "text-red-400 hover:bg-red-500 tooltip"
-    | 3 => "text-red-500 hover:bg-red-600 tooltip"
-    | 4 => "text-red-600 hover:bg-red-700 tooltip"
-    | 5 => "text-red-700 hover:bg-gray-400 tooltip"
-    | _ => "text-gray-400 hover:bg-red-400 tooltip"
-    }
+    let score =  PressureSore.calculatePushScore(p.length, p.width, p.exudate_amount, p.tissue_type) 
+    if score <= 0.0 { "text-gray-400 hover:bg-red-400 tooltip" } 
+    else if score <= 3.0 { "text-red-200 hover:bg-red-400 tooltip" }
+    else if score <= 6.0 { "text-red-400 hover:bg-red-500 tooltip" }
+    else if score <= 10.0 { "text-red-500 hover:bg-red-600 tooltip" }
+    else if score <= 15.0 { "text-red-600 hover:bg-red-700 tooltip" }
+    else { "text-red-700 hover:bg-red-800 tooltip" }
   | None => "text-gray-400 hover:text-red-200 tooltip"
   }
 }
 // UI for each Label
-let selectedLabelClass = part => {
+let selectedLabelClass = (part: option<PressureSore.part>) => {
   switch part {
   | Some(p) =>
-    switch PressureSore.scale(p) {
-    | 1 => "bg-red-200 text-red-700 hover:bg-red-400"
-    | 2 => "bg-red-400 text-white hover:bg-red-500"
-    | 3 => "bg-red-500 text-white hover:bg-red-600"
-    | 4 => "bg-red-600 text-white hover:bg-red-700"
-    | 5 => "bg-red-700 text-white hover:bg-red-200"
-    | _ => "bg-gray-300 text-black hover:bg-gray-400"
-    }
+    let score =  PressureSore.calculatePushScore(p.length, p.width, p.exudate_amount, p.tissue_type) 
+    if score <= 0.0 { "bg-gray-300 text-black hover:bg-gray-400" }
+    else if score <= 3.0 { "bg-red-200 text-red-700 hover:bg-red-400" }
+    else if score <= 6.0 { "bg-red-400 text-white hover:bg-red-500" }
+    else if score <= 10.0 { "bg-red-500 text-white hover:bg-red-600" }
+    else if score <= 15.0 { "bg-red-600 text-white hover:bg-red-700" }
+    else { "bg-red-700 text-white hover:bg-red-200" }
   | None => "bg-gray-300 text-black hover:bg-red-200"
   }
 }
 
-// String for Braden Scale Value
 let pushScoreValue = (selectedPart: option<PressureSore.part>) => {
   switch selectedPart {
   | Some(p) => PressureSore.calculatePushScore(p.length, p.width, p.exudate_amount, p.tissue_type)
@@ -307,17 +304,14 @@ let renderBody = (state, send, title, partPaths, substr) => {
             fill="currentColor"
             id={"part" ++ PressureSore.regionToString(regionType)}
             onClick={e => {
-              Js.log("clicked")
               send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
             }}
             onMouseOver={e => {
-              Js.log("enter")
               if state.previewMode {
                 send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
               }
             }}
             onMouseLeave={_ => {
-              Js.log("left")
               if state.previewMode {
                 send(SetSelectedRegion(PressureSore.Other))
               }

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -1,6 +1,9 @@
 @val external setTimeout: (unit => unit, int) => float = "setTimeout"
 @val external clearTimeout: float => unit = "clearTimeout"
 
+@val external innerWidth: int = "window.innerWidth"
+@val external innerHeight: int = "window.innerHeight"
+
 @val external document: 'a = "document"
 %%raw("import './styles.css'")
 
@@ -239,7 +242,7 @@ let renderBody = (state, send, title, partPaths, substr) => {
     <div className="text-left font-bold mx-auto mt-5">
       {str("Braden Scale (Risk Severity) (" ++ title ++ ")")}
     </div>
-    // Braden Scale Divs
+    // Badges
     <div className="mx-auto overflow-x-scroll my-3 border-2">
       <div className="grid grid-rows-3 grid-flow-col auto-cols-max md:flex md:flex-wrap">
         {Js.Array.mapi((part, index) => {
@@ -251,14 +254,8 @@ let renderBody = (state, send, title, partPaths, substr) => {
             className={"p-1 col-auto text-sm rounded m-1 cursor-pointer " ++
             selectedLabelClass(selectedPart)}
             id={PressureSore.regionToString(regionType)}
-            onClick={state.previewMode
-              ? _ => getIntoView(PressureSore.regionToString(regionType), false)
-              : _ => {
-                  switch selectedPart {
-                  | Some(p) => send(AutoManageScale(p))
-                  | None => send(AddPressureSore(regionType))
-                  }
-                }}>
+            onClick={_ => getIntoView(PressureSore.regionToString(regionType), false)}
+          >
             <div className="flex justify-between">
               <div className="border-white px-1">
                 {str(
@@ -312,7 +309,7 @@ let renderBody = (state, send, title, partPaths, substr) => {
             onClick={e => {
               send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
             }}
-            onMouseOver={e => {
+            onMouseEnter={e => {
               if state.previewMode {
                 send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
               }

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -306,13 +306,13 @@ let renderBody = (state, send, title, partPaths, substr) => {
             onClick={e => {
               send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
             }}
-            onMouseOver={e => {
-              if state.previewMode {
+            onMouseEnter={e => {
+              if state.previewMode && innerWidth > 720 {
                 send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
               }
             }}
             onMouseLeave={_ => {
-              if state.previewMode {
+              if state.previewMode && innerWidth > 720 {
                 send(SetSelectedRegion(PressureSore.Other))
               }
             }}

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -192,19 +192,11 @@ let selectedLabelClass = part => {
 }
 
 // String for Braden Scale Value
-let bradenScaleValue = selectedPart => {
+let pushScoreValue = (selectedPart: option<PressureSore.part>) => {
   switch selectedPart {
-  | Some(p) =>
-    switch PressureSore.scale(p) {
-    | 1 => ": 1"
-    | 2 => ": 2"
-    | 3 => ": 3"
-    | 4 => ": 4"
-    | 5 => ": 5"
-    | _ => ""
-    }
-  | None => ""
-  }
+  | Some(p) => PressureSore.calculatePushScore(p.length, p.width, p.exudate_amount, p.tissue_type)
+  | None => 0.0
+  }->Js.Float.toString
 }
 
 let getIntoView = (region: string, isPart: bool) => {
@@ -272,7 +264,7 @@ let renderBody = (state, send, title, partPaths, substr) => {
                 {str(
                   Js.String.sliceToEnd(
                     ~from=substr,
-                    PressureSore.regionToString(regionType) ++ bradenScaleValue(selectedPart),
+                    PressureSore.regionToString(regionType) ++ (pushScoreValue(selectedPart) === "0" ? "" : " : " ++ pushScoreValue(selectedPart)),
                   ),
                 )}
               </div>
@@ -317,11 +309,9 @@ let renderBody = (state, send, title, partPaths, substr) => {
             className={selectedClass(selectedPart)}
             fill="currentColor"
             id={"part" ++ PressureSore.regionToString(regionType)}
-            onClick={state.previewMode
-              ? _ => getIntoView(PressureSore.regionToString(regionType), true)
-              : e => {
-                  send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
-                }}
+            onClick={e => {
+              send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
+            }}
             onMouseOver={e => {
               if state.previewMode {
                 send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -304,6 +304,7 @@ let renderBody = (state, send, title, partPaths, substr) => {
           )
         }
         updatePart={part => send(UpdateSelectedPart(part))}
+        previewMode={state.previewMode}
       />
       <svg className="h-screen py-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 344.7 932.661">
         {Js.Array.mapi((part, renderIndex) => {
@@ -321,6 +322,16 @@ let renderBody = (state, send, title, partPaths, substr) => {
               : e => {
                   send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
                 }}
+            onMouseOver={e => {
+              if state.previewMode {
+                send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
+              }
+            }}
+            onMouseLeave={_ => {
+              if state.previewMode {
+                send(SetSelectedRegion(PressureSore.Other))
+              }
+            }}
           >
             <title className=""> {str(PressureSore.regionToString(regionType))} </title>
           </path>

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -1,4 +1,5 @@
 @val external innerWidth: int = "window.innerWidth"
+@val external innerHeight: int = "window.innerHeight"
 
 let str = React.string
 open CriticalCare__Types
@@ -25,7 +26,12 @@ let make = (
   }, (part, show))
 
   React.useEffect1(() => {
-    let score = PressureSore.calculatePushScore(state.length, state.width, state.exudate_amount, state.tissue_type)
+    let score = PressureSore.calculatePushScore(
+      state.length,
+      state.width,
+      state.exudate_amount,
+      state.tissue_type,
+    )
     setPushScore(_ => score)
     None
   }, [state])
@@ -50,11 +56,15 @@ let make = (
         ref={ReactDOM.Ref.domRef(ref)}
         style={ReactDOMStyle.make(
           ~position={innerWidth >= 640 ? "absolute" : ""},
-          ~left=`${position["x"]->Belt.Int.toString}px`,
-          ~top=`${position["y"]->Belt.Int.toString}px`,
+          ~left=`${(
+              innerWidth - position["x"] < 350 ? position["x"] - 350 : position["x"]
+            )->Belt.Int.toString}px`,
+          ~top=`${(
+              innerHeight - position["y"] < 352 ? position["y"] - 352 : position["y"]
+            )->Belt.Int.toString}px`,
           (),
         )}
-        className="transform w-4/5 rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
+        className="transform max-w-[350px] rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
         <div className="bg-white px-4 pt-2 pb-4 sm:p-6 sm:pb-4">
           <div className="sm:flex sm:items-start">
             <div className="mt-3 text-center sm:mt-0 sm:text-left">

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -45,6 +45,28 @@ let make = (
     }
   `)
 
+  let getModalPosition = React.useMemo(() => {
+    () => {
+      let modalWidth = 350
+      let modalHeight = 352
+      if previewMode && innerWidth < 720 {
+        {
+          "top": ((innerHeight - modalHeight) / 2)->Belt.Int.toString ++ "px",
+          "left": ((innerWidth - modalWidth) / 2)->Belt.Int.toString ++ "px",
+        }
+      } else {
+        {
+          "top": (
+            innerHeight - position["y"] < modalHeight ? position["y"] - modalHeight : position["y"]
+          )->Belt.Int.toString ++ "px",
+          "left": (
+            innerWidth - position["x"] < modalWidth ? position["x"] - modalWidth : position["x"]
+          )->Belt.Int.toString ++ "px",
+        }
+      }
+    }
+  })
+
   <div
     hidden={!show}
     onClick={e => handleClickOutside(e, ref, hideModal)}
@@ -55,13 +77,9 @@ let make = (
       <div
         ref={ReactDOM.Ref.domRef(ref)}
         style={ReactDOMStyle.make(
-          ~position={innerWidth >= 640 ? "absolute" : ""},
-          ~left=`${(
-              innerWidth - position["x"] < 350 ? position["x"] - 350 : position["x"]
-            )->Belt.Int.toString}px`,
-          ~top=`${(
-              innerHeight - position["y"] < 352 ? position["y"] - 352 : position["y"]
-            )->Belt.Int.toString}px`,
+          ~position={innerWidth >= 720 || previewMode ? "absolute" : ""},
+          ~left=getModalPosition()["left"],
+          ~top=getModalPosition()["top"],
           (),
         )}
         className="transform max-w-[350px] rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
@@ -163,9 +181,9 @@ let make = (
             <span> {str("Push Score: ")} </span>
             <span className="text-black"> {str(pushScore->Belt.Float.toString)} </span>
           </div>
-          {!previewMode
-            ? <div className="flex flex-col-reverse sm:flex-row-reverse w-full gap-2">
-                <button
+          <div className="flex flex-col-reverse sm:flex-row-reverse w-full gap-2">
+            {!previewMode
+              ? <button
                   type_="button"
                   onClick={e => {
                     updatePart(state)
@@ -174,14 +192,14 @@ let make = (
                   className="inline-flex w-full justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:ml-3 sm:w-auto sm:text-sm">
                   {str("Apply")}
                 </button>
-                <button
-                  type_="button"
-                  onClick={hideModal}
-                  className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-                  {str("Cancel")}
-                </button>
-              </div>
-            : React.null}
+              : React.null}
+            <button
+              type_="button"
+              onClick={hideModal}
+              className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+              {str("Cancel")}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -3,16 +3,19 @@
 let str = React.string
 open CriticalCare__Types
 
-type position = {
-  "x": int,
-  "y": int,
-}
+type position = {"x": int, "y": int}
 
 type part = PressureSore.part
 
 @react.component
-let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: position, ~part: part, ~updatePart: part => unit) => {
-
+let make = (
+  ~show: bool,
+  ~previewMode: bool,
+  ~hideModal: ReactEvent.Mouse.t => unit,
+  ~position: position,
+  ~part: part,
+  ~updatePart: part => unit,
+) => {
   let (state, setState) = React.useState(_ => part)
   let (pushScore, setPushScore) = React.useState(_ => 0.0)
 
@@ -27,9 +30,25 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
     let tissueTypes = ["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
 
     let area = state.length *. state.width
-    let areaScore = areaIntervalPoints->Belt.Array.getIndexBy(interval => interval >= area)->Belt.Option.getWithDefault(10)->float_of_int
-    let exudateScore = exudateAmounts->Belt.Array.getIndexBy(amount => amount == state.exudate_amount->PressureSore.extrudateAmountToString)->Belt.Option.getWithDefault(0)->float_of_int
-    let tissueScore = tissueTypes->Belt.Array.getIndexBy(tissue => tissue == state.tissue_type->PressureSore.tissueTypeToString)->Belt.Option.getWithDefault(0)->float_of_int
+    let areaScore =
+      areaIntervalPoints
+      ->Belt.Array.getIndexBy(interval => interval >= area)
+      ->Belt.Option.getWithDefault(10)
+      ->float_of_int
+    let exudateScore =
+      exudateAmounts
+      ->Belt.Array.getIndexBy(amount =>
+        amount == state.exudate_amount->PressureSore.extrudateAmountToString
+      )
+      ->Belt.Option.getWithDefault(0)
+      ->float_of_int
+    let tissueScore =
+      tissueTypes
+      ->Belt.Array.getIndexBy(tissue =>
+        tissue == state.tissue_type->PressureSore.tissueTypeToString
+      )
+      ->Belt.Option.getWithDefault(0)
+      ->float_of_int
 
     let score = areaScore +. exudateScore +. tissueScore
     setPushScore(_ => score)
@@ -45,41 +64,41 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
     }
   `)
 
-  <div 
-    hidden={!show} 
-    onClick={e => handleClickOutside(e, ref, hideModal)} 
-    className="fixed w-full inset-0 z-40 overflow-y-auto"
-  >
+  <div
+    hidden={!show}
+    onClick={e => handleClickOutside(e, ref, hideModal)}
+    className={previewMode ? "" : "fixed w-full inset-0 z-40 overflow-y-auto"}>
     <div
-      hidden={!show} 
-      className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
-    >
+      hidden={!show}
+      className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
       <div
         ref={ReactDOM.Ref.domRef(ref)}
         style={ReactDOMStyle.make(
           ~position={innerWidth >= 640 ? "absolute" : ""},
-          ~left= `${position["x"]->Belt.Int.toString}px`,
+          ~left=`${position["x"]->Belt.Int.toString}px`,
           ~top=`${position["y"]->Belt.Int.toString}px`,
-          ()
+          (),
         )}
-        className="transform w-4/5 rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit"
-      >
+        className="transform w-4/5 rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-fit">
         <div className="bg-white px-4 pt-2 pb-4 sm:p-6 sm:pb-4">
           <div className="sm:flex sm:items-start">
             <div className="mt-3 text-center sm:mt-0 sm:text-left">
               <div className="flex gap-2 justify-center">
-                <span>{str("Region: ")}</span>
-                <span className="text-black">{str(PressureSore.regionToString(state.region))}</span>
+                <span> {str("Region: ")} </span>
+                <span className="text-black">
+                  {str(PressureSore.regionToString(state.region))}
+                </span>
               </div>
               <div className="flex flex-col sm:flex-row gap-2 mt-2">
                 <div>
-                  <label className="block font-medium text-black text-left">{str("Width")}</label>
+                  <label className="block font-medium text-black text-left"> {str("Width")} </label>
                   <input
                     type_="number"
                     value={state.width->Belt.Float.toString}
                     step={0.1}
                     placeholder="Width (cm)"
                     className="border border-gray-300 rounded-md w-full px-2 py-1"
+                    disabled={previewMode}
                     onChange={e => {
                       let value = ReactEvent.Form.target(e)["value"]->Belt.Float.fromString
                       switch value {
@@ -90,13 +109,16 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
                   />
                 </div>
                 <div>
-                  <label className="block font-medium text-black text-left">{str("Height")}</label>
+                  <label className="block font-medium text-black text-left">
+                    {str("Height")}
+                  </label>
                   <input
                     type_="number"
                     value={state.length->Belt.Float.toString}
                     step={0.1}
                     placeholder="Length (cm)"
                     className="border border-gray-300 rounded-md w-full px-2 py-1"
+                    disabled={previewMode}
                     onChange={e => {
                       let value = ReactEvent.Form.target(e)["value"]->Belt.Float.fromString
                       switch value {
@@ -108,26 +130,34 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
                 </div>
               </div>
               <div className="flex flex-col sm:flex-row gap-2 mt-2">
-                  <CriticalCare__Dropdown
-                    id="exudate-amount"
-                    label="Exudate amount"
-                    value={state.exudate_amount->PressureSore.encodeExudateAmount}
-                    updateCB=(value => setState(prev => {...prev, exudate_amount: value->PressureSore.decodeExtrudateAmount}))
-                    placeholder="Exudate amount"
-                    selectables=["None", "Light", "Moderate", "Heavy"]
-                  />
-                  <CriticalCare__Dropdown
-                    id="tissue-type"
-                    label="Tissue type"
-                    value={state.tissue_type->PressureSore.encodeTissueType}
-                    updateCB=(value => setState(prev => {...prev, tissue_type: value->PressureSore.decodeTissueType}))
-                    placeholder="Tissue type"
-                    selectables=["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
-                  />
+                <CriticalCare__Dropdown
+                  id="exudate-amount"
+                  label="Exudate amount"
+                  value={state.exudate_amount->PressureSore.encodeExudateAmount}
+                  updateCB={value =>
+                    setState(prev => {
+                      ...prev,
+                      exudate_amount: value->PressureSore.decodeExtrudateAmount,
+                    })}
+                  placeholder="Exudate amount"
+                  selectables=["None", "Light", "Moderate", "Heavy"]
+                  disabled={previewMode}
+                />
+                <CriticalCare__Dropdown
+                  id="tissue-type"
+                  label="Tissue type"
+                  value={state.tissue_type->PressureSore.encodeTissueType}
+                  updateCB={value =>
+                    setState(prev => {...prev, tissue_type: value->PressureSore.decodeTissueType})}
+                  placeholder="Tissue type"
+                  selectables=["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
+                  disabled={previewMode}
+                />
               </div>
-              
               <div className="mt-2">
-                <label className="block font-medium text-black text-left">{str("Description")}</label>
+                <label className="block font-medium text-black text-left">
+                  {str("Description")}
+                </label>
                 <textarea
                   placeholder="Description"
                   value={state.description}
@@ -136,36 +166,39 @@ let make = (~show: bool, ~hideModal: ReactEvent.Mouse.t => unit, ~position: posi
                     setState(prev => {...prev, description: value})
                   }}
                   className="border border-gray-300 rounded-md px-2 py-1 w-full"
+                  disabled={previewMode}
                 />
               </div>
             </div>
           </div>
         </div>
-        <div className="bg-gray-50 px-4 py-3 sm:px-6 flex flex-col sm:flex-row items-center justify-between gap-2">
+        <div
+          className="bg-gray-50 px-4 py-3 sm:px-6 flex flex-col sm:flex-row items-center justify-between gap-2">
           <div className="flex gap-2 w-full justify-center sm:justify-start items-center">
-            <span>{str("Push Score: ")}</span>
-            <span className="text-black">{str(pushScore->Belt.Float.toString)}</span>
+            <span> {str("Push Score: ")} </span>
+            <span className="text-black"> {str(pushScore->Belt.Float.toString)} </span>
           </div>
-          <div className="flex flex-col-reverse sm:flex-row-reverse w-full gap-2">
-            <button
-              type_="button"
-              onClick=(e => {
-                updatePart(state)
-                hideModal(e)
-              })
-              className="inline-flex w-full justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:ml-3 sm:w-auto sm:text-sm">
-              {str("Apply")}
-            </button>
-            <button
-              type_="button"
-              onClick={hideModal}
-              className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-              {str("Cancel")}
-            </button>
-          </div>
+          {!previewMode
+            ? <div className="flex flex-col-reverse sm:flex-row-reverse w-full gap-2">
+                <button
+                  type_="button"
+                  onClick={e => {
+                    updatePart(state)
+                    hideModal(e)
+                  }}
+                  className="inline-flex w-full justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:ml-3 sm:w-auto sm:text-sm">
+                  {str("Apply")}
+                </button>
+                <button
+                  type_="button"
+                  onClick={hideModal}
+                  className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+                  {str("Cancel")}
+                </button>
+              </div>
+            : React.null}
         </div>
       </div>
     </div>
   </div>
-
 }

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -25,32 +25,7 @@ let make = (
   }, (part, show))
 
   React.useEffect1(() => {
-    let areaIntervalPoints = [0.0, 0.3, 0.6, 1.0, 2.2, 3.0, 4.0, 8.0, 12.0, 24.0]
-    let exudateAmounts = ["None", "Light", "Moderate", "Heavy"]
-    let tissueTypes = ["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
-
-    let area = state.length *. state.width
-    let areaScore =
-      areaIntervalPoints
-      ->Belt.Array.getIndexBy(interval => interval >= area)
-      ->Belt.Option.getWithDefault(10)
-      ->float_of_int
-    let exudateScore =
-      exudateAmounts
-      ->Belt.Array.getIndexBy(amount =>
-        amount == state.exudate_amount->PressureSore.extrudateAmountToString
-      )
-      ->Belt.Option.getWithDefault(0)
-      ->float_of_int
-    let tissueScore =
-      tissueTypes
-      ->Belt.Array.getIndexBy(tissue =>
-        tissue == state.tissue_type->PressureSore.tissueTypeToString
-      )
-      ->Belt.Option.getWithDefault(0)
-      ->float_of_int
-
-    let score = areaScore +. exudateScore +. tissueScore
+    let score = PressureSore.calculatePushScore(state.length, state.width, state.exudate_amount, state.tissue_type)
     setPushScore(_ => score)
     None
   }, [state])

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -49,20 +49,14 @@ let make = (
     () => {
       let modalWidth = 350
       let modalHeight = 352
-      if previewMode && innerWidth < 720 {
-        {
-          "top": ((innerHeight - modalHeight) / 2)->Belt.Int.toString ++ "px",
-          "left": ((innerWidth - modalWidth) / 2)->Belt.Int.toString ++ "px",
-        }
-      } else {
-        {
-          "top": (
-            innerHeight - position["y"] < modalHeight ? position["y"] - modalHeight : position["y"]
-          )->Belt.Int.toString ++ "px",
-          "left": (
-            innerWidth - position["x"] < modalWidth ? position["x"] - modalWidth : position["x"]
-          )->Belt.Int.toString ++ "px",
-        }
+      
+      {
+        "top": (
+          innerHeight - position["y"] < modalHeight ? position["y"] - modalHeight : position["y"]
+        )->Belt.Int.toString ++ "px",
+        "left": (
+          innerWidth - position["x"] < modalWidth ? position["x"] - modalWidth : position["x"]
+        )->Belt.Int.toString ++ "px",
       }
     }
   })
@@ -70,14 +64,14 @@ let make = (
   <div
     hidden={!show}
     onClick={e => handleClickOutside(e, ref, hideModal)}
-    className={previewMode ? "" : "fixed w-full inset-0 z-40 overflow-y-auto"}>
+    className={previewMode && innerWidth > 720 ? "" : "fixed w-full inset-0 z-40 overflow-y-auto"}>
     <div
       hidden={!show}
       className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
       <div
         ref={ReactDOM.Ref.domRef(ref)}
         style={ReactDOMStyle.make(
-          ~position={innerWidth >= 720 || previewMode ? "absolute" : ""},
+          ~position={innerWidth >= 720 ? "absolute" : ""},
           ~left=getModalPosition()["left"],
           ~top=getModalPosition()["top"],
           (),

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -11,6 +11,7 @@ type part = PressureSore.part
 @react.component
 let make = (
   ~show: bool,
+  ~modalRef: ReactDOM.domRef,
   ~previewMode: bool,
   ~hideModal: ReactEvent.Mouse.t => unit,
   ~position: position,
@@ -36,7 +37,6 @@ let make = (
     None
   }, [state])
 
-  let ref = React.useRef(Js.Nullable.null)
   let handleClickOutside = %raw(`
     function (event, ref, hideModal) {
       if (ref.current && !ref.current.contains(event.target)) {
@@ -63,13 +63,18 @@ let make = (
 
   <div
     hidden={!show}
-    onClick={e => handleClickOutside(e, ref, hideModal)}
+    onClick={e => handleClickOutside(e, modalRef, hideModal)}
     className={previewMode && innerWidth > 720 ? "" : "fixed w-full inset-0 z-40 overflow-y-auto"}>
     <div
       hidden={!show}
       className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
       <div
-        ref={ReactDOM.Ref.domRef(ref)}
+        ref={modalRef}
+        onMouseLeave={e => {
+          if (previewMode && innerWidth > 720) {
+            hideModal(e)
+          }
+        }}
         style={ReactDOMStyle.make(
           ~position={innerWidth >= 720 ? "absolute" : ""},
           ~left=getModalPosition()["left"],

--- a/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
+++ b/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
@@ -54,7 +54,7 @@ let renderDropdown = results =>
   </div>
 
 @react.component
-let make = (~id, ~value, ~updateCB, ~placeholder, ~selectables, ~label="") => {
+let make = (~id, ~value, ~updateCB, ~placeholder, ~selectables, ~label="", ~disabled=false) => {
   let results = searchResult(value, updateCB, selectables)
   let (showDropdown, setShowDropdown) = React.useState(_ => false)
   React.useEffect1(() => {
@@ -80,6 +80,7 @@ let make = (~id, ~value, ~updateCB, ~placeholder, ~selectables, ~label="") => {
       onClick={_ => setShowDropdown(_ => !showDropdown)}
       onChange={e => updateCB(ReactEvent.Form.target(e)["value"])}
       className="appearance-none h-10 mt-1 block w-full border border-gray-400 rounded py-2 px-4 text-sm bg-gray-100 hover:bg-gray-200 focus:outline-none focus:bg-white focus:ring-primary-500"
+      disabled
       placeholder
       required=true
     />

--- a/src/Components/CriticalCareRecording/types/CriticalCare__PressureSore.res
+++ b/src/Components/CriticalCareRecording/types/CriticalCare__PressureSore.res
@@ -285,6 +285,35 @@ let makeDefault = (region) => {
   description: ""
 }
 
+let calculatePushScore = (length, width, exudate_amount, tissue_type) => {
+  let areaIntervalPoints = [0.0, 0.3, 0.6, 1.0, 2.2, 3.0, 4.0, 8.0, 12.0, 24.0]
+    let exudateAmounts = ["None", "Light", "Moderate", "Heavy"]
+    let tissueTypes = ["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
+
+    let area = length *. width
+    let areaScore =
+      areaIntervalPoints
+      ->Belt.Array.getIndexBy(interval => interval >= area)
+      ->Belt.Option.getWithDefault(10)
+      ->float_of_int
+    let exudateScore =
+      exudateAmounts
+      ->Belt.Array.getIndexBy(amount =>
+        amount == exudate_amount->extrudateAmountToString
+      )
+      ->Belt.Option.getWithDefault(0)
+      ->float_of_int
+    let tissueScore =
+      tissueTypes
+      ->Belt.Array.getIndexBy(tissue =>
+        tissue == tissue_type->tissueTypeToString
+      )
+      ->Belt.Option.getWithDefault(0)
+      ->float_of_int
+
+    areaScore +. exudateScore +. tissueScore
+}
+
 let autoScale = part => {
   {...part, scale: mod(part.scale + 1, 6)}
 }


### PR DESCRIPTION
Fixes #3917 

## Proposed Changes

- added show details modal in preview on hover
- show push score value in badges instead of scale values
- remapped colors based on push score

![image](https://user-images.githubusercontent.com/29787772/200010798-f181c564-8781-4259-8967-ad98df11bad4.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
