### PR TITLE
preserve query params in `useLocationHistory`'s history stack

### DIFF
--- a/src/CAREUI/misc/HistoryAPIProvider.tsx
+++ b/src/CAREUI/misc/HistoryAPIProvider.tsx
@@ -10,17 +10,18 @@ export const HistoryAPIProvider = (props: { children: ReactNode }) => {
 
   useLocationChange(
     (newLocation) => {
+      const newPath = newLocation.fullPath + newLocation.search;
       setHistory((history) => {
-        if (history.length && newLocation.fullPath === history[0])
+        if (history.length && newPath === history[0])
           // Ignore push if navigate to same path (for some weird unknown reasons?)
           return history;
 
-        if (history.length > 1 && newLocation.fullPath === history[1])
+        if (history.length > 1 && newPath === history[1])
           // Pop current path if navigate back to previous path
           return history.slice(1);
 
         // Otherwise just push the current path
-        return [newLocation.fullPath, ...history];
+        return [newPath, ...history];
       });
     },
     { onInitial: true }


### PR DESCRIPTION
## Proposed Changes

- Fixes #4773 

https://user-images.githubusercontent.com/25143503/216961290-4991e97f-2ab5-49b4-90e7-f893b8676b9a.mp4


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
