### PR TITLE
Removed hover effect for push score details in preview mode in Pressure Sore

### DIFF
--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -305,7 +305,7 @@ let renderBody = (state, send, title, partPaths, substr) => {
           previewMode={state.previewMode}
         />
       </div>
-      <svg className="h-screen py-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 344.7 932.661">
+      <svg className="h-screen py-4 cursor-pointer" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 344.7 932.661">
         {Js.Array.mapi((part, renderIndex) => {
           let regionType = PressureSore.regionForPath(part)
           let selectedPart = Js.Array.find(p => PressureSore.region(p) === regionType, state.parts)

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -319,16 +319,6 @@ let renderBody = (state, send, title, partPaths, substr) => {
             onClick={e => {
               send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
             }}
-            onMouseOver={e => {
-              if state.previewMode && innerWidth > 720 {
-                send(ShowInputModal(part.region, {"x": e->ReactEvent.Mouse.clientX, "y": e->ReactEvent.Mouse.clientY}))
-              }
-            }}
-            onMouseLeave={e => {
-              if state.previewMode && innerWidth > 720 && !isMouseOverInputModal(e, inputModal) {
-                send(SetSelectedRegion(PressureSore.Other))
-              }
-            }}
           >
             <title className=""> {str(PressureSore.regionToString(regionType))} </title>
           </path>

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -70,11 +70,6 @@ let make = (
       className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
       <div
         ref={modalRef}
-        onMouseLeave={e => {
-          if (previewMode && innerWidth > 720) {
-            hideModal(e)
-          }
-        }}
         style={ReactDOMStyle.make(
           ~position={innerWidth >= 720 ? "absolute" : ""},
           ~left=getModalPosition()["left"],


### PR DESCRIPTION
## Proposed Changes

- Fixes #4128 
- Removed hover effect for push score details in preview mode
- Made the cursor as a pointer for the body diagram

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
