### PR TITLE
Fixed facility cover photo

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -47,7 +47,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
 
   return (
     <div key={`usr_${facility.id}`} className="w-full">
-      <div className="block rounded-lg h-full overflow-clip bg-white shadow hover:border-primary-500">
+      <div className="block rounded-lg h-64 overflow-clip bg-white shadow hover:border-primary-500">
         <div className="flex h-full">
           <Link
             href={`/facility/${facility.id}`}
@@ -57,7 +57,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
               <img
                 src={facility.read_cover_image_url}
                 alt={facility.name}
-                className="h-full object-cover"
+                className="object-cover w-full h-full"
               />
             )) || (
               <i className="fas fa-hospital text-4xl block text-gray-500" />

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -57,7 +57,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
               <img
                 src={facility.read_cover_image_url}
                 alt={facility.name}
-                className="w-full h-[210px] object-cover"
+                className="h-full object-cover"
               />
             )) || (
               <i className="fas fa-hospital text-4xl block text-gray-500" />


### PR DESCRIPTION
## Proposed Changes

- Fixes #4755 
- Removed gray padding in the facility cover images

### Screenshot
![image](https://user-images.githubusercontent.com/40627011/216828389-7830de18-f3e8-47a7-8196-0b26f8c521e2.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
