### PR TITLE
fix: Missing ascending/descending icons in patient ordering filter

### DIFF
--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -378,8 +378,8 @@ export default function PatientFilterV2(props: any) {
             <CareIcon
               className={`${
                 option.order === "Ascending"
-                  ? "care-l-amount-up"
-                  : "care-l-amount-down"
+                  ? "care-l-sort-amount-up"
+                  : "care-l-sort-amount-down"
               }`}
             />
           )}


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Updated classname of sort icon from `l-amount` to `l-sort-amount`

## Associated Issue

- Fixes #4345

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/210294562-813e7e31-9660-425d-846f-b5350dffe2c7.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug/test a new feature.
- [ ] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [x] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
