### PR TITLE
Fixed facility search offset

### DIFF
--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -98,7 +98,7 @@ export const HospitalList = (props: any) => {
         facility_type: qParams.facility_type,
         kasp_empanelled: qParams.kasp_empanelled,
       };
-
+      if (params.search_text) params.offset = 0;
       const res = await dispatchAction(getPermittedFacilities(params));
       if (!status.aborted) {
         if (res && res.data) {


### PR DESCRIPTION
Fixes #4003
## Proposed Changes

- Fixed the issue in facility search where, when a particular facility is searched for it shows no facilities found even when the total no. of facilities is greater than zero.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
