### PR TITLE
Replaced MUI modal with custom DialogModal Component in AssetImportMo…

### DIFF
--- a/src/Components/Assets/AssetImportModal.tsx
+++ b/src/Components/Assets/AssetImportModal.tsx
@@ -1,4 +1,3 @@
-import { Modal } from "@material-ui/core";
 import { ChangeEventHandler, useEffect, useState } from "react";
 import useDragAndDrop from "../../Utils/useDragAndDrop";
 import { sleep } from "../../Utils/utils";
@@ -17,6 +16,7 @@ import {
 } from "../../Common/constants";
 import { parseCsvFile } from "../../Utils/utils";
 import useConfig from "../../Common/hooks/useConfig";
+import DialogModal from "../Common/Dialog";
 
 interface Props {
   open: boolean;
@@ -172,177 +172,173 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
   };
 
   return (
-    <Modal open={open} onClose={closeModal}>
-      <div className="h-screen w-full absolute flex items-center justify-center bg-modal">
-        <div className="m-4 bg-white rounded-xl w-11/12 max-w-3xl min-h-[24rem] max-h-screen overflow-auto flex flex-col shadow">
-          <div className="px-6 py-6 flex flex-col bg-gray-300">
-            <span className="text-xl font-medium">Import Assets</span>
-            <span className="mt-1 text-gray-700">{facility.name}</span>
+    <DialogModal
+      title="Import Assets"
+      show={open}
+      onClose={closeModal}
+      className="w-[48rem]"
+      fixedWidth={false}
+    >
+      <span className="mt-1 text-gray-700">{facility.name}</span>
+      {locations.length === 0 ? (
+        <>
+          <div className="flex flex-col items-center justify-center h-full">
+            <h1 className="text-2xl font-medium text-gray-700 m-7">
+              You need at least one location to import an assest.
+            </h1>
+            <Link href={`/facility/${facility.id}/location/add`}>
+              <a className="bg-primary text-white px-4 py-2 rounded-md">
+                Add Asset Location
+              </a>
+            </Link>
           </div>
-          {locations.length === 0 ? (
-            <>
-              <div className="flex flex-col items-center justify-center h-full">
-                <h1 className="text-2xl font-medium text-gray-700 m-7">
-                  You need at least one location to import an assest.
-                </h1>
-                <Link href={`/facility/${facility.id}/location/add`}>
-                  <a className="bg-primary text-white px-4 py-2 rounded-md">
-                    Add Asset Location
-                  </a>
-                </Link>
+          <div className="mt-6 flex flex-col justify-center items-center">
+            <Cancel
+              onClick={closeModal}
+              disabled={isImporting}
+              className="px-4 py-2 w-1/4"
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          {preview && preview?.length > 0 ? (
+            <div className="flex flex-col rounded-lg items-center justify-center">
+              <h1 className="text-2xl font-medium text-gray-700 m-7">
+                {preview.length} assets will be imported
+              </h1>
+              <div className="w-1/2 p-4">
+                <label htmlFor="asset-location">
+                  Select location for import *
+                </label>
+                <div className="mt-2">
+                  <SelectMenuV2
+                    required
+                    options={[
+                      {
+                        title: "Select",
+                        description: "Select the location",
+                        value: "0",
+                      },
+                      ...locations.map((location: any) => ({
+                        title: location.name,
+                        description: location.facility.name,
+                        value: location.id,
+                      })),
+                    ]}
+                    optionLabel={(o) => o.title}
+                    optionValue={(o) => o.value}
+                    value={location}
+                    onChange={(e) => setLocation(e)}
+                  />
+                </div>
               </div>
-              <div className="mt-6 flex flex-col justify-center items-center">
-                <Cancel
-                  onClick={closeModal}
-                  disabled={isImporting}
-                  className="px-4 py-2 w-1/4"
-                />
-              </div>
-            </>
-          ) : (
-            <>
-              {preview && preview?.length > 0 ? (
-                <div className="flex flex-col rounded-lg items-center justify-center">
-                  <h1 className="text-2xl font-medium text-gray-700 m-7">
-                    {preview.length} assets will be imported
-                  </h1>
-                  <div className="w-1/2 p-4">
-                    <label htmlFor="asset-location">
-                      Select location for import *
-                    </label>
-                    <div className="mt-2">
-                      <SelectMenuV2
-                        required
-                        options={[
-                          {
-                            title: "Select",
-                            description: "Select the location",
-                            value: "0",
-                          },
-                          ...locations.map((location: any) => ({
-                            title: location.name,
-                            description: location.facility.name,
-                            value: location.id,
-                          })),
-                        ]}
-                        optionLabel={(o) => o.title}
-                        optionValue={(o) => o.value}
-                        value={location}
-                        onChange={(e) => setLocation(e)}
-                      />
-                    </div>
-                  </div>
-                  <div className="bg-white rounded overflow-y-scroll h-80 border border-gray-500 md:min-w-[500px]">
-                    <div className="p-2 border-b flex">
-                      <div className="p-2 mr-2 font-bold">#</div>
-                      <div className="p-2 mr-2 md:w-1/2 font-bold">Name</div>
-                      <div className="p-2 mr-2 md:w-1/2 font-bold">
-                        Description
+              <div className="bg-white rounded overflow-y-scroll h-80 border border-gray-500 md:min-w-[500px]">
+                <div className="p-2 border-b flex">
+                  <div className="p-2 mr-2 font-bold">#</div>
+                  <div className="p-2 mr-2 md:w-1/2 font-bold">Name</div>
+                  <div className="p-2 mr-2 md:w-1/2 font-bold">Description</div>
+                </div>
+                {preview.map((data: AssetData, index: number) => {
+                  return (
+                    <div key={index} className="p-2 border-b flex">
+                      <div className="p-2 mr-2">{index + 1}</div>
+                      <div className="p-2 mr-2 md:w-1/2">{data.name}</div>
+                      <div className="p-2 mr-2 md:w-1/2">
+                        {data.description}
                       </div>
                     </div>
-                    {preview.map((data: AssetData, index: number) => {
-                      return (
-                        <div key={index} className="p-2 border-b flex">
-                          <div className="p-2 mr-2">{index + 1}</div>
-                          <div className="p-2 mr-2 md:w-1/2">{data.name}</div>
-                          <div className="p-2 mr-2 md:w-1/2">
-                            {data.description}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : (
-                <div
-                  onDragOver={dragProps.onDragOver}
-                  onDragLeave={dragProps.onDragLeave}
-                  onDrop={onDrop}
-                  className={`px-3 py-6 flex-1 flex flex-col m-8 rounded-lg items-center justify-center border-[3px] border-dashed ${
-                    dragProps.dragOver && "border-primary-500"
-                  } ${
-                    dragProps.fileDropError !== ""
-                      ? "border-red-500"
-                      : "border-gray-500"
-                  }`}
-                >
-                  <svg
-                    stroke="currentColor"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                    className={`w-12 h-12 ${
-                      dragProps.dragOver && "text-primary-500"
-                    } ${
-                      dragProps.fileDropError !== ""
-                        ? "text-red-500"
-                        : "text-gray-600"
-                    }`}
-                  >
-                    <path d="M12.71,11.29a1,1,0,0,0-.33-.21,1,1,0,0,0-.76,0,1,1,0,0,0-.33.21l-2,2a1,1,0,0,0,1.42,1.42l.29-.3V17a1,1,0,0,0,2,0V14.41l.29.3a1,1,0,0,0,1.42,0,1,1,0,0,0,0-1.42ZM20,8.94a1.31,1.31,0,0,0-.06-.27l0-.09a1.07,1.07,0,0,0-.19-.28h0l-6-6h0a1.07,1.07,0,0,0-.28-.19l-.1,0A1.1,1.1,0,0,0,13.06,2H7A3,3,0,0,0,4,5V19a3,3,0,0,0,3,3H17a3,3,0,0,0,3-3V9S20,9,20,8.94ZM14,5.41,16.59,8H15a1,1,0,0,1-1-1ZM18,19a1,1,0,0,1-1,1H7a1,1,0,0,1-1-1V5A1,1,0,0,1,7,4h5V7a3,3,0,0,0,3,3h3Z" />
-                  </svg>
-                  <p
-                    className={`text-sm ${
-                      dragProps.dragOver && "text-primary-500"
-                    } ${
-                      dragProps.fileDropError !== ""
-                        ? "text-red-500"
-                        : "text-gray-700"
-                    } text-center`}
-                  >
-                    {dragProps.fileDropError !== ""
-                      ? dragProps.fileDropError
-                      : "Drag & drop JSON / Excel (xlsx, csv)  file to upload"}
-                  </p>
-                  <a
-                    className="mt-4 ml-auto mr-auto max-w-xs items-center px-3 py-2 border border-primary-500 text-sm leading-4 font-medium rounded-md text-primary-700 bg-white hover:text-primary-500 focus:outline-none focus:border-primary-300 focus:ring-blue active:text-primary-800 active:bg-gray-50 transition ease-in-out duration-150 hover:shadow"
-                    href={sample_format_asset_import}
-                  >
-                    <i className="fa fa-download mr-1" aria-hidden="true"></i>{" "}
-                    <span>Sample Format</span>
-                  </a>
-                </div>
-              )}
-
-              <div className="flex flex-col sm:flex-row p-4 gap-2">
-                <div>
-                  <label className="rounded-lg bg-white py-2 px-4 text-primary-500 font-medium border border-primary-500 hover:text-primary-400 hover:border-primary-400 text-sm flex gap-1 items-center justify-center cursor-pointer transition-all">
-                    <i className="fas fa-cloud-upload-alt mr-2"></i>Upload a
-                    file
-                    <input
-                      title="changeFile"
-                      type="file"
-                      accept=".json, .xlsx, .csv"
-                      className="hidden"
-                      onChange={onSelectFile}
-                      onClick={() => {
-                        setPreview(undefined);
-                      }}
-                    />
-                  </label>
-                </div>
-                <div className="sm:flex-1" />
-                <Cancel
-                  onClick={() => {
-                    closeModal();
-                    dragProps.setFileDropError("");
-                  }}
-                  disabled={isImporting}
-                />
-                <Submit onClick={handleUpload} disabled={isImporting}>
-                  {isImporting ? (
-                    <i className="fa-solid fa-spinner animate-spin" />
-                  ) : (
-                    <i className="fa-solid fa-file-import" />
-                  )}
-                  <span>{isImporting ? "Importing..." : "Import"}</span>
-                </Submit>
+                  );
+                })}
               </div>
-            </>
+            </div>
+          ) : (
+            <div
+              onDragOver={dragProps.onDragOver}
+              onDragLeave={dragProps.onDragLeave}
+              onDrop={onDrop}
+              className={`px-3 py-6 flex-1 flex flex-col mb-8 mt-5 rounded-lg items-center justify-center border-[3px] border-dashed ${
+                dragProps.dragOver && "border-primary-500"
+              } ${
+                dragProps.fileDropError !== ""
+                  ? "border-red-500"
+                  : "border-gray-500"
+              }`}
+            >
+              <svg
+                stroke="currentColor"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                className={`w-12 h-12 ${
+                  dragProps.dragOver && "text-primary-500"
+                } ${
+                  dragProps.fileDropError !== ""
+                    ? "text-red-500"
+                    : "text-gray-600"
+                }`}
+              >
+                <path d="M12.71,11.29a1,1,0,0,0-.33-.21,1,1,0,0,0-.76,0,1,1,0,0,0-.33.21l-2,2a1,1,0,0,0,1.42,1.42l.29-.3V17a1,1,0,0,0,2,0V14.41l.29.3a1,1,0,0,0,1.42,0,1,1,0,0,0,0-1.42ZM20,8.94a1.31,1.31,0,0,0-.06-.27l0-.09a1.07,1.07,0,0,0-.19-.28h0l-6-6h0a1.07,1.07,0,0,0-.28-.19l-.1,0A1.1,1.1,0,0,0,13.06,2H7A3,3,0,0,0,4,5V19a3,3,0,0,0,3,3H17a3,3,0,0,0,3-3V9S20,9,20,8.94ZM14,5.41,16.59,8H15a1,1,0,0,1-1-1ZM18,19a1,1,0,0,1-1,1H7a1,1,0,0,1-1-1V5A1,1,0,0,1,7,4h5V7a3,3,0,0,0,3,3h3Z" />
+              </svg>
+              <p
+                className={`text-sm ${
+                  dragProps.dragOver && "text-primary-500"
+                } ${
+                  dragProps.fileDropError !== ""
+                    ? "text-red-500"
+                    : "text-gray-700"
+                } text-center`}
+              >
+                {dragProps.fileDropError !== ""
+                  ? dragProps.fileDropError
+                  : "Drag & drop JSON / Excel (xlsx, csv)  file to upload"}
+              </p>
+              <a
+                className="mt-4 ml-auto mr-auto max-w-xs items-center px-3 py-2 border border-primary-500 text-sm leading-4 font-medium rounded-md text-primary-700 bg-white hover:text-primary-500 focus:outline-none focus:border-primary-300 focus:ring-blue active:text-primary-800 active:bg-gray-50 transition ease-in-out duration-150 hover:shadow"
+                href={sample_format_asset_import}
+              >
+                <i className="fa fa-download mr-1" aria-hidden="true"></i>{" "}
+                <span>Sample Format</span>
+              </a>
+            </div>
           )}
-        </div>
-      </div>
-    </Modal>
+
+          <div className="flex flex-col sm:flex-row gap-2">
+            <div>
+              <label className="rounded-lg bg-white py-2 px-4 text-primary-500 font-medium border border-primary-500 hover:text-primary-400 hover:border-primary-400 text-sm flex gap-1 items-center justify-center cursor-pointer transition-all">
+                <i className="fas fa-cloud-upload-alt mr-2"></i>Upload a file
+                <input
+                  title="changeFile"
+                  type="file"
+                  accept=".json, .xlsx, .csv"
+                  className="hidden"
+                  onChange={onSelectFile}
+                  onClick={() => {
+                    setPreview(undefined);
+                  }}
+                />
+              </label>
+            </div>
+            <div className="sm:flex-1" />
+            <Cancel
+              onClick={() => {
+                closeModal();
+                dragProps.setFileDropError("");
+              }}
+              disabled={isImporting}
+            />
+            <Submit onClick={handleUpload} disabled={isImporting}>
+              {isImporting ? (
+                <i className="fa-solid fa-spinner animate-spin" />
+              ) : (
+                <i className="fa-solid fa-file-import" />
+              )}
+              <span>{isImporting ? "Importing..." : "Import"}</span>
+            </Submit>
+          </div>
+        </>
+      )}
+    </DialogModal>
   );
 };
 

--- a/src/Components/Common/Dialog.tsx
+++ b/src/Components/Common/Dialog.tsx
@@ -9,10 +9,19 @@ type DialogProps = {
   onClose: () => void;
   children: React.ReactNode;
   className?: string;
+  fixedWidth?: boolean;
 };
 
 const DialogModal = (props: DialogProps) => {
-  const { title, description, show, onClose, children, className } = props;
+  const {
+    title,
+    description,
+    show,
+    onClose,
+    children,
+    className,
+    fixedWidth = true,
+  } = props;
   return (
     <div>
       <Transition appear show={show} as={React.Fragment}>
@@ -43,7 +52,8 @@ const DialogModal = (props: DialogProps) => {
                 <Dialog.Panel
                   className={classNames(
                     className,
-                    "w-full max-w-md transform rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
+                    fixedWidth && "max-w-md w-full",
+                    "transform rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
                   )}
                 >
                   <Dialog.Title


### PR DESCRIPTION
## Proposed Changes

- Fixes #4928 
- Replaced MUI modal with custom DialogModal Component in `AssetImportModal.tsx`
@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Screenshot
![image](https://user-images.githubusercontent.com/40627011/223627643-7dfff929-21e0-4517-8b37-2c75fd6489ec.png)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
