### PR TITLE
Fix input type for LegendInput

### DIFF
--- a/src/CAREUI/interactive/LegendInput.tsx
+++ b/src/CAREUI/interactive/LegendInput.tsx
@@ -72,9 +72,7 @@ export default function LegendInput(props: InputProps) {
 
         <input
           ref={ref}
-          type={
-            props.type === "PASSWORD" && !showPassword ? "password" : "text"
-          }
+          type={props.type === "PASSWORD" && showPassword ? "text" : props.type}
           name={props.name}
           id={props.id || props.name}
           placeholder={props.placeholder}


### PR DESCRIPTION
Fixes #4147

Fixes the logic for input type in `LegendInput` component to support other input types too (email and number).

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
