### PR TITLE
use tailwind buttons and make btns responsive

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1,14 +1,12 @@
 import loadable from "@loadable/component";
 import {
   Box,
-  Button,
   CardContent,
   FormControlLabel,
   InputLabel,
   Radio,
   RadioGroup,
 } from "@material-ui/core";
-import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import { navigate } from "raviger";
 import moment from "moment";
 import React, {
@@ -68,6 +66,7 @@ import ProcedureBuilder, {
   ProcedureType,
 } from "../Common/prescription-builder/ProcedureBuilder";
 import { ICD11DiagnosisModel } from "./models";
+import ButtonV2 from "../Common/components/ButtonV2";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -1180,29 +1179,25 @@ export const ConsultationForm = (props: any) => {
                 m<sup>2</sup>
               </div>
               {/* End of Telemedicine fields */}
-              <div className="mt-4 flex justify-between">
-                <Button
-                  color="default"
-                  variant="contained"
+              <div className="mt-4 sm:flex grid sm:justify-between">
+                <ButtonV2
+                  variant="secondary"
                   type="button"
+                  className="mb-2 sm:mb-0"
                   onClick={() =>
                     navigate(`/facility/${facilityId}/patient/${patientId}`)
                   }
                 >
-                  Cancel{" "}
-                </Button>
-                <Button
-                  color="primary"
-                  variant="contained"
+                  Cancel
+                </ButtonV2>
+                <ButtonV2
+                  variant="primary"
                   type="submit"
-                  style={{ marginLeft: "auto" }}
-                  startIcon={
-                    <CheckCircleOutlineIcon>save</CheckCircleOutlineIcon>
-                  }
                   onClick={(e) => handleSubmit(e)}
                 >
+                  <i className="fa-regular fa-circle-check" />
                   {buttonText}
-                </Button>
+                </ButtonV2>
               </div>
             </CardContent>
           </form>


### PR DESCRIPTION
## Proposed Changes

- Use tailwind button `ButtonV2` instead of material-ui 
- Make buttons responsive for small devices

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="569" alt="image" src="https://user-images.githubusercontent.com/57039447/201050958-105a2335-3de7-4507-b064-d6646cff9e31.png"></td>
    <td>
<img width="598" alt="image" src="https://user-images.githubusercontent.com/57039447/201051160-73508a6b-b9c4-472d-99b0-5789df67cffe.png">
</td>
  </tr>
  <tr>
    <td><img width="249" alt="image" src="https://user-images.githubusercontent.com/57039447/201051088-8947e990-b9cd-4809-84ba-79f98709d620.png"></td>
    <td><img width="267" alt="image" src="https://user-images.githubusercontent.com/57039447/201051281-58c73b75-d08f-411e-9aca-83f6b13e5a55.png"></td>
  </tr>
</table>

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
