### PR TITLE
Run `lint-staged` only for `*.{ts,tsx,js,jsx}` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,9 +244,9 @@
     ]
   },
   "lint-staged": {
-    "**/*": [
+    "*.{ts,tsx,js,jsx}": [
       "prettier --write --ignore-unknown",
-      "eslint --fix --ignore-pattern '*.md' --ignore-pattern '*.stories.mdx' --ignore-pattern 'Dockerfile' --ignore-pattern 'netlify.toml'",
+      "eslint --fix",
       "git update-index --again"
     ]
   },


### PR DESCRIPTION
## Proposed Changes

- Resolves Fixes #4520
- Runs `eslint` for `ts, tsx, js, jsx` files only.
- Did not make it specific to files under src directory since we need coverage outside src directory for files like `tailwind-config.js`...

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
