### PR TITLE
remove docker cache, use prebuilt care

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -22,11 +22,8 @@ jobs:
           repository: coronasafe/care
           path: care
 
-      - name: Docker Layer Caching 🍥
-        uses: satackey/action-docker-layer-caching@v0.0.11
-
       - name: Run docker compose up on care 🐳
-        run: cd care && touch .env && make build && make up && cd .. && sleep 30s
+        run: cd care && touch .env && make docker_config_file=docker-compose.pre-built.yaml up && cd .. && sleep 30s
         # Voluntarily kept 30 seconds delay to wait for migrations to complete.
 
       - name: Run Django collectstatic and load dummy data on care 🐍

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -21,7 +21,6 @@ jobs:
         with:
           repository: coronasafe/care
           path: care
-          ref: prebuilt
 
       - name: Run docker compose up on care 🐳
         run: cd care && touch .env && make docker_config_file=docker-compose.pre-built.yaml up && cd .. && sleep 30s

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           repository: coronasafe/care
           path: care
+          ref: prebuilt
 
       - name: Run docker compose up on care 🐳
         run: cd care && touch .env && make docker_config_file=docker-compose.pre-built.yaml up && cd .. && sleep 30s
@@ -28,7 +29,6 @@ jobs:
 
       - name: Run Django collectstatic and load dummy data on care 🐍
         run: |
-          docker exec care python manage.py collectstatic
           docker exec care python manage.py load_dummy_data
 
       - name: Check care is up ♻


### PR DESCRIPTION
## Proposed Changes

- Use the care pre-built instead of using cached builds.

This also reduces the time by half required to set up the care backend.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
