### PR TITLE
Use `cui-input-base` class for inputs pressure sore popup

### DIFF
--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -49,7 +49,7 @@ let make = (
     () => {
       let modalWidth = 350
       let modalHeight = 352
-      
+
       {
         "top": (
           innerHeight - position["y"] < modalHeight ? position["y"] - modalHeight : position["y"]
@@ -94,7 +94,7 @@ let make = (
                     value={state.width->Belt.Float.toString}
                     step={0.1}
                     placeholder="Width (cm)"
-                    className="border border-gray-300 rounded-md w-full px-2 py-1"
+                    className="cui-input-base px-2 py-1"
                     disabled={previewMode}
                     onChange={e => {
                       let value = ReactEvent.Form.target(e)["value"]->Belt.Float.fromString
@@ -114,7 +114,7 @@ let make = (
                     value={state.length->Belt.Float.toString}
                     step={0.1}
                     placeholder="Length (cm)"
-                    className="border border-gray-300 rounded-md w-full px-2 py-1"
+                    className="cui-input-base px-2 py-1"
                     disabled={previewMode}
                     onChange={e => {
                       let value = ReactEvent.Form.target(e)["value"]->Belt.Float.fromString
@@ -162,7 +162,7 @@ let make = (
                     let value = ReactEvent.Form.target(e)["value"]
                     setState(prev => {...prev, description: value})
                   }}
-                  className="border border-gray-300 rounded-md px-2 py-1 w-full"
+                  className="cui-input-base px-2 py-1"
                   disabled={previewMode}
                 />
               </div>

--- a/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
+++ b/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
@@ -72,14 +72,14 @@ let make = (~id, ~value, ~updateCB, ~placeholder, ~selectables, ~label="", ~disa
   }, [showDropdown])
 
   <div className="relative inline-block text-left w-full">
-    <label className="block font-medium text-black" hidden={label == ""}>{str(label)}</label>
+    <label className="block font-medium text-black" hidden={label == ""}> {str(label)} </label>
     <input
       id
       value
       autoComplete="off"
       onClick={_ => setShowDropdown(_ => !showDropdown)}
       onChange={e => updateCB(ReactEvent.Form.target(e)["value"])}
-      className="appearance-none h-10 mt-1 block w-full border border-gray-400 rounded py-2 px-4 text-sm bg-gray-100 hover:bg-gray-200 focus:outline-none focus:bg-white focus:ring-primary-500"
+      className="cui-input-base appearance-none h-10 mt-1 block py-2 px-4"
       disabled
       placeholder
       required=true


### PR DESCRIPTION
## Proposed Changes

- Fixes #4526

![image](https://user-images.githubusercontent.com/25143503/211021254-b9465ecc-07d5-4f41-9985-a4c66597b259.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
