### PR TITLE
Disable picking future dates in consultation form's admission and symptoms onset date fields

### DIFF
--- a/src/Components/Common/DateRangeInputV2.tsx
+++ b/src/Components/Common/DateRangeInputV2.tsx
@@ -10,32 +10,36 @@ type Props = {
   onChange: (value: DateRange) => void;
   className?: string;
   disabled?: boolean | undefined;
+  max?: Date;
+  min?: Date;
 };
 
-const DateRangeInputV2 = ({ value, onChange, className, disabled }: Props) => {
+const DateRangeInputV2 = ({ value, onChange, ...props }: Props) => {
   const { start, end } = value ?? { start: undefined, end: undefined };
 
   return (
     <div className="flex gap-2">
       <div className="flex-auto">
         <DateInputV2
-          className={className}
+          className={props.className}
           value={start}
           onChange={(start) => onChange({ start, end })}
-          max={end}
+          min={props.min}
+          max={end || props.max}
           position="RIGHT"
           placeholder="Start date"
-          disabled={disabled}
+          disabled={props.disabled}
         />
       </div>
       <div className="flex-auto">
         <DateInputV2
-          className={className}
+          className={props.className}
           value={end}
           onChange={(end) => onChange({ start, end })}
-          min={start}
+          min={start || props.min}
+          max={props.max}
           position="CENTER"
-          disabled={disabled || !start}
+          disabled={props.disabled || !start}
           placeholder="End date"
         />
       </div>

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -641,6 +641,7 @@ export const ConsultationForm = (props: any) => {
         {hasSymptoms && (
           <DateFormField
             {...field("symptoms_onset_date")}
+            disableFuture
             required
             label="Date of onset of the symptoms"
           />
@@ -693,8 +694,9 @@ export const ConsultationForm = (props: any) => {
         {state.form.suggestion === "A" && (
           <>
             <DateFormField
-              required
               {...field("admission_date")}
+              disablePast
+              required
               label="Admission date"
             />
 

--- a/src/Components/Form/FormFields/DateFormField.tsx
+++ b/src/Components/Form/FormFields/DateFormField.tsx
@@ -9,11 +9,27 @@ import {
 
 type Props = FormFieldBaseProps<Date> & {
   placeholder?: string;
-  maxDate?: Date;
-  minDate?: Date;
+  max?: Date;
+  min?: Date;
   position?: DatePickerPosition;
+  disableFuture?: boolean;
+  disablePast?: boolean;
 };
 
+/**
+ * A FormField to pick date.
+ *
+ * Example usage:
+ *
+ * ```jsx
+ * <DateFormField
+ *   {...field("user_date_of_birth")}
+ *   label="Date of birth"
+ *   required
+ *   disableFuture // equivalent to max={new Date()}
+ * />
+ * ```
+ */
 const DateFormField = ({ position = "RIGHT", ...props }: Props) => {
   const handleChange = resolveFormFieldChangeEventHandler(props);
   const error = resolveFormFieldError(props);
@@ -25,8 +41,8 @@ const DateFormField = ({ position = "RIGHT", ...props }: Props) => {
         className={classNames(error && "border-danger-500")}
         value={props.value}
         onChange={(value) => handleChange({ name, value })}
-        max={props.maxDate}
-        min={props.minDate}
+        max={props.max || (props.disableFuture ? new Date() : undefined)}
+        min={props.min || (props.disablePast ? new Date() : undefined)}
         position={position}
         disabled={props.disabled}
         placeholder={props.placeholder}

--- a/src/Components/Form/FormFields/DateFormField.tsx
+++ b/src/Components/Form/FormFields/DateFormField.tsx
@@ -42,7 +42,7 @@ const DateFormField = ({ position = "RIGHT", ...props }: Props) => {
         value={props.value}
         onChange={(value) => handleChange({ name, value })}
         max={props.max || (props.disableFuture ? new Date() : undefined)}
-        min={props.min || (props.disablePast ? new Date() : undefined)}
+        min={props.min || (props.disablePast ? yesterday() : undefined)}
         position={position}
         disabled={props.disabled}
         placeholder={props.placeholder}
@@ -52,3 +52,9 @@ const DateFormField = ({ position = "RIGHT", ...props }: Props) => {
 };
 
 export default DateFormField;
+
+const yesterday = () => {
+  const date = new Date();
+  date.setDate(date.getDate() - 1);
+  return date;
+};

--- a/src/Components/Form/FormFields/DateFormField.tsx
+++ b/src/Components/Form/FormFields/DateFormField.tsx
@@ -9,6 +9,8 @@ import {
 
 type Props = FormFieldBaseProps<Date> & {
   placeholder?: string;
+  maxDate?: Date;
+  minDate?: Date;
   position?: DatePickerPosition;
 };
 
@@ -20,9 +22,11 @@ const DateFormField = ({ position = "RIGHT", ...props }: Props) => {
   return (
     <FormField props={props}>
       <DateInputV2
-        className={classNames(error && "border-red-500")}
+        className={classNames(error && "border-danger-500")}
         value={props.value}
         onChange={(value) => handleChange({ name, value })}
+        max={props.maxDate}
+        min={props.minDate}
         position={position}
         disabled={props.disabled}
         placeholder={props.placeholder}

--- a/src/Components/Form/FormFields/DateRangeFormField.tsx
+++ b/src/Components/Form/FormFields/DateRangeFormField.tsx
@@ -14,6 +14,20 @@ type Props = FormFieldBaseProps<DateRange> & {
   disablePast?: boolean;
 };
 
+/**
+ * A FormField to pick a date range.
+ *
+ * Example usage:
+ *
+ * ```jsx
+ * <DateRangeFormField
+ *   {...field("user_date_of_birth_prediction")}
+ *   label="Predicted date of birth"
+ *   required
+ *   disablePast // equivalent to min={new Date()}
+ * />
+ * ```
+ */
 const DateRangeFormField = (props: Props) => {
   const handleChange = resolveFormFieldChangeEventHandler(props);
   const error = resolveFormFieldError(props);

--- a/src/Components/Form/FormFields/DateRangeFormField.tsx
+++ b/src/Components/Form/FormFields/DateRangeFormField.tsx
@@ -8,7 +8,10 @@ import {
 } from "./Utils";
 
 type Props = FormFieldBaseProps<DateRange> & {
-  placeholder?: string;
+  max?: Date;
+  min?: Date;
+  disableFuture?: boolean;
+  disablePast?: boolean;
 };
 
 const DateRangeFormField = (props: Props) => {
@@ -22,6 +25,8 @@ const DateRangeFormField = (props: Props) => {
         className={classNames(error && "border-red-500")}
         value={props.value}
         onChange={(value) => handleChange({ name, value })}
+        min={props.min || (props.disableFuture ? new Date() : undefined)}
+        max={props.max || (props.disablePast ? new Date() : undefined)}
         disabled={props.disabled}
       />
     </FormField>


### PR DESCRIPTION
## Proposed Changes

- Fixes #4405 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
