### PR TITLE
Highlight English as default language if no language preference present.

### DIFF
--- a/src/Components/Common/LanguageSelectorLogin.tsx
+++ b/src/Components/Common/LanguageSelectorLogin.tsx
@@ -29,7 +29,9 @@ export const LanguageSelectorLogin = () => {
             onClick={() => handleLanguage(e)}
             className={classNames(
               "text-primary-400 hover:text-primary-600",
-              (i18n.language === e || !i18n.language && e === "en") && "text-primary-600 underline"
+              (i18n.language === e ||
+                (i18n.language === "en-US" && e === "en")) &&
+                "text-primary-600 underline"
             )}
           >
             {LANGUAGE_NAMES[e]}

--- a/src/Components/Common/LanguageSelectorLogin.tsx
+++ b/src/Components/Common/LanguageSelectorLogin.tsx
@@ -29,8 +29,7 @@ export const LanguageSelectorLogin = () => {
             onClick={() => handleLanguage(e)}
             className={classNames(
               "text-primary-400 hover:text-primary-600",
-              i18n.language === e && "text-primary-600 underline",
-              !i18n.language && e === "en" && "text-primary-600 underline"
+              (i18n.language === e || !i18n.language && e === "en") && "text-primary-600 underline"
             )}
           >
             {LANGUAGE_NAMES[e]}

--- a/src/Components/Common/LanguageSelectorLogin.tsx
+++ b/src/Components/Common/LanguageSelectorLogin.tsx
@@ -29,7 +29,8 @@ export const LanguageSelectorLogin = () => {
             onClick={() => handleLanguage(e)}
             className={classNames(
               "text-primary-400 hover:text-primary-600",
-              i18n.language === e && "text-primary-600 underline"
+              i18n.language === e && "text-primary-600 underline",
+              !i18n.language && e === "en" && "text-primary-600 underline"
             )}
           >
             {LANGUAGE_NAMES[e]}


### PR DESCRIPTION
## Proposed Changes

- Resolves #5057
- By default selected language was `en-US` but language names has `en` as the option. Hence `"en" === "en-US"` never matched. Fixed that by checking if `en-US`

![image](https://user-images.githubusercontent.com/25143503/223622164-7e9bb0b3-daf9-487a-a563-f4b7f0b6a895.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
