### PR TITLE
Disable delete skill button for unauthorized users

### DIFF
--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -152,7 +152,7 @@ export default ({ show, setShow, username }: IProps) => {
                           size="small"
                           variant="danger"
                           ghost={true}
-                          disabled={isLoading}
+                          disabled={isLoading || !authorizeForAddSkill}
                           onClick={() => setDeleteSkill(skill)}
                         >
                           <CareIcon className="care-l-times text-lg" />


### PR DESCRIPTION
Fixes #4855

This pull request addresses an issue where the "Delete Skill" button was still visible even when the user did not have the necessary permissions to delete a skill. To fix this, a new conditional statement has been added that disables the button when the user is not authorized to perform this action.

![image](https://user-images.githubusercontent.com/3626859/220258850-d45156fc-9378-4b75-ba84-3dc8d1350cd3.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
