### PR TITLE
Whatsapp number field bug resolved on add user page

### DIFF
--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -703,6 +703,7 @@ export const PhoneNumberField = (props: any) => {
           variant="secondary"
           type="button"
           ghost
+          disabled={disabled}
           onClick={() => onChange("+91")}
         >
           <CareIcon className="care-l-multiply" />

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -343,11 +343,17 @@ export const UserAdd = (props: UserProps) => {
   };
 
   useAbortableEffect(() => {
-    phoneIsWhatsApp &&
+    if (phoneIsWhatsApp) {
       handleFieldChange({
         name: "alt_phone_number",
         value: state.form.phone_number,
       });
+    } else {
+      handleFieldChange({
+        name: "alt_phone_number",
+        value: "+91",
+      });
+    }
   }, [phoneIsWhatsApp, state.form.phone_number]);
 
   const setFacility = (selected: FacilityModel | FacilityModel[] | null) => {


### PR DESCRIPTION
Fixes #4864 
- when we untick the field "is the phone number a WhatsApp number", the WhatsApp number field is reset to a blank input box
- when we tick the field "is the phone number a WhatsApp number" the WhatsApp number field is greyed out, and we aren't able to remove the number using the cross.
http://localhost:4000/users/add
![image](https://user-images.githubusercontent.com/70687348/220634378-89e6c72d-8416-4251-9a28-1e7d2efdbac3.png)
