### PR TITLE
fix: Pressure sore reflection in view details page is malfunctioning

### DIFF
--- a/src/Components/CriticalCareRecording/CriticalCare__Index.res
+++ b/src/Components/CriticalCareRecording/CriticalCare__Index.res
@@ -176,7 +176,13 @@ let make = (
         <div className="grow border-t border-gray-400 mt-4" />
         <div>
           <CriticalCare__PageTitle title="Pressure Sore" />
-          <DailyRound__PressureSore pressureSoreParameter />
+          <CriticalCare__PressureSoreEditor
+            pressureSoreParameter={pressureSoreParameter}
+            previewMode={true}
+            updateCB={_ => ()}
+            id={id}
+            consultationId={consultationId}
+          />
         </div>
         <div className="grow border-t border-gray-400 mt-4" />
         <div>

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -37,6 +37,17 @@ let make = (
     None
   }, [state])
 
+  let handleSubmit = e => {
+    updatePart(state)
+    hideModal(e)
+    let region = PressureSore.regionToString(state.region)
+    if (state.length > 0.0 && state.width == 0.0) || (state.length == 0.0 && state.width > 0.0) {
+      Notifications.error({msg: `Please fill in both width and length for ${region} part`})
+    } else {
+      Notifications.success({msg: `${region} part updated`})
+    }
+  }
+
   let handleClickOutside = %raw(`
     function (event, ref, hideModal) {
       if (ref.current && !ref.current.contains(event.target)) {
@@ -179,10 +190,7 @@ let make = (
             {!previewMode
               ? <button
                   type_="button"
-                  onClick={e => {
-                    updatePart(state)
-                    hideModal(e)
-                  }}
+                  onClick={handleSubmit}
                   className="inline-flex w-full justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:ml-3 sm:w-auto sm:text-sm">
                   {str("Apply")}
                 </button>

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -43,6 +43,7 @@ let make = (
     let region = PressureSore.regionToString(state.region)
     if (state.length > 0.0 && state.width == 0.0) || (state.length == 0.0 && state.width > 0.0) {
       Notifications.error({msg: `Please fill in both width and length for ${region} part`})
+      setState(prev => {...prev, length: 0.0, width: 0.0})
     } else {
       Notifications.success({msg: `${region} part updated`})
     }

--- a/src/Components/CriticalCareRecording/PressureSore/DailyRound__PressureSore.res
+++ b/src/Components/CriticalCareRecording/PressureSore/DailyRound__PressureSore.res
@@ -3,11 +3,6 @@ open CriticalCare__Types
 
 @react.component
 let make = (~pressureSoreParameter) => {
-  let filteredResults = Js.Array.filter(
-    pressure => PressureSore.calculateScore(pressure) > 0.0,
-    pressureSoreParameter,
-  )
-
   <table className="text-left px-4 py-2 border bg-gray-100 m-1 rounded-lg shadow md:w-1/2 w-full">
     <tr>
       <th className="text-left border p-2 w-1/2"> {str("Part")} </th> <th> {str("Push Score")} </th>
@@ -21,6 +16,6 @@ let make = (~pressureSoreParameter) => {
           {React.float(PressureSore.calculateScore(pressure))}
         </td>
       </tr>
-    }, filteredResults)->React.array}
+    }, pressureSoreParameter)->React.array}
   </table>
 }

--- a/src/Components/CriticalCareRecording/PressureSore/DailyRound__PressureSore.res
+++ b/src/Components/CriticalCareRecording/PressureSore/DailyRound__PressureSore.res
@@ -3,17 +3,24 @@ open CriticalCare__Types
 
 @react.component
 let make = (~pressureSoreParameter) => {
+  let filteredResults = Js.Array.filter(
+    pressure => PressureSore.calculateScore(pressure) > 0.0,
+    pressureSoreParameter,
+  )
+
   <table className="text-left px-4 py-2 border bg-gray-100 m-1 rounded-lg shadow md:w-1/2 w-full">
     <tr>
-      <th className="text-left border p-2 w-1/2"> {str("Part")} </th> <th> {str("Scale")} </th>
+      <th className="text-left border p-2 w-1/2"> {str("Part")} </th> <th> {str("Push Score")} </th>
     </tr>
     {Js.Array.map(pressure => {
       <tr>
         <td className="text-left border p-2 w-1/2">
           {str(PressureSore.regionToString(PressureSore.region(pressure)))}
         </td>
-        <td className="text-left border p-2 w-1/2"> {React.int(PressureSore.scale(pressure))} </td>
+        <td className="text-left border p-2 w-1/2">
+          {React.float(PressureSore.calculateScore(pressure))}
+        </td>
       </tr>
-    }, pressureSoreParameter)->React.array}
+    }, filteredResults)->React.array}
   </table>
 }

--- a/src/Components/CriticalCareRecording/types/CriticalCare__PressureSore.res
+++ b/src/Components/CriticalCareRecording/types/CriticalCare__PressureSore.res
@@ -41,17 +41,17 @@ type region =
   | PosteriorRightFoot
   | Other
 
-type extrudateAmount = 
+type extrudateAmount =
   | None
   | Light
   | Moderate
   | Heavy
 
-type tissueType = 
+type tissueType =
   | Closed
-  | Epithelial 
-  | Granulation 
-  | Slough 
+  | Epithelial
+  | Granulation
+  | Slough
   | Necrotic
 
 type path = {d: string, transform: string, region: region}
@@ -60,18 +60,19 @@ let transform = path => path.transform
 let regionForPath = path => path.region
 
 type part = {
-  region: region, 
-  scale: int, 
-  length: float, 
+  region: region,
+  scale: int,
+  length: float,
   width: float,
   exudate_amount: extrudateAmount,
   tissue_type: tissueType,
   description: string,
 }
 
-export type t = array<part>
+@genType type t = array<part>
 
-let decodeRegion = region => switch region {
+let decodeRegion = region =>
+  switch region {
   | "anterior_head" => AnteriorHead
   | "anterior_neck" => AnteriorNeck
   | "anterior_right_shoulder" => AnteriorRightShoulder
@@ -115,7 +116,8 @@ let decodeRegion = region => switch region {
   | _ => Other
   }
 
-  let decodeExtrudateAmount = extrudateAmount => switch extrudateAmount {
+let decodeExtrudateAmount = extrudateAmount =>
+  switch extrudateAmount {
   | "None" => None
   | "Light" => Light
   | "Moderate" => Moderate
@@ -123,7 +125,8 @@ let decodeRegion = region => switch region {
   | _ => None
   }
 
-  let decodeTissueType = tissueType => switch tissueType {
+let decodeTissueType = tissueType =>
+  switch tissueType {
   | "Closed" => Closed
   | "Epithelial" => Epithelial
   | "Granulation" => Granulation
@@ -164,22 +167,22 @@ let extrudateAmountToString = extrudateAmount => {
 
 let encodeTissueType = tissueType => {
   switch tissueType {
-    | Closed => "Closed"
-    | Epithelial => "Epithelial"
-    | Granulation => "Granulation"
-    | Slough => "Slough"
-    | Necrotic => "Necrotic"
-  }
-}
-
-let tissueTypeToString = tissueType => switch tissueType {
   | Closed => "Closed"
   | Epithelial => "Epithelial"
   | Granulation => "Granulation"
   | Slough => "Slough"
   | Necrotic => "Necrotic"
+  }
 }
 
+let tissueTypeToString = tissueType =>
+  switch tissueType {
+  | Closed => "Closed"
+  | Epithelial => "Epithelial"
+  | Granulation => "Granulation"
+  | Slough => "Slough"
+  | Necrotic => "Necrotic"
+  }
 
 let endcodeRegion = part => {
   switch part.region {
@@ -275,44 +278,43 @@ let regionToString = region => {
 
 let region = part => part.region
 let scale = part => part.scale
-let makeDefault = (region) => {
-  region: region, 
-  scale: 1, 
-  length: 0.0, 
-  width: 0.0, 
-  exudate_amount: None, 
-  tissue_type: Closed, 
-  description: ""
+let makeDefault = region => {
+  region: region,
+  scale: 1,
+  length: 0.0,
+  width: 0.0,
+  exudate_amount: None,
+  tissue_type: Closed,
+  description: "",
 }
 
 let calculatePushScore = (length, width, exudate_amount, tissue_type) => {
   let areaIntervalPoints = [0.0, 0.3, 0.6, 1.0, 2.2, 3.0, 4.0, 8.0, 12.0, 24.0]
-    let exudateAmounts = ["None", "Light", "Moderate", "Heavy"]
-    let tissueTypes = ["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
+  let exudateAmounts = ["None", "Light", "Moderate", "Heavy"]
+  let tissueTypes = ["Closed", "Epithelial", "Granulation", "Slough", "Necrotic"]
 
-    let area = length *. width
-    let areaScore =
-      areaIntervalPoints
-      ->Belt.Array.getIndexBy(interval => interval >= area)
-      ->Belt.Option.getWithDefault(10)
-      ->float_of_int
-    let exudateScore =
-      exudateAmounts
-      ->Belt.Array.getIndexBy(amount =>
-        amount == exudate_amount->extrudateAmountToString
-      )
-      ->Belt.Option.getWithDefault(0)
-      ->float_of_int
-    let tissueScore =
-      tissueTypes
-      ->Belt.Array.getIndexBy(tissue =>
-        tissue == tissue_type->tissueTypeToString
-      )
-      ->Belt.Option.getWithDefault(0)
-      ->float_of_int
+  let area = length *. width
+  let areaScore =
+    areaIntervalPoints
+    ->Belt.Array.getIndexBy(interval => interval >= area)
+    ->Belt.Option.getWithDefault(10)
+    ->float_of_int
+  let exudateScore =
+    exudateAmounts
+    ->Belt.Array.getIndexBy(amount => amount == exudate_amount->extrudateAmountToString)
+    ->Belt.Option.getWithDefault(0)
+    ->float_of_int
+  let tissueScore =
+    tissueTypes
+    ->Belt.Array.getIndexBy(tissue => tissue == tissue_type->tissueTypeToString)
+    ->Belt.Option.getWithDefault(0)
+    ->float_of_int
 
-    areaScore +. exudateScore +. tissueScore
+  areaScore +. exudateScore +. tissueScore
 }
+
+let calculateScore = part =>
+  calculatePushScore(part.length, part.width, part.exudate_amount, part.tissue_type)
 
 let autoScale = part => {
   {...part, scale: mod(part.scale + 1, 6)}


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- [x] Replaced `Scale` with `Push Score` for `Pressure Sore` in the log update
- [x] Added a validation to prevent a `zero push score`

## Associated Issue

- Fixes #5041 

## Screenshot

### For Pressure Sore

![image](https://user-images.githubusercontent.com/77210185/223653736-f5df9c54-83bc-42b6-9414-6d111138660f.png)
![image](https://user-images.githubusercontent.com/77210185/223653849-337de156-0db5-424a-9f51-8cb4db94d71d.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug/test a new feature.
- [x] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [x] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
