### PR TITLE
Add workflow to auto label issues as WIP

### DIFF
--- a/.github/workflows/label-wip.yml
+++ b/.github/workflows/label-wip.yml
@@ -1,0 +1,53 @@
+name: Auto Label WIP
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - closed
+
+jobs:
+  check-linked-issues:
+    name: Check linked issues
+    runs-on: ubuntu-latest
+    outputs:
+      linked_issues: ${{ steps.issue-output.outputs.linked_issues }}
+    steps:
+      - name: Get issues
+        id: get-issues
+        uses: mondeja/pr-linked-issues-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set output
+        id: issue-output
+        run: echo "linked_issues=${{ steps.get-issues.outputs.issues }}" >> $GITHUB_OUTPUT
+
+  label-issues:
+    name: Label linked issues
+    runs-on: ubuntu-latest
+    needs: check-linked-issues
+    permissions: write-all
+    if: join(needs.check-linked-issues.outputs.linked_issues) != ''
+    steps:
+      - name: Label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issues = "${{  needs.check-linked-issues.outputs.linked_issues  }}".split(',')
+            for (const issue of issues) {
+              if ("${{ github.event.pull_request.state }}" == "open")
+                github.rest.issues.addLabels({
+                  issue_number: issue,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  labels: ["work-in-progress"]
+                })
+              else
+                github.rest.issues.removeLabel({
+                  issue_number: issue,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: ["work-in-progress"]
+                })
+            }


### PR DESCRIPTION
## Proposed Changes

- Fixes #4156 
- Adds a workflow that:
  1. Adds the `work-in-progress` label to issues if they have a PR linked to them
  2. Removes the `work-in-progress` label from issues when the linked PR is closed/merged

![image](https://user-images.githubusercontent.com/3626859/206439009-adc97af7-cf60-4017-b501-e753f42e4d00.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
