### PR TITLE
Autocomplete for location field in asset create form

### DIFF
--- a/src/Components/Common/components/Switch.tsx
+++ b/src/Components/Common/components/Switch.tsx
@@ -1,3 +1,4 @@
+import { FieldLabel } from "../../Form/FormFields/FormField";
 import { ErrorHelperText } from "../HelperInputFields";
 
 type SwitchProps<T> = {
@@ -16,12 +17,13 @@ type SwitchProps<T> = {
 export default function SwitchV2<T>(props: SwitchProps<T>) {
   return (
     <div className={props.className}>
-      {props.label && (
-        <label htmlFor="is_working" className="mb-3">
-          {props.label}
-          {props.required && " *"}
-        </label>
-      )}
+      <FieldLabel
+        htmlFor={props.name}
+        required={props.required}
+        className="mb-3"
+      >
+        {props.label}
+      </FieldLabel>
       <ul role="list" className="flex">
         {props.options.map((option, index) => {
           const selected = option === props.value;

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -376,7 +376,7 @@ const AssetCreate = (props: AssetProps) => {
         return;
       }
     } catch (err) {
-      console.log(err);
+      console.error(err);
       Notification.Error({ msg: err });
     }
     Notification.Error({ msg: "Invalid Asset Id" });

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -27,9 +27,10 @@ import TextInputFieldV2 from "../Common/components/TextInputFieldV2";
 import SwitchV2 from "../Common/components/Switch";
 import useVisibility from "../../Utils/useVisibility";
 import { goBack } from "../../Utils/utils";
-import SelectMenuV2 from "../Form/SelectMenuV2";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import DateInputV2 from "../Common/DateInputV2";
+import AutocompleteFormField from "../Form/FormFields/Autocomplete";
+import { SelectFormField } from "../Form/FormFields/SelectFormField";
 const Loading = loadable(() => import("../Common/Loading"));
 
 const formErrorKeys = [
@@ -113,7 +114,9 @@ const AssetCreate = (props: AssetProps) => {
   const [support_email, setSupportEmail] = useState("");
   const [location, setLocation] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [locations, setLocations] = useState<any>([]);
+  const [locations, setLocations] = useState<{ name: string; id: string }[]>(
+    []
+  );
   const [asset, setAsset] = useState<AssetData>();
   const [facilityName, setFacilityName] = useState("");
   const [qrCodeId, setQrCodeId] = useState("");
@@ -518,92 +521,70 @@ const AssetCreate = (props: AssetProps) => {
                     />
                   </div>
 
-                  <div className="col-span-6 flex flex-col lg:flex-row gap-x-12 xl:gap-x-16 transition-all">
-                    {/* Location */}
-                    <div ref={fieldRef["location"]}>
-                      <label htmlFor="asset-location">Location *</label>
-                      <div className="mt-2">
-                        <SelectMenuV2
-                          required
-                          options={[
-                            {
-                              title: "Select",
-                              description: "Select the location",
-                              value: "0",
-                            },
-                            ...locations.map((location: any) => ({
-                              title: location.name,
-                              description: location.facility.name,
-                              value: location.id,
-                            })),
-                          ]}
-                          optionLabel={(o) => o.title}
-                          optionValue={(o) => o.value}
-                          value={location}
-                          onChange={(e) => setLocation(e)}
-                        />
-                      </div>
-                      <ErrorHelperText error={state.errors.location} />
-                    </div>
+                  {/* Location */}
+                  <div ref={fieldRef["location"]} className="col-span-6">
+                    <AutocompleteFormField
+                      name="location"
+                      label="Location"
+                      required
+                      placeholder="Select the location of the asset"
+                      options={locations}
+                      optionLabel={({ name }) => name}
+                      optionValue={({ id }) => id}
+                      value={location}
+                      onChange={({ value }) => setLocation(value)}
+                      error={state.errors.location}
+                    />
+                  </div>
 
+                  <div className="col-span-6 flex flex-col lg:flex-row gap-x-12 xl:gap-x-16 transition-all">
                     {/* Asset Type */}
-                    <div ref={fieldRef["asset_type"]}>
-                      <label htmlFor="asset-type">Asset Type *</label>
-                      <div className="mt-2">
-                        <SelectMenuV2
-                          required
-                          options={[
-                            {
-                              title: "Internal",
-                              description:
-                                "Asset is inside the facility premises.",
-                              value: "INTERNAL",
-                            },
-                            {
-                              title: "External",
-                              description:
-                                "Asset is outside the facility premises.",
-                              value: "EXTERNAL",
-                            },
-                          ]}
-                          value={asset_type}
-                          placeholder="Select"
-                          optionLabel={(o) => o.title}
-                          optionValue={(o) =>
-                            o.value === "INTERNAL"
-                              ? AssetType.INTERNAL
-                              : AssetType.EXTERNAL
-                          }
-                          onChange={(e) => setAssetType(e)}
-                        />
-                      </div>
-                      <ErrorHelperText error={state.errors.asset_type} />
+                    <div ref={fieldRef["asset_type"]} className="flex-1">
+                      <SelectFormField
+                        label="Asset Type"
+                        name="asset_type"
+                        required
+                        options={[
+                          {
+                            title: "Internal",
+                            description:
+                              "Asset is inside the facility premises.",
+                            value: AssetType.INTERNAL,
+                          },
+                          {
+                            title: "External",
+                            description:
+                              "Asset is outside the facility premises.",
+                            value: AssetType.EXTERNAL,
+                          },
+                        ]}
+                        value={asset_type}
+                        optionLabel={({ title }) => title}
+                        optionDescription={({ description }) => description}
+                        optionValue={({ value }) => value}
+                        onChange={({ value }) => setAssetType(value)}
+                        error={state.errors.asset_type}
+                      />
                     </div>
 
                     {/* Asset Class */}
-                    <div ref={fieldRef["asset_class"]}>
-                      <label htmlFor="asset-class">Asset Class</label>
-                      <div className="mt-2">
-                        <SelectMenuV2
-                          options={[
-                            { title: "ONVIF Camera", value: "ONVIF" },
-                            {
-                              title: "HL7 Vitals Monitor",
-                              value: "HL7MONITOR",
-                            },
-                          ]}
-                          value={asset_class}
-                          placeholder="Select"
-                          optionLabel={(o) => o.title}
-                          optionValue={(o) =>
-                            o.value === "ONVIF"
-                              ? AssetClass.ONVIF
-                              : AssetClass.HL7MONITOR
-                          }
-                          onChange={(e) => setAssetClass(e)}
-                        />
-                      </div>
-                      <ErrorHelperText error={state.errors.asset_class} />
+                    <div ref={fieldRef["asset_class"]} className="flex-1">
+                      <SelectFormField
+                        name="asset_class"
+                        label="Asset Class"
+                        value={asset_class}
+                        options={[
+                          { title: "ONVIF Camera", value: AssetClass.ONVIF },
+                          {
+                            title: "HL7 Vitals Monitor",
+                            value: AssetClass.HL7MONITOR,
+                          },
+                        ]}
+                        optionLabel={({ title }) => title}
+                        optionValue={({ value }) => value}
+                        onChange={({ value }) => setAssetClass(value)}
+                        error={state.errors.asset_class}
+                      />
                     </div>
                   </div>
 

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -31,6 +31,8 @@ import { Cancel, Submit } from "../Common/components/ButtonV2";
 import DateInputV2 from "../Common/DateInputV2";
 import AutocompleteFormField from "../Form/FormFields/Autocomplete";
 import { SelectFormField } from "../Form/FormFields/SelectFormField";
+import TextFormField from "../Form/FormFields/TextFormField";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 const Loading = loadable(() => import("../Common/Loading"));
 
 const formErrorKeys = [
@@ -511,13 +513,13 @@ const AssetCreate = (props: AssetProps) => {
 
                   {/* Asset Name */}
                   <div className="col-span-6" ref={fieldRef["name"]}>
-                    <TextInputFieldV2
-                      id="asset-name"
+                    <TextFormField
+                      name="name"
                       label="Asset Name"
-                      value={name}
-                      onValueChange={setName}
-                      error={state.errors.name}
                       required
+                      value={name}
+                      onChange={({ value }) => setName(value)}
+                      error={state.errors.name}
                     />
                   </div>
 
@@ -590,23 +592,14 @@ const AssetCreate = (props: AssetProps) => {
 
                   {/* Description */}
                   <div className="col-span-6">
-                    <label htmlFor="asset-description">
-                      Describe the asset
-                    </label>
-                    <textarea
-                      id="asset-description"
-                      className={
-                        "mt-2 block w-full input" +
-                        ((state.errors.description && " border-red-500") || "")
-                      }
-                      name="asset-description"
-                      placeholder="Eg. Details about the equipment"
+                    <TextAreaFormField
+                      name="asset_description"
+                      label="Description"
+                      placeholder="Details about the equipment"
                       value={description}
-                      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                        setDescription(e.target.value)
-                      }
+                      onChange={({ value }) => setDescription(value)}
+                      error={state.errors.description}
                     />
-                    <ErrorHelperText error={state.errors.description} />
                   </div>
 
                   {/* Divider */}

--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -113,8 +113,6 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
 
   const filteredOptions = valueOptions.filter((o) => o.search.includes(query));
 
-  console.log(value);
-
   return (
     <div className={props.className} id={props.id}>
       <Combobox

--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -1,10 +1,53 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Combobox } from "@headlessui/react";
-import { DropdownTransition } from "../Common/components/HelperComponents";
-import CareIcon from "../../CAREUI/icons/CareIcon";
-import { dropdownOptionClassNames } from "./MultiSelectMenuV2";
+import { DropdownTransition } from "../../Common/components/HelperComponents";
+import CareIcon from "../../../CAREUI/icons/CareIcon";
+import { dropdownOptionClassNames } from "../MultiSelectMenuV2";
+import {
+  FormFieldBaseProps,
+  resolveFormFieldChangeEventHandler,
+} from "./Utils";
+import FormField from "./FormField";
 
 type OptionCallback<T, R> = (option: T) => R;
+
+type AutocompleteFormFieldProps<T, V> = FormFieldBaseProps<V> & {
+  placeholder?: string;
+  options: T[];
+  optionLabel: OptionCallback<T, string>;
+  optionValue?: OptionCallback<T, V>;
+  optionIcon?: OptionCallback<T, React.ReactNode>;
+  onQuery?: (query: string) => void;
+  dropdownIcon?: React.ReactNode | undefined;
+};
+
+const AutocompleteFormField = <T, V>(
+  props: AutocompleteFormFieldProps<T, V>
+) => {
+  const { name } = props;
+  const handleChange = resolveFormFieldChangeEventHandler(props);
+
+  return (
+    <FormField props={props}>
+      <Autocomplete
+        id={props.id}
+        options={props.options}
+        disabled={props.disabled}
+        value={props.value}
+        placeholder={props.placeholder}
+        optionLabel={props.optionLabel}
+        optionIcon={props.optionIcon}
+        optionValue={props.optionValue}
+        className={props.className}
+        required={props.required}
+        onQuery={props.onQuery}
+        onChange={(value: any) => handleChange({ name, value })}
+      />
+    </FormField>
+  );
+};
+
+export default AutocompleteFormField;
 
 type AutocompleteProps<T, V = T> = {
   id?: string;
@@ -15,9 +58,9 @@ type AutocompleteProps<T, V = T> = {
   optionLabel: OptionCallback<T, string>;
   optionIcon?: OptionCallback<T, React.ReactNode>;
   optionValue?: OptionCallback<T, V>;
-  showIconWhenSelected?: boolean;
   className?: string;
-  chevronIcon?: React.ReactNode | undefined;
+  onQuery?: (query: string) => void;
+  isLoading?: boolean;
 } & (
   | {
       required?: false;
@@ -36,8 +79,11 @@ type AutocompleteProps<T, V = T> = {
  * Use this only when you want to hack into the design and get more
  * customizability.
  */
-export const AutocompleteV2 = <T, V>(props: AutocompleteProps<T, V>) => {
+export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
   const [query, setQuery] = useState(""); // Ensure lower case
+  useEffect(() => {
+    props.onQuery && props.onQuery(query);
+  }, [query]);
 
   const valueOptions = props.options.map((option) => {
     const label = props.optionLabel(option);
@@ -67,6 +113,8 @@ export const AutocompleteV2 = <T, V>(props: AutocompleteProps<T, V>) => {
 
   const filteredOptions = valueOptions.filter((o) => o.search.includes(query));
 
+  console.log(value);
+
   return (
     <div className={props.className} id={props.id}>
       <Combobox
@@ -79,12 +127,14 @@ export const AutocompleteV2 = <T, V>(props: AutocompleteProps<T, V>) => {
             <Combobox.Input
               className="cui-input-base pr-16 truncate"
               placeholder={placeholder}
-              displayValue={props.optionLabel}
+              displayValue={(value: any) => value.label}
               onChange={(event) => setQuery(event.target.value.toLowerCase())}
             />
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
               <div className="absolute top-1 right-0 flex items-center mr-2 text-lg text-gray-900">
-                {props.chevronIcon || (
+                {props.isLoading ? (
+                  <CareIcon className="care-l-spinner animate-spin" />
+                ) : (
                   <CareIcon className="care-l-angle-down -mb-1.5" />
                 )}
               </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #4406 
- Use FormField components for fields in General Details section
- Move fields Asset Type and Asset Class to next row

![image](https://user-images.githubusercontent.com/25143503/210240652-9f7a1182-9597-4ad5-a107-a50b1eca53a0.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
