### PR TITLE
Log tab result button is disabled in discharged patient UI

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -50,6 +50,7 @@ import { formatDate } from "../../Utils/utils";
 import ResponsiveMedicineTable from "../Common/components/ResponsiveMedicineTables";
 import PatientInfoCard from "../Patient/PatientInfoCard";
 import PatientVitalsCard from "../Patient/PatientVitalsCard";
+import ButtonV2 from "../Common/components/ButtonV2";
 interface PreDischargeFormInterface {
   discharge_reason: string;
   discharge_notes: string;
@@ -1178,8 +1179,9 @@ export const ConsultationDetails = (props: any) => {
                 breadcrumbs={false}
               />
               <div className="pt-6">
-                <button
-                  className="btn btn-primary w-full"
+                <ButtonV2
+                  disabled={!patientData.is_active}
+                  variant="primary"
                   onClick={() =>
                     navigate(
                       `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/investigation/`
@@ -1187,7 +1189,7 @@ export const ConsultationDetails = (props: any) => {
                   }
                 >
                   <i className="fas fa-plus w-4 mr-3"></i> Log Lab Result
-                </button>
+                </ButtonV2>
               </div>
             </div>
             <ViewInvestigations


### PR DESCRIPTION
## Proposed Changes

- Fixes #4212 
- Log tab result button is disabled in discharged patient UI
![image](https://user-images.githubusercontent.com/59426397/208445703-f54b0459-b4a5-4ee9-8a5b-1e32e527dda4.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
