### PR TITLE
Now on hovering the Post Doctor notes btn in discharged patient UI disabled symbol is shown

### DIFF
--- a/src/Components/Common/RoleButton.tsx
+++ b/src/Components/Common/RoleButton.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import Button from "@material-ui/core/Button";
 import { ButtonProps } from "@material-ui/core/Button";
 
 export type roleType = "readOnly";
@@ -58,7 +57,7 @@ export function RoleButton(props: {
 
   const renderMaterialUIButton = () => {
     return (
-      <Button
+      <button
         id={props.id}
         className={props.className}
         {...props.materialButtonProps}
@@ -66,7 +65,7 @@ export function RoleButton(props: {
         disabled={getDisableButton(type, props.disableFor) || props.disabled}
       >
         {props.children}
-      </Button>
+      </button>
     );
   };
 

--- a/src/Components/Patient/PatientNotes.tsx
+++ b/src/Components/Patient/PatientNotes.tsx
@@ -124,7 +124,7 @@ const PatientNotes = (props: PatientNotesProps) => {
       <div className="flex w-full justify-end pr-10">
         <RoleButton
           handleClickCB={onAddNote}
-          className="border border-solid border-primary-600 hover:border-primary-700 text-primary-600 hover:bg-white capitalize my-2 text-sm"
+          className="border border-solid border-primary-600 hover:border-primary-700 rounded-md text-primary-600 hover:bg-white capitalize my-2 p-2 text-sm"
           disableFor="readOnly"
           disabled={!patientActive}
           buttonType="materialUI"


### PR DESCRIPTION


## Proposed Changes

- Fixes #4213 


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
