### PR TITLE
Fix (Sidebar): made the sidebar collapse on clicking active links

### DIFF
--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -104,7 +104,7 @@ const StatelessSidebar = ({
     } else {
       indicatorRef.current.style.display = "none";
     }
-  }, [activeLink, lastIndicatorPosition]);
+  }, [activeLink]);
 
   return (
     <nav

--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -19,11 +19,13 @@ type StatelessSidebarProps =
       shrinkable: true;
       shrinked: boolean;
       setShrinked: (state: boolean) => void;
+      setOpenCB?: undefined;
     }
   | {
       shrinkable?: false;
       shrinked?: false;
       setShrinked?: undefined;
+      setOpenCB: (open: boolean) => void;
     };
 
 const NavItems = [
@@ -46,6 +48,7 @@ const StatelessSidebar = ({
   shrinkable = false,
   shrinked = false,
   setShrinked,
+  setOpenCB,
 }: StatelessSidebarProps) => {
   const activeLink = useActiveLink();
   const Item = shrinked ? ShrinkedSidebarItem : SidebarItem;
@@ -101,7 +104,7 @@ const StatelessSidebar = ({
     } else {
       indicatorRef.current.style.display = "none";
     }
-  }, [activeLink]);
+  }, [activeLink, lastIndicatorPosition]);
 
   return (
     <nav
@@ -123,7 +126,7 @@ const StatelessSidebar = ({
             ref={indicatorRef}
             className={`absolute left-2 w-1 hidden md:block
             bg-primary-400 rounded z-10 transition-all`}
-           />
+          />
           {NavItems.map((i) => {
             return (
               <Item
@@ -131,6 +134,7 @@ const StatelessSidebar = ({
                 {...i}
                 icon={<CareIcon className={`${i.icon} h-5`} />}
                 selected={i.to === activeLink}
+                do={() => setOpenCB && setOpenCB(false)}
               />
             );
           })}
@@ -220,7 +224,7 @@ export const MobileSidebar = ({ open, setOpen }: MobileSidebarProps) => {
                 leaveTo="-translate-x-full"
               >
                 <Dialog.Panel className="pointer-events-auto w-screen max-w-fit">
-                  <StatelessSidebar />
+                  <StatelessSidebar setOpenCB={setOpen} />
                 </Dialog.Panel>
               </Transition.Child>
             </div>

--- a/src/Components/Common/Sidebar/SidebarItem.tsx
+++ b/src/Components/Common/Sidebar/SidebarItem.tsx
@@ -10,7 +10,7 @@ type SidebarItemProps = {
   external?: true | undefined;
   badgeCount?: number | undefined;
   selected?: boolean | undefined;
-} & ({ to: string; do?: undefined } | { to?: undefined; do: () => void });
+} & ({ to: string; do?: undefined } | { to?: string; do: () => void });
 
 type SidebarItemBaseProps = SidebarItemProps & { shrinked?: boolean };
 const SidebarItemBase = ({


### PR DESCRIPTION
## Proposed Changes

- Fixes #4372
- Made the mobile sidebar collapse on clicking the active/current tab

https://user-images.githubusercontent.com/57593654/208735156-5f1aa605-68b3-41c1-b049-525348f7685b.mp4




@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
