### PR TITLE
Fix: Clear date fields  and age field in patient filters 

### DIFF
--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -19,7 +19,6 @@ import {
 } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
 import { navigate } from "raviger";
-import { getDate } from "../Common/DateRangePicker";
 import DistrictSelect from "../Facility/FacilityFilter/DistrictSelect";
 import SelectMenuV2 from "../Form/SelectMenuV2";
 import TextFormField from "../Form/FormFields/TextFormField";
@@ -39,6 +38,9 @@ const useMergeState = (initialState: any) => {
     setState((prevState: any) => Object.assign({}, prevState, newState));
   return [state, setMergedState];
 };
+
+const getDate = (value: any) =>
+  value && moment(value).isValid() && moment(value).toDate();
 
 export default function PatientFilterV2(props: any) {
   const { filter, onChange, closeFilter } = props;
@@ -104,36 +106,36 @@ export default function PatientFilterV2(props: any) {
     facility_ref: null,
     lsgBody_ref: null,
     district_ref: null,
-    date_declared_positive_before: null,
-    date_declared_positive_after: null,
-    date_of_result_before: null,
-    date_of_result_after: null,
-    created_date_before: null,
-    created_date_after: null,
-    modified_date_before: null,
-    modified_date_after: null,
+    date_declared_positive_before: "",
+    date_declared_positive_after: "",
+    date_of_result_before: "",
+    date_of_result_after: "",
+    created_date_before: "",
+    created_date_after: "",
+    modified_date_before: "",
+    modified_date_after: "",
     ordering: "",
     category: null,
     gender: null,
     disease_status: null,
-    age_min: null,
-    age_max: null,
+    age_min: "",
+    age_max: "",
     date_of_result: null,
     date_declared_positive: null,
-    last_consultation_admission_date_before: null,
-    last_consultation_admission_date_after: null,
-    last_consultation_discharge_date_before: null,
-    last_consultation_discharge_date_after: null,
+    last_consultation_admission_date_before: "",
+    last_consultation_admission_date_after: "",
+    last_consultation_discharge_date_before: "",
+    last_consultation_discharge_date_after: "",
     last_consultation_admitted_to_list: [],
     srf_id: "",
     number_of_doses: null,
     covin_id: "",
     is_kasp: null,
     is_declared_positive: null,
-    last_consultation_symptoms_onset_date_before: null,
-    last_consultation_symptoms_onset_date_after: null,
-    last_vaccinated_date_before: null,
-    last_vaccinated_date_after: null,
+    last_consultation_symptoms_onset_date_before: "",
+    last_consultation_symptoms_onset_date_after: "",
+    last_vaccinated_date_before: "",
+    last_vaccinated_date_after: "",
     last_consultation_is_telemedicine: null,
     is_antenatal: null,
   };
@@ -613,8 +615,8 @@ export default function PatientFilterV2(props: any) {
           name="date_of_result"
           label="Date of result"
           value={{
-            start: getDate(filterState.date_of_result_after)?.toDate(),
-            end: getDate(filterState.date_of_result_before)?.toDate(),
+            start: getDate(filterState.date_of_result_after),
+            end: getDate(filterState.date_of_result_before),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"
@@ -624,8 +626,8 @@ export default function PatientFilterV2(props: any) {
           name="date_declared_positive"
           label="Date Declared Positive"
           value={{
-            start: getDate(filterState.date_declared_positive_after)?.toDate(),
-            end: getDate(filterState.date_declared_positive_before)?.toDate(),
+            start: getDate(filterState.date_declared_positive_after),
+            end: getDate(filterState.date_declared_positive_before),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"
@@ -635,8 +637,8 @@ export default function PatientFilterV2(props: any) {
           name="created_date"
           label="Created Date"
           value={{
-            start: getDate(filterState.created_date_after)?.toDate(),
-            end: getDate(filterState.created_date_before)?.toDate(),
+            start: getDate(filterState.created_date_after),
+            end: getDate(filterState.created_date_before),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"
@@ -646,8 +648,8 @@ export default function PatientFilterV2(props: any) {
           name="modified_date"
           label="Modified Date"
           value={{
-            start: getDate(filterState.modified_date_after)?.toDate(),
-            end: getDate(filterState.modified_date_before)?.toDate(),
+            start: getDate(filterState.modified_date_after),
+            end: getDate(filterState.modified_date_before),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"
@@ -657,12 +659,8 @@ export default function PatientFilterV2(props: any) {
           name="last_consultation_admission_date"
           label="Admit Date"
           value={{
-            start: getDate(
-              filterState.last_consultation_admission_date_after
-            )?.toDate(),
-            end: getDate(
-              filterState.last_consultation_admission_date_before
-            )?.toDate(),
+            start: getDate(filterState.last_consultation_admission_date_after),
+            end: getDate(filterState.last_consultation_admission_date_before),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"
@@ -672,12 +670,8 @@ export default function PatientFilterV2(props: any) {
           name="last_consultation_discharge_date"
           label="Discharge Date"
           value={{
-            start: getDate(
-              filterState.last_consultation_discharge_date_after
-            )?.toDate(),
-            end: getDate(
-              filterState.last_consultation_discharge_date_before
-            )?.toDate(),
+            start: getDate(filterState.last_consultation_discharge_date_after),
+            end: getDate(filterState.last_consultation_discharge_date_before),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"
@@ -689,10 +683,10 @@ export default function PatientFilterV2(props: any) {
           value={{
             start: getDate(
               filterState.last_consultation_symptoms_onset_date_after
-            )?.toDate(),
+            ),
             end: getDate(
               filterState.last_consultation_symptoms_onset_date_before
-            )?.toDate(),
+            ),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"
@@ -702,8 +696,8 @@ export default function PatientFilterV2(props: any) {
           name="last_vaccinated_date"
           label="Vaccination Date"
           value={{
-            start: getDate(filterState.last_vaccinated_date_after)?.toDate(),
-            end: getDate(filterState.last_vaccinated_date_before)?.toDate(),
+            start: getDate(filterState.last_vaccinated_date_after),
+            end: getDate(filterState.last_vaccinated_date_before),
           }}
           onChange={handleDateRangeChange}
           errorClassName="hidden"


### PR DESCRIPTION
## Proposed Changes

- Fixes #3982 
- Cleared the date fields and age field in patient filters when clear filters is pressed

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
