### PR TITLE
Tailwinds delete bed type and delete doctor type dialogs

### DIFF
--- a/src/Components/Common/ConfirmDialogV2.tsx
+++ b/src/Components/Common/ConfirmDialogV2.tsx
@@ -30,17 +30,17 @@ const ConfirmDialogV2 = ({
     <DialogModal
       onClose={onClose}
       title={title}
-      description={description}
+      description={
+        <span className={`font-medium text-${variant || "secondary"}-500`}>
+          {description}
+        </span>
+      }
       show={show}
     >
       {children}
-      <div className="mt-4 flex justify-between gap-2 w-full flex-col md:flex-row">
+      <div className="mt-6 flex justify-end gap-2 w-full flex-col md:flex-row">
         <Cancel onClick={onClose} label={cancelLabel} />
-        <ButtonV2
-          onClick={onConfirm}
-          variant={variant || "primary"}
-          disabled={disabled}
-        >
+        <ButtonV2 onClick={onConfirm} variant={variant} disabled={disabled}>
           {action}
         </ButtonV2>
       </div>

--- a/src/Components/Common/Dialog.tsx
+++ b/src/Components/Common/Dialog.tsx
@@ -53,7 +53,7 @@ const DialogModal = (props: DialogProps) => {
                     <h4>{title}</h4>
                   </Dialog.Title>
                   <div className="mt-2">
-                    <p className="text-sm text-gray-500">{description}</p>
+                    <p className="text-sm text-gray-600">{description}</p>
                   </div>
                   {children}
                 </Dialog.Panel>

--- a/src/Components/Facility/BedTypeCard.tsx
+++ b/src/Components/Facility/BedTypeCard.tsx
@@ -3,17 +3,11 @@ import moment from "moment";
 import * as Notification from "../../Utils/Notifications";
 import { animated, config, useSpring } from "@react-spring/web";
 import { useDispatch } from "react-redux";
-import {
-  DialogContentText,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-} from "@material-ui/core";
 import { deleteCapacity } from "../../Redux/actions";
 import { RoleButton } from "../Common/RoleButton";
 import { BedCapacity } from "./BedCapacity";
 import DialogModal from "../Common/Dialog";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 
 interface BedTypeCardProps {
   facilityId?: string;
@@ -63,10 +57,6 @@ export const BedTypeCard: React.FC<BedTypeCardProps> = ({
         }
       }
     }
-  };
-
-  const handleDeleteClose = () => {
-    setOpenDeleteDialog(false);
   };
 
   const _p = total ? Math.round((used / total) * 100) : 0;
@@ -216,32 +206,15 @@ export const BedTypeCard: React.FC<BedTypeCardProps> = ({
           </p>
         </div>
       </div>
-      <Dialog
-        maxWidth={"md"}
-        open={openDeleteDialog}
-        onClose={handleDeleteClose}
-      >
-        <DialogTitle className="flex justify-center bg-primary-100">
-          Are you sure you want to delete {label} type?
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            You will not be able to access this bed type later.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <button onClick={handleDeleteClose} className="btn btn-primary">
-            Cancel
-          </button>
-          <button
-            onClick={handleDeleteSubmit}
-            id="facility-delete-confirm"
-            className="btn btn-danger"
-          >
-            Delete
-          </button>
-        </DialogActions>
-      </Dialog>
+      <ConfirmDialogV2
+        show={openDeleteDialog}
+        onClose={() => setOpenDeleteDialog(false)}
+        title={`Delete ${label}?`}
+        description="You will not be able to access this bed type later."
+        action="Delete"
+        variant="danger"
+        onConfirm={handleDeleteSubmit}
+      />
       {open && (
         <DialogModal
           show={open}

--- a/src/Components/Facility/DoctorsCountCard.tsx
+++ b/src/Components/Facility/DoctorsCountCard.tsx
@@ -5,16 +5,10 @@ import { RoleButton } from "../Common/RoleButton";
 import { useDispatch } from "react-redux";
 import { deleteDoctor } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications";
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-} from "@material-ui/core";
 import { DoctorIcon } from "../TeleIcu/Icons/DoctorIcon";
 import { DoctorCapacity } from "./DoctorCapacity";
 import DialogModal from "../Common/Dialog";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 
 interface DoctorsCountProps extends DoctorModal {
   facilityId: string;
@@ -88,33 +82,15 @@ const DoctorsCountCard = (props: DoctorsCountProps) => {
             Delete
           </RoleButton>
         </div>
-        <Dialog
-          maxWidth={"md"}
-          open={openDeleteDialog}
+        <ConfirmDialogV2
+          show={openDeleteDialog}
           onClose={handleDeleteClose}
-        >
-          <DialogTitle className="flex justify-center bg-primary-100">
-            Are you sure you want to delete {specialization?.text} doctors?
-          </DialogTitle>
-          <DialogContent>
-            <DialogContentText>
-              You will not be able to access this docter specialization type
-              later.
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <button onClick={handleDeleteClose} className="btn btn-primary">
-              Cancel
-            </button>
-            <button
-              onClick={handleDeleteSubmit}
-              id="facility-delete-confirm"
-              className="btn btn-danger"
-            >
-              Delete
-            </button>
-          </DialogActions>
-        </Dialog>
+          title={`Delete ${specialization?.text} doctors`}
+          description="You will not be able to access this docter specialization type later."
+          action="Delete"
+          variant="danger"
+          onConfirm={handleDeleteSubmit}
+        />
       </div>
       {open && (
         <DialogModal


### PR DESCRIPTION
## Proposed Changes

- Fixes #4646
- Fixes #4645 
- `justify-end` action buttons of Confirm Dialog

![image](https://user-images.githubusercontent.com/25143503/213847105-a3b2f913-a788-4ab4-a61a-e4b3f3963a4b.png)


![image](https://user-images.githubusercontent.com/25143503/213847094-1b11680e-a2c3-4f95-a40e-8ee6d8d58957.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
