### PR TITLE
Added indicators for no updates in last 24 hours

### DIFF
--- a/src/Components/Common/components/ButtonV2.tsx
+++ b/src/Components/Common/components/ButtonV2.tsx
@@ -44,6 +44,8 @@ export type ButtonProps = RawButtonProps &
      * - `"alert"` is ideal for actions that require alert.
      */
     variant?: ButtonVariant;
+    /** Specify text alignment. Defaults to `center` */
+    align?: "left" | "center" | "right" | "between";
     /** If set, gives an elevated button with hover effects. */
     shadow?: boolean | undefined;
     /** If set, removes the background to give a simple text button. */
@@ -79,6 +81,7 @@ const ButtonV2 = ({
   authorizeFor,
   size = "default",
   variant = "primary",
+  align = "center",
   circle,
   shadow,
   ghost,
@@ -91,13 +94,14 @@ const ButtonV2 = ({
   ...props
 }: ButtonProps) => {
   const className = classNames(
-    "font-medium h-min inline-flex items-center justify-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1",
+    props.className,
+    "font-medium h-min inline-flex items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1",
     `button-size-${size}`,
+    `justify-${align}`,
     `button-shape-${circle ? "circle" : "square"}`,
     ghost ? `button-${variant}-ghost` : `button-${variant}-default`,
     border && `button-${variant}-border`,
-    shadow && "shadow enabled:hover:shadow-lg",
-    props.className
+    shadow && "shadow enabled:hover:shadow-lg"
   );
 
   if (authorizeFor) {

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -492,6 +492,7 @@ export const PatientManager = () => {
                       Number(patient.last_consultation?.review_interval) > 0 &&
                       moment().isAfter(patient.review_time) && (
                         <Chip
+                          size="small"
                           color="red"
                           startIcon="clock"
                           text="Review Missed"
@@ -499,24 +500,32 @@ export const PatientManager = () => {
                       )}
                     {patient.allow_transfer ? (
                       <Chip
+                        size="small"
                         color="yellow"
                         startIcon="unlock"
                         text="Transfer Allowed"
                       />
                     ) : (
                       <Chip
+                        size="small"
                         color="primary"
                         startIcon="lock"
                         text="Transfer Blocked"
                       />
                     )}
                     {patient.disease_status === "POSITIVE" && (
-                      <Chip color="red" startIcon="radiation" text="Positive" />
+                      <Chip
+                        size="small"
+                        color="red"
+                        startIcon="radiation"
+                        text="Positive"
+                      />
                     )}
                     {patient.gender === 2 &&
                       patient.is_antenatal &&
                       patient.is_active && (
                         <Chip
+                          size="small"
                           color="blue"
                           startIcon="baby-carriage"
                           text="Antenatal"
@@ -524,6 +533,7 @@ export const PatientManager = () => {
                       )}
                     {patient.is_medical_worker && patient.is_active && (
                       <Chip
+                        size="small"
                         color="blue"
                         startIcon="user-md"
                         text="Medical Worker"
@@ -531,6 +541,7 @@ export const PatientManager = () => {
                     )}
                     {patient.disease_status === "EXPIRED" && (
                       <Chip
+                        size="small"
                         color="yellow"
                         startIcon="exclamation-triangle"
                         text="Patient Expired"
@@ -543,6 +554,7 @@ export const PatientManager = () => {
                         patient.is_active)) && (
                       <span className="relative inline-flex">
                         <Chip
+                          size="small"
                           color="red"
                           startIcon="notes-medical"
                           text="No Consultation Filed"
@@ -553,6 +565,29 @@ export const PatientManager = () => {
                         </span>
                       </span>
                     )}
+                    {!(
+                      patient.last_consultation?.facility !== patient.facility
+                    ) &&
+                      !(
+                        patient.last_consultation?.discharge_date ||
+                        !patient.is_active
+                      ) &&
+                      moment(patient.last_consultation?.modified_date).isBefore(
+                        new Date().getTime() - 24 * 60 * 60 * 1000
+                      ) && (
+                        <span className="relative inline-flex">
+                          <Chip
+                            size="small"
+                            color="red"
+                            startIcon="circle-exclamation"
+                            text="No update in 24 hours"
+                          />
+                          <span className="flex absolute h-3 w-3 -top-1 -right-1 items-center justify-center">
+                            <span className="animate-ping absolute inline-flex h-4 w-4 center rounded-full bg-red-400"></span>
+                            <span className="relative inline-flex rounded-full h-3 w-3 bg-red-600"></span>
+                          </span>
+                        </span>
+                      )}
                   </div>
                 </div>
               </div>

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -7,6 +7,8 @@ import { useState } from "react";
 import { PatientCategory } from "../Facility/models";
 import { PATIENT_CATEGORIES } from "../../Common/constants";
 import moment from "moment";
+import ButtonV2 from "../Common/components/ButtonV2";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 export default function PatientInfoCard(props: {
   patient: PatientModel;
@@ -183,7 +185,7 @@ export default function PatientInfoCard(props: {
           [
             `/facility/${patient.facility}/patient/${patient.id}/consultation/${patient.last_consultation?.id}/update`,
             "Edit Consultation Details",
-            "pencil-alt",
+            "pen",
             patient.is_active && patient.last_consultation?.id,
           ],
           [
@@ -191,30 +193,59 @@ export default function PatientInfoCard(props: {
             "Log Update",
             "plus",
             patient.is_active && patient.last_consultation?.id,
+            [
+              !(patient.last_consultation?.facility !== patient.facility) &&
+                !(
+                  patient.last_consultation?.discharge_date ||
+                  !patient.is_active
+                ) &&
+                moment(patient.last_consultation?.modified_date).isBefore(
+                  new Date().getTime() - 24 * 60 * 60 * 1000
+                ),
+              <div className="text-center">
+                <CareIcon className="care-l-exclamation-triangle" /> No update
+                filed in the last 24 hours
+              </div>,
+            ],
           ],
           [
             `/patient/${patient.id}/investigation_reports`,
             "Investigation Summary",
-            "address-card",
+            "align-alt",
             true,
           ],
           [
             `/facility/${patient.facility}/patient/${patient.id}/consultation/${patient.last_consultation?.id}/treatment-summary`,
             "Treatment Summary",
-            "prescription-bottle-medical",
+            "file-medical",
             patient.last_consultation?.id,
           ],
         ].map(
-          (action, i) =>
+          (action: any, i) =>
             action[3] && (
-              <Link
-                key={i}
-                href={`${action[0]}`}
-                className="btn btn-primary hover:text-white flex justify-start"
-              >
-                <i className={`fas fa-${action[2]} w-4 mr-3`}></i>
-                <p className="font-semibold">{action[1]}</p>
-              </Link>
+              <div className="relative">
+                <ButtonV2
+                  key={i}
+                  variant={action[4] && action[4][0] ? "danger" : "primary"}
+                  href={`${action[0]}`}
+                  align="left"
+                  className="w-full"
+                >
+                  <CareIcon className={`care-l-${action[2]}`} />
+                  <p className="font-semibold">{action[1]}</p>
+                </ButtonV2>
+                {action[4] && action[4][0] && (
+                  <>
+                    <span className="flex absolute h-3 w-3 -top-1 -right-1 items-center justify-center">
+                      <span className="animate-ping absolute inline-flex h-4 w-4 center rounded-full bg-red-400"></span>
+                      <span className="relative inline-flex rounded-full h-3 w-3 bg-red-600"></span>
+                    </span>
+                    <p className="text-xs text-red-500 animate-pulse mt-1">
+                      {action[4][1]}
+                    </p>
+                  </>
+                )}
+              </div>
             )
         )}
       </div>

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -236,13 +236,7 @@ export default function PatientInfoCard(props: {
                 </ButtonV2>
                 {action[4] && action[4][0] && (
                   <>
-                    <span className="flex absolute h-3 w-3 -top-1 -right-1 items-center justify-center">
-                      <span className="animate-ping absolute inline-flex h-4 w-4 center rounded-full bg-red-400"></span>
-                      <span className="relative inline-flex rounded-full h-3 w-3 bg-red-600"></span>
-                    </span>
-                    <p className="text-xs text-red-500 animate-pulse mt-1">
-                      {action[4][1]}
-                    </p>
+                    <p className="text-xs text-red-500 mt-1">{action[4][1]}</p>
                   </>
                 )}
               </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #4498 ?
- Adds a chip to patient tile indicating no updates in last 24 hours
- Shows warning and turns log update button red if there is no update in last 24 hours.
- Reduced chip size in patient tiles to use up less space.
- Added an alignment option to ButtonV2

![image](https://user-images.githubusercontent.com/23238460/210958562-6e715b51-07f8-4197-8080-d647b4054f78.png)
![image](https://user-images.githubusercontent.com/23238460/211343892-71a47c01-0b2d-4882-9817-ec1790824109.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
