### PR TITLE
Skip esc key trigger on empty search input

### DIFF
--- a/src/Components/Form/SearchInput.tsx
+++ b/src/Components/Form/SearchInput.tsx
@@ -61,7 +61,7 @@ const SearchInput = ({
     ));
 
   // Escape hotkey to clear related
-  useKeyboardShortcut(["Escape"], () => setValue(""), {
+  useKeyboardShortcut(["Escape"], () => value && setValue(""), {
     ignoreInputFields: false,
   });
 


### PR DESCRIPTION
Fixes #4207

- Search `onChange` would not trigger if the input is empty.

![image](https://user-images.githubusercontent.com/3626859/205933536-d09909e0-a334-4dca-b78b-e36f19bdb2f3.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers