### PR TITLE
fix(FacilitySelect): Minor UI fix in patient popup

### DIFF
--- a/src/Components/Common/ConfirmDialogV2.tsx
+++ b/src/Components/Common/ConfirmDialogV2.tsx
@@ -1,0 +1,55 @@
+import DialogModal from "./Dialog";
+import ButtonV2, { ButtonVariant } from "./components/ButtonV2";
+
+type ConfirmDialogV2Props = {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  disabled?: boolean;
+  show: boolean;
+  action: string;
+  variant?: ButtonVariant;
+  onClose: () => void;
+  onConfirm: () => void;
+  children?: React.ReactNode;
+  cancelText?: React.ReactNode;
+};
+
+const ConfirmDialogV2 = (props: ConfirmDialogV2Props) => {
+  const {
+    title,
+    description,
+    show,
+    disabled,
+    variant,
+    action,
+    onClose,
+    onConfirm,
+    cancelText,
+    children,
+  } = props;
+
+  return (
+    <DialogModal
+      onClose={onClose}
+      title={title}
+      description={description}
+      show={show}
+    >
+      {children}
+      <div className="mt-4 flex justify-between">
+        <ButtonV2 onClick={onClose} variant="danger">
+          {cancelText || "Cancel"}
+        </ButtonV2>
+        <ButtonV2
+          onClick={onConfirm}
+          variant={variant || "primary"}
+          disabled={disabled}
+        >
+          {action}
+        </ButtonV2>
+      </div>
+    </DialogModal>
+  );
+};
+
+export default ConfirmDialogV2;

