### PR TITLE
Prevent log update without bed

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -9,6 +9,7 @@ import { PATIENT_CATEGORIES } from "../../Common/constants";
 import moment from "moment";
 import ButtonV2 from "../Common/components/ButtonV2";
 import CareIcon from "../../CAREUI/icons/CareIcon";
+import * as Notification from "../../Utils/Notifications.js";
 
 export default function PatientInfoCard(props: {
   patient: PatientModel;
@@ -227,7 +228,19 @@ export default function PatientInfoCard(props: {
                 <ButtonV2
                   key={i}
                   variant={action[4] && action[4][0] ? "danger" : "primary"}
-                  href={`${action[0]}`}
+                  href={
+                    !patient.last_consultation?.current_bed && i === 1
+                      ? undefined
+                      : `${action[0]}`
+                  }
+                  onClick={() => {
+                    if (!patient.last_consultation?.current_bed && i === 1) {
+                      Notification.Error({
+                        msg: "Please assign a bed to the patient",
+                      });
+                      setOpen(true);
+                    }
+                  }}
                   align="start"
                   className="w-full"
                 >


### PR DESCRIPTION
## Proposed Changes

- Fixes #4628 ?
- Shows an error message when clicked on log update button if a bed is not assigned
- Automatically opens the assign bed modal
- Backend PR will soon follow

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
