### PR TITLE
Use the standard `Cancel` and `Submit` buttons for Facility Notify modal

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { sendNotificationMessages } from "../../Redux/actions";
 import { FACILITY_FEATURE_TYPES, KASP_STRING } from "../../Common/constants";
-import ButtonV2 from "../Common/components/ButtonV2";
+import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
 import * as Notification from "../../Utils/Notifications.js";
 import { getFacilityFeatureIcon } from "./FacilityHome";
 import DialogModal from "../Common/Dialog";
@@ -156,27 +156,18 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                       }}
                       className="bg-white text-center flex flex-col w-full"
                     >
-                      <div>
-                        <TextAreaFormField
-                          id="NotifyModalMessageInput"
-                          name="message"
-                          rows={6}
-                          required
-                          className="py-2"
-                          onChange={(e) => setNotifyMessage(e.value)}
-                          placeholder="Type your message..."
-                        />
-                      </div>
+                      <TextAreaFormField
+                        id="NotifyModalMessageInput"
+                        name="message"
+                        required
+                        rows={5}
+                        className="pt-4 pb-2"
+                        onChange={(e) => setNotifyMessage(e.value)}
+                        placeholder="Type your message..."
+                      />
                       <div className="flex flex-col-reverse md:flex-row gap-2 justify-between">
-                        <ButtonV2
-                          variant="secondary"
-                          onClick={() => setNotifyModalFor(undefined)}
-                        >
-                          Cancel
-                        </ButtonV2>
-                        <ButtonV2 variant="primary" type="submit">
-                          Send Notification
-                        </ButtonV2>
+                        <Cancel onClick={() => setNotifyModalFor(undefined)} />
+                        <Submit label="Notify" />
                       </div>
                     </form>
                   </DialogModal>


### PR DESCRIPTION
## Proposed Changes

- Migrate Cancel and Notify buttons to standardized Cancel and Submit buttons.
- Automatically fixes #4451 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
