### PR TITLE
Scoll date range select into view when export is clicked in Patients Page

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -670,7 +670,7 @@ export const PatientManager = () => {
             }}
           >
             <CareIcon className="care-l-plus text-lg" />
-            <p>Add Patient Details</p>
+            <p className="lg:my-[2px]">Add Patient Details</p>
           </ButtonV2>
           <ButtonV2
             ghost
@@ -707,7 +707,7 @@ export const PatientManager = () => {
                 {" "}
               </line>
             </svg>
-            <span>Advanced Filters</span>
+            <span className="lg:my-[2px]">Advanced Filters</span>
           </ButtonV2>
           <DropdownMenu
             title="Sort by"
@@ -751,11 +751,10 @@ export const PatientManager = () => {
                     });
                   }, 500);
                 }}
-                variant="secondary"
-                className="lg:w-fit w-full"
+                className="lg:w-fit w-full mr-5"
               >
                 <CareIcon className="care-l-import" />
-                Export
+                <span className="lg:my-[3px]">Export</span>
               </ButtonV2>
             ) : (
               <ExportMenu

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -38,6 +38,7 @@ import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 import { FieldChangeEvent } from "../Form/FormFields/Utils";
 import DropdownMenu, { DropdownItem } from "../Common/components/Menu";
 import DoctorVideoSlideover from "../Facility/DoctorVideoSlideover";
+import * as Notification from "../../Utils/Notifications.js";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -738,20 +739,41 @@ export const PatientManager = () => {
             })}
           </DropdownMenu>
           <div className="tooltip">
-            <ExportMenu
-              disabled={!isExportAllowed}
-              exportItems={[
-                {
-                  label:
-                    tabValue === 0 ? "Live patients" : "Discharged patients",
-                  action: exportPatients(true),
-                },
-                {
-                  label: "All patients",
-                  action: exportPatients(false),
-                },
-              ]}
-            />
+            {!isExportAllowed ? (
+              <ButtonV2
+                onClick={() => {
+                  advancedFilter.setShow(true);
+                  setTimeout(() => {
+                    const element = document.getElementById("bed-type-select");
+                    if (element) element.scrollIntoView({ behavior: "smooth" });
+                    Notification.Warn({
+                      msg: "Please select a seven day period.",
+                    });
+                  }, 500);
+                }}
+                variant="secondary"
+                className="lg:w-fit w-full"
+              >
+                <CareIcon className="care-l-import" />
+                Export
+              </ButtonV2>
+            ) : (
+              <ExportMenu
+                disabled={!isExportAllowed}
+                exportItems={[
+                  {
+                    label:
+                      tabValue === 0 ? "Live patients" : "Discharged patients",
+                    action: exportPatients(true),
+                  },
+                  {
+                    label: "All patients",
+                    action: exportPatients(false),
+                  },
+                ]}
+              />
+            )}
+
             {!isExportAllowed && (
               <span className="tooltip-text tooltip-bottom -translate-x-1/2">
                 Select a seven day period

--- a/src/Components/Patient/PatientFilterV2.tsx
+++ b/src/Components/Patient/PatientFilterV2.tsx
@@ -557,7 +557,7 @@ export default function PatientFilterV2(props: any) {
             errorClassName="hidden"
           />
         </div>
-        <div className="w-full flex-none">
+        <div className="w-full flex-none" id="bed-type-select">
           <FieldLabel className="text-sm">Admitted to (Bed Types)</FieldLabel>
           <MultiSelectMenuV2
             id="last_consultation_admitted_bed_type_list"

--- a/src/Utils/Notifications.js
+++ b/src/Utils/Notifications.js
@@ -73,6 +73,11 @@ export const Error = ({ msg }) => {
   notify(msg, "error");
 };
 
+/** Warning message handler */
+export const Warn = ({ msg }) => {
+  notify(msg, "notice");
+};
+
 /** 400 Bad Request handler */
 export const BadRequest = ({ errs }) => {
   if (Array.isArray(errs)) {


### PR DESCRIPTION
## Proposed Changes

- Fixes #4753
-  Scoll date range selects into view when export menu is pressed in patients page to select a seven day period.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
