### PR TITLE
Added 11 digit restriction for toll free numbers

### DIFF
--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -29,7 +29,7 @@ import {
 } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
 import { debounce } from "lodash";
-import React, { ChangeEvent, useState } from "react";
+import React, { ChangeEvent } from "react";
 import PhoneInput, { ICountryData } from "react-phone-input-2";
 import "react-phone-input-2/lib/high-res.css";
 
@@ -661,15 +661,8 @@ export const PhoneNumberField = (props: any) => {
     event: ChangeEvent<HTMLInputElement>,
     formattedValue: string
   ) => {
-    const tollFreeCheck = value.slice(2, 6);
-    if (tollFreeCheck === "1800") {
-      setMaxLength(16);
-    } else {
-      setMaxLength(15);
-    }
     onChangeHandler(formattedValue);
   };
-  const [maxLength, setMaxLength] = useState(15);
   return (
     <>
       {label && <InputLabel>{label}</InputLabel>}
@@ -687,7 +680,7 @@ export const PhoneNumberField = (props: any) => {
           autoFormat={!turnOffAutoFormat}
           enableLongNumbers={enableTollFree}
           inputProps={{
-            maxLength: maxLength,
+            maxLength: 16,
           }}
           {...countryRestriction}
         />

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -29,7 +29,7 @@ import {
 } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
 import { debounce } from "lodash";
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, useState } from "react";
 import PhoneInput, { ICountryData } from "react-phone-input-2";
 import "react-phone-input-2/lib/high-res.css";
 
@@ -650,6 +650,8 @@ export const PhoneNumberField = (props: any) => {
     turnOffAutoFormat,
     disabled,
     bgColor,
+    enableTollFree,
+    countryCodeEditable = false,
   } = props;
   const countryRestriction = onlyIndia ? { onlyCountries: ["in"] } : {};
   const onChangeHandler = debounce(onChange, 500);
@@ -659,8 +661,15 @@ export const PhoneNumberField = (props: any) => {
     event: ChangeEvent<HTMLInputElement>,
     formattedValue: string
   ) => {
+    const tollFreeCheck = value.slice(2, 6);
+    if (tollFreeCheck === "1800") {
+      setMaxLength(16);
+    } else {
+      setMaxLength(15);
+    }
     onChangeHandler(formattedValue);
   };
+  const [maxLength, setMaxLength] = useState(15);
   return (
     <>
       {label && <InputLabel>{label}</InputLabel>}
@@ -669,14 +678,17 @@ export const PhoneNumberField = (props: any) => {
           inputClass={` ${
             bgColor || " bg-gray-200 "
           }  py-3 text-sm border-gray-200 shadow-none focus:border-primary-400`}
-          countryCodeEditable={false}
+          countryCodeEditable={countryCodeEditable}
           value={value}
           placeholder={placeholder}
           onChange={handleChange}
           country="in"
           disabled={disabled}
           autoFormat={!turnOffAutoFormat}
-          enableLongNumbers={true}
+          enableLongNumbers={enableTollFree}
+          inputProps={{
+            maxLength: maxLength,
+          }}
           {...countryRestriction}
         />
         <div

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -676,6 +676,7 @@ export const PhoneNumberField = (props: any) => {
           country="in"
           disabled={disabled}
           autoFormat={!turnOffAutoFormat}
+          enableLongNumbers={true}
           {...countryRestriction}
         />
         <div

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -247,7 +247,6 @@ const AssetCreate = (props: AssetProps) => {
             .replace(/[^0-9]/g, "")
             .slice(2);
           const checkTollFree = supportPhoneSimple.startsWith("1800");
-          console.log(supportPhoneSimple, checkTollFree);
           if (supportPhoneSimple.length > 10 && !checkTollFree) {
             errors[field] = "Please enter valid phone number";
             invalidForm = true;

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -775,6 +775,7 @@ const AssetCreate = (props: AssetProps) => {
                       Customer Support Number *{" "}
                     </label>
                     <PhoneNumberField
+                      enableTollFree
                       value={support_phone}
                       onChange={setSupportPhone}
                       errors={state.errors.support_phone}

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -237,18 +237,29 @@ const AssetCreate = (props: AssetProps) => {
             invalidForm = true;
           }
           return;
-        case "support_phone":
+        case "support_phone": {
           if (!support_phone) {
             errors[field] = "Field is required";
             invalidForm = true;
           }
           // eslint-disable-next-line no-case-declarations
-          const phoneNumber = parsePhoneNumberFromString(support_phone);
-          if (!phoneNumber?.isPossible()) {
+          const supportPhoneSimple = support_phone
+            .replace(/[^0-9]/g, "")
+            .slice(2);
+          const checkTollFree = supportPhoneSimple.startsWith("1800");
+          console.log(supportPhoneSimple, checkTollFree);
+          if (supportPhoneSimple.length > 10 && !checkTollFree) {
+            errors[field] = "Please enter valid phone number";
+            invalidForm = true;
+          } else if (supportPhoneSimple.length > 11 && checkTollFree) {
+            errors[field] = "Please enter valid phone number";
+            invalidForm = true;
+          } else if (supportPhoneSimple.length < 10) {
             errors[field] = "Please enter valid phone number";
             invalidForm = true;
           }
           return;
+        }
         case "support_email":
           if (support_email && !validateEmailAddress(support_email)) {
             errors[field] = "Please enter valid email id";


### PR DESCRIPTION
## Proposed Changes

- Fixes #4289 
- Allows 11 digits only if they start from `1800`

## Backend Changes Required

- Waiting for [https://github.com/coronasafe/care/pull/1121](https://github.com/coronasafe/care/pull/1121) to be merged.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
