### PR TITLE
Improvements to Sign out button

### DIFF
--- a/src/Components/Common/Sidebar/SidebarUserCard.tsx
+++ b/src/Components/Common/Sidebar/SidebarUserCard.tsx
@@ -22,9 +22,12 @@ const SidebarUserCard = ({ shrinked }: { shrinked: boolean }) => {
       <Link href="/user/profile" className="flex-none py-3">
         <CareIcon className="care-l-user-circle text-3xl text-white" />
       </Link>
-      <div className="cursor-pointer" onClick={() => handleSignOut(true)}>
+      <div
+        className="cursor-pointer flex justify-center"
+        onClick={() => handleSignOut(true)}
+      >
         <CareIcon
-          className={`care-l-sign-out-alt text-3xl text-white ${
+          className={`care-l-sign-out-alt text-2xl text-gray-400 ${
             shrinked ? "visible" : "hidden"
           }`}
         />
@@ -48,10 +51,10 @@ const SidebarUserCard = ({ shrinked }: { shrinked: boolean }) => {
         >
           <CareIcon
             className={`care-l-sign-out-alt ${
-              shrinked ? "text-3xl" : "mr-1"
-            } text-white`}
+              shrinked ? "text-xl" : "mr-1"
+            } text-gray-400`}
           />
-          <p className="text-gray-300 text-opacity-80">{t("sign_out")}</p>
+          <p className="text-gray-400 text-opacity-80">{t("sign_out")}</p>
         </div>
       </div>
     </div>

--- a/src/Components/Common/Sidebar/SidebarUserCard.tsx
+++ b/src/Components/Common/Sidebar/SidebarUserCard.tsx
@@ -16,14 +16,23 @@ const SidebarUserCard = ({ shrinked }: { shrinked: boolean }) => {
   return (
     <div
       className={`flex my-2 ${
-        shrinked ? "mx-auto" : "mx-5"
+        shrinked ? "mx-auto flex-col" : "mx-5"
       } transition-all duration-200 ease-in-out`}
     >
-      <Link href="/user/profile" className="flex-none">
+      <Link href="/user/profile" className="flex-none py-3">
         <CareIcon className="care-l-user-circle text-3xl text-white" />
       </Link>
+      <div className="cursor-pointer" onClick={() => handleSignOut(true)}>
+        <CareIcon
+          className={`care-l-sign-out-alt text-3xl text-white ${
+            shrinked ? "visible" : "hidden"
+          }`}
+        />
+      </div>
       <div
-        className={`${shrinked ? "hidden" : "grow"} pl-3 flex flex-col min-w-0`}
+        className={`${
+          shrinked ? "hidden" : "grow"
+        } pl-3 flex flex-col min-w-0 pb-2`}
       >
         <div className="min-h-6 flex items-center">
           <Link
@@ -33,12 +42,17 @@ const SidebarUserCard = ({ shrinked }: { shrinked: boolean }) => {
             {profileName}
           </Link>
         </div>
-        <p
+        <div
+          className="min-h-6 flex items-center cursor-pointer"
           onClick={() => handleSignOut(true)}
-          className="text-gray-100 text-opacity-60 cursor-pointer text-sm"
         >
-          {t("sign_out")}
-        </p>
+          <CareIcon
+            className={`care-l-sign-out-alt ${
+              shrinked ? "text-3xl" : "mr-1"
+            } text-white`}
+          />
+          <p className="text-gray-300 text-opacity-80">{t("sign_out")}</p>
+        </div>
       </div>
     </div>
   );

--- a/src/Components/Users/UserProfile.tsx
+++ b/src/Components/Users/UserProfile.tsx
@@ -16,7 +16,9 @@ import LanguageSelector from "../../Components/Common/LanguageSelector";
 import TextInputFieldV2 from "../Common/components/TextInputFieldV2";
 import SelectMenuV2 from "../Form/SelectMenuV2";
 import { FieldLabel } from "../Form/FormFields/FormField";
-import { Submit } from "../Common/components/ButtonV2";
+import ButtonV2, { Submit } from "../Common/components/ButtonV2";
+import { handleSignOut } from "../../Utils/utils";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -321,16 +323,18 @@ export default function UserProfile() {
               <h3 className="text-lg font-medium leading-6 text-gray-900">
                 Personal Information
               </h3>
-              <p className="mt-1 text-sm leading-5 text-gray-600">
+              <p className="mt-1 text-sm leading-5 text-gray-600 mb-1">
                 Local Body, District and State are Non Editable Settings.
               </p>
-              <button
-                onClick={(_) => setShowEdit(!showEdit)}
-                type="button"
-                className="relative inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-500 focus:outline-none focus:shadow-outline-primary focus:border-primary-700 active:bg-primary-700 mt-4"
-              >
-                {showEdit ? "Cancel" : "Edit User Profile"}
-              </button>
+              <div className="flex flex-col gap-2">
+                <ButtonV2 onClick={(_) => setShowEdit(!showEdit)} type="button">
+                  {showEdit ? "Cancel" : "Edit User Profile"}
+                </ButtonV2>
+                <ButtonV2 variant="danger" onClick={(_) => handleSignOut(true)}>
+                  <CareIcon className="care-l-sign-out-alt" />
+                  Sign out
+                </ButtonV2>
+              </div>
             </div>
           </div>
           <div className="mt-5 lg:mt-0 lg:col-span-2">


### PR DESCRIPTION
Fixes #4443 

1. Added bottom padding to make it more visible
2. Added icon to sign out option
![image](https://user-images.githubusercontent.com/3626859/210067446-f2da1587-76b8-4698-a7c9-6ac4bd776db2.png)
3. Show the sign out option in collapsed menu
![image](https://user-images.githubusercontent.com/3626859/210067470-cfec275f-2ff1-4594-ae9e-1c2f299ae117.png)
4. Added Sign out option to profile page:
![image](https://user-images.githubusercontent.com/3626859/210067871-896d8d80-337c-46ae-8dca-171e60c898aa.png)


@coronasafe/care-fe-code-reviewers @coronasafe/care-fe-code-reviewers 