### PR TITLE
Use std. Cancel, Submit buttons in Discharge modal

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -433,7 +433,7 @@ export const ConsultationDetails = (props: any) => {
           />
         </div>
 
-        <div className="flex gap-2 justify-end">
+        <div className="flex flex-col md:flex-row gap-2 md:justify-end">
           <Cancel onClick={handleDischargeClose} />
           {isSendingDischargeApi ? (
             <CircularProgress size={20} />

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -45,12 +45,11 @@ import { formatDate } from "../../Utils/utils";
 import ResponsiveMedicineTable from "../Common/components/ResponsiveMedicineTables";
 import PatientInfoCard from "../Patient/PatientInfoCard";
 import PatientVitalsCard from "../Patient/PatientVitalsCard";
-import { FieldErrorText, FieldLabel } from "../Form/FormFields/FormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import DialogModal from "../Common/Dialog";
-import SelectMenuV2 from "../Form/SelectMenuV2";
-import ButtonV2 from "../Common/components/ButtonV2";
+import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
+import { SelectFormField } from "../Form/FormFields/SelectFormField";
 interface PreDischargeFormInterface {
   discharge_reason: string;
   discharge_notes: string;
@@ -398,25 +397,23 @@ export const ConsultationDetails = (props: any) => {
         onClose={handleDischargeClose}
       >
         <div className="mt-6 flex flex-col">
-          <div>
-            <FieldLabel required>Reason</FieldLabel>
-            <SelectMenuV2
-              required
-              id="discharge_reason"
-              value={preDischargeForm.discharge_reason}
-              options={DISCHARGE_REASONS}
-              optionValue={({ id }) => id}
-              optionLabel={({ text }) => text}
-              onChange={(value) =>
-                setPreDischargeForm((prev) => ({
-                  ...prev,
-                  discharge_reason: value,
-                }))
-              }
-            />
-            <FieldErrorText error={errors?.discharge_reason} />
-          </div>
-
+          <SelectFormField
+            required
+            label="Reason"
+            name="discharge_reason"
+            id="discharge_reason"
+            value={preDischargeForm.discharge_reason}
+            options={DISCHARGE_REASONS}
+            optionValue={({ id }) => id}
+            optionLabel={({ text }) => text}
+            onChange={(e) =>
+              setPreDischargeForm((prev) => ({
+                ...prev,
+                discharge_reason: e.value,
+              }))
+            }
+            error={errors?.discharge_reason}
+          />
           <TextAreaFormField
             required={preDischargeForm.discharge_reason == "EXP"}
             label={
@@ -437,20 +434,15 @@ export const ConsultationDetails = (props: any) => {
         </div>
 
         <div className="flex gap-2 justify-end">
-          <ButtonV2 variant="secondary" onClick={handleDischargeClose}>
-            Cancel
-          </ButtonV2>
-
+          <Cancel onClick={handleDischargeClose} />
           {isSendingDischargeApi ? (
             <CircularProgress size={20} />
           ) : (
-            <ButtonV2
-              variant="primary"
+            <Submit
               onClick={() => handlePatientDischarge(false)}
+              label="Confirm Discharge"
               autoFocus
-            >
-              Confirm Discharge
-            </ButtonV2>
+            />
           )}
         </div>
       </DialogModal>


### PR DESCRIPTION
## Proposed Changes

- Fixes #4404 
- Replace `SelectMenuV2` with `SelectFormField` in discharge modal.

![image](https://user-images.githubusercontent.com/25143503/209488561-9a53daa9-1ec4-459e-abfc-c3946aede581.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
