### PR TITLE
Improve applied filter badges on Users page

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -202,12 +202,12 @@ export default function ManageUsers() {
   const badge = (key: string, value: any, paramKey: string) => {
     return (
       value && (
-        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border">
+        <span className="flex flex-row items-center px-3 py-1 rounded-full text-xs font-medium leading-4 bg-white text-gray-600 border w-full sm:w-auto">
           {key}
           {": "}
           {value}
           <i
-            className="fas fa-times ml-2 rounded-full cursor-pointer hover:bg-gray-500 px-1 py-0.5"
+            className="fas fa-times rounded-full cursor-pointer hover:bg-gray-500 px-1 py-0.5 w-auto ml-auto mr-0 sm:mx-auto sm:ml-2"
             onClick={() => removeFilter(paramKey)}
           ></i>
         </span>


### PR DESCRIPTION
Fixes #4029 

- This PR makes the badges uniform on smaller screens; they are now easier to read and delete individually. 
- This PR only changes the badges on small screens (<=640px). Badges are unaffected for larger displays.

Before: 
![image](https://user-images.githubusercontent.com/3626859/201371459-9134d56f-764c-4154-9551-cdb051ec802f.png)

After:
![RemarkableNurseshark](https://user-images.githubusercontent.com/3626859/201370809-204aa765-4431-49a4-9670-c74bf782aa86.gif)

On larger displays (No change):
![image](https://user-images.githubusercontent.com/3626859/201371569-ff23f622-18fb-453b-8755-1e67974cfbe0.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers