### PR TITLE
Removed expired option from COVID disease status (Patient Registration)

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -368,7 +368,6 @@ export const DISEASE_STATUS = [
   "SUSPECTED",
   "NEGATIVE",
   "RECOVERED",
-  "EXPIRED",
 ];
 
 export const TEST_TYPE = [


### PR DESCRIPTION
## Proposed Changes

- Fixes #4563 
Removed expired option from COVID disease status in Patient Registration

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
