### PR TITLE
Added link to home page on sidebar logo

### DIFF
--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import CareIcon from "../../../CAREUI/icons/CareIcon";
 import useConfig from "../../../Common/hooks/useConfig";
 import SlideOver from "../../../CAREUI/interactive/SlideOver";
 import { classNames } from "../../../Utils/utils";
+import { Link } from "raviger";
 
 export const SIDEBAR_SHRINK_PREFERENCE_KEY = "sidebarShrinkPreference";
 
@@ -115,12 +116,14 @@ const StatelessSidebar = ({
       } transition-all duration-300 ease-in-out overflow-y-auto overflow-x-hidden`}
     >
       <div className="h-3" /> {/* flexible spacing */}
-      <img
-        className={`${
-          shrinked ? "mx-auto" : "ml-5"
-        } h-5 md:h-8 self-start transition mb-2 md:mb-5`}
-        src={shrinked ? LOGO_COLLAPSE : LOGO}
-      />
+      <Link href="/">
+        <img
+          className={`${
+            shrinked ? "mx-auto" : "ml-5"
+          } h-5 md:h-8 self-start transition mb-2 md:mb-5`}
+          src={shrinked ? LOGO_COLLAPSE : LOGO}
+        />
+      </Link>
       <div className="h-3" /> {/* flexible spacing */}
       <div className="flex flex-col relative h-full mb-4 md:mb-0">
         <div className="flex flex-col relative flex-1 md:flex-none">


### PR DESCRIPTION
## Proposed Changes

- Previously sidebar logo was not clickable
- Conventionally logos should redirect to home page

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
