### PR TITLE
Send null when location is not selected

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -421,8 +421,8 @@ export const FacilityCreate = (props: FacilityProps) => {
         features: state.form.features,
         ward: state.form.ward,
         kasp_empanelled: JSON.parse(state.form.kasp_empanelled),
-        latitude: state.form.latitude,
-        longitude: state.form.longitude,
+        latitude: state.form.latitude || null,
+        longitude: state.form.longitude || null,
         phone_number: parsePhoneNumberFromString(
           state.form.phone_number
         )?.format("E.164"),


### PR DESCRIPTION
## Proposed Changes

- Fixes #4080
- Send null for latitude and longitude instead of empty string when location is not selected

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
