### PR TITLE
Allow state level users to assign facility from any district while creating a user

### DIFF
--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -610,11 +610,6 @@ export const UserAdd = (props: UserProps) => {
                   name="facilities"
                   selected={selectedFacility}
                   setSelected={setFacility}
-                  district={
-                    currentUser?.data?.user_type.toLowerCase().includes("state")
-                      ? undefined
-                      : currentUser.data.district
-                  }
                   errors={state.errors.facilities}
                   showAll={false}
                 />

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -610,7 +610,11 @@ export const UserAdd = (props: UserProps) => {
                   name="facilities"
                   selected={selectedFacility}
                   setSelected={setFacility}
-                  district={currentUser.data.district}
+                  district={
+                    currentUser?.data?.user_type.toLowerCase().includes("state")
+                      ? undefined
+                      : currentUser.data.district
+                  }
                   errors={state.errors.facilities}
                   showAll={false}
                 />


### PR DESCRIPTION
## Proposed Changes

- Fixes #4102 
- removed district limitation from FacilitySelect in user add 
_already FacilitySelect fetches facilities that the current user is associated with, district was an extra filter, so removed it_


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
