### PR TITLE
Resolved overlapping Icon and Goal content

### DIFF
--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -217,7 +217,7 @@ export const Login = (props: { forgot?: boolean }) => {
             </div>
           </div>
         </div>
-        <div className="flex items-center xl:absolute xl:inset-x-0 xl:py-12 xl:px-16 pb-10 xl:bottom-0 xl:z-20">
+        <div className="flex items-center">
           <div className="text-xs md:text-sm max-w-lg">
             <div className="ml-1 flex items-center gap-4 mb-2">
               <a href={dpg_url} rel="noopener noreferrer" target="_blank">

--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -217,7 +217,7 @@ export const Login = (props: { forgot?: boolean }) => {
             </div>
           </div>
         </div>
-        <div className="flex items-center lg:absolute lg:inset-x-0 lg:py-12 lg:px-16 pb-10 lg:bottom-0 lg:z-20">
+        <div className="flex items-center xl:absolute xl:inset-x-0 xl:py-12 xl:px-16 pb-10 xl:bottom-0 xl:z-20">
           <div className="text-xs md:text-sm max-w-lg">
             <div className="ml-1 flex items-center gap-4 mb-2">
               <a href={dpg_url} rel="noopener noreferrer" target="_blank">


### PR DESCRIPTION
FIxes #4797 
Resolved overlapping Icon and Goal content on the home page
![Screenshot from 2023-02-10 12-40-55](https://user-images.githubusercontent.com/70687348/218026258-1e83dc7b-e639-40a2-8dd6-639480531c6d.png)