### PR TITLE
fix: badges are malfunctioning in patient tab

### DIFF
--- a/src/Common/hooks/useFilters.tsx
+++ b/src/Common/hooks/useFilters.tsx
@@ -115,8 +115,10 @@ export default function useFilters({ limit = 14 }: { limit?: number }) {
 
   const FilterBadges = ({
     badges,
+    children,
   }: {
     badges: (utils: typeof badgeUtils) => FilterBadgeProps[];
+    children?: React.ReactNode;
   }) => {
     const compiledBadges = badges(badgeUtils);
     const { t } = useTranslation();
@@ -125,6 +127,7 @@ export default function useFilters({ limit = 14 }: { limit?: number }) {
         {compiledBadges.map((props) => (
           <FilterBadge {...props} name={t(props.name)} key={props.name} />
         ))}
+        {children}
       </div>
     );
   };

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -251,6 +251,12 @@ export const PatientManager = () => {
 
   useEffect(() => {
     setIsLoading(true);
+    if (!params.phone_number) {
+      setPhoneNumber("+91");
+    }
+    if (!params.emergency_phone_number) {
+      setEmergencyPhoneNumber("+91");
+    }
     dispatch(getAllPatient(params, "listPatients")).then((res: any) => {
       if (res && res.data) {
         setData(res.data.results);
@@ -358,7 +364,6 @@ export const PatientManager = () => {
     },
     [fetchFacilityBadgeName]
   );
-
   const LastAdmittedToTypeBadges = () => {
     const badge = (key: string, value: any, id: string) => {
       return (
@@ -367,13 +372,13 @@ export const PatientManager = () => {
             name={key}
             value={value}
             onRemove={() => {
-              const lcat = qParams.last_consultation_admitted_to_list
+              const lcat = qParams.last_consultation_admitted_bed_type_list
                 .split(",")
                 .filter((x: string) => x != id)
                 .join(",");
               updateQuery({
                 ...qParams,
-                last_consultation_admitted_to_list: lcat,
+                last_consultation_admitted_bed_type_list: lcat,
               });
             }}
           />
@@ -822,7 +827,7 @@ export const PatientManager = () => {
           </div>
         </div>
       </div>
-      <div className="flex flex-wrap w-full col-span-3 mt-6">
+      <div className="flex flex-wrap col-span-3 mt-6">
         <FilterBadges
           badges={({ badge, value, kasp, phoneNumber, dateRange, range }) => [
             phoneNumber("Primary number", "phone_number"),
@@ -870,9 +875,11 @@ export const PatientManager = () => {
               paramKey: "last_consultation_is_telemedicine",
             },
           ]}
+          children={
+            qParams.last_consultation_admitted_bed_type_list &&
+            LastAdmittedToTypeBadges()
+          }
         />
-        {qParams.last_consultation_admitted_bed_type_list &&
-          LastAdmittedToTypeBadges()}
       </div>
       <div>
         <SlideOver {...advancedFilter}>


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Properly aligned `Bed Type` badge
- Reset the `Phone Number` and `Emergency Phone Number` boxes on removing the filter badge
- Enable removal of the `Bed Type` badge

## Associated Issue

- Fixes #4831

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/220076836-1e35d1d3-ae08-477b-9ff8-9a963ef69cd9.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug/test a new feature.
- [x] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [x] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
