### PR TITLE
Fix: disallow negative values on age field in patient filters

### DIFF
--- a/src/Components/Form/FormFields/TextFormField.tsx
+++ b/src/Components/Form/FormFields/TextFormField.tsx
@@ -10,13 +10,15 @@ export type TextFormFieldProps = FormFieldBaseProps<string> & {
   placeholder?: string;
   value?: string | number;
   autoComplete?: string;
-  type?: "email" | "password" | "search" | "text";
+  type?: "email" | "password" | "search" | "text" | "number";
   className?: string | undefined;
   removeDefaultClasses?: true | undefined;
   leading?: React.ReactNode | undefined;
   trailing?: React.ReactNode | undefined;
   leadingFocused?: React.ReactNode | undefined;
   trailingFocused?: React.ReactNode | undefined;
+  min?: string | number;
+  max?: string | number;
 };
 
 const TextFormField = React.forwardRef((props: TextFormFieldProps, ref) => {
@@ -44,6 +46,8 @@ const TextFormField = React.forwardRef((props: TextFormFieldProps, ref) => {
       placeholder={props.placeholder}
       name={props.name}
       value={props.value}
+      min={props.min}
+      max={props.max}
       autoComplete={props.autoComplete}
       required={props.required}
       onChange={(event) => {

--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -716,7 +716,12 @@ export default function PatientFilterV2(props: any) {
               name="age_min"
               placeholder="Min. age"
               label={null}
-              value={filterState.age_min}
+              value={
+                filterState.age_min &&
+                (filterState.age_min > 0 ? filterState.age_min : 0)
+              }
+              type="number"
+              min={0}
               onChange={handleFormFieldChange}
               errorClassName="hidden"
             />
@@ -724,7 +729,12 @@ export default function PatientFilterV2(props: any) {
               name="age_max"
               placeholder="Max. age"
               label={null}
-              value={filterState.age_max}
+              type="number"
+              min={0}
+              value={
+                filterState.age_max &&
+                (filterState.age_max > 0 ? filterState.age_max : 0)
+              }
               onChange={handleFormFieldChange}
               errorClassName="hidden"
             />


### PR DESCRIPTION
## Proposed Changes

- Fixes #3981 
- Negative values are now not allowed in the `Age min` and `Age max` fields of patient filter.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
