### PR TITLE
Care UI: fix button `bg-color` being reset by styles from `index.css`

### DIFF
--- a/src/style/CAREUI.css
+++ b/src/style/CAREUI.css
@@ -98,24 +98,24 @@
     @apply h-full md:h-[300px] w-full
 }
 
-.button-primary-default { @apply accent-primary-500 bg-primary-500 hover:bg-primary-400 text-white }
-.button-primary-ghost { @apply accent-primary-500 hover:bg-primary-100 text-primary-500 }
+.button-primary-default { @apply accent-primary-500 bg-primary-500 hover:bg-primary-400 text-white !important }
+.button-primary-ghost { @apply accent-primary-500 hover:bg-primary-100 text-primary-500 !important }
 .button-primary-border { @apply border border-primary-500 }
 
-.button-secondary-default { @apply accent-secondary-200 bg-secondary-300 hover:bg-secondary-200 text-secondary-800 }
-.button-secondary-ghost { @apply accent-secondary-200 hover:bg-secondary-100 text-secondary-700 }
+.button-secondary-default { @apply accent-secondary-200 bg-secondary-300 hover:bg-secondary-200 text-secondary-800 !important }
+.button-secondary-ghost { @apply accent-secondary-200 hover:bg-secondary-100 text-secondary-700 !important }
 .button-secondary-border { @apply border border-secondary-300 }
 
-.button-danger-default { @apply accent-danger-500 bg-danger-500 hover:bg-danger-400 text-white }
-.button-danger-ghost { @apply accent-danger-500 hover:bg-danger-100 text-danger-500 }
+.button-danger-default { @apply accent-danger-500 bg-danger-500 hover:bg-danger-400 text-white !important }
+.button-danger-ghost { @apply accent-danger-500 hover:bg-danger-100 text-danger-500 !important }
 .button-danger-border { @apply border border-danger-500 }
 
-.button-warning-default { @apply accent-warning-500 bg-warning-500 hover:bg-warning-400 text-white }
-.button-warning-ghost { @apply accent-warning-500 hover:bg-warning-100 text-warning-500 }
+.button-warning-default { @apply accent-warning-500 bg-warning-500 hover:bg-warning-400 text-white !important }
+.button-warning-ghost { @apply accent-warning-500 hover:bg-warning-100 text-warning-500 !important }
 .button-warning-border { @apply border border-warning-500 }
 
-.button-alert-default { @apply accent-alert-600 bg-alert-600 hover:bg-alert-500 text-white }
-.button-alert-ghost { @apply accent-alert-600 hover:bg-alert-100 text-alert-600 }
+.button-alert-default { @apply accent-alert-600 bg-alert-600 hover:bg-alert-500 text-white !important }
+.button-alert-ghost { @apply accent-alert-600 hover:bg-alert-100 text-alert-600 !important }
 .button-alert-border { @apply border border-alert-600 }
 
 .button-shape-square { @apply rounded }

--- a/src/style/CAREUI.css
+++ b/src/style/CAREUI.css
@@ -98,144 +98,65 @@
     @apply h-full md:h-[300px] w-full
 }
 
-.button-primary-default { 
-  @apply accent-primary-500 bg-primary-500 text-white
-}
-a.button-primary-default { 
-  @apply hover:bg-primary-400
-}
-button.button-primary-default { 
-  @apply enabled:hover:bg-primary-400
-}
-.button-primary-ghost { 
-  @apply accent-primary-500 text-primary-500
-}
-a.button-primary-ghost { 
-  @apply hover:bg-primary-100
-}
-button.button-primary-ghost { 
-  @apply enabled:hover:bg-primary-100
-}
-.button-primary-border {
-  @apply border border-primary-500
-}
-.button-secondary-default { 
-  @apply accent-secondary-200 bg-secondary-300 text-secondary-800
-}
-a.button-secondary-default { 
-  @apply hover:bg-secondary-200
-}
-button.button-secondary-default { 
-  @apply enabled:hover:bg-secondary-200
-}
-.button-secondary-ghost { 
-  @apply accent-secondary-200 text-secondary-700
-}
-a.button-secondary-ghost { 
-  @apply hover:bg-secondary-100
-}
-button.button-secondary-ghost { 
-  @apply enabled:hover:bg-secondary-100
-}
-.button-secondary-border {
-  @apply border border-secondary-300
-}
-.button-danger-default { 
-  @apply accent-danger-500 bg-danger-500 text-white
-}
-a.button-danger-default{
-    @apply hover:bg-danger-400
-}
-button.button-danger-default{
-    @apply enabled:hover:bg-danger-400
-}
-.button-danger-ghost { 
-  @apply accent-danger-500 text-danger-500
-}
-a.button-danger-ghost { 
-  @apply hover:bg-danger-100
-}
-button.button-danger-ghost { 
-  @apply enabled:hover:bg-danger-100
-}
-.button-danger-border {
-  @apply border border-danger-500
-}
-.button-warning-default { 
-  @apply accent-warning-500 bg-warning-500 text-white
-}
-a.button-warning-default { 
-  @apply hover:bg-warning-400
-}
-button.button-warning-default { 
-  @apply enabled:hover:bg-warning-400
-}
-.button-warning-ghost { 
-  @apply accent-warning-500 text-warning-500
-}
-a.button-warning-ghost { 
-  @apply hover:bg-warning-100
-}
-button.button-warning-ghost { 
-  @apply enabled:hover:bg-warning-100
-}
-.button-warning-border {
-  @apply border border-warning-500
-}
-.button-alert-default { 
-  @apply accent-alert-600 bg-alert-600 text-white
-}
-a.button-alert-default { 
-  @apply hover:bg-alert-500
-}
-button.button-alert-default { 
-  @apply enabled:hover:bg-alert-500
-}
-.button-alert-ghost { 
-  @apply accent-alert-600 text-alert-600
-}
-a.button-alert-ghost { 
-  @apply hover:bg-alert-100
-}
-button.button-alert-ghost { 
-  @apply enabled:hover:bg-alert-100
-}
-.button-alert-border {
-  @apply border border-alert-600
-}
+.button-primary-default { @apply accent-primary-500 bg-primary-500 hover:bg-primary-400 text-white }
+.button-primary-ghost { @apply accent-primary-500 hover:bg-primary-100 text-primary-500 }
+.button-primary-border { @apply border border-primary-500 }
 
