### PR TITLE
fix: facility home page buttons are misaligned

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { navigate } from "raviger";
-import { TextField, Modal } from "@material-ui/core";
 import { useTranslation } from "react-i18next";
 
 import { sendNotificationMessages } from "../../Redux/actions";
@@ -9,6 +8,8 @@ import { FACILITY_FEATURE_TYPES, KASP_STRING } from "../../Common/constants";
 import ButtonV2 from "../Common/components/ButtonV2";
 import * as Notification from "../../Utils/Notifications.js";
 import { getFacilityFeatureIcon } from "./FacilityHome";
+import DialogModal from "../Common/Dialog";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 
 export const FacilityCard = (props: { facility: any; userType: any }) => {
   const { facility, userType } = props;
@@ -139,54 +140,46 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                   ) : (
                     <></>
                   )}
-                  <Modal
-                    open={notifyModalFor === facility.id}
+                  <DialogModal
+                    show={notifyModalFor === facility.id}
+                    title={
+                      <span className="flex justify-center text-2xl">
+                        Notify: {facility.name}
+                      </span>
+                    }
                     onClose={() => setNotifyModalFor(undefined)}
-                    aria-labelledby="Notify This Facility"
-                    aria-describedby="Type a message and notify this facility"
-                    className=""
                   >
-                    <div className="h-screen w-full absolute flex items-center justify-center bg-modal">
-                      <form
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          handleNotifySubmit(notifyModalFor);
-                        }}
-                        className="bg-white rounded shadow p-8 m-4 max-h-full text-center flex flex-col max-w-lg w-2/3 min-w-max-content"
-                      >
-                        <div className="mb-4">
-                          <h1 className="text-2xl">Notify: {facility.name}</h1>
-                        </div>
-                        <div>
-                          <TextField
-                            id="NotifyModalMessageInput"
-                            rows={6}
-                            multiline
-                            required
-                            className="w-full border p-2 max-h-64"
-                            onChange={(e) => setNotifyMessage(e.target.value)}
-                            placeholder="Type your message..."
-                            variant="outlined"
-                          />
-                        </div>
-                        <div className="flex flex-col-reverse md:flex-row gap-2 mt-4 justify-end">
-                          <button
-                            type="button"
-                            className="btn-danger btn mr-2 w-full md:w-auto"
-                            onClick={() => setNotifyModalFor(undefined)}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="submit"
-                            className="btn-primary btn mr-2 w-full md:w-auto"
-                          >
-                            Send Notification
-                          </button>
-                        </div>
-                      </form>
-                    </div>
-                  </Modal>
+                    <form
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        handleNotifySubmit(notifyModalFor);
+                      }}
+                      className="bg-white text-center flex flex-col w-full"
+                    >
+                      <div>
+                        <TextAreaFormField
+                          id="NotifyModalMessageInput"
+                          name="message"
+                          rows={6}
+                          required
+                          className="py-2"
+                          onChange={(e) => setNotifyMessage(e.value)}
+                          placeholder="Type your message..."
+                        />
+                      </div>
+                      <div className="flex flex-col-reverse md:flex-row gap-2 justify-between">
+                        <ButtonV2
+                          variant="secondary"
+                          onClick={() => setNotifyModalFor(undefined)}
+                        >
+                          Cancel
+                        </ButtonV2>
+                        <ButtonV2 variant="primary" type="submit">
+                          Send Notification
+                        </ButtonV2>
+                      </div>
+                    </form>
+                  </DialogModal>
                 </div>
                 <div className="flex gap-2 ">
                   <ButtonV2

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -126,7 +126,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                 <div>
                   {userType !== "Staff" ? (
                     <ButtonV2
-                      className="flex gap-3 bg-white"
+                      className="flex gap-3 items-center bg-white"
                       name="facility-notify"
                       shadow
                       border
@@ -134,7 +134,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                       onClick={() => setNotifyModalFor(facility.id)}
                     >
                       <i className="far fa-comment-dots"></i>
-                      Notify
+                      <span>Notify</span>
                     </ButtonV2>
                   ) : (
                     <></>
@@ -190,7 +190,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                 </div>
                 <div className="flex gap-2 ">
                   <ButtonV2
-                    className="flex gap-3 bg-white"
+                    className="flex gap-3 items-center bg-white"
                     name="facility-details"
                     shadow
                     border
@@ -198,10 +198,10 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                     onClick={() => navigate(`/facility/${facility.id}`)}
                   >
                     <i className="fas fa-hospital"></i>
-                    {t("Facility")}
+                    <span>{t("Facility")}</span>
                   </ButtonV2>
                   <ButtonV2
-                    className="flex gap-3 bg-white"
+                    className="flex gap-3 items-center bg-white"
                     name="facility-patients"
                     shadow
                     border
@@ -211,7 +211,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                     }
                   >
                     <i className="fas fa-user-injured"></i>
-                    {t("Patients")}
+                    <span>{t("Patients")}</span>
                   </ButtonV2>
                 </div>
               </div>


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Tailwind the notify modal
- Fixed alignment in buttons present on facility card

## Associated Issue

- Fixes #4334

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/208243706-02e86aea-fc91-4043-9ae8-66e1379a3af4.png)
![image](https://user-images.githubusercontent.com/77210185/208243062-0016d59c-f30c-4f15-a840-8ba18b8c9ddf.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
