### PR TITLE
Fixes Date field positions in Consultation Form

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -846,6 +846,7 @@ export const ConsultationForm = (props: any) => {
               {...field("admission_date")}
               required
               label="Admission date"
+              position="LEFT"
             />
 
             {!isUpdate && (

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -755,6 +755,7 @@ export const ConsultationForm = (props: any) => {
             disableFuture
             required
             label="Date of onset of the symptoms"
+            position="LEFT"
           />
         )}
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #4832
- Left Align date picker position of: Onset Symptoms Date
- Left Align picker position of: Admission Date

![image](https://user-images.githubusercontent.com/25143503/219367269-d7d983b8-d547-4646-bf00-3ecaf7f24754.png)

![image](https://user-images.githubusercontent.com/25143503/219367421-2058a511-2310-4dad-a2cd-4a4b76bea0d1.png)



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
