### PR TITLE
Fixed selection issue in Prescription Builder

### DIFF
--- a/src/Components/Common/FacilitySelect.tsx
+++ b/src/Components/Common/FacilitySelect.tsx
@@ -67,6 +67,7 @@ export const FacilitySelect = (props: FacilitySelectProps) => {
         option.name +
         (option.district_object ? `, ${option.district_object.name}` : "")
       }
+      compareBy="id"
       className={className}
       error={errors}
     />

--- a/src/Components/Facility/FacilityFilter/DistrictSelect.tsx
+++ b/src/Components/Facility/FacilityFilter/DistrictSelect.tsx
@@ -33,6 +33,7 @@ function DistrictSelect(props: DistrictSelectProps) {
       fetchData={districtSearch}
       onChange={setSelected}
       optionLabel={(option: any) => option.name}
+      compareBy="id"
       error={errors}
       className={className}
     />

--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -27,7 +27,7 @@ const AutoCompleteAsync = (props: Props) => {
     optionLabel = (option: any) => option.label,
     showNOptions = 10,
     multiple = false,
-    compareBy = "id",
+    compareBy,
     debounceTime = 300,
     className = "",
     placeholder,

--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -407,6 +407,7 @@ export default function PatientFilterV2(props: any) {
                 })
               }
               optionLabel={(option) => option.name}
+              compareBy="id"
             />
           </div>
         </div>


### PR DESCRIPTION
Fixes #3960 

## Proposed Changes

- Changed default compareBy to undefined from "id" in AutoCompleteAsync
- Added compareBy property to other instances

_As in prescriptions we were passing string instead of objects there was no need for compareBy prop_

![image](https://user-images.githubusercontent.com/29787772/200114222-f36061f7-740d-4c80-89f8-99ad27f27eb2.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
