### PR TITLE
Cypress: Fix external result's import test

### DIFF
--- a/cypress/e2e/external_results_spec/external_result.cy.ts
+++ b/cypress/e2e/external_results_spec/external_result.cy.ts
@@ -30,6 +30,7 @@ describe("Edit Profile Testing", () => {
   });
 
   it("import", () => {
+    cy.wait(100);
     cy.contains("Import/Export").click().wait(100);
     cy.contains("Import Results").click().wait(100);
     // TODO: attach file and save


### PR DESCRIPTION
## Proposed Changes

- Adds wait before attempting to click Import/Export (since it's jumping around)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
