### PR TITLE
Adds Config: `SENTRY_DSN`

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -10,6 +10,7 @@
     "gmaps_api_key": "AIzaSyDsBAc3y7deI5ZO3NtK5GuzKwtUzQNJNUk",
     "gov_data_api_key": "579b464db66ec23bdd000001cdd3946e44ce4aad7209ff7b23ac571b",
     "recaptcha_site_key": "6LdvxuQUAAAAADDWVflgBqyHGfq-xmvNJaToM0pN",
+    "sentry_dsn": "https://8801155bd0b848a09de9ebf6f387ebc8@sentry.io/5183632",
     "kasp_enabled": false,
     "kasp_string": "KASP",
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",

--- a/public/config.json
+++ b/public/config.json
@@ -11,6 +11,7 @@
     "gov_data_api_key": "579b464db66ec23bdd000001cdd3946e44ce4aad7209ff7b23ac571b",
     "recaptcha_site_key": "6LdvxuQUAAAAADDWVflgBqyHGfq-xmvNJaToM0pN",
     "sentry_dsn": "https://8801155bd0b848a09de9ebf6f387ebc8@sentry.io/5183632",
+    "sentry_environment": "staging",
     "kasp_enabled": false,
     "kasp_string": "KASP",
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useAbortableEffect, statusType } from "./Common/utils";
 import axios from "axios";
 import { HistoryAPIProvider } from "./CAREUI/misc/HistoryAPIProvider";
 import * as Sentry from "@sentry/browser";
+import { IConfig } from "./Common/hooks/useConfig";
 
 const Loading = loadable(() => import("./Components/Common/Loading"));
 
@@ -20,14 +21,16 @@ const App: React.FC = () => {
   useAbortableEffect(async () => {
     const res = await dispatch(getConfig());
     if (res.data && res.status < 400) {
-      if (res.data.sentry_dsn && process.env.NODE_ENV === "production") {
+      const config = res.data as IConfig;
+
+      if (config.sentry_dsn && process.env.NODE_ENV === "production") {
         Sentry.init({
-          environment: process.env.NODE_ENV,
-          dsn: res.data.sentry_dsn,
+          environment: config.sentry_environment,
+          dsn: config.sentry_dsn,
         });
       }
 
-      localStorage.setItem("config", JSON.stringify(res.data));
+      localStorage.setItem("config", JSON.stringify(config));
     }
   }, [dispatch]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { getConfig, getCurrentUser } from "./Redux/actions";
 import { useAbortableEffect, statusType } from "./Common/utils";
 import axios from "axios";
 import { HistoryAPIProvider } from "./CAREUI/misc/HistoryAPIProvider";
+import * as Sentry from "@sentry/browser";
 
 const Loading = loadable(() => import("./Components/Common/Loading"));
 
@@ -19,6 +20,13 @@ const App: React.FC = () => {
   useAbortableEffect(async () => {
     const res = await dispatch(getConfig());
     if (res.data && res.status < 400) {
+      if (res.data.sentry_dsn && process.env.NODE_ENV === "production") {
+        Sentry.init({
+          environment: process.env.NODE_ENV,
+          dsn: res.data.sentry_dsn,
+        });
+      }
+
       localStorage.setItem("config", JSON.stringify(res.data));
     }
   }, [dispatch]);

--- a/src/Common/hooks/useConfig.ts
+++ b/src/Common/hooks/useConfig.ts
@@ -22,6 +22,14 @@ export interface IConfig {
    */
   gov_data_api_key: string;
   recaptcha_site_key: string;
+  /**
+   * SENTRY_DSN
+   */
+  sentry_dsn: string;
+  /**
+   * SENTRY_ENVIRONMENT
+   */
+  sentry_environment: string;
   kasp_enabled: boolean;
   kasp_string: string;
   kasp_full_string: string;


### PR DESCRIPTION
## Proposed Changes

- Fixes #4813
- Adds Config: `sentry_dsn`
- Adds Config: `sentry_environment`
- Uses the hardcoded sentry DSN initially until config.json is loaded, and then re-initializes with the `config.json`'s `sentry_dsn`

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
