### PR TITLE
Show modal for asset delete confirmation

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -19,6 +19,7 @@ import CareIcon from "../../CAREUI/icons/CareIcon";
 import ButtonV2 from "../Common/components/ButtonV2";
 import { UserRole, USER_TYPES } from "../../Common/constants";
 import moment from "moment";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -49,6 +50,7 @@ const AssetManage = (props: AssetManageProps) => {
   const limit = 14;
   const { currentUser }: any = useSelector((state) => state);
   const user_type = currentUser.data.user_type;
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   const fetchData = useCallback(
     async (status: statusType) => {
@@ -190,10 +192,7 @@ const AssetManage = (props: AssetManageProps) => {
   };
 
   const handleDelete = async () => {
-    const confirm = window.confirm(
-      "Are you sure you want to delete this asset?"
-    );
-    if (asset && confirm) {
+    if (asset) {
       const response = await dispatch(deleteAsset(asset.id));
       if (response && response.status === 204) {
         navigate("/assets");
@@ -212,6 +211,14 @@ const AssetManage = (props: AssetManageProps) => {
             name: asset?.name,
           },
         }}
+      />
+      <ConfirmDialogV2
+        title="Delete Asset"
+        description="Are you sure you want to delete this asset?"
+        action="Confirm"
+        show={showDeleteDialog}
+        onClose={() => setShowDeleteDialog(false)}
+        onConfirm={handleDelete}
       />
       <div className="flex flex-col xl:flex-row gap-8">
         <div className="bg-white rounded-lg md:rounded-xl w-full flex flex-col md:flex-row">
@@ -310,7 +317,7 @@ const AssetManage = (props: AssetManageProps) => {
               )}
               {checkAuthority(user_type, "DistrictAdmin") && (
                 <ButtonV2
-                  onClick={handleDelete}
+                  onClick={() => setShowDeleteDialog(true)}
                   variant={"danger"}
                   className="inline-flex"
                 >


### PR DESCRIPTION
## Proposed Changes

- Fixes #4434 
- When an asset is to be deleted, a modal popsup to confirm the delete action
### Screenshot
![image](https://user-images.githubusercontent.com/40627011/209964681-a1b7aacb-25f6-4a3f-9b05-edab29aceff4.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
