### PR TITLE
Made secondary button look like its not disabled

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1053,7 +1053,7 @@ button:disabled,
   @apply border border-primary-500
 }
 .button-secondary-default { 
-  @apply accent-secondary-200 bg-secondary-100 enabled:hover:bg-secondary-200 text-secondary-700
+  @apply accent-secondary-200 bg-secondary-300 enabled:hover:bg-secondary-400 text-secondary-800
 }
 .button-secondary-ghost { 
   @apply accent-secondary-200 enabled:hover:bg-secondary-200 text-secondary-700


### PR DESCRIPTION
## Proposed Changes

![image](https://user-images.githubusercontent.com/23238460/210358650-1e0ac7b0-eb7d-4e31-bf55-e754a977d5fa.png)
After

![image](https://user-images.githubusercontent.com/23238460/210358683-475c50f2-948b-40ff-9faf-3a6a82475a02.png)
Before

- Fixes #4300 
- Darkens button color scheme

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
