### PR TITLE
Make Asset transactions work with qr_code_id

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -22,6 +22,7 @@ import moment from "moment";
 import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
+import * as Notification from "../../Utils/Notifications.js";
 
 interface AssetManageProps {
   assetId: string;
@@ -55,16 +56,31 @@ const AssetManage = (props: AssetManageProps) => {
   const fetchData = useCallback(
     async (status: statusType) => {
       setIsLoading(true);
-      const [assetData, transactionsData]: any = await Promise.all([
-        dispatch(getAsset(assetId)),
-        dispatch(listAssetTransaction({ asset: assetId, limit, offset })),
-      ]);
+      const assetData = await dispatch(getAsset(assetId));
       if (!status.aborted) {
         setIsLoading(false);
         if (assetData && assetData.data) {
           setAsset(assetData.data);
-          setTransactions(transactionsData.data.results);
-          setTotalCount(transactionsData.data.count);
+
+          const transactionFilter = assetData.qr_code_id
+            ? { qr_code_id: assetData.qr_code_id }
+            : { external_id: assetId };
+
+          const transactionsData = await dispatch(
+            listAssetTransaction({
+              ...transactionFilter,
+              limit,
+              offset,
+            })
+          );
+          if (transactionsData && transactionsData.data) {
+            setTransactions(transactionsData.data.results);
+            setTotalCount(transactionsData.data.count);
+          } else {
+            Notification.Error({
+              msg: "Error fetching transactions",
+            });
+          }
         } else {
           navigate("/not-found");
         }


### PR DESCRIPTION
Fixes #3479
Backend PR: https://github.com/coronasafe/care/pull/1206 

Allow Asset Transaction logs to be retrieved using the `qr_code_id` field, if that's empty, the `external_id` would be used as a fallback.

![image](https://user-images.githubusercontent.com/3626859/221499030-d4fbe665-0bc8-4146-b4d2-4069b8b2f23b.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
