### PR TITLE
Show default cursor in log update tile and upgrade its buttons

### DIFF
--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -10,6 +10,8 @@ import { DailyRoundsModel } from "../../Patient/models";
 import { formatDate } from "../../../Utils/utils";
 import { PatientCategory } from "../models";
 import { PATIENT_CATEGORIES } from "../../../Common/constants";
+import ButtonV2 from "../../Common/components/ButtonV2";
+import CareIcon from "../../../CAREUI/icons/CareIcon";
 
 const PageTitle = loadable(() => import("../../Common/PageTitle"));
 
@@ -197,19 +199,23 @@ export const DailyRoundsList = (props: any) => {
                 </Grid>
               </Grid>
               <div className="mt-2 flex md:flex-row flex-col md:space-y-0 space-y-2 space-x-0 md:space-x-2">
-                <button
-                  className="btn btn-default"
+                <ButtonV2
+                  variant="secondary"
+                  border
+                  ghost
                   onClick={() =>
                     navigate(
                       `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/daily_rounds/${itemData.id}`
                     )
                   }
                 >
-                  <i className="fas fa-eye mr-2" />
-                  View Details
-                </button>
-                <button
-                  className="btn btn-default"
+                  <CareIcon className="care-l-eye text-lg" />
+                  <span>View Details</span>
+                </ButtonV2>
+                <ButtonV2
+                  variant="secondary"
+                  border
+                  ghost
                   onClick={() => {
                     if (itemData.rounds_type === "NORMAL") {
                       navigate(
@@ -222,9 +228,9 @@ export const DailyRoundsList = (props: any) => {
                     }
                   }}
                 >
-                  <i className="fas fa-pencil-alt mr-2" />
-                  Update Log
-                </button>
+                  <CareIcon className="care-l-pen text-lg" />
+                  <span>Update Log</span>
+                </ButtonV2>
               </div>
             </div>
           </div>

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -112,7 +112,7 @@ export const DailyRoundsList = (props: any) => {
           <div
             className={`block border rounded-lg ${
               telemedicine_doctor_update ? "bg-purple-200" : "bg-white"
-            } shadow cursor-pointer`}
+            } shadow`}
           >
             <div className="p-2">
               <Grid container justify="space-between" alignItems="center">


### PR DESCRIPTION
## Proposed Changes

- Fixes #4402
- Upgrade log update tile buttons to `ButtonV2`

![image](https://user-images.githubusercontent.com/25143503/209488370-eadb5a7c-6077-4cbb-a165-9132f75ed210.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
