### PR TITLE
fix: notification is missing for critical care log update

### DIFF
--- a/src/Components/CriticalCareRecording/Recording/CriticalCare__Recording.res
+++ b/src/Components/CriticalCareRecording/Recording/CriticalCare__Recording.res
@@ -254,7 +254,7 @@ let make = (~id, ~facilityId, ~patientId, ~consultationId, ~dailyRound) => {
           </div>
           <Link
             href={`/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}`}>
-            <div className="btn btn-primary w-full mt-6"> {str("Complete")} </div>
+            <button onClick={_ => Notifications.success({msg: "Critical care log updates are filed sucessfully"})} className="btn btn-primary w-full mt-6"> {str("Complete")} </button>
           </Link>
         </div>
       }}


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Added `Success Notification` for Critical care update

## Associated Issue

- Fixes #4545

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/220133566-423cd01a-45b3-4e95-8a77-4e8c22262ef8.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug/test a new feature.
- [x] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [x] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
