### PR TITLE
Added confirmation popup when replacing home facility

### DIFF
--- a/src/Components/Users/ConfirmHomeFacilityUpdateDialog.tsx
+++ b/src/Components/Users/ConfirmHomeFacilityUpdateDialog.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
+
+interface ConfirmDialogProps {
+  previousFacilityName: string;
+  userName: string;
+  newFacilityName: string;
+  handleCancel: () => void;
+  handleOk: () => void;
+}
+
+const ConfirmHomeFacilityUpdateDialog = (props: ConfirmDialogProps) => {
+  const {
+    previousFacilityName,
+    userName,
+    newFacilityName,
+    handleCancel,
+    handleOk,
+  } = props;
+
+  const [disable, setDisable] = useState(false);
+
+  const handleSubmit = () => {
+    handleOk();
+    setDisable(true);
+  };
+  return (
+    <ConfirmDialogV2
+      title={<span>Replace Home Facility</span>}
+      show={true}
+      action={"Replace"}
+      onClose={handleCancel}
+      onConfirm={handleSubmit}
+      disabled={disable}
+      variant="danger"
+    >
+      <div className="flex text-gray-800 leading-relaxed">
+        <div>
+          Are you sure you want to replace{" "}
+          <strong>{previousFacilityName}</strong> with{" "}
+          <strong>{newFacilityName}</strong> as home facility for user{" "}
+          <strong>{userName}</strong>
+          ?
+          <br />
+        </div>
+      </div>
+    </ConfirmDialogV2>
+  );
+};
+
+export default ConfirmHomeFacilityUpdateDialog;

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -634,9 +634,6 @@ function UserFacilities(props: { user: any }) {
 
   const updateHomeFacility = async (username: string, facility: any) => {
     setIsLoading(true);
-    if (user?.home_facility_object) {
-      // show popup for confirmation
-    }
     const res = await dispatch(
       partialUpdateUser(username, { home_facility: facility.id })
     );
@@ -792,6 +789,7 @@ function UserFacilities(props: { user: any }) {
                             className="tooltip text-lg hover:text-primary-500"
                             onClick={() => {
                               if (user?.home_facility_object) {
+                                // has previous home facility
                                 setReplaceHomeFacility({
                                   show: true,
                                   userName: username,
@@ -799,6 +797,7 @@ function UserFacilities(props: { user: any }) {
                                   newFacility: facility,
                                 });
                               } else {
+                                // no previous home facility
                                 updateHomeFacility(username, facility);
                               }
                             }}

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -33,6 +33,7 @@ import ButtonV2 from "../Common/components/ButtonV2";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import SkillsSlideOver from "./SkillsSlideOver";
 import { FacilitySelect } from "../Common/FacilitySelect";
+import ConfirmHomeFacilityUpdateDialog from "./ConfirmHomeFacilityUpdateDialog";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -588,6 +589,27 @@ function UserFacilities(props: { user: any }) {
     facility?: FacilityModel;
     isHomeFacility: boolean;
   }>({ show: false, userName: "", facility: undefined, isHomeFacility: false });
+
+  const [replaceHomeFacility, setReplaceHomeFacility] = useState<{
+    show: boolean;
+    userName: string;
+    previousFacility?: FacilityModel;
+    newFacility?: FacilityModel;
+  }>({
+    show: false,
+    userName: "",
+    previousFacility: undefined,
+    newFacility: undefined,
+  });
+  const hideReplaceHomeFacilityModal = () => {
+    setReplaceHomeFacility({
+      show: false,
+      previousFacility: undefined,
+      userName: "",
+      newFacility: undefined,
+    });
+  };
+
   const [linkFacility, setLinkFacility] = useState<{
     show: boolean;
     username: string;
@@ -612,6 +634,9 @@ function UserFacilities(props: { user: any }) {
 
   const updateHomeFacility = async (username: string, facility: any) => {
     setIsLoading(true);
+    if (user?.home_facility_object) {
+      // show popup for confirmation
+    }
     const res = await dispatch(
       partialUpdateUser(username, { home_facility: facility.id })
     );
@@ -765,9 +790,18 @@ function UserFacilities(props: { user: any }) {
                         <div className="flex items-center gap-2">
                           <button
                             className="tooltip text-lg hover:text-primary-500"
-                            onClick={() =>
-                              updateHomeFacility(username, facility)
-                            }
+                            onClick={() => {
+                              if (user?.home_facility_object) {
+                                setReplaceHomeFacility({
+                                  show: true,
+                                  userName: username,
+                                  previousFacility: user?.home_facility_object,
+                                  newFacility: facility,
+                                });
+                              } else {
+                                updateHomeFacility(username, facility);
+                              }
+                            }}
                           >
                             <CareIcon className="care-l-estate" />
                             <span className="tooltip-text tooltip-left">
@@ -799,6 +833,28 @@ function UserFacilities(props: { user: any }) {
             </div>
           )}
         </div>
+      )}
+      {replaceHomeFacility.show && (
+        <ConfirmHomeFacilityUpdateDialog
+          previousFacilityName={
+            replaceHomeFacility.previousFacility?.name || ""
+          }
+          userName={replaceHomeFacility.userName}
+          newFacilityName={replaceHomeFacility.newFacility?.name || ""}
+          handleCancel={hideReplaceHomeFacilityModal}
+          handleOk={() => {
+            updateHomeFacility(
+              replaceHomeFacility.userName,
+              replaceHomeFacility.newFacility
+            );
+            setReplaceHomeFacility({
+              show: false,
+              previousFacility: undefined,
+              userName: "",
+              newFacility: undefined,
+            });
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Fixes #5014 
Added Confirmation popup when replacing home facility on the users page
http://localhost:4000/users
![image](https://user-images.githubusercontent.com/70687348/222217024-d75aefed-ff89-405c-b4b0-b799f8b8b06d.png)
