### PR TITLE
fix: misalignment in forgot password page

### DIFF
--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -330,7 +330,10 @@ export const Login = (props: { forgot?: boolean }) => {
               type="button"
               className="text-sm text-primary-400 hover:text-primary-500 mb-4"
             >
-              <CareIcon className="care-l-arrow-left h-5" /> Back to login
+              <div className="flex justify-center">
+                <CareIcon className="care-l-arrow-left h-5" />
+                <span>Back to login</span>
+              </div>
             </button>
             <div className="text-4xl w-[300px] font-black mb-8 text-primary-600">
               {t("forget_password")}


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Fixed alignment of back arrow and button on `Forgot password` page

## Associated Issue

- Fixes #4330

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/208237357-11785129-1dfa-4f7c-b7ba-c132b9e2bf33.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update product[documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
