### PR TITLE
Added No linked facility text on users page

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -798,6 +798,20 @@ function UserFacilities(props: { user: any }) {
               </div>
             </div>
           )}
+          {!user?.home_facility_object && facilities.length === 0 && (
+            <div className="mb-2 mt-2 flex flex-col justify-center align-middle content-center h-96">
+              <div className="w-full">
+                <img
+                  src={`${process.env.PUBLIC_URL}/images/404.svg`}
+                  alt="Error 404"
+                  className="w-80 mx-auto"
+                />
+              </div>
+              <p className="text-lg font-semibold text-center text-primary pt-4">
+                No Linked Facilities
+              </p>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -803,7 +803,7 @@ function UserFacilities(props: { user: any }) {
               <div className="w-full">
                 <img
                   src={`${process.env.PUBLIC_URL}/images/404.svg`}
-                  alt="Error 404"
+                  alt="No linked facilities"
                   className="w-80 mx-auto"
                 />
               </div>


### PR DESCRIPTION
Fixes #5012 
Added `No Linked Facility` text on view linked facilities of user slide over on the users page

![Screenshot from 2023-02-28 15-02-58](https://user-images.githubusercontent.com/70687348/221813192-513ea9b2-e169-4a05-82cd-e0ef757a5f5c.png)
