### PR TITLE
Allow 11 digits only when a phone number starts with 1800

### DIFF
--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -29,7 +29,7 @@ import {
 } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
 import { debounce } from "lodash";
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, useState } from "react";
 import PhoneInput, { ICountryData } from "react-phone-input-2";
 import "react-phone-input-2/lib/high-res.css";
 
@@ -653,8 +653,11 @@ export const PhoneNumberField = (props: any) => {
     enableTollFree,
     countryCodeEditable = false,
   } = props;
+  const [maxLength, setMaxLength] = useState(15);
+
   const countryRestriction = onlyIndia ? { onlyCountries: ["in"] } : {};
   const onChangeHandler = debounce(onChange, 500);
+
   const handleChange = (
     value: string,
     data: Partial<ICountryData>,
@@ -662,7 +665,9 @@ export const PhoneNumberField = (props: any) => {
     formattedValue: string
   ) => {
     onChangeHandler(formattedValue);
+    setMaxLength(() => (value.slice(2, 7) === "18001" ? 16 : 15));
   };
+
   return (
     <>
       {label && <InputLabel>{label}</InputLabel>}
@@ -680,7 +685,7 @@ export const PhoneNumberField = (props: any) => {
           autoFormat={!turnOffAutoFormat}
           enableLongNumbers={enableTollFree}
           inputProps={{
-            maxLength: 16,
+            maxLength,
           }}
           {...countryRestriction}
         />

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -29,7 +29,7 @@ import {
 } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
 import { debounce } from "lodash";
-import React, { ChangeEvent, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import PhoneInput, { ICountryData } from "react-phone-input-2";
 import "react-phone-input-2/lib/high-res.css";
 
@@ -658,6 +658,10 @@ export const PhoneNumberField = (props: any) => {
   const countryRestriction = onlyIndia ? { onlyCountries: ["in"] } : {};
   const onChangeHandler = debounce(onChange, 500);
 
+  useEffect(() => {
+    setMaxLength(() => (value.slice(2, 6) === "1800" ? 16 : 15));
+  }, [value]);
+
   const handleChange = (
     value: string,
     data: Partial<ICountryData>,
@@ -665,7 +669,6 @@ export const PhoneNumberField = (props: any) => {
     formattedValue: string
   ) => {
     onChangeHandler(formattedValue);
-    setMaxLength(() => (value.slice(2, 6) === "1800" ? 16 : 15));
   };
 
   return (

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -659,7 +659,7 @@ export const PhoneNumberField = (props: any) => {
   const onChangeHandler = debounce(onChange, 500);
 
   useEffect(() => {
-    setMaxLength(() => (value.slice(2, 6) === "1800" ? 16 : 15));
+    setMaxLength(() => (value.slice(4, 8) === "1800" ? 16 : 15));
   }, [value]);
 
   const handleChange = (

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -665,7 +665,7 @@ export const PhoneNumberField = (props: any) => {
     formattedValue: string
   ) => {
     onChangeHandler(formattedValue);
-    setMaxLength(() => (value.slice(2, 7) === "18001" ? 16 : 15));
+    setMaxLength(() => (value.slice(2, 6) === "1800" ? 16 : 15));
   };
 
   return (


### PR DESCRIPTION
## Proposed Changes

- Fixes #4365 
- Allow 11 digits only when a phone number starts with 18001


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
