### PR TITLE
Workflow to comment on P1 labelled issues

### DIFF
--- a/.github/workflows/comment-p1-issues.yml
+++ b/.github/workflows/comment-p1-issues.yml
@@ -1,0 +1,20 @@
+name: Comment on P1 issues
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  add-comment:
+    if: github.event.label.name == 'P1'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v2.1.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            :warning: **Refrain from assigning this issue to yourself if you have another P1 issues assigned that is not yet closed.**

--- a/.github/workflows/comment-p1-issues.yml
+++ b/.github/workflows/comment-p1-issues.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            :warning: **Refrain from assigning this issue to yourself if you have another P1 issues assigned that is not yet closed.**
+            :warning: **Refrain from assigning this issue to yourself if you have another P1 issue assigned that is not yet closed.**

--- a/.github/workflows/comment-p1-issues.yml
+++ b/.github/workflows/comment-p1-issues.yml
@@ -13,8 +13,31 @@ jobs:
       issues: write
     steps:
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@v2.1.0
+        uses: actions/github-script@v6.3.3
         with:
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            :warning: **Refrain from assigning this issue to yourself if you have another P1 issue assigned that is not yet closed.**
+          script: |
+            const body = ':warning: **Refrain from assigning this issue to yourself if you have another `P1` issue assigned that is not yet closed.**'
+            const options = {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }
+
+            const result = await github.rest.issues.get({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+
+            const { assignees } = result.data
+
+            if (assignees.length == 0) {
+              await github.rest.issues.createComment({ ...options, body })
+              return
+            }
+
+            const assignees_tagged = assignees.map((user) => '@' + user.login).join(' ')
+            await github.rest.issues.createComment({
+              ...options,
+              body: body + `\n ${assignees_tagged} kindly acknowledge this message by commenting 'Acknowledged' below.`,
+            })


### PR DESCRIPTION
## Proposed Changes

- Resolves #4259 
- The following is commented by the workflow when issues are labelled with 'P1'

:warning: **Refrain from assigning this issue to yourself if you have another P1 issue assigned that is not yet closed.**

- Additionally, if the P1 label is added when the issue is already assigned, the comment tags the assignees and requests to acknowledge the comment.


### References
 - [Commenting on an issue when a label is added](https://docs.github.com/en/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added)
 - [GitHub Action: Create or Update Comment](https://github.com/marketplace/actions/create-or-update-comment)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