--- a/src/Components/Common/ConfirmDialogV2.tsx
+++ b/src/Components/Common/ConfirmDialogV2.tsx
@@ -37,7 +37,7 @@ const ConfirmDialogV2 = (props: ConfirmDialogV2Props) => {
     >
       {children}
       <div className="mt-4 flex justify-between">
-        <ButtonV2 onClick={onClose} variant="danger">
+        <ButtonV2 onClick={onClose} variant="secondary">
           {cancelText || "Cancel"}
         </ButtonV2>
         <ButtonV2

--- a/src/Components/Common/Dialog.tsx
+++ b/src/Components/Common/Dialog.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Dialog, Transition } from "@headlessui/react";
+
+type DialogProps = {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  show: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+const DialogModal = (props: DialogProps) => {
+  const { title, description, show, onClose, children } = props;
+  return (
+    <div>
+      <Transition appear show={show} as={React.Fragment}>
+        <Dialog as="div" className="relative z-10" onClose={onClose}>
+          <Transition.Child
+            as={React.Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black bg-opacity-25" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-4 text-center">
+              <Transition.Child
+                as={React.Fragment}
+                enter="ease-out duration-300"
+                enterFrom="opacity-0 scale-95"
+                enterTo="opacity-100 scale-100"
+                leave="ease-in duration-200"
+                leaveFrom="opacity-100 scale-100"
+                leaveTo="opacity-0 scale-95"
+              >
+                <Dialog.Panel className="w-full max-w-md transform rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                  <Dialog.Title
+                    as="h3"
+                    className="text-lg font-medium leading-6 text-gray-900"
+                  >
+                    {title}
+                  </Dialog.Title>
+                  <div className="mt-2">
+                    <p className="text-sm text-gray-500">{description}</p>
+                  </div>
+                  {children}
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition>
+    </div>
+  );
+};
+
+export default DialogModal;

--- a/src/Components/ExternalResult/FacilitiesSelectDialogue.tsx
+++ b/src/Components/ExternalResult/FacilitiesSelectDialogue.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
+import ButtonV2 from "../Common/components/ButtonV2";
+import DialogModal from "../Common/Dialog";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { FacilityModel } from "../Facility/models";
 import { FieldLabel } from "../Form/FormFields/FormField";
@@ -16,14 +17,10 @@ const FacilitiesSelectDialog = (props: Props) => {
   const { show, handleOk, handleCancel, selectedFacility, setSelected } = props;
 
   return (
-    <ConfirmDialogV2
-      action={"Continue"}
+    <DialogModal
       title={<FieldLabel className="text-lg">Search for Facility</FieldLabel>}
       show={show}
-      variant={"primary"}
-      disabled={!selectedFacility}
       onClose={handleCancel}
-      onConfirm={handleOk}
     >
       <FacilitySelect
         name="facilities"
@@ -33,7 +30,19 @@ const FacilitiesSelectDialog = (props: Props) => {
         showAll={false}
         multiple={false}
       />
-    </ConfirmDialogV2>
+      <div className="mt-4 flex justify-between">
+        <ButtonV2 onClick={handleCancel} variant="secondary">
+          Cancel
+        </ButtonV2>
+        <ButtonV2
+          onClick={handleOk}
+          variant="primary"
+          disabled={!selectedFacility.id}
+        >
+          Continue
+        </ButtonV2>
+      </div>
+    </DialogModal>
   );
 };
 

--- a/src/Components/ExternalResult/FacilitiesSelectDialogue.tsx
+++ b/src/Components/ExternalResult/FacilitiesSelectDialogue.tsx
@@ -1,26 +1,11 @@
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-} from "@material-ui/core";
-import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import React from "react";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { FacilityModel } from "../Facility/models";
-import { makeStyles } from "@material-ui/core/styles";
-
-const useStyles = makeStyles({
-  paperFullWidth: {
-    overflowY: "visible",
-  },
-  dialogContentRoot: {
-    overflowY: "visible",
-  },
-});
+import { FieldLabel } from "../Form/FormFields/FormField";
 
 interface Props {
+  show: boolean;
   handleOk: () => void;
   handleCancel: () => void;
   selectedFacility: FacilityModel;
@@ -28,64 +13,27 @@ interface Props {
 }
 
 const FacilitiesSelectDialog = (props: Props) => {
-  const { handleOk, handleCancel, selectedFacility, setSelected } = props;
-  const classes = useStyles();
-
-  const handleEscKeyPress = (event: any) => {
-    if (event.key === "Escape") {
-      handleCancel();
-    }
-  };
+  const { show, handleOk, handleCancel, selectedFacility, setSelected } = props;
 
   return (
-    <Dialog
-      open={true}
-      fullWidth={true}
-      classes={{
-        paperFullWidth: classes.paperFullWidth,
-      }}
-      onKeyDown={(e) => handleEscKeyPress(e)}
+    <ConfirmDialogV2
+      action={"Continue"}
+      title={<FieldLabel className="text-lg">Search for Facility</FieldLabel>}
+      show={show}
+      variant={"primary"}
+      disabled={!selectedFacility}
+      onClose={handleCancel}
+      onConfirm={handleOk}
     >
-      <DialogTitle
-        className="font-semibold text-3xl max-w-md md:min-w-[400px]"
-        id="font-semibold text-3xl"
-      >
-        Search for a facility
-      </DialogTitle>
-      <DialogContent
-        classes={{
-          root: classes.dialogContentRoot,
-        }}
-      >
-        <FacilitySelect
-          name="facilities"
-          selected={selectedFacility}
-          setSelected={setSelected}
-          errors=""
-          showAll={false}
-          multiple={false}
-          className="z-40"
-        />
-      </DialogContent>
-      <DialogActions style={{ justifyContent: "space-between" }}>
-        <Button
-          className="capitalize"
-          color="secondary"
-          onClick={() => handleCancel()}
-        >
-          Cancel
-        </Button>
-        <Button
-          onClick={handleOk}
-          color="primary"
-          variant="contained"
-          disabled={!selectedFacility?.name || !selectedFacility}
-          startIcon={<CheckCircleOutlineIcon>save</CheckCircleOutlineIcon>}
-        >
-          Continue
-        </Button>
-      </DialogActions>
-    </Dialog>
+      <FacilitySelect
+        name="facilities"
+        selected={selectedFacility}
+        setSelected={setSelected}
+        errors=""
+        showAll={false}
+        multiple={false}
+      />
+    </ConfirmDialogV2>
   );
 };
 

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -232,18 +232,17 @@ export default function ResultList() {
 
   return (
     <div className="px-6">
-      {showDialog && (
-        <FacilitiesSelectDialogue
-          setSelected={(e) => setSelectedFacility(e)}
-          selectedFacility={selectedFacility}
-          handleOk={() =>
-            navigate(`facility/${selectedFacility.id}/patient`, {
-              query: { extId: resultId },
-            })
-          }
-          handleCancel={() => setShowDialog(false)}
-        />
-      )}
+      <FacilitiesSelectDialogue
+        show={showDialog}
+        setSelected={(e) => setSelectedFacility(e)}
+        selectedFacility={selectedFacility}
+        handleOk={() =>
+          navigate(`facility/${selectedFacility.id}/patient`, {
+            query: { extId: resultId },
+          })
+        }
+        handleCancel={() => setShowDialog(false)}
+      />
       <PageTitle title="External Results" hideBack={true} breadcrumbs={false} />
       <div className="mt-5 lg:grid grid-cols-1 gap-5 sm:grid-cols-3 my-4 px-2 md:px-0 relative">
         <div className="bg-white overflow-hidden shadow rounded-lg">

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -582,18 +582,17 @@ export const PatientManager = (props: any) => {
 
   return (
     <div>
-      {showDialog && (
-        <FacilitiesSelectDialogue
-          setSelected={(e) => setSelectedFacility(e)}
-          selectedFacility={selectedFacility}
-          handleOk={() => navigate(`facility/${selectedFacility.id}/patient`)}
-          handleCancel={() => {
-            setShowDialog(false);
-            setSelectedFacility({ name: "" });
-          }}
-        />
-      )}
-      <div className="flex flex-wrap flex-col right-3 gap-2 mr-3 sm:flex-row-reverse ml-auto">
+      <FacilitiesSelectDialogue
+        show={showDialog}
+        setSelected={(e) => setSelectedFacility(e)}
+        selectedFacility={selectedFacility}
+        handleOk={() => navigate(`facility/${selectedFacility.id}/patient`)}
+        handleCancel={() => {
+          setShowDialog(false);
+          setSelectedFacility({ name: "" });
+        }}
+      />
+      <div className="flex flex-col right-3 gap-2 mr-3 sm:flex-row ml-auto w-max">
         <Tooltip
           title={
             !isDownloadAllowed ? (


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Added Tailwind Dialog Modal
- Fixed the `Add patient` popup size
- Fixed alignment of buttons in the `Add patient` popup

## Associated Issue

- Fixes #3886
- Fixes #3908

## Screenshot

- FacilitySelect Popup

![image](https://user-images.githubusercontent.com/77210185/202194488-e4779bdd-fbfa-4e6e-b399-a31f7d0bfbf6.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update product[documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [x] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
