### PR TITLE
fix: Showing Consultation and discharge dates

### DIFF
--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -130,6 +130,9 @@ export interface ConsultationModel {
   last_daily_round?: any;
   current_bed?: CurrentBed;
   review_interval?: number;
+  cause_of_death?: string;
+  death_datetime?: string;
+  death_confirmed_doctor?: string;
 }
 export interface PatientStatsModel {
   id?: number;

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -189,7 +189,18 @@ export default function PatientInfoCard(props: {
                       suggestion.id === patient.last_consultation?.suggestion
                   )?.text
                 }{" "}
-                on {moment(patient.last_consultation?.created_date).format("L")}
+                on{" "}
+                {patient.last_consultation?.suggestion === "A"
+                  ? moment(patient.last_consultation?.admission_date).format(
+                      "DD/MM/YYYY"
+                    )
+                  : patient.last_consultation?.suggestion === "DD"
+                  ? moment(patient.last_consultation?.death_datetime).format(
+                      "DD/MM/YYYY"
+                    )
+                  : moment(patient.last_consultation?.created_date).format(
+                      "DD/MM/YYYY"
+                    )}
               </div>
               {patient.is_active === false &&
                 patient.last_consultation?.suggestion !== "OP" &&
@@ -197,7 +208,7 @@ export default function PatientInfoCard(props: {
                   <div>
                     Discharged on{" "}
                     {moment(patient.last_consultation?.discharge_date).format(
-                      "L"
+                      "DD/MM/YYYY"
                     )}
                   </div>
                 )}

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -5,7 +5,11 @@ import DialogModal from "../Common/Dialog";
 import Beds from "../Facility/Consultations/Beds";
 import { useState } from "react";
 import { PatientCategory } from "../Facility/models";
-import { DISCHARGE_REASONS, PATIENT_CATEGORIES } from "../../Common/constants";
+import {
+  CONSULTATION_SUGGESTION,
+  DISCHARGE_REASONS,
+  PATIENT_CATEGORIES,
+} from "../../Common/constants";
 import moment from "moment";
 import ButtonV2 from "../Common/components/ButtonV2";
 import CareIcon from "../../CAREUI/icons/CareIcon";
@@ -177,8 +181,30 @@ export default function PatientInfoCard(props: {
                 );
               })}
             </div>
+            <div className="flex gap-4 text-sm mt-3 px-3 py-1 font-medium bg-cyan-300">
+              <div>
+                {
+                  CONSULTATION_SUGGESTION.find(
+                    (suggestion) =>
+                      suggestion.id === patient.last_consultation?.suggestion
+                  )?.text
+                }{" "}
+                on {moment(patient.last_consultation?.created_date).format("L")}
+              </div>
+              {patient.is_active === false &&
+                patient.last_consultation?.suggestion !== "OP" &&
+                patient.last_consultation?.suggestion !== "DD" && (
+                  <div>
+                    Discharged on{" "}
+                    {moment(patient.last_consultation?.discharge_date).format(
+                      "L"
+                    )}
+                  </div>
+                )}
+            </div>
           </div>
         </div>
+
         <div className="w-full lg:w-fit flex gap-2 flex-col px-4 py-1 lg:p-6">
           {patient.is_active === false && (
             <div className="flex flex-col justify-center items-center">


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Added `consultation` and `discharge dates` fields on the `Consultation Card`

## Associated Issue

- Fixes #4872

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/223186054-911f34dc-6203-411b-ab84-1b6fccc99b52.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug/test a new feature.
- [x] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA
