### PR TITLE
fix: additional space between pagination bar and components in update log component

### DIFF
--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -9,7 +9,6 @@ import Pagination from "../../Common/Pagination";
 import { DailyRoundsModel } from "../../Patient/models";
 import { formatDate } from "../../../Utils/utils";
 
-
 const PageTitle = loadable(() => import("../../Common/PageTitle"));
 
 const getName = (item: any) => {
@@ -232,7 +231,9 @@ export const DailyRoundsList = (props: any) => {
           />
         </div>
         <div className={!isDailyRoundLoading ? "flex flex-wrap" : ""}>
-          <div className="overflow-y-auto h-screen space-y-4">{roundsList}</div>
+          <div className="overflow-y-auto max-h-screen space-y-4">
+            {roundsList}
+          </div>
           {!isDailyRoundLoading && totalCount > limit && (
             <div className="mt-4 flex justify-center">
               <Pagination


### PR DESCRIPTION
closes #3985 

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/61267953/200218577-a2febf56-0e25-4a43-87cd-fd89632ff49f.png">