### PR TITLE
Added daily round symptoms to symptoms card, and updated time handling

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -60,6 +60,7 @@ import PRNPrescriptionBuilder, {
   PRNPrescriptionType,
 } from "../Common/prescription-builder/PRNPrescriptionBuilder";
 import { formatDate } from "../../Utils/utils";
+import Chip from "../../CAREUI/display/Chip";
 interface PreDischargeFormInterface {
   discharge_reason: string;
   discharge_notes: string;
@@ -795,25 +796,84 @@ export const ConsultationDetails = (props: any) => {
                 {consultationData.symptoms_text && (
                   <div className="bg-white overflow-hidden shadow rounded-lg">
                     <div className="px-4 py-5 sm:p-6">
-                      <h3 className="text-lg font-semibold leading-relaxed text-gray-900">
+                      <h3 className="text-lg font-semibold leading-relaxed text-gray-900 mb-4">
                         Symptoms
                       </h3>
                       <div className="">
-                        <div className="capitalize">
-                          {consultationData.symptoms_text}
+                        <div className="font-semibold uppercase text-sm">
+                          Last Daily Update
+                        </div>
+                        {consultationData.last_daily_round
+                          ?.additional_symptoms && (
+                          <>
+                            <div className="flex flex-wrap items-center gap-2 my-4">
+                              {consultationData.last_daily_round?.additional_symptoms.map(
+                                (symptom: any, index: number) => (
+                                  <Chip
+                                    key={index}
+                                    text={
+                                      SYMPTOM_CHOICES.find(
+                                        (choice) => choice.id === symptom
+                                      )?.text || "Err. Unknown"
+                                    }
+                                    color={"primary"}
+                                    size={"small"}
+                                  />
+                                )
+                              )}
+                            </div>
+                            {consultationData.last_daily_round
+                              ?.other_symptoms && (
+                              <div className="capitalize">
+                                <div className="font-semibold text-xs">
+                                  Other Symptoms:
+                                </div>
+                                {
+                                  consultationData.last_daily_round
+                                    ?.other_symptoms
+                                }
+                              </div>
+                            )}
+                            <span className="font-semibold leading-relaxed text-gray-800 text-xs">
+                              from{" "}
+                              {moment(
+                                consultationData.last_daily_round.created_at
+                              ).format("DD/MM/YYYY")}
+                            </span>
+                          </>
+                        )}
+                        <hr className="border border-gray-300 my-4" />
+                        <div className="font-semibold uppercase text-sm">
+                          Consultation Update
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2 my-4">
+                          {consultationData.symptoms?.map((symptom, index) => (
+                            <Chip
+                              key={index}
+                              text={
+                                SYMPTOM_CHOICES.find(
+                                  (choice) => choice.id === symptom
+                                )?.text || "Err. Unknown"
+                              }
+                              color={"primary"}
+                              size={"small"}
+                            />
+                          ))}
                         </div>
                         {consultationData.other_symptoms && (
                           <div className="capitalize">
-                            <span className="font-semibold leading-relaxed">
-                              Other Symptoms:{" "}
-                            </span>
+                            <div className="font-semibold text-xs">
+                              Other Symptoms:
+                            </div>
                             {consultationData.other_symptoms}
                           </div>
                         )}
                         <span className="font-semibold leading-relaxed text-gray-800 text-xs">
                           from{" "}
                           {consultationData.symptoms_onset_date
-                            ? formatDate(consultationData.symptoms_onset_date)
+                            ? moment(
+                                consultationData.symptoms_onset_date
+                              ).format("DD/MM/YYYY")
                             : "--:--"}
                         </span>
                       </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #4834 ?
- Now only shows date instead of time.
- Symptoms card now shows daily round update symptoms

after:
![image](https://user-images.githubusercontent.com/23238460/220005828-426a3d51-d8bf-44c1-88e1-73b2a4de05a0.png)

before:
![image](https://user-images.githubusercontent.com/23238460/220005934-8b220005-568c-479c-9859-07b226e0804f.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
