### PR TITLE
`useActiveLink` hook for detecting sidebar selected or not.

### DIFF
--- a/src/Common/hooks/useActiveLink.ts
+++ b/src/Common/hooks/useActiveLink.ts
@@ -1,0 +1,31 @@
+import { usePath } from "raviger";
+
+/**
+ * Keys can be any value that is present in the url.
+ * Value must be equivalent to the link of the sidebar item.
+ * Entries must be sorted based on priority.
+ * Whichever key is present in the url first, becomes the active link returned
+ * by `useActiveLink` hook.
+ */
+const activeLinkPriority = {
+  "/patients": "/patients",
+  "/patient/": "/patients",
+  "/death_report": "/patients",
+  "/assets": "/assets",
+  "/sample": "/sample",
+  "/shifting": "/shifting",
+  "/resource": "/resource",
+  "/external_results": "/external_results",
+  "/users": "/users",
+  "/notice_board": "/notice_board",
+  "/facility": "/facility",
+};
+
+/**
+ * @returns The active link of the current path.
+ */
+export default function useActiveLink() {
+  const path = usePath() || "";
+  const key = Object.keys(activeLinkPriority).find((key) => path.includes(key));
+  return key && (activeLinkPriority as any)[key];
+}

--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { SidebarItem, ShrinkedSidebarItem } from "./SidebarItem";
 import SidebarUserCard from "./SidebarUserCard";
 import NotificationItem from "../../Notifications/NotificationsList";
 import { Dialog, Transition } from "@headlessui/react";
-import { usePath } from "raviger";
+import useActiveLink from "../../../Common/hooks/useActiveLink";
 
 export const SIDEBAR_SHRINK_PREFERENCE_KEY = "sidebarShrinkPreference";
 
@@ -54,13 +54,8 @@ const StatelessSidebar = ({
   shrinked = false,
   setShrinked,
 }: StatelessSidebarProps) => {
-  const path = usePath();
+  const activeLink = useActiveLink();
   const Item = shrinked ? ShrinkedSidebarItem : SidebarItem;
-
-  const activeItem = NavItems.reduce((acc, item) => {
-    const tag = item.to.replaceAll("/", "");
-    return path?.includes(tag) ? tag : acc;
-  }, "");
 
   return (
     <nav
@@ -76,10 +71,9 @@ const StatelessSidebar = ({
         src={shrinked ? LOGO_COLLAPSE : LOGO}
       />
       <div className="h-7" /> {/* flexible spacing */}
-      {NavItems.map((item) => {
-        const itemSelected = item.to.replaceAll("/", "") === activeItem;
-        return <Item key={item.text} {...item} selected={itemSelected} />;
-      })}
+      {NavItems.map((i) => (
+        <Item key={i.text} {...i} selected={activeLink === i.to} />
+      ))}
       <NotificationItem shrinked={shrinked} />
       <Item text="Dashboard" to={DASHBOARD} icon={<Dashboard />} external />
       <div className="flex-1" />

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -158,7 +158,7 @@ export default function ManageUsers() {
   const addUser = (
     <button
       className="px-4 py-1 w-full md:w-auto rounded-md bg-primary-500 text-white text-lg font-semibold shadow"
-      onClick={() => navigate("/user/add")}
+      onClick={() => navigate("/users/add")}
     >
       <i className="fas fa-plus mr-2"></i>
       Add New User

--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -77,7 +77,7 @@ const routes = {
   "/hub": () => <HubDashboard />,
   "/": () => <HospitalList />,
   "/users": () => <ManageUsers />,
-  "/user/add": () => <UserAdd />,
+  "/users/add": () => <UserAdd />,
   "/user/profile": () => <UserProfile />,
   "/patients": () => <PatientManager />,
   "/patient/:id": ({ id }: any) => <PatientHome id={id} />,


### PR DESCRIPTION
## Proposed Changes

- Resolves #3958 
- Changed route: `/user/add` to `/users/add`.

![image](https://user-images.githubusercontent.com/25143503/200320448-d18856d9-dfb8-48d6-aaae-c3b6a028a0b6.png)

![image](https://user-images.githubusercontent.com/25143503/200320706-8e9ea1bc-607a-4a39-9032-f4050ddd2c33.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
