### PR TITLE
fix(patient): re-admission is using existing consultation

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -386,7 +386,8 @@ export const PatientManager = (props: any) => {
       let patientUrl = "";
       if (
         patient.last_consultation &&
-        patient.last_consultation?.facility === patient.facility
+        patient.last_consultation?.facility === patient.facility &&
+        !(patient.last_consultation?.discharge_date && patient.is_active)
       ) {
         patientUrl = `/facility/${patient.facility}/patient/${patient.id}/consultation/${patient.last_consultation.id}`;
       } else if (patient.facility) {
@@ -535,7 +536,9 @@ export const PatientManager = (props: any) => {
                     )}
                     {(!patient.last_consultation ||
                       patient.last_consultation?.facility !==
-                        patient.facility) && (
+                        patient.facility ||
+                      (patient.last_consultation?.discharge_date &&
+                        patient.is_active)) && (
                       <span className="relative inline-flex">
                         <Chip
                           color="red"

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -333,10 +333,7 @@ export const PatientHome = (props: any) => {
 
   if (isConsultationLoading) {
     consultationList = <CircularProgress size={20} />;
-  } else if (
-    consultationListData.length === 0 ||
-    (consultationListData.at(0)?.discharge_date && patientData.is_active)
-  ) {
+  } else if (consultationListData.length === 0) {
     consultationList = (
       <div>
         <hr />

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -333,7 +333,10 @@ export const PatientHome = (props: any) => {
 
   if (isConsultationLoading) {
     consultationList = <CircularProgress size={20} />;
-  } else if (consultationListData.length === 0) {
+  } else if (
+    consultationListData.length === 0 ||
+    (consultationListData.at(0)?.discharge_date && patientData.is_active)
+  ) {
     consultationList = (
       <div>
         <hr />
@@ -447,7 +450,9 @@ export const PatientHome = (props: any) => {
             </div>
           </div>
         </div>
-        {patientData?.facility != patientData?.last_consultation?.facility && (
+        {(patientData?.facility != patientData?.last_consultation?.facility ||
+          (patientData.is_active &&
+            patientData?.last_consultation?.discharge_date)) && (
           <div className="relative mt-2">
             <div className="max-w-screen-xl mx-auto py-3 px-3 sm:px-6 lg:px-8 rounded-lg shadow bg-red-200 ">
               <div className="text-center">


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Added `No consultation filed` for re-admitted patient having no new consultation
- Added consultation button for the above patient types

## Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/4125

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update product[documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
