### PR TITLE
Hide active tab indicator when `activeLink` is `undefined`

### DIFF
--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import useActiveLink from "../../../Common/hooks/useActiveLink";
 import CareIcon from "../../../CAREUI/icons/CareIcon";
 import useConfig from "../../../Common/hooks/useConfig";
 import SlideOver from "../../../CAREUI/interactive/SlideOver";
+import { classNames } from "../../../Utils/utils";
 
 export const SIDEBAR_SHRINK_PREFERENCE_KEY = "sidebarShrinkPreference";
 
@@ -68,7 +69,7 @@ const StatelessSidebar = ({
       const bottomItemOffset = 2;
 
       const indexDifference = index - lastIndicatorPosition;
-      e.style.display = "block";
+      // e.style.display = "block";
 
       // if (indexDifference > 0) {
       //   console.log("indexDifference > 0");
@@ -101,9 +102,10 @@ const StatelessSidebar = ({
         e.style.height = "0.75rem";
         setLastIndicatorPosition(index);
       }, 300);
-    } else {
-      indicatorRef.current.style.display = "none";
     }
+    // else {
+    //   indicatorRef.current.style.display = "none";
+    // }
   }, [activeLink]);
 
   return (
@@ -124,8 +126,11 @@ const StatelessSidebar = ({
         <div className="flex flex-col relative flex-1 md:flex-none">
           <div
             ref={indicatorRef}
-            className={`absolute left-2 w-1 hidden md:block
-            bg-primary-400 rounded z-10 transition-all`}
+            // className="absolute left-2 w-1 hidden md:block bg-primary-400 rounded z-10 transition-all"
+            className={classNames(
+              "block absolute left-2 w-1 bg-primary-400 rounded z-10 transition-all duration-200 ease-in-out",
+              activeLink ? "opacity-0 md:opacity-100" : "opacity-0"
+            )}
           />
           {NavItems.map((i) => {
             return (


### PR DESCRIPTION
## Proposed Changes

- Fixes #4548
- Fade animation for the indicator visibility.

The issue was caused because styles set via `indicatorRef` were being overridden by tailwind classes.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
