### PR TITLE
Added user details and time of archive in the more details modal

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -96,7 +96,7 @@ interface ModalDetails {
   name?: string;
   id?: string;
   reason?: string;
-  userArchived?: any;
+  userArchived?: string;
   archiveTime?: any;
 }
 

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -96,6 +96,8 @@ interface ModalDetails {
   name?: string;
   id?: string;
   reason?: string;
+  userArchived?: any;
+  archiveTime?: any;
 }
 
 interface StateInterface {
@@ -785,9 +787,12 @@ export const FileUpload = (props: FileUploadProps) => {
                   </label>
                   <label
                     onClick={() => {
+                      console.log(item);
                       setModalDetails({
                         name: item.name,
                         reason: item.archive_reason,
+                        userArchived: item.archived_by?.username,
+                        archiveTime: item.archived_datetime,
                       });
                       setModalOpenForMoreDetails(true);
                     }}
@@ -1260,11 +1265,18 @@ export const FileUpload = (props: FileUploadProps) => {
               <div className="text-center">
                 <i className="fa-solid fa-file-circle-xmark my-2 fa-4x text-primary-500"></i>
               </div>
-              <div className="text-md text-center">
-                <b>{modalDetails?.name}</b> file is archived.
+              <div className="text-md text-center m-2">
+                <b>{modalDetails?.name} file is archived.</b>
               </div>
               <div className="text-md text-center">
                 <b>Reason:</b> {modalDetails?.reason}
+              </div>
+              <div className="text-md text-center">
+                <b>Archived_by:</b> {modalDetails?.userArchived}
+              </div>
+              <div className="text-md text-center">
+                <b>Time of Archive:</b>
+                {formatDate(modalDetails?.archiveTime)}
               </div>
             </div>
             <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -787,7 +787,6 @@ export const FileUpload = (props: FileUploadProps) => {
                   </label>
                   <label
                     onClick={() => {
-                      console.log(item);
                       setModalDetails({
                         name: item.name,
                         reason: item.archive_reason,

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -306,4 +306,6 @@ export interface FileUploadModel {
   is_archived?: boolean;
   archive_reason?: string;
   extension?: string;
+  archived_by?: { username?: string };
+  archived_datetime?: string;
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes #4180 
Added user details and time of archive in the more details modal
![image](https://user-images.githubusercontent.com/59426397/207026932-26e56163-ca66-4f28-bad9-e770513ce7e6.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
