### PR TITLE
Add cause of death for expired patients

### DIFF
--- a/src/Components/DeathReport/DeathReport.tsx
+++ b/src/Components/DeathReport/DeathReport.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useCallback } from "react";
+import { useState, useCallback } from "react";
 import loadable from "@loadable/component";
 import { useDispatch } from "react-redux";
 import { getPatient } from "../../Redux/actions";
-import { PatientModel } from "../Patient/models";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { GENDER_TYPES } from "../../Common/constants";
 import {
@@ -44,7 +43,7 @@ export default function PrintDeathReport(props: { id: string }) {
 
   const [patientData, setPatientData] = useState(initialState);
   const [patientName, setPatientName] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
+  const [_isLoading, setIsLoading] = useState(true);
   const [isPrintMode, setIsPrintMode] = useState(false);
   const { id } = props;
   const dispatch: any = useDispatch();
@@ -87,6 +86,8 @@ export default function PrintDeathReport(props: { id: string }) {
               ? "Yes"
               : "No",
             is_vaccinated: patientData.is_vaccinated ? "Yes" : "No",
+            cause_of_death:
+              patientRes.data.last_consultation?.discharge_notes || "",
           };
           setPatientData(data);
         }
@@ -287,7 +288,7 @@ export default function PrintDeathReport(props: { id: string }) {
       ) : (
         <div className="m-5 p-5 bg-gray-100 border rounded-xl shadow">
           <PageTitle
-            title={`Covid-19 Death Reporting : Form 1`}
+            title={"Covid-19 Death Reporting : Form 1"}
             crumbsReplacements={{
               [props.id]: { name: patientName },
               death_report: { style: "pointer-events-none" },

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -402,7 +402,11 @@ export const ConsultationDetails = (props: any) => {
             </div>
 
             <div id="discharge-notes-div">
-              <InputLabel id="refered-label">Discharge Notes</InputLabel>
+              <InputLabel id="refered-label">
+                {preDischargeForm.discharge_reason == "EXP"
+                  ? "Cause of death"
+                  : "Discharge notes"}
+              </InputLabel>
               <MultilineInputField
                 name="discharge_notes"
                 variant="outlined"

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -167,6 +167,18 @@ export const ConsultationDetails = (props: any) => {
       return;
     }
 
+    if (
+      preDischargeForm.discharge_reason == "EXP" &&
+      !preDischargeForm.discharge_notes.trim()
+    ) {
+      setErrors({
+        ...errors,
+        discharge_notes: "Please enter the cause of death",
+      });
+      setIsSendingDischargeApi(false);
+      return;
+    }
+
     const dischargeResponse = await dispatch(
       dischargePatient(
         { discharge: value, ...preDischargeForm },
@@ -404,7 +416,7 @@ export const ConsultationDetails = (props: any) => {
             <div id="discharge-notes-div">
               <InputLabel id="refered-label">
                 {preDischargeForm.discharge_reason == "EXP"
-                  ? "Cause of death"
+                  ? "Cause of death *"
                   : "Discharge notes"}
               </InputLabel>
               <MultilineInputField


### PR DESCRIPTION
Fixes #1649

Change "Discharge notes" to "Cause of death" when discharge reason is "Expired". Also, pre-fill the cause on the Death report. 

![image](https://user-images.githubusercontent.com/3626859/203782323-d51417db-f8ad-425b-a6be-91618975c78d.png)
![image](https://user-images.githubusercontent.com/3626859/203782258-f8d5783d-2d01-47aa-9678-f02a10188aa6.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers