### PR TITLE
Care UI Slideover, upgrades Notifications List and Mobile Sidebar

### DIFF
--- a/src/CAREUI/interactive/SlideOver.tsx
+++ b/src/CAREUI/interactive/SlideOver.tsx
@@ -77,9 +77,11 @@ export default function SlideOver({
           leaveTo={directionClasses[slideFrom].animateStart + " opacity-0"}
         >
           <Dialog.Panel
-            className={`fixed pointer-events-auto ${
-              directionClasses[slideFrom].stick
-            } ${onlyChild || "md:p-2"}`}
+            className={classNames(
+              "fixed pointer-events-auto",
+              directionClasses[slideFrom].stick,
+              !onlyChild && "md:p-2"
+            )}
           >
             {onlyChild ? (
               children

--- a/src/CAREUI/interactive/SlideOver.tsx
+++ b/src/CAREUI/interactive/SlideOver.tsx
@@ -1,5 +1,7 @@
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment } from "react";
+import { classNames } from "../../Utils/utils";
+import CareIcon from "../icons/CareIcon";
 
 export type SlideFromEdges = "left" | "top" | "right" | "bottom";
 
@@ -81,19 +83,18 @@ export default function SlideOver({
               children
             ) : (
               <div
-                className={
-                  "bg-white md:rounded-xl flex flex-col " +
-                  directionClasses[slideFrom].proportions +
-                  " " +
+                className={classNames(
+                  "bg-white md:rounded-xl flex flex-col",
+                  directionClasses[slideFrom].proportions,
                   dialogClass
-                }
+                )}
               >
                 <div className="flex items-center p-2 gap-2 pt-4">
                   <button
                     className="w-8 h-8 rounded-lg flex justify-center items-center text-2xl hover:bg-black/20"
                     onClick={() => setOpen(false)}
                   >
-                    <i className="uil uil-arrow-left" />
+                    <CareIcon className="care-l-arrow-left" />
                   </button>
                   <div>
                     <h1 className="text-xl font-black">{title}</h1>

--- a/src/CAREUI/interactive/SlideOver.tsx
+++ b/src/CAREUI/interactive/SlideOver.tsx
@@ -13,6 +13,7 @@ export type SlideOverProps = {
   dialogClass?: string;
   title?: string;
   onlyChild?: boolean;
+  onCloseClick?: () => void;
 };
 
 export default function SlideOver({
@@ -23,6 +24,7 @@ export default function SlideOver({
   dialogClass,
   title,
   onlyChild = false,
+  onCloseClick,
 }: SlideOverProps) {
   const directionClasses = {
     left: {
@@ -92,7 +94,10 @@ export default function SlideOver({
                 <div className="flex items-center p-2 gap-2 pt-4">
                   <button
                     className="w-8 h-8 rounded-lg flex justify-center items-center text-2xl hover:bg-black/20"
-                    onClick={() => setOpen(false)}
+                    onClick={() => {
+                      setOpen(false);
+                      onCloseClick && onCloseClick();
+                    }}
                   >
                     <CareIcon className="care-l-arrow-left" />
                   </button>

--- a/src/CAREUI/interactive/SlideOver.tsx
+++ b/src/CAREUI/interactive/SlideOver.tsx
@@ -1,0 +1,110 @@
+import { Dialog, Transition } from "@headlessui/react";
+import { Fragment } from "react";
+
+export type SlideFromEdges = "left" | "top" | "right" | "bottom";
+
+export type SlideOverProps = {
+  open: boolean;
+  setOpen: (state: boolean) => void;
+  children: React.ReactNode;
+  slideFrom?: SlideFromEdges;
+  dialogClass?: string;
+  title?: string;
+  onlyChild?: boolean;
+};
+
+export default function SlideOver({
+  open,
+  setOpen,
+  children,
+  slideFrom = "right",
+  dialogClass,
+  title,
+  onlyChild = false,
+}: SlideOverProps) {
+  const directionClasses = {
+    left: {
+      stick: "left-0 top-0 h-full",
+      animateStart: "-translate-x-20",
+      animateEnd: "translate-x-0",
+      proportions: " cui-slideover-x",
+    },
+    right: {
+      stick: "right-0 top-0 h-full",
+      animateStart: "translate-x-20",
+      animateEnd: "-translate-x-0",
+      proportions: "cui-slideover-x",
+    },
+    top: {
+      stick: "top-0 left-0 w-full",
+      animateStart: "-translate-y-20",
+      animateEnd: "translate-y-0",
+      proportions: "cui-slideover-y",
+    },
+    bottom: {
+      stick: "bottom-0 left-0 w-full",
+      animateStart: "translate-y-20",
+      animateEnd: "-translate-y-0",
+      proportions: "cui-slideover-y",
+    },
+  };
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-in-out duration-500"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in-out duration-500"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/75 backdrop-blur-sm transition-all" />
+        </Transition.Child>
+        <Transition.Child
+          as={Fragment}
+          enter="transition-all"
+          enterFrom={directionClasses[slideFrom].animateStart + " opacity-0"}
+          enterTo={directionClasses[slideFrom].animateEnd + " opacity-100"}
+          leave="transition-all"
+          leaveFrom={directionClasses[slideFrom].animateEnd + " opacity-100"}
+          leaveTo={directionClasses[slideFrom].animateStart + " opacity-0"}
+        >
+          <Dialog.Panel
+            className={`fixed pointer-events-auto ${
+              directionClasses[slideFrom].stick
+            } ${onlyChild || "md:p-2"}`}
+          >
+            {onlyChild ? (
+              children
+            ) : (
+              <div
+                className={
+                  "bg-white md:rounded-xl flex flex-col " +
+                  directionClasses[slideFrom].proportions +
+                  " " +
+                  dialogClass
+                }
+              >
+                <div className="flex items-center p-2 gap-2 pt-4">
+                  <button
+                    className="w-8 h-8 rounded-lg flex justify-center items-center text-2xl hover:bg-black/20"
+                    onClick={() => setOpen(false)}
+                  >
+                    <i className="uil uil-arrow-left" />
+                  </button>
+                  <div>
+                    <h1 className="text-xl font-black">{title}</h1>
+                  </div>
+                </div>
+                <div className="overflow-auto flex-1 p-4">{children}</div>
+              </div>
+            )}
+          </Dialog.Panel>
+        </Transition.Child>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -139,7 +139,10 @@ const StatelessSidebar = ({
             );
           })}
 
-          <NotificationItem shrinked={shrinked} />
+          <NotificationItem
+            shrinked={shrinked}
+            onClickCB={() => onItemClick && onItemClick(false)}
+          />
           <Item
             text="Dashboard"
             to={dashboard_url}

--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -1,11 +1,11 @@
-import { Fragment, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { SidebarItem, ShrinkedSidebarItem } from "./SidebarItem";
 import SidebarUserCard from "./SidebarUserCard";
 import NotificationItem from "../../Notifications/NotificationsList";
-import { Dialog, Transition } from "@headlessui/react";
 import useActiveLink from "../../../Common/hooks/useActiveLink";
 import CareIcon from "../../../CAREUI/icons/CareIcon";
 import useConfig from "../../../Common/hooks/useConfig";
+import SlideOver from "../../../CAREUI/interactive/SlideOver";
 
 export const SIDEBAR_SHRINK_PREFERENCE_KEY = "sidebarShrinkPreference";
 
@@ -18,13 +18,13 @@ type StatelessSidebarProps =
       shrinkable: true;
       shrinked: boolean;
       setShrinked: (state: boolean) => void;
-      setOpenCB?: undefined;
+      onItemClick?: undefined;
     }
   | {
       shrinkable?: false;
       shrinked?: false;
       setShrinked?: undefined;
-      setOpenCB: (open: boolean) => void;
+      onItemClick: (open: boolean) => void;
     };
 
 const NavItems = [
@@ -47,7 +47,7 @@ const StatelessSidebar = ({
   shrinkable = false,
   shrinked = false,
   setShrinked,
-  setOpenCB,
+  onItemClick,
 }: StatelessSidebarProps) => {
   const activeLink = useActiveLink();
   const Item = shrinked ? ShrinkedSidebarItem : SidebarItem;
@@ -134,7 +134,7 @@ const StatelessSidebar = ({
                 {...i}
                 icon={<CareIcon className={`${i.icon} h-5`} />}
                 selected={i.to === activeLink}
-                do={() => setOpenCB && setOpenCB(false)}
+                do={() => onItemClick && onItemClick(false)}
               />
             );
           })}
@@ -195,43 +195,11 @@ interface MobileSidebarProps {
   setOpen: (state: boolean) => void;
 }
 
-export const MobileSidebar = ({ open, setOpen }: MobileSidebarProps) => {
+export const MobileSidebar = (props: MobileSidebarProps) => {
   return (
-    <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={setOpen}>
-        <Transition.Child
-          as={Fragment}
-          enter="ease-in-out duration-500"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in-out duration-500"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-black/75 backdrop-blur-sm transition-all" />
-        </Transition.Child>
-
-        <div className="fixed inset-0 overflow-hidden">
-          <div className="absolute inset-0 overflow-hidden">
-            <div className="pointer-events-none fixed inset-y-0 left-0 flex max-w-full pr-10">
-              <Transition.Child
-                as={Fragment}
-                enter="transform transition ease-out duration-200"
-                enterFrom="-translate-x-full"
-                enterTo="translate-x-0"
-                leave="transform transition ease-in duration-200"
-                leaveFrom="translate-x-0"
-                leaveTo="-translate-x-full"
-              >
-                <Dialog.Panel className="pointer-events-auto w-screen max-w-fit">
-                  <StatelessSidebar setOpenCB={setOpen} />
-                </Dialog.Panel>
-              </Transition.Child>
-            </div>
-          </div>
-        </div>
-      </Dialog>
-    </Transition.Root>
+    <SlideOver {...props} slideFrom="left" onlyChild>
+      <StatelessSidebar onItemClick={props.setOpen} />
+    </SlideOver>
   );
 };
 

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -105,7 +105,7 @@ const NotificationTile = ({
         <div className="flex justify-end gap-2">
           <ButtonV2
             className={classNames(
-              "font-semibold p-2 md:py-1 bg-white hover:bg-secondary-300",
+              "font-semibold px-2 py-1 bg-white hover:bg-secondary-300",
               result.read_at && "invisible"
             )}
             variant="secondary"
@@ -129,7 +129,7 @@ const NotificationTile = ({
           <ButtonV2
             border
             ghost
-            className="font-semibold p-2 md:py-1 bg-white hover:bg-secondary-300 flex-shrink-0"
+            className="font-semibold px-2 py-1 bg-white hover:bg-secondary-300 flex-shrink-0"
           >
             <CareIcon className="care-l-envelope-open" />
             <span className="text-xs">Open</span>
@@ -406,6 +406,7 @@ export default function NotificationsList({
         slideFrom="right"
         title="Notifications"
         dialogClass="md:w-[400px]"
+        onCloseClick={onClickCB}
       >
         <div className="flex flex-col gap-3">
           <div className="flex flex-wrap">

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -85,7 +85,7 @@ const NotificationTile = ({
         setShowNotifications(false);
       }}
       className={classNames(
-        "relative py-5 px-4 lg:px-8 hover:bg-gray-200 focus:bg-gray-200 transition ease-in-out duration-150 cursor-pointer",
+        "relative py-5 px-4 lg:px-8 hover:bg-gray-200 focus:bg-gray-200 transition ease-in-out duration-200 rounded md:rounded-lg cursor-pointer",
         result.read_at && "text-gray-500"
       )}
     >
@@ -93,44 +93,47 @@ const NotificationTile = ({
         <div className="text-lg font-bold">
           {getNotificationTitle(result.event)}
         </div>
-        <div className="">
+        <div>
           <i className={`${getNotificationIcon(result.event)} fa-2x `} />
         </div>
       </div>
       <div className="text-sm py-1">{result.message}</div>
-      <div className="flex justify-between items-end">
-        <ButtonV2
-          className={classNames(
-            "font-semibold p-2 md:py-1 bg-white hover:bg-gray-300 border text-xs flex-shrink-0",
-            result.read_at && "invisible"
-          )}
-          disabled={isMarkingAsRead}
-          onClick={(event) => {
-            event.stopPropagation();
-            handleMarkAsRead();
-          }}
-        >
-          {isMarkingAsRead ? (
-            <Spinner />
-          ) : (
-            <i className="fa-solid fa-check mr-2 text-primary-500" />
-          )}
-          Mark as Read
-        </ButtonV2>
-        <div>
-          <div className="text-xs text-right py-1">
-            {formatDate(result.created_date)}
-          </div>
-          <div className="mt-2 text-right min-h-min">
-            <ButtonV2
-              className="font-semibold p-2 md:py-1 bg-white hover:bg-gray-300 text-black border rounded text-xs flex-shrink-0"
-              ghost
-              shadow
-              border
-            >
-              <i className="fas fa-eye mr-2 text-primary-500" /> Visit Link
-            </ButtonV2>
-          </div>
+      <div className="flex flex-col justify-end gap-2">
+        <div className="text-xs text-right py-1 text-secondary-700">
+          {formatDate(result.created_date)}
+        </div>
+        <div className="flex justify-end gap-2">
+          <ButtonV2
+            className={classNames(
+              "font-semibold p-2 md:py-1 bg-white hover:bg-secondary-300",
+              result.read_at && "invisible"
+            )}
+            variant="secondary"
+            border
+            ghost
+            disabled={isMarkingAsRead}
+            onClick={(event) => {
+              event.stopPropagation();
+              handleMarkAsRead();
+            }}
+          >
+            <CareIcon
+              className={
+                isMarkingAsRead
+                  ? "care-l-spinner animate-spin"
+                  : "care-l-envelope-check"
+              }
+            />
+            <span className="text-xs">Mark as Read</span>
+          </ButtonV2>
+          <ButtonV2
+            border
+            ghost
+            className="font-semibold p-2 md:py-1 bg-white hover:bg-secondary-300 flex-shrink-0"
+          >
+            <CareIcon className="care-l-envelope-open" />
+            <span className="text-xs">Open</span>
+          </ButtonV2>
         </div>
       </div>
     </div>
@@ -204,22 +207,22 @@ export default function NotificationsList({
     if (status === "NotSubscribed") {
       return (
         <>
-          {" "}
-          <i className="fa-solid fa-bell mr-2"></i>Subscribe
+          <CareIcon className="care-l-bell" />
+          <span className="text-xs">Subscribe</span>
         </>
       );
     } else if (status === "SubscribedOnAnotherDevice") {
       return (
         <>
-          {" "}
-          <i className="fa-solid fa-bell mr-2"></i>Subscribe On This Device
+          <CareIcon className="care-l-bell" />
+          <span className="text-xs">Subscribe on this device</span>
         </>
       );
     } else {
       return (
         <>
-          {" "}
-          <i className="fa-solid fa-bell-slash mr-2"></i>Unsubscribe
+          <CareIcon className="care-l-bell-slash" />
+          <span className="text-xs">Unsubscribe</span>
         </>
       );
     }
@@ -368,7 +371,9 @@ export default function NotificationsList({
             <ButtonV2
               className="w-full"
               disabled={isLoading}
+              variant="secondary"
               shadow
+              border
               onClick={() => setOffset((prev) => prev + RESULT_LIMIT)}
             >
               {isLoading ? "Loading..." : "Load More"}
@@ -400,27 +405,25 @@ export default function NotificationsList({
         setOpen={setOpen}
         slideFrom="right"
         title="Notifications"
-        dialogClass="md:w-[350px]"
+        dialogClass="md:w-[400px]"
       >
-        <div className="flex flex-col">
-          <div className="flex gap-2 flex-wrap mb-2">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap">
             <ButtonV2
-              className="text-xs"
               ghost
               variant="secondary"
-              onClick={(_) => {
+              onClick={() => {
                 setReload(!reload);
                 setData([]);
                 setUnreadCount(0);
                 setOffset(0);
               }}
             >
-              <i className="fa-fw fas fa-sync cursor-pointer mr-2" /> Reload
+              <CareIcon className="care-l-sync" />
+              <span className="text-xs">Reload</span>
             </ButtonV2>
-
             <ButtonV2
               onClick={handleSubscribeClick}
-              className="text-xs"
               ghost
               variant="secondary"
               disabled={isSubscribing}
@@ -429,18 +432,19 @@ export default function NotificationsList({
               {getButtonText()}
             </ButtonV2>
             <ButtonV2
-              className="text-xs"
               ghost
               variant="secondary"
               disabled={isMarkingAllAsRead}
               onClick={handleMarkAllAsRead}
             >
-              {isMarkingAllAsRead ? (
-                <Spinner />
-              ) : (
-                <i className="fa-solid fa-check-double mr-2 text-primary-500" />
-              )}
-              Mark All as Read
+              <CareIcon
+                className={
+                  isMarkingAllAsRead
+                    ? "care-l-spinner animate-spin"
+                    : "care-l-envelope-check"
+                }
+              />
+              <span className="text-xs">Mark all as Read</span>
             </ButtonV2>
           </div>
 

--- a/src/style/CAREUI.css
+++ b/src/style/CAREUI.css
@@ -86,5 +86,14 @@
 .cui-input:-webkit-autofill:hover,
 .cui-input:-webkit-autofill:focus,
 .cui-input:-webkit-autofill:active {
+    box-shadow: 0 0 0 40px #f9fafb inset !important;
     -webkit-box-shadow: 0 0 0 40px #f9fafb inset !important;
+}
+
+.cui-slideover-x {
+    @apply w-full md:w-[300px] h-full
+}
+
+.cui-slideover-y {
+    @apply h-full md:h-[300px] w-full
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes #4387
- New component: `SlideOver`
- Replaces the custom slide-over of the mobile sidebar with the new slide-over component.

Co-authored by @skks1212 via #3996

### Desktop view (notifications)

![image](https://user-images.githubusercontent.com/25143503/210481704-ba0bc721-5054-45d6-8cbc-494d8a53848c.png)


### Mobile view (sidebar and notifications)

![image](https://user-images.githubusercontent.com/25143503/210481640-5de0a909-3925-4d42-95bc-eadc88f0f5b1.png)

![image](https://user-images.githubusercontent.com/25143503/210481684-a76c925b-f573-450b-b9bd-b60a2231e5e3.png)




@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
