### PR TITLE
Fixed responsive bug in asset details

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -214,7 +214,7 @@ const AssetManage = (props: AssetManageProps) => {
         }}
       />
       <div className="flex flex-col xl:flex-row gap-8">
-        <div className="bg-white rounded-lg md:rounded-xl w-full flex flex-col md:flex-row">
+        <div className="bg-white rounded-lg md:rounded-xl w-full flex service-panel">
           <div className="w-full md:p-8 md:pt-6 p-6 pt-4 flex flex-col justify-between gap-6">
             <div>
               <div className="flex flex-wrap items-center gap-2 justify-between w-full">

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1135,3 +1135,13 @@ input[type="search"]::-webkit-search-decoration,
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-results-button,
 input[type="search"]::-webkit-search-results-decoration { display: none; }
+
+.service-panel{
+  @apply flex-row
+}
+
+@media screen and (max-width: 920px) {
+  .service-panel{
+    @apply flex-col
+  }
+}


### PR DESCRIPTION
## Proposed Changes

- Fixes #4379 ?
- The page does not overflow anymore

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
