### PR TITLE
Fix query params not preserved between views

### DIFF
--- a/src/Components/Resource/ListView.tsx
+++ b/src/Components/Resource/ListView.tsx
@@ -45,7 +45,8 @@ export default function ListView() {
     setDownloadFile(res.data);
     document.getElementById("resourceRequests-ALL")?.click();
   };
-  const onBoardViewBtnClick = () => navigate("/resource/board-view", qParams);
+  const onBoardViewBtnClick = () =>
+    navigate("/resource/board-view", { query: qParams });
   const appliedFilters = formatFilter(qParams);
 
   const refreshList = () => {

--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -51,7 +51,7 @@ export default function BoardView() {
   };
 
   const onListViewBtnClick = () => {
-    navigate("/resource/list-view", qParams);
+    navigate("/resource/list-view", { query: qParams });
     localStorage.setItem("defaultResourceView", "list");
   };
 

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -107,7 +107,9 @@ export default function BoardView() {
           <div className="mt-1 w-fit inline-flex space-x-1 lg:space-x-4">
             <button
               className="px-4 py-2 rounded-full border-2 border-gray-200 text-sm bg-white text-gray-800 w-28 md:w-36 leading-none transition-colors duration-300 ease-in focus:outline-none hover:text-primary-600 hover:border-gray-400 focus:text-primary-600 focus:border-gray-400"
-              onClick={() => navigate("/shifting/list-view", qParams)}
+              onClick={() =>
+                navigate("/shifting/list-view", { query: qParams })
+              }
             >
               <i className="fa fa-list-ul mr-1" aria-hidden="true"></i>
               List View

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -347,7 +347,7 @@ export default function ListView() {
         <div className="my-2 md:my-0">
           <button
             className="px-4 py-2 rounded-full border-2 border-gray-200 text-sm bg-white text-gray-800 w-32 leading-none transition-colors duration-300 ease-in focus:outline-none hover:text-primary-600 hover:border-gray-400 focus:text-primary-600 focus:border-gray-400"
-            onClick={() => navigate("/shifting/board-view", qParams)}
+            onClick={() => navigate("/shifting/board-view", { query: qParams })}
           >
             <i
               className="fa fa-list mr-1 transform rotate-90"


### PR DESCRIPTION
## Proposed Changes

- Fixes #4103
- Fix syntax error in `navigate()` in raviger that was causing applied filters to clear.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers