### PR TITLE
fix: Bed Assignment necessary before filing log update for patients admitted

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -229,12 +229,18 @@ export default function PatientInfoCard(props: {
                   key={i}
                   variant={action[4] && action[4][0] ? "danger" : "primary"}
                   href={
-                    !patient.last_consultation?.current_bed && i === 1
+                    patient.last_consultation?.admitted &&
+                    !patient.last_consultation?.current_bed &&
+                    i === 1
                       ? undefined
                       : `${action[0]}`
                   }
                   onClick={() => {
-                    if (!patient.last_consultation?.current_bed && i === 1) {
+                    if (
+                      patient.last_consultation?.admitted &&
+                      !patient.last_consultation?.current_bed &&
+                      i === 1
+                    ) {
                       Notification.Error({
                         msg: "Please assign a bed to the patient",
                       });


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Removed bed assignment dialog for non-admitted patient for log update

## Associated Issue

- Fixes #4707

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug/test a new feature.
- [x] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
