### PR TITLE
Feat: Status during consultation

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -282,6 +282,14 @@ export const CONSULTATION_SUGGESTION = [
   { id: "DC", text: "Domiciliary Care" },
 ];
 
+export const CONSULTATION_STATUS = [
+  { id: "1", text: "Brought Dead" },
+  { id: "2", text: "Transferred from ward" },
+  { id: "3", text: "Transferred from ICU" },
+  { id: "4", text: "Referred from other hospital" },
+  { id: "5", text: "Out-patient (walk in)" },
+];
+
 export const ADMITTED_TO = [
   { id: "1", text: "Isolation" },
   { id: "2", text: "ICU" },

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -18,6 +18,7 @@ import {
   REVIEW_AT_CHOICES,
   KASP_STRING,
   KASP_ENABLED,
+  CONSULTATION_STATUS,
 } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
@@ -69,6 +70,7 @@ type FormDetails = {
   other_symptoms: string;
   symptoms_onset_date?: Date;
   suggestion: string;
+  consultation_status: number;
   patient: string;
   facility: string;
   admitted: BooleanStrings;
@@ -110,6 +112,7 @@ const initForm: FormDetails = {
   other_symptoms: "",
   symptoms_onset_date: undefined,
   suggestion: "A",
+  consultation_status: 0,
   patient: "",
   facility: "",
   admitted: "false",
@@ -317,6 +320,13 @@ export const ConsultationForm = (props: any) => {
             invalidForm = true;
           }
           return;
+        case "consultation_status":
+          if (!state.form[field]) {
+            errors[field] = "Please select the consultation status";
+            if (!error_div) error_div = field;
+            invalidForm = true;
+          }
+          return;
         case "ip_no":
           if (!state.form[field]) {
             errors[field] = "Please enter IP Number";
@@ -480,6 +490,7 @@ export const ConsultationForm = (props: any) => {
           ? state.form.symptoms_onset_date
           : undefined,
         suggestion: state.form.suggestion,
+        consultation_status: Number(state.form.consultation_status),
         admitted: state.form.suggestion === "A",
         admission_date:
           state.form.suggestion === "A" ? state.form.admission_date : undefined,
@@ -675,6 +686,13 @@ export const ConsultationForm = (props: any) => {
           label="Decision after consultation"
           {...selectField("suggestion")}
           options={CONSULTATION_SUGGESTION}
+        />
+
+        <SelectFormField
+          required
+          label="Status during the consultation"
+          {...selectField("consultation_status")}
+          options={CONSULTATION_STATUS}
         />
 
         {state.form.suggestion === "R" && (


### PR DESCRIPTION
# Feature Request

## Proposed Changes

- Added `Status during the consultation` field in consultation form

## Associated Issue

- Fixes #4496

## Associated PRs

- Related backend PR coronasafe/care#1143

## Scrrenshot

![image](https://user-images.githubusercontent.com/77210185/210550680-fcc9bbff-1e7b-4be9-85b9-38481b4bd7b4.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug/test a new feature.
- [ ] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
