### PR TITLE
Remove "required" attribute from oxygen capacity fields in FaclityCreate

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -877,7 +877,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       type="number"
                       placeholder="0"
                       label={t("liquid_oxygen_capacity")}
-                      required
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("litres")} />}
                       min={0}
@@ -886,7 +885,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       {...field("expected_oxygen_requirement")}
                       type="number"
                       placeholder="0"
-                      required
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("litres_per_day")} />}
                       label={t("expected_burn_rate")}
@@ -897,7 +895,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       {...field("type_b_cylinders")}
                       type="number"
                       placeholder="0"
-                      required
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("cylinders")} />}
                       min={0}
@@ -906,7 +903,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       {...field("expected_type_b_cylinders")}
                       type="number"
                       placeholder="0"
-                      required
                       label={t("expected_burn_rate")}
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("cylinders_per_day")} />}
@@ -916,7 +912,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       {...field("type_c_cylinders")}
                       type="number"
                       placeholder="0"
-                      required
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("cylinders")} />}
                       min={0}
@@ -925,7 +920,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       {...field("expected_type_c_cylinders")}
                       type="number"
                       placeholder="0"
-                      required
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("cylinders_per_day")} />}
                       label={t("expected_burn_rate")}
@@ -935,7 +929,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       {...field("type_d_cylinders")}
                       type="number"
                       placeholder="0"
-                      required
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("cylinders")} />}
                       min={0}
@@ -944,7 +937,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                       {...field("expected_type_d_cylinders")}
                       type="number"
                       placeholder="0"
-                      required
                       label={t("expected_burn_rate")}
                       trailingPadding=" "
                       trailing={<FieldUnit unit={t("cylinders_per_day")} />}


### PR DESCRIPTION
Fixes #4860 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers