### PR TITLE
Migrate Asset Class Icons to use Care Icons only

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -283,7 +283,7 @@ const AssetManage = (props: AssetManageProps) => {
                 },
                 {
                   label: "Asset Class",
-                  icon: assetClassProp.uicon,
+                  icon: assetClassProp.icon,
                   content: assetClassProp.name,
                 },
                 {

--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -31,7 +31,7 @@ export const assetClassProps = {
   HL7MONITOR: {
     name: "HL7 Vitals Monitor",
     description: "",
-    icon: "heart-rate",
+    icon: "monitor-heart-rate",
   },
   NONE: {
     name: "N/A",

--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -27,18 +27,15 @@ export const assetClassProps = {
     name: "ONVIF Camera",
     description: "",
     icon: "camera",
-    uicon: "camera",
   },
   HL7MONITOR: {
     name: "HL7 Vitals Monitor",
     description: "",
-    icon: "tv",
-    uicon: "tv-retro",
+    icon: "heart-rate",
   },
   NONE: {
     name: "N/A",
-    icon: "cart-plus",
-    uicon: "shopping-cart",
+    icon: "box",
   },
 };
 

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -244,7 +244,7 @@ const AssetsList = () => {
                           assetClassProps[asset.asset_class]) ||
                         assetClassProps.NONE
                       ).icon
-                    } text-lg`}
+                    } text-2xl`}
                   />
                 </span>
                 <p className="truncate w-48">{asset.name}</p>

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -237,13 +237,14 @@ const AssetsList = () => {
             <div className="md:flex">
               <p className="text-xl flex font-medium capitalize break-words">
                 <span className="mr-2 text-primary-500">
-                  <i
-                    className={`fas fa-${(
-                      (asset.asset_class &&
-                        assetClassProps[asset.asset_class]) ||
-                      assetClassProps.NONE
-                    ).icon
-                      }`}
+                  <CareIcon
+                    className={`care-l-${
+                      (
+                        (asset.asset_class &&
+                          assetClassProps[asset.asset_class]) ||
+                        assetClassProps.NONE
+                      ).icon
+                    }`}
                   />
                 </span>
                 <p className="truncate w-48">{asset.name}</p>

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -244,7 +244,7 @@ const AssetsList = () => {
                           assetClassProps[asset.asset_class]) ||
                         assetClassProps.NONE
                       ).icon
-                    }`}
+                    } text-lg`}
                   />
                 </span>
                 <p className="truncate w-48">{asset.name}</p>


### PR DESCRIPTION
## Proposed Changes

- Fixes #5030

![image](https://user-images.githubusercontent.com/25143503/222434834-84bb42f0-08df-4390-a6a4-e2a871efb28a.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
