### PR TITLE
Show 18 cards per page on Users page

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -44,7 +44,7 @@ export default function ManageUsers() {
     FilterBadges,
     advancedFilter,
     resultsPerPage,
-  } = useFilters({ limit: 15 });
+  } = useFilters({ limit: 18 });
   const dispatch: any = useDispatch();
   const initialData: any[] = [];
   let manageUsers: any = null;


### PR DESCRIPTION
Fixes #4553 
Display 18 cards per page instead of 15.
![image](https://user-images.githubusercontent.com/70687348/211562535-6fd9931d-70b7-41de-ad50-8456ce16e03d.png)
