### PR TITLE
Made neurological monitoring tab ui responsive in tab devices

### DIFF
--- a/src/Components/Facility/Consultations/NeurologicalTables.tsx
+++ b/src/Components/Facility/Consultations/NeurologicalTables.tsx
@@ -409,7 +409,7 @@ export const NeurologicalTable = (props: any) => {
         </div>
         <div className="mb-6">
           <div className="text-xl font-semibold my-2">Scale Description</div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             <div className="px-4 py-2 bg-white border rounded-lg shadow">
               <div className="text-xl font-semibold mb-2">Eye Open</div>
               <div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #4655 
- Made neurological monitoring tab ui responsive in tab devices
![image](https://user-images.githubusercontent.com/59426397/215470209-31402b3d-f05b-46c6-ad00-b7cd67439052.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
