### PR TITLE
fix: replaced multiselect with new tailwind component

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -201,6 +201,7 @@ export const REVIEW_AT_CHOICES: Array<OptionsType> = [
 ];
 
 export const SYMPTOM_CHOICES: Array<OptionsType> = [
+  { id: 1, text: "ASYMPTOMATIC" },
   { id: 2, text: "FEVER" },
   { id: 3, text: "SORE THROAT" },
   { id: 4, text: "COUGH" },

--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -201,7 +201,6 @@ export const REVIEW_AT_CHOICES: Array<OptionsType> = [
 ];
 
 export const SYMPTOM_CHOICES: Array<OptionsType> = [
-  { id: 1, text: "ASYMPTOMATIC" },
   { id: 2, text: "FEVER" },
   { id: 3, text: "SORE THROAT" },
   { id: 4, text: "COUGH" },

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -40,7 +40,6 @@ import {
   DateInputField,
   ErrorHelperText,
   MultilineInputField,
-  MultiSelectField,
   NativeSelectField,
   SelectField,
   TextInputField,
@@ -67,6 +66,8 @@ import ProcedureBuilder, {
 } from "../Common/prescription-builder/ProcedureBuilder";
 import { ICD11DiagnosisModel } from "./models";
 import ButtonV2 from "../Common/components/ButtonV2";
+import MultiSelectMenuV2 from "../Form/MultiSelectMenuV2";
+import { FieldLabel } from "../Form/FormFields/FormField";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -598,34 +599,16 @@ export const ConsultationForm = (props: any) => {
         form: {
           ...state.form,
           [e.target.name]: e.target.value,
-          // admitted: e.target.value === "A" ? "true" : "false",
         },
       });
   };
 
-  const handleSymptomChange = (e: any, child?: any) => {
-    const form = { ...state.form };
-    const { value } = e?.target;
-    const otherSymptoms = value.filter((i: number) => i !== 1);
-    // prevent user from selecting asymptomatic along with other options
-    form.symptoms =
-      child?.props?.value === 1
-        ? otherSymptoms.length
-          ? [1]
-          : value
-        : otherSymptoms;
-    form.hasSymptom = !!form.symptoms.filter((i: number) => i !== 1).length;
-    form.otherSymptom = !!form.symptoms.filter((i: number) => i === 9).length;
-    dispatch({ type: "set_form", form });
+  const handleValueChange = (value: any, field: string) => {
+    dispatch({
+      type: "set_form",
+      form: { ...state.form, [field]: value },
+    });
   };
-
-  // ------------- DEPRECATED -------------
-  // const handleDateChange = (date: any, key: string) => {
-  //   if (moment(date).isValid()) {
-  //     const form = { ...state.form };
-  //     form[key] = date;
-  //     dispatch({ type: "set_form", form });
-  //   }
 
   const handleDateChange = (date: MaterialUiPickersDate, key: string) => {
     moment(date).isValid() &&
@@ -683,13 +666,15 @@ export const ConsultationForm = (props: any) => {
             <CardContent>
               <div className="grid gap-4 grid-cols-1">
                 <div id="symptoms-div">
-                  <InputLabel id="symptoms-label">Symptoms*</InputLabel>
-                  <MultiSelectField
-                    name="symptoms"
-                    variant="outlined"
+                  <FieldLabel className="text-sm">Symptoms</FieldLabel>
+                  <MultiSelectMenuV2
+                    id="symptoms"
+                    placeholder="Symptoms"
                     value={state.form.symptoms}
                     options={symptomChoices}
-                    onChange={handleSymptomChange}
+                    optionLabel={(o) => o.text}
+                    optionValue={(o) => o.id}
+                    onChange={(o) => handleValueChange(o, "symptoms")}
                   />
                   <ErrorHelperText error={state.errors.symptoms} />
                 </div>

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -67,7 +67,6 @@ import ProcedureBuilder, {
 import { ICD11DiagnosisModel } from "./models";
 import ButtonV2 from "../Common/components/ButtonV2";
 import MultiSelectMenuV2 from "../Form/MultiSelectMenuV2";
-import { FieldLabel } from "../Form/FormFields/FormField";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -602,19 +601,15 @@ export const ConsultationForm = (props: any) => {
       });
   };
 
-  const handleSymptomChange = (value: any, field: string) => {
-    if (state.form.is_asymptomatic) {
-      dispatch({
-        type: "set_form",
-        form: { ...state.form, [field]: [1], symptoms_onset_date: null },
-      });
-    }
+  const handleSymptomChange = (value: any) => {
+    const checkSymptoms = value.includes(1);
     dispatch({
       type: "set_form",
       form: {
         ...state.form,
-        [field]: value,
-        ["otherSymptom"]: value.includes(9),
+        is_asymptomatic: checkSymptoms,
+        symptoms: checkSymptoms ? [1] : value,
+        otherSymptom: checkSymptoms ? false : value.includes(9),
       },
     });
   };
@@ -675,37 +670,14 @@ export const ConsultationForm = (props: any) => {
             <CardContent>
               <div className="grid gap-4 grid-cols-1">
                 <div id="symptoms-div">
-                  <div className="flex gap-10 items-start">
-                    <FieldLabel className="text-sm">Symptoms</FieldLabel>
-                    <div className="flex gap-2">
-                      <input
-                        type={"checkbox"}
-                        className="mt-[0.7]"
-                        name={"is_asymptomatic"}
-                        checked={state.form.is_asymptomatic}
-                        onChange={(e) => {
-                          dispatch({
-                            type: "set_form",
-                            form: {
-                              ...state.form,
-                              is_asymptomatic: e.target.checked,
-                              symptoms: e.target.checked ? [1] : [],
-                            },
-                          });
-                        }}
-                      />
-                      <FieldLabel className="text-sm">Asymptomatic</FieldLabel>
-                    </div>
-                  </div>
                   <MultiSelectMenuV2
                     id="symptoms"
                     placeholder="Symptoms"
                     value={state.form.symptoms}
-                    disabled={state.form.is_asymptomatic}
                     options={symptomChoices}
                     optionLabel={(o) => o.text}
                     optionValue={(o) => o.id}
-                    onChange={(o) => handleSymptomChange(o, "symptoms")}
+                    onChange={(o) => handleSymptomChange(o)}
                   />
                   <ErrorHelperText error={state.errors.symptoms} />
                 </div>

--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -40,8 +40,8 @@ import {
 } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
 import {
+  ErrorHelperText,
   MultilineInputField,
-  MultiSelectField,
   PhoneNumberField,
   SelectField,
   TextInputField,
@@ -49,6 +49,7 @@ import {
 import GLocationPicker from "../Common/GLocationPicker";
 import { goBack } from "../../Utils/utils";
 import useWindowDimensions from "../../Common/hooks/useWindowDimensions";
+import MultiSelectMenuV2 from "../Form/MultiSelectMenuV2";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
@@ -73,7 +74,7 @@ type FacilityForm = {
   state: string;
   district: string;
   local_body: string;
-  features: string[];
+  features: number[];
   ward: string;
   kasp_empanelled: string;
   address: string;
@@ -572,17 +573,16 @@ export const FacilityCreate = (props: FacilityProps) => {
               </div>
               <div className="">
                 <InputLabel id="features-label">Features</InputLabel>
-                <MultiSelectField
-                  data-test="facility-features"
-                  name="features"
-                  variant="outlined"
-                  margin="dense"
+                <MultiSelectMenuV2
+                  id="features"
+                  placeholder="Features"
                   value={state.form.features}
                   options={FACILITY_FEATURE_TYPES}
-                  onChange={(e) => handleChange(e)}
-                  optionValue="name"
-                  errors={state.errors.features}
+                  optionLabel={(o) => o.name}
+                  optionValue={(o) => o.id}
+                  onChange={(o) => handleValueChange(o, "features")}
                 />
+                <ErrorHelperText error={state.errors.features} />
               </div>
               <div>
                 <InputLabel id="gender-label">State*</InputLabel>

--- a/src/Components/Form/MultiSelectMenuV2.tsx
+++ b/src/Components/Form/MultiSelectMenuV2.tsx
@@ -15,6 +15,7 @@ type Props<T, V = T> = {
   optionIcon?: OptionCallback<T, React.ReactNode>;
   optionValue?: OptionCallback<T, V>;
   className?: string;
+  disabled?: boolean;
   renderSelectedOptions?: OptionCallback<T[], React.ReactNode>;
   onChange: OptionCallback<V[]>;
 };
@@ -59,6 +60,7 @@ const MultiSelectMenuV2 = <T, V>(props: Props<T, V>) => {
   return (
     <div className={props.className}>
       <Listbox
+        disabled={props.disabled}
         value={selectedOptions}
         onChange={(opts: typeof options) =>
           props.onChange(opts.map((o) => o.value) as any)


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Replaced multiselect from MUI to Tailwind

## Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/3858

## Screenshots

- Facility
![image](https://user-images.githubusercontent.com/77210185/200160043-86e0d603-7fe3-41e9-9a11-00bddc11af5a.png)

- Consultation
![image](https://user-images.githubusercontent.com/57055998/202151004-8e421282-ef30-4a95-871b-89ffbace42e9.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep the screenshot or demo video for the changelog entry, and attach it to the issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
