### PR TITLE
Migrate all existing usages `PhoneNumberField` to `PhoneNumberFormField` and deprecates the legacy component

### DIFF
--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -641,6 +641,9 @@ export const AutoCompleteAsyncField = (props: AutoCompleteAsyncFieldProps) => {
   );
 };
 
+/**
+ * Deprecated. Use `PhoneNumberFormField` instead.
+ */
 export const PhoneNumberField = (props: any) => {
   const {
     label,

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -699,6 +699,7 @@ export const PhoneNumberField = (props: any) => {
         <ButtonV2
           className="absolute right-[1px] top-[1px] inset-y-0 h-[40px]"
           variant="secondary"
+          type="button"
           ghost
           onClick={() => onChange("+91")}
         >

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -9,12 +9,12 @@ import { make as SlideOver } from "../Common/SlideOver.gen";
 import ListFilter from "./ListFilter";
 import FacilitiesSelectDialogue from "./FacilitiesSelectDialogue";
 import { FacilityModel } from "../Facility/models";
-import { PhoneNumberField } from "../Common/HelperInputFields";
 import parsePhoneNumberFromString from "libphonenumber-js";
 import SearchInput from "../Form/SearchInput";
 import useFilters from "../../Common/hooks/useFilters";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import ExportMenu from "../Common/Export";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -283,12 +283,13 @@ export default function ResultList() {
           />
           <div className="text-sm font-medium my-2">Search by number</div>
           <div className="w-full max-w-sm">
-            <PhoneNumberField
+            <PhoneNumberFormField
+              name="mobile_number"
+              labelClassName="hidden"
               value={qParams.mobile_number || "+91"}
-              onChange={(value: any) => updateQuery({ mobile_number: value })}
+              onChange={(event) => updateQuery({ [event.name]: event.value })}
               placeholder="Search by Phone Number"
-              turnOffAutoFormat={false}
-              errors=""
+              noAutoFormat
             />
           </div>
         </div>

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -13,7 +13,6 @@ import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { validateEmailAddress } from "../../Common/validation";
 import {
   ActionTextInputField,
-  PhoneNumberField,
   ErrorHelperText,
 } from "../Common/HelperInputFields";
 import { AssetClass, AssetData, AssetType } from "../Assets/AssetTypes";
@@ -33,6 +32,7 @@ import AutocompleteFormField from "../Form/FormFields/Autocomplete";
 import { SelectFormField } from "../Form/FormFields/SelectFormField";
 import TextFormField from "../Form/FormFields/TextFormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 const Loading = loadable(() => import("../Common/Loading"));
 
 const formErrorKeys = [
@@ -766,14 +766,14 @@ const AssetCreate = (props: AssetProps) => {
                     className="col-span-6 sm:col-span-3"
                     ref={fieldRef["support_phone"]}
                   >
-                    <label htmlFor="support-name">
-                      Customer Support Number *{" "}
-                    </label>
-                    <PhoneNumberField
-                      enableTollFree
+                    <PhoneNumberFormField
+                      name="support_phone"
+                      label="Customer support number"
+                      required
+                      tollFree
                       value={support_phone}
-                      onChange={setSupportPhone}
-                      errors={state.errors.support_phone}
+                      onChange={(e) => setSupportPhone(e.value)}
+                      error={state.errors.support_phone}
                     />
                   </div>
 

--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -34,7 +34,7 @@ import {
   getWardByLocalBody,
 } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { ErrorHelperText, PhoneNumberField } from "../Common/HelperInputFields";
+import { ErrorHelperText } from "../Common/HelperInputFields";
 import GLocationPicker from "../Common/GLocationPicker";
 import {
   includesIgnoreCase as includesIgnoreCase,
@@ -50,6 +50,7 @@ import RadioInputsV2 from "../Common/components/RadioInputsV2";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import TextFormField from "../Form/FormFields/TextFormField";
 import { FieldLabel } from "../Form/FormFields/FormField";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
@@ -762,20 +763,14 @@ export const FacilityCreate = (props: FacilityProps) => {
                 />
               </div>
               <div>
-                <FieldLabel
-                  htmlFor="facility-tel"
-                  className="mb-1"
-                  required={true}
-                >
-                  Emergency Contact Number
-                </FieldLabel>
-                <PhoneNumberField
+                <PhoneNumberFormField
+                  name="phone_number"
+                  label="Emergency Contact Number"
+                  required
                   value={state.form.phone_number}
-                  onChange={(value: string) =>
-                    handleValueChange(value, "phone_number")
-                  }
-                  errors={state.errors.phone_number}
-                  onlyIndia={true}
+                  onChange={handleChange}
+                  error={state.errors.phone_number}
+                  onlyIndia
                 />
               </div>
 

--- a/src/Components/Form/FormFields/PhoneNumberFormField.tsx
+++ b/src/Components/Form/FormFields/PhoneNumberFormField.tsx
@@ -14,7 +14,7 @@ type Props = FormFieldBaseProps<string> & {
   countryCodeEditable?: boolean;
 };
 
-export const PhoneNumberFormField = (props: Props) => {
+const PhoneNumberFormField = (props: Props) => {
   const { name } = props;
   const handleChange = resolveFormFieldChangeEventHandler(props);
 
@@ -34,3 +34,5 @@ export const PhoneNumberFormField = (props: Props) => {
     </FormField>
   );
 };
+
+export default PhoneNumberFormField;

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -33,7 +33,7 @@ import FilterBadge from "../../CAREUI/display/FilterBadge";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import ButtonV2 from "../Common/components/ButtonV2";
 import { ExportMenu } from "../Common/Export";
-import { PhoneNumberFormField } from "../Form/FormFields/PhoneNumberFormField";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 import { FieldChangeEvent } from "../Form/FormFields/Utils";
 
 const Loading = loadable(() => import("../Common/Loading"));

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -42,7 +42,6 @@ import {
   CheckboxField,
   DateInputField,
   ErrorHelperText,
-  PhoneNumberField,
   SelectField,
   TextInputField,
 } from "../Common/HelperInputFields";
@@ -69,6 +68,8 @@ import ButtonV2 from "../Common/components/ButtonV2";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import { FieldLabel } from "../Form/FormFields/FormField";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
 // const debounce = require("lodash.debounce");
 
 interface PatientRegisterProps extends PatientModel {
@@ -894,15 +895,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     dispatch({ type: "set_form", form });
   };
 
-  const handleTextAreaChange = (e: any) => {
+  const handleFormFieldChange = (e: FieldChangeEvent<unknown>) => {
     const form = { ...state.form };
     form[e.name] = e.value;
-    dispatch({ type: "set_form", form });
-  };
-
-  const handleValueChange = (value: any, name: string) => {
-    const form = { ...state.form };
-    form[name] = value;
     dispatch({ type: "set_form", form });
   };
 
@@ -981,7 +976,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
               rows={2}
               name={textField}
               value={state.form[textField]}
-              onChange={handleTextAreaChange}
+              onChange={handleFormFieldChange}
               error={state.errors[textField]}
             />
           </div>
@@ -1100,30 +1095,29 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                       </h1>
                       <div className="grid gap-4 xl:gap-x-20 xl:gap-y-6 grid-cols-1 md:grid-cols-2">
                         <div data-testid="phone-number" id="phone_number-div">
-                          <PhoneNumberField
-                            label="Phone Number *"
+                          <PhoneNumberFormField
+                            name="phone_number"
+                            label="Phone Number"
+                            required
                             value={state.form.phone_number}
-                            onChange={(value: any) => [
-                              duplicateCheck(value),
-                              handleValueChange(value, "phone_number"),
-                            ]}
-                            errors={state.errors.phone_number}
+                            onChange={(event) => {
+                              duplicateCheck(event.value);
+                              handleFormFieldChange(event);
+                            }}
+                            error={state.errors.phone_number}
                           />
                         </div>
                         <div
                           data-testid="emergency-phone-number"
                           id="emergency_phone_number-div"
                         >
-                          <PhoneNumberField
-                            label="Emergency contact number *"
+                          <PhoneNumberFormField
+                            label="Emergency contact number"
+                            required
+                            name="emergency_phone_number"
                             value={state.form.emergency_phone_number}
-                            onChange={(value: any) => [
-                              handleValueChange(
-                                value,
-                                "emergency_phone_number"
-                              ),
-                            ]}
-                            errors={state.errors.emergency_phone_number}
+                            onChange={handleFormFieldChange}
+                            error={state.errors.emergency_phone_number}
                           />
                         </div>
                         <div data-testid="name" id="name-div">
@@ -1230,7 +1224,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             name="address"
                             placeholder="Enter the current address"
                             value={state.form.address}
-                            onChange={handleTextAreaChange}
+                            onChange={handleFormFieldChange}
                             error={state.errors.address}
                           />
                         </div>
@@ -1257,7 +1251,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                 ? state.form.address
                                 : state.form.permanent_address
                             }
-                            onChange={handleTextAreaChange}
+                            onChange={handleFormFieldChange}
                             error={state.errors.permanent_address}
                           />
 
@@ -1959,7 +1953,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             name="present_health"
                             placeholder="Optional Information"
                             value={state.form.present_health}
-                            onChange={handleTextAreaChange}
+                            onChange={handleFormFieldChange}
                             error={state.errors.present_health}
                           />
                         </div>
@@ -1977,7 +1971,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             name="ongoing_medication"
                             placeholder="Optional Information"
                             value={state.form.ongoing_medication}
-                            onChange={handleTextAreaChange}
+                            onChange={handleFormFieldChange}
                             error={state.errors.ongoing_medication}
                           />
                         </div>
@@ -2002,7 +1996,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             name="allergies"
                             placeholder="Optional Information"
                             value={state.form.allergies}
-                            onChange={handleTextAreaChange}
+                            onChange={handleFormFieldChange}
                             error={state.errors.allergies}
                           />
                         </div>

--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -5,7 +5,6 @@ import {
   TextInputField,
   MultilineInputField,
   ErrorHelperText,
-  PhoneNumberField,
   SelectField,
 } from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
@@ -31,6 +30,8 @@ import { phonePreg } from "../../Common/validation";
 import { createShift, getPatient } from "../../Redux/actions";
 import { goBack } from "../../Utils/utils";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -177,6 +178,13 @@ export const ShiftCreate = (props: patientShiftProps) => {
     dispatch({ type: "set_form", form });
   };
 
+  const handleFormFieldChange = (event: FieldChangeEvent<unknown>) => {
+    dispatch({
+      type: "set_form",
+      form: { ...state.form, [event.name]: event.value },
+    });
+  };
+
   const handleSubmit = async () => {
     const validForm = validateForm();
 
@@ -253,14 +261,14 @@ export const ShiftCreate = (props: patientShiftProps) => {
               </div>
 
               <div>
-                <PhoneNumberField
-                  label="Contact person phone*"
-                  onlyIndia={true}
+                <PhoneNumberFormField
+                  label="Contact person phone"
+                  name="refering_facility_contact_number"
+                  required
+                  onlyIndia
                   value={state.form.refering_facility_contact_number}
-                  onChange={(value: any) =>
-                    handleValueChange(value, "refering_facility_contact_number")
-                  }
-                  errors={state.errors.refering_facility_contact_number}
+                  onChange={handleFormFieldChange}
+                  error={state.errors.refering_facility_contact_number}
                 />
               </div>
 

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -5,7 +5,6 @@ import {
   TextInputField,
   MultilineInputField,
   ErrorHelperText,
-  PhoneNumberField,
   SelectField,
 } from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
@@ -30,6 +29,8 @@ import { phonePreg } from "../../Common/validation";
 import { createResource, getAnyFacility } from "../../Redux/actions";
 import { goBack } from "../../Utils/utils";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -171,6 +172,13 @@ export default function ResourceCreate(props: resourceProps) {
     dispatch({ type: "set_form", form });
   };
 
+  const handleFormFieldChange = (event: FieldChangeEvent<unknown>) => {
+    dispatch({
+      type: "set_form",
+      form: { ...state.form, [event.name]: event.value },
+    });
+  };
+
   const handleSubmit = async () => {
     const validForm = validateForm();
 
@@ -240,14 +248,14 @@ export default function ResourceCreate(props: resourceProps) {
               </div>
 
               <div>
-                <PhoneNumberField
-                  label="Contact person phone*"
-                  onlyIndia={true}
+                <PhoneNumberFormField
+                  label="Contact person phone"
+                  name="refering_facility_contact_number"
+                  required
+                  onlyIndia
                   value={state.form.refering_facility_contact_number}
-                  onChange={(value: any) =>
-                    handleValueChange(value, "refering_facility_contact_number")
-                  }
-                  errors={state.errors.refering_facility_contact_number}
+                  onChange={handleFormFieldChange}
+                  error={state.errors.refering_facility_contact_number}
                 />
               </div>
 

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { UserSelect } from "../Common/UserSelect2";
-import { SelectField, PhoneNumberField } from "../Common/HelperInputFields";
+import { SelectField } from "../Common/HelperInputFields";
 import {
   SHIFTING_FILTER_ORDER,
   DISEASE_STATUS,
@@ -18,6 +18,8 @@ import { Link } from "raviger";
 import { DateRangePicker, getDate } from "../Common/DateRangePicker";
 import parsePhoneNumberFromString from "libphonenumber-js";
 import useMergeState from "../../Common/hooks/useMergeState";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
 
 const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text);
 
@@ -149,6 +151,13 @@ export default function ListFilter(props: any) {
     filterData[name] = value;
 
     setFilterState(filterData);
+  };
+
+  const handleFormFieldChange = (event: FieldChangeEvent<unknown>) => {
+    setFilterState({
+      ...filterState,
+      [event.name]: event.value === "--" ? "" : event.value,
+    });
   };
 
   const clearFilters = () => {
@@ -438,14 +447,11 @@ export default function ListFilter(props: any) {
         </div>
 
         <div className="w-full flex-none">
-          <span className="text-sm font-semibold">Patient Phone Number</span>
-          <PhoneNumberField
+          <PhoneNumberFormField
+            label="Patient Phone Number"
             name="patient_phone_number"
-            placeholder="Patinet phone number"
             value={filterState.patient_phone_number}
-            onChange={(value: string) => {
-              handleChange({ target: { name: "patient_phone_number", value } });
-            }}
+            onChange={handleFormFieldChange}
           />
         </div>
 

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -30,7 +30,6 @@ import * as Notification from "../../Utils/Notifications.js";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import {
   DateInputField,
-  PhoneNumberField,
   SelectField,
   TextInputField,
   CheckboxField,
@@ -39,6 +38,7 @@ import { FacilityModel } from "../Facility/models";
 
 import { classNames, goBack } from "../../Utils/utils";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -649,15 +649,17 @@ export const UserAdd = (props: UserProps) => {
               </div>
 
               <div>
-                <PhoneNumberField
+                <PhoneNumberFormField
                   placeholder="Phone Number"
-                  label="Phone Number*"
+                  label="Phone Number"
+                  name="phone_number"
+                  required
                   value={state.form.phone_number}
-                  onChange={(value: any) =>
-                    handleValueChange(value, "phone_number")
+                  onChange={(event) =>
+                    handleValueChange(event.value, event.name)
                   }
-                  errors={state.errors.phone_number}
-                  onlyIndia={true}
+                  error={state.errors.phone_number}
+                  onlyIndia
                 />
                 <CheckboxField
                   checked={phoneIsWhatsApp}
@@ -671,16 +673,17 @@ export const UserAdd = (props: UserProps) => {
               </div>
 
               <div>
-                <PhoneNumberField
+                <PhoneNumberFormField
                   placeholder="WhatsApp Phone Number"
                   label="Whatsapp Number"
+                  name="alt_phone_number"
                   value={state.form.alt_phone_number}
-                  onChange={(value: any) =>
-                    handleValueChange(value, "alt_phone_number")
+                  onChange={(event) =>
+                    handleValueChange(event.value, event.name)
                   }
                   disabled={phoneIsWhatsApp}
-                  errors={state.errors.alt_phone_number}
-                  onlyIndia={true}
+                  error={state.errors.alt_phone_number}
+                  onlyIndia
                 />
               </div>
 

--- a/src/Components/Users/UserFilter.tsx
+++ b/src/Components/Users/UserFilter.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { getDistrict } from "../../Redux/actions";
-import { PhoneNumberField } from "../Common/HelperInputFields";
 import { navigate } from "raviger";
 import DistrictSelect from "../Facility/FacilityFilter/DistrictSelect";
 import parsePhoneNumberFromString from "libphonenumber-js";
@@ -12,6 +11,7 @@ import { FieldLabel } from "../Form/FormFields/FormField";
 import { USER_TYPE_OPTIONS } from "../../Common/constants";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import useMergeState from "../../Common/hooks/useMergeState";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 
 const parsePhoneNumberForFilterParam = (phoneNumber: string) => {
   if (!phoneNumber) return "";
@@ -146,33 +146,23 @@ export default function UserFilter(props: any) {
 
         <div className="flex flex-wrap">
           <div className="w-full flex-none">
-            <FieldLabel className="text-sm">Phone Number</FieldLabel>
-            <div className="flex justify-between">
-              <div className="w-full">
-                <PhoneNumberField
-                  placeholder="Phone Number"
-                  value={filterState.phone_number}
-                  onChange={(value: string) => {
-                    handleChange({ name: "phone_number", value });
-                  }}
-                />
-              </div>
-            </div>
+            <PhoneNumberFormField
+              label="Phone Number"
+              name="phone_number"
+              placeholder="Phone Number"
+              value={filterState.phone_number}
+              onChange={handleChange}
+            />
           </div>
 
           <div className="w-full flex-none -mt-2">
-            <FieldLabel className="text-sm">Whatsapp Number</FieldLabel>
-            <div className="flex justify-between">
-              <div className="w-full">
-                <PhoneNumberField
-                  placeholder="WhatsApp Phone Number"
-                  value={filterState.alt_phone_number}
-                  onChange={(value: string) => {
-                    handleChange({ name: "alt_phone_number", value });
-                  }}
-                />
-              </div>
-            </div>
+            <PhoneNumberFormField
+              label="Whatsapp Number"
+              name="alt_phone_number"
+              placeholder="WhatsApp Phone Number"
+              value={filterState.alt_phone_number}
+              onChange={handleChange}
+            />
           </div>
         </div>
       </div>

--- a/src/Components/Users/UserProfile.tsx
+++ b/src/Components/Users/UserProfile.tsx
@@ -8,7 +8,7 @@ import {
   partialUpdateUser,
   updateUserPassword,
 } from "../../Redux/actions";
-import { ErrorHelperText, PhoneNumberField } from "../Common/HelperInputFields";
+import { ErrorHelperText } from "../Common/HelperInputFields";
 import { parsePhoneNumberFromString } from "libphonenumber-js/max";
 import { validateEmailAddress } from "../../Common/validation";
 import * as Notification from "../../Utils/Notifications.js";
@@ -19,6 +19,7 @@ import { FieldLabel } from "../Form/FormFields/FormField";
 import ButtonV2, { Submit } from "../Common/components/ButtonV2";
 import { handleSignOut } from "../../Utils/utils";
 import CareIcon from "../../CAREUI/icons/CareIcon";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -507,27 +508,29 @@ export default function UserProfile() {
                         </div>
 
                         <div className="col-span-6 sm:col-span-3">
-                          <PhoneNumberField
-                            label="Phone Number*"
+                          <PhoneNumberFormField
+                            label="Phone Number"
+                            required
+                            name="phoneNumber"
                             placeholder="Phone Number"
                             value={states.form.phoneNumber}
-                            onChange={(value: string) =>
-                              handleValueChange(value, "phoneNumber")
+                            onChange={(event) =>
+                              handleValueChange(event.value, event.name)
                             }
-                            errors={states.errors.phoneNumber}
+                            error={states.errors.phoneNumber}
                           />
                         </div>
 
                         <div className="col-span-6 sm:col-span-3">
-                          <PhoneNumberField
+                          <PhoneNumberFormField
                             name="altPhoneNumber"
                             label="Whatsapp Number"
                             placeholder="WhatsApp Number"
                             value={states.form.altPhoneNumber}
-                            onChange={(value: string) =>
-                              handleValueChange(value, "altPhoneNumber")
+                            onChange={(event) =>
+                              handleValueChange(event.value, event.name)
                             }
-                            errors={states.errors.altPhoneNumber}
+                            error={states.errors.altPhoneNumber}
                           />
                         </div>
                         <div className="col-span-6 sm:col-span-3">


### PR DESCRIPTION
## Proposed Changes

- Fixes #4524
- Deprecates `PhoneNumberField` in favour of having `FormField` compliant components.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
