### PR TITLE
Use `URLSearchParam` instead of the deprecated `querystring`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "moment": "^2.29.4",
         "postcss-loader": "^7.0.2",
         "qrcode.react": "^1.0.1",
-        "querystring": "^0.2.1",
         "raviger": "^4.1.2",
         "react": "18.2.0",
         "react-copy-to-clipboard": "^5.0.3",
@@ -37702,15 +37701,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
@@ -73489,11 +73479,6 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
-    },
-    "querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
     "querystring-es3": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "moment": "^2.29.4",
     "postcss-loader": "^7.0.2",
     "qrcode.react": "^1.0.1",
-    "querystring": "^0.2.1",
     "raviger": "^4.1.2",
     "react": "18.2.0",
     "react-copy-to-clipboard": "^5.0.3",

--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -1,7 +1,6 @@
 import axios from "axios";
 import api from "./api";
 import * as Notification from "../Utils/Notifications.js";
-import querystring from "querystring";
 const requestMap: any = api;
 export const actions = {
   FETCH_REQUEST: "FETCH_REQUEST",
@@ -68,7 +67,7 @@ export const fireRequest = (
     }
     if (request.method === undefined || request.method === "GET") {
       request.method = "GET";
-      const qs = querystring.stringify(params);
+      const qs = new URLSearchParams(params).toString();
       if (qs !== "") {
         request.path += `?${qs}`;
       }
@@ -188,7 +187,7 @@ export const fireRequestV2 = (
   }
   if (request.method === undefined || request.method === "GET") {
     request.method = "GET";
-    const qs = querystring.stringify(params);
+    const qs = new URLSearchParams(params).toString();
     if (qs !== "") {
       request.path += `?${qs}`;
     }
@@ -296,7 +295,7 @@ export const fireRequestForFiles = (
     }
     if (request.method === undefined || request.method === "GET") {
       request.method = "GET";
-      const qs = querystring.stringify(params);
+      const qs = new URLSearchParams(params).toString();
       if (qs !== "") {
         request.path += `?${qs}`;
       }

--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import api from "./api";
 import * as Notification from "../Utils/Notifications.js";
+import { isEmpty, omitBy } from "lodash";
 const requestMap: any = api;
 export const actions = {
   FETCH_REQUEST: "FETCH_REQUEST",
@@ -67,7 +68,7 @@ export const fireRequest = (
     }
     if (request.method === undefined || request.method === "GET") {
       request.method = "GET";
-      const qs = new URLSearchParams(params).toString();
+      const qs = new URLSearchParams(omitBy(params, isEmpty)).toString();
       if (qs !== "") {
         request.path += `?${qs}`;
       }
@@ -187,7 +188,7 @@ export const fireRequestV2 = (
   }
   if (request.method === undefined || request.method === "GET") {
     request.method = "GET";
-    const qs = new URLSearchParams(params).toString();
+    const qs = new URLSearchParams(omitBy(params, isEmpty)).toString();
     if (qs !== "") {
       request.path += `?${qs}`;
     }
@@ -295,7 +296,7 @@ export const fireRequestForFiles = (
     }
     if (request.method === undefined || request.method === "GET") {
       request.method = "GET";
-      const qs = new URLSearchParams(params).toString();
+      const qs = new URLSearchParams(omitBy(params, isEmpty)).toString();
       if (qs !== "") {
         request.path += `?${qs}`;
       }


### PR DESCRIPTION
## Proposed Changes

- Fixes #4454

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
