### PR TITLE
CareUI: `bg-white` for `secondary` variant `ButtonV2`

### DIFF
--- a/src/Components/Common/components/ButtonV2.tsx
+++ b/src/Components/Common/components/ButtonV2.tsx
@@ -151,7 +151,6 @@ export const Submit = ({ label = "Submit", ...props }: CommonButtonProps) => {
       id="submit"
       type="submit"
       className="w-full md:w-auto"
-      // Voluntarily setting children this way, so that it's overridable when using.
       children={
         <>
           <CareIcon className="care-l-check-circle text-lg" />
@@ -170,8 +169,8 @@ export const Cancel = ({ label = "Cancel", ...props }: CommonButtonProps) => {
       id="cancel"
       type="button"
       variant="secondary"
+      border
       className="w-full md:w-auto"
-      // Voluntarily setting children this way, so that it's overridable when using.
       children={
         <>
           <CareIcon className="care-l-times-circle text-lg" />

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -983,7 +983,7 @@ export const ConsultationForm = (props: any) => {
         </div>
         {/* End of Telemedicine fields */}
 
-        <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-between">
+        <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-end">
           <Cancel
             onClick={() =>
               navigate(`/facility/${facilityId}/patient/${patientId}`)

--- a/src/style/CAREUI.css
+++ b/src/style/CAREUI.css
@@ -102,7 +102,7 @@
 .button-primary-ghost { @apply accent-primary-500 hover:bg-primary-100 text-primary-500 !important }
 .button-primary-border { @apply border border-primary-500 }
 
-.button-secondary-default { @apply accent-secondary-200 bg-secondary-300 hover:bg-secondary-200 text-secondary-800 !important }
+.button-secondary-default { @apply accent-secondary-200 bg-white hover:bg-secondary-200 text-secondary-800 !important }
 .button-secondary-ghost { @apply accent-secondary-200 hover:bg-secondary-100 text-secondary-700 !important }
 .button-secondary-border { @apply border border-secondary-300 }
 


### PR DESCRIPTION
## Proposed Changes

- Closes #4624
- Instead of introducing a `tertiary` variant button, and potentially causing confusion on what to use when, made `secondary` to be `bg-white` and added `border` prop for Cancel secondary buttons used in Forms

![image](https://user-images.githubusercontent.com/25143503/213101835-48d44379-daca-4029-8a73-211670d42ef4.png)

![image](https://user-images.githubusercontent.com/25143503/213101810-46391f52-dc69-42cc-9ca5-8d5af0ec1a6c.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
