### PR TITLE
Disable proceed button for edit patient file name

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1134,28 +1134,45 @@ export const FileUpload = (props: FileUploadProps) => {
                 errors={editFileNameError}
               />
             </div>
-            {btnloader ? (
-              <div className="flex justify-center mt-4">
-                <CircularProgress />
-              </div>
-            ) : (
-              <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">
-                <button
-                  type="submit"
-                  className="btn-primary btn mr-2 w-full md:w-auto"
-                  disabled={modalDetails?.name === editFileName}
+            <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">
+              <button
+                type="submit"
+                disabled={modalDetails?.name === editFileName || btnloader}
+                className="btn-primary btn mr-2 w-full md:w-auto"
+              >
+                <svg
+                  className={`animate-spin -ml-1 mr-3 h-5 w-5 text-primary ${
+                    !btnloader ? " hidden " : " "
+                  }`}
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
                 >
-                  Proceed
-                </button>
-                <button
-                  type="button"
-                  className="btn-danger btn mr-2 w-full md:w-auto"
-                  onClick={(_) => setModalOpenForEdit(false)}
-                >
-                  Cancel
-                </button>
-              </div>
-            )}
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    stroke-width="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                Proceed
+              </button>
+              <button
+                type="button"
+                className="btn-danger btn mr-2 w-full md:w-auto"
+                disabled={btnloader}
+                onClick={(_) => setModalOpenForEdit(false)}
+              >
+                Cancel
+              </button>
+            </div>
           </form>
         </div>
       </Modal>

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1134,15 +1134,10 @@ export const FileUpload = (props: FileUploadProps) => {
                 errors={editFileNameError}
               />
             </div>
-            <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">
-              <button
-                type="submit"
-                className="btn-primary btn mr-2 w-full md:w-auto"
-              >
+            {btnloader ? (
+              <div className="flex justify-center mt-4">
                 <svg
-                  className={`animate-spin -ml-1 mr-3 h-5 w-5 text-white ${
-                    !btnloader ? " hidden " : " "
-                  }`}
+                  className="animate-spin -ml-1 mr-3 h-5 w-5 text-primary"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -1161,16 +1156,47 @@ export const FileUpload = (props: FileUploadProps) => {
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                   ></path>
                 </svg>
-                Proceed
-              </button>
-              <button
-                type="button"
-                className="btn-danger btn mr-2 w-full md:w-auto"
-                onClick={(_) => setModalOpenForEdit(false)}
-              >
-                Cancel
-              </button>
-            </div>
+              </div>
+            ) : (
+              <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">
+                <button
+                  type="submit"
+                  className="btn-primary btn mr-2 w-full md:w-auto"
+                  disabled={modalDetails?.name === editFileName}
+                >
+                  {/* <svg
+                    className={`animate-spin -ml-1 mr-3 h-5 w-5 text-white ${
+                      !btnloader ? " hidden " : " "
+                    }`}
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      stroke-width="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg> */}
+                  Proceed
+                </button>
+                <button
+                  type="button"
+                  className="btn-danger btn mr-2 w-full md:w-auto"
+                  onClick={(_) => setModalOpenForEdit(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
           </form>
         </div>
       </Modal>

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1137,26 +1137,6 @@ export const FileUpload = (props: FileUploadProps) => {
             {btnloader ? (
               <div className="flex justify-center mt-4">
                 <CircularProgress />
-                {/* <svg
-                  className="animate-spin -ml-1 mr-3 h-5 w-5 text-primary"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    stroke-width="4"
-                  ></circle>
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  ></path>
-                </svg> */}
               </div>
             ) : (
               <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">
@@ -1165,28 +1145,6 @@ export const FileUpload = (props: FileUploadProps) => {
                   className="btn-primary btn mr-2 w-full md:w-auto"
                   disabled={modalDetails?.name === editFileName}
                 >
-                  {/* <svg
-                    className={`animate-spin -ml-1 mr-3 h-5 w-5 text-white ${
-                      !btnloader ? " hidden " : " "
-                    }`}
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      stroke-width="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg> */}
                   Proceed
                 </button>
                 <button

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1136,7 +1136,8 @@ export const FileUpload = (props: FileUploadProps) => {
             </div>
             {btnloader ? (
               <div className="flex justify-center mt-4">
-                <svg
+                <CircularProgress />
+                {/* <svg
                   className="animate-spin -ml-1 mr-3 h-5 w-5 text-primary"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
@@ -1155,7 +1156,7 @@ export const FileUpload = (props: FileUploadProps) => {
                     fill="currentColor"
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                   ></path>
-                </svg>
+                </svg> */}
               </div>
             ) : (
               <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">


### PR DESCRIPTION
Fixes #4282 
http://localhost:4000/facility/e02905de-2e0e-41ff-abd1-2eb169a509bc/patient/2db5d708-b2e0-4beb-9c55-fde58131ee6d/consultation/d6d2a4ef-a3cd-4f0a-9618-fa5a02878719/files
Disabled the `Proceed` button if the new file name is the same as the previous name
![image](https://user-images.githubusercontent.com/70687348/207033480-38406a2c-cfa9-429c-974c-3e5cdeef31c8.png)

Disable buttons when loading
![image](https://user-images.githubusercontent.com/70687348/207363067-bf4bacbb-12d0-4d55-b53d-e7acbc53087a.png)
