### PR TITLE
Optimize job runs of deploy failed labeller

### DIFF
--- a/.github/workflows/label-deploy-failed.yml
+++ b/.github/workflows/label-deploy-failed.yml
@@ -5,17 +5,19 @@ permissions:
 
 on:
   issue_comment:
-    types: [created, edited]
+    types:
+      - created
+      - edited
 
 jobs:
   auto-label-deploy-failed:
     runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, 'Deploy Preview')
     steps:
       - name: Add 'Deploy-Failed'
-        if: |
-          github.event.issue.pull_request && 
-          contains(github.event.comment.body, 'Deploy Preview') && 
-          contains(github.event.comment.body, 'failed')
+        if: contains(github.event.comment.body, 'failed')
         uses: actions/github-script@v6
         with:
           script: |
@@ -27,10 +29,7 @@ jobs:
             })
 
       - name: Remove 'Deploy-Failed' label
-        if: |
-          github.event.issue.pull_request && 
-          contains(github.event.comment.body, 'Deploy Preview') && 
-          contains(github.event.comment.body, 'ready')
+        if: contains(github.event.comment.body, 'ready')
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
## Proposed Changes

- Resolves #4258
- Skip running the auto label deploy failed job altogether if conditions don't pass. (To save running some ubuntus)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
