### PR TITLE
Fix updatePreset

### DIFF
--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -300,7 +300,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId }) => {
     },
     updatePreset: (option) => {
       getCameraStatus({
-        onSuccess: async ({ data }) => {
+        onSuccess: async (data) => {
           if (currentPreset?.asset_object?.id && data?.position) {
             setLoading(option.loadingLabel);
             const response = await dispatch(

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -236,7 +236,7 @@ const LiveFeed = (props: any) => {
     },
     updatePreset: (option) => {
       getCameraStatus({
-        onSuccess: async ({ data }) => {
+        onSuccess: async (data) => {
           console.log({ currentPreset, data });
           if (currentPreset?.asset_object?.id && data?.position) {
             setLoading(option.loadingLabel);


### PR DESCRIPTION
Fixes #4141

A recent change to the `getCameraStatus` method ( [care_fe/pull/3767#useFeedPTZ.ts](https://github.com/coronasafe/care_fe/pull/3767/files#diff-1e5a8875fbda16cf406f25e6def8d955c7774eeb32da266d24185a231ed26195L78) ) broke the updatePreset method, as `onSuccess` callback was now called with the result object from the response directly rather than the whole response data.

This PR fixes that and `updatePreset` now works again.

Fix is done on both the Patient Camera Feed page and Asset configuration page.

![image](https://user-images.githubusercontent.com/3626859/204988852-14fe22c0-0294-4993-af7d-07e41317be2f.png)
![image](https://user-images.githubusercontent.com/3626859/204988953-2a0c99d1-9407-416b-8324-5a4438cb3d42.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
