### PR TITLE
Removed the transfer flags from the patient list

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -513,21 +513,6 @@ export const PatientManager = () => {
                           text="Review Missed"
                         />
                       )}
-                    {patient.allow_transfer ? (
-                      <Chip
-                        size="small"
-                        color="yellow"
-                        startIcon="unlock"
-                        text="Transfer Allowed"
-                      />
-                    ) : (
-                      <Chip
-                        size="small"
-                        color="primary"
-                        startIcon="lock"
-                        text="Transfer Blocked"
-                      />
-                    )}
                     {patient.disease_status === "POSITIVE" && (
                       <Chip
                         size="small"


### PR DESCRIPTION
## Proposed Changes

- Fixes #4886
- Removed the transfer flags from the patient list
- It will still be visible in individual records
- 
@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews

![image](https://user-images.githubusercontent.com/83979298/222955228-b0ca87b2-01c1-4242-bf74-1ef95b539dbd.png)



