### PR TITLE
fix: Tailwind delete user confirm dialog to use ConfirmDialog component

### DIFF
--- a/src/Components/Common/ConfirmDialogV2.tsx
+++ b/src/Components/Common/ConfirmDialogV2.tsx
@@ -34,7 +34,7 @@ const ConfirmDialogV2 = ({
       show={show}
     >
       {children}
-      <div className="mt-4 flex justify-between">
+      <div className="mt-4 flex justify-between gap-2 w-full flex-col md:flex-row">
         <Cancel onClick={onClose} label={cancelLabel} />
         <ButtonV2
           onClick={onConfirm}

--- a/src/Components/Users/UnlinkFacilityDialog.tsx
+++ b/src/Components/Users/UnlinkFacilityDialog.tsx
@@ -21,7 +21,7 @@ const UnlinkFacilityDialog = (props: ConfirmDialogProps) => {
     <ConfirmDialogV2
       title={<span>Unlink User Facility</span>}
       show={true}
-      action="Delete"
+      action="Unlink"
       onClose={handleCancel}
       onConfirm={handleSubmit}
       disabled={disable}

--- a/src/Components/Users/UnlinkFacilityDialog.tsx
+++ b/src/Components/Users/UnlinkFacilityDialog.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  Button,
-} from "@material-ui/core";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 
 interface ConfirmDialogProps {
   facilityName: string;
@@ -24,35 +18,24 @@ const UnlinkFacilityDialog = (props: ConfirmDialogProps) => {
     setDisable(true);
   };
   return (
-    <Dialog open={true} onClose={handleCancel}>
-      <DialogContent>
-        <div className="md:min-w-[400px] max-w-[650px]">
-          <DialogContentText
-            id="alert-dialog-description"
-            className="flex text-gray-800 leading-relaxed sm:min-w-[400px]"
-          >
-            <div>
-              Are you sure you want to unlink the facility{" "}
-              <strong>{facilityName}</strong> from user{" "}
-              <strong>{userName}</strong>? The user will lose access to the
-              facility.
-            </div>
-          </DialogContentText>
+    <ConfirmDialogV2
+      title={<span>Unlink User Facility</span>}
+      show={true}
+      action="Delete"
+      onClose={handleCancel}
+      onConfirm={handleSubmit}
+      disabled={disable}
+      variant="danger"
+    >
+      <div className="flex text-gray-800 leading-relaxed">
+        <div>
+          Are you sure you want to unlink the facility{" "}
+          <strong>{facilityName}</strong> from user <strong>{userName}</strong>?
+          <br />
+          The user will lose access to the facility.
         </div>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleCancel} color="primary">
-          Cancel
-        </Button>
-        <button
-          onClick={handleSubmit}
-          className="font-medium btn btn-danger"
-          disabled={disable}
-        >
-          Delete
-        </button>
-      </DialogActions>
-    </Dialog>
+      </div>
+    </ConfirmDialogV2>
   );
 };
 


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Tailwind the user unlink facility dialog

## Associated Issue

- Fixes #4446

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/212464163-a8dd3eb2-ef1c-4685-a9b5-878f1dd3ba00.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