-.button-shape-square { 
-  @apply rounded
-}
-.button-shape-circle { 
-  @apply rounded-full
-}
+.button-secondary-default { @apply accent-secondary-200 bg-secondary-300 hover:bg-secondary-200 text-secondary-800 }
+.button-secondary-ghost { @apply accent-secondary-200 hover:bg-secondary-100 text-secondary-700 }
+.button-secondary-border { @apply border border-secondary-300 }
 
-.button-size-small { 
-  @apply px-2 py-1 text-xs
-}
-.button-size-default { 
-  @apply py-2 px-4 text-sm
-}
-.button-size-large { 
-  @apply py-3 px-5 text-base
-}
+.button-danger-default { @apply accent-danger-500 bg-danger-500 hover:bg-danger-400 text-white }
+.button-danger-ghost { @apply accent-danger-500 hover:bg-danger-100 text-danger-500 }
+.button-danger-border { @apply border border-danger-500 }
 
-.dropdown-item-primary { 
-  @apply accent-primary-500 hover:bg-primary-100 text-black hover:text-primary-500
-}
-.dropdown-item-secondary { 
-  @apply accent-secondary-200 hover:bg-secondary-200 text-secondary-700
-}
-.dropdown-item-danger { 
-  @apply accent-danger-500 hover:bg-danger-100 text-danger-500
-}
-.dropdown-item-warning { 
-  @apply accent-warning-500 hover:bg-warning-100 text-warning-500
-}
-.dropdown-item-alert { 
-  @apply accent-alert-600 hover:bg-alert-100 text-alert-600
-}
+.button-warning-default { @apply accent-warning-500 bg-warning-500 hover:bg-warning-400 text-white }
+.button-warning-ghost { @apply accent-warning-500 hover:bg-warning-100 text-warning-500 }
+.button-warning-border { @apply border border-warning-500 }
+
+.button-alert-default { @apply accent-alert-600 bg-alert-600 hover:bg-alert-500 text-white }
+.button-alert-ghost { @apply accent-alert-600 hover:bg-alert-100 text-alert-600 }
+.button-alert-border { @apply border border-alert-600 }
+
+.button-shape-square { @apply rounded }
+.button-shape-circle { @apply rounded-full }
+
 .button-size-small { @apply px-2 py-1 text-xs }
 .button-size-default { @apply py-2 px-4 text-sm }
 .button-size-large { @apply py-3 px-5 text-base }
+
+.dropdown-item-primary { @apply accent-primary-500 hover:bg-primary-100 text-black hover:text-primary-500 }
+.dropdown-item-secondary { @apply accent-secondary-200 hover:bg-secondary-200 text-secondary-700 }
+.dropdown-item-danger { @apply accent-danger-500 hover:bg-danger-100 text-danger-500 }
+.dropdown-item-warning { @apply accent-warning-500 hover:bg-warning-100 text-warning-500 }
+.dropdown-item-alert { @apply accent-alert-600 hover:bg-alert-100 text-alert-600 }
+
+a.button-primary-default { @apply hover:bg-primary-400 }
+a.button-primary-ghost { @apply hover:bg-primary-100 }
+
+a.button-secondary-default { @apply hover:bg-secondary-200 }
+a.button-secondary-ghost { @apply hover:bg-secondary-100 }
+
+a.button-danger-default { @apply hover:bg-danger-400 }
+a.button-danger-ghost { @apply hover:bg-danger-100 }
+
+a.button-warning-default { @apply hover:bg-warning-400 }
+a.button-warning-ghost { @apply hover:bg-warning-100 }
+
+a.button-alert-default { @apply hover:bg-alert-500 }
+a.button-alert-ghost { @apply hover:bg-alert-100 }
+
+button.button-primary-default { @apply enabled:hover:bg-primary-400 }
+button.button-primary-ghost { @apply enabled:hover:bg-primary-100 }
+
+button.button-secondary-default { @apply enabled:hover:bg-secondary-200 }
+button.button-secondary-ghost { @apply enabled:hover:bg-secondary-100 }
+
+button.button-danger-default { @apply enabled:hover:bg-danger-400 }
+button.button-danger-ghost { @apply enabled:hover:bg-danger-100 }
+
+button.button-warning-default { @apply enabled:hover:bg-warning-400 }
+button.button-warning-ghost { @apply enabled:hover:bg-warning-100 }
+
+button.button-alert-default { @apply enabled:hover:bg-alert-500 }
+button.button-alert-ghost { @apply enabled:hover:bg-alert-100 }


### PR DESCRIPTION
## Proposed Changes

- Fixes #4555 
- Refactor CAREUI.css to make the code look pretty and organized too :)

The issue was, the `bg-color` from `CAREUI.css` button classes was being reset from a class in `index.css`.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
