### PR TITLE
Replaced DateInputV2 with TextFormField

### DIFF
--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -27,7 +27,6 @@ import SwitchV2 from "../Common/components/Switch";
 import useVisibility from "../../Utils/useVisibility";
 import { goBack } from "../../Utils/utils";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
-import DateInputV2 from "../Common/DateInputV2";
 import AutocompleteFormField from "../Form/FormFields/Autocomplete";
 import { SelectFormField } from "../Form/FormFields/SelectFormField";
 import TextFormField from "../Form/FormFields/TextFormField";
@@ -723,23 +722,25 @@ const AssetCreate = (props: AssetProps) => {
                     ref={fieldRef["warranty_amc_end_of_validity"]}
                   >
                     <label className="mb-2">Warranty / AMC Expiry</label>
-                    <DateInputV2
-                      className="border-1 border-gray-200"
+                    <TextFormField
+                      name="WarrantyAMCExpiry"
                       value={warranty_amc_end_of_validity}
                       onChange={(date) => {
                         if (
-                          moment(date).format("YYYY-MM-DD") <
+                          moment(date.value).format("YYYY-MM-DD") <
                           new Date().toLocaleDateString("en-ca")
                         ) {
                           Notification.Error({
                             msg: "Warranty / AMC Expiry date can't be in past",
                           });
                         } else {
-                          setWarrantyAmcEndOfValidity(moment(date).toDate());
+                          setWarrantyAmcEndOfValidity(
+                            moment(date.value).format("YYYY-MM-DD")
+                          );
                         }
                       }}
-                      position="LEFT"
-                      min={yesterday}
+                      type="date"
+                      min={moment(yesterday).format("YYYY-MM-DD")}
                     />
                     <ErrorHelperText
                       error={state.errors.warranty_amc_end_of_validity}
@@ -832,23 +833,26 @@ const AssetCreate = (props: AssetProps) => {
                     ref={fieldRef["last_serviced_on"]}
                   >
                     <label htmlFor="last-serviced-on">Last Serviced On</label>
-                    <DateInputV2
-                      className="border-1 border-gray-200"
+                    <TextFormField
+                      name="LastServicedOn"
+                      className="mt-2"
                       value={last_serviced_on}
                       onChange={(date) => {
                         if (
-                          moment(date).format("YYYY-MM-DD") >
+                          moment(date.value).format("YYYY-MM-DD") >
                           new Date().toLocaleDateString("en-ca")
                         ) {
                           Notification.Error({
                             msg: "Last Serviced date can't be in future",
                           });
                         } else {
-                          setLastServicedOn(moment(date).toDate());
+                          setLastServicedOn(
+                            moment(date.value).format("YYYY-MM-DD")
+                          );
                         }
                       }}
-                      position="LEFT"
-                      max={new Date()}
+                      type="date"
+                      max={moment(new Date()).format("YYYY-MM-DD")}
                     />
                     <ErrorHelperText error={state.errors.last_serviced_on} />
                   </div>

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -202,11 +202,8 @@ const AssetCreate = (props: AssetProps) => {
       setQrCodeId(asset.qr_code_id);
       setManufacturer(asset.manufacturer);
       asset.warranty_amc_end_of_validity &&
-        setWarrantyAmcEndOfValidity(
-          moment(asset.warranty_amc_end_of_validity).toDate()
-        );
-      asset.last_serviced_on &&
-        setLastServicedOn(moment(asset.last_serviced_on).toDate());
+        setWarrantyAmcEndOfValidity(asset.warranty_amc_end_of_validity);
+      asset.last_serviced_on && setLastServicedOn(asset.last_serviced_on);
       setNotes(asset.notes);
     }
   }, [asset]);

--- a/src/Components/Form/FormFields/TextFormField.tsx
+++ b/src/Components/Form/FormFields/TextFormField.tsx
@@ -12,7 +12,7 @@ export type TextFormFieldProps = FormFieldBaseProps<string> & {
   placeholder?: string;
   value?: string | number;
   autoComplete?: string;
-  type?: "email" | "password" | "search" | "text" | "number";
+  type?: "email" | "password" | "search" | "text" | "number" | "date";
   className?: string | undefined;
   leading?: React.ReactNode | undefined;
   trailing?: React.ReactNode | undefined;


### PR DESCRIPTION
## Proposed Changes
Replaced DateInputV2 with TextFormField with type attribute set to 'date'.

- Fixes #4534 

### Screenshot
![image](https://user-images.githubusercontent.com/40627011/211051673-d737e3bd-08f9-4c97-9dc4-acbd32f8dbdd.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
