### PR TITLE
Uninstall and replaces all Material UI icons with Care Icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@headlessui/react": "^1.7.3",
         "@loadable/component": "^5.15.0",
         "@material-ui/core": "^4.11.4",
-        "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.58",
         "@material-ui/pickers": "^3.3.10",
         "@material-ui/styles": "^4.11.4",
@@ -7956,29 +7955,6 @@
         "url": "https://opencollective.com/material-ui"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/icons": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.3.tgz",
-      "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@material-ui/core": "^4.0.0",
         "@types/react": "^16.8.6 || ^17.0.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
@@ -52604,14 +52580,6 @@
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0 || ^17.0.0",
         "react-transition-group": "^4.4.0"
-      }
-    },
-    "@material-ui/icons": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.3.tgz",
-      "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
-      "requires": {
-        "@babel/runtime": "^7.4.4"
       }
     },
     "@material-ui/lab": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@headlessui/react": "^1.7.3",
     "@loadable/component": "^5.15.0",
     "@material-ui/core": "^4.11.4",
-    "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/pickers": "^3.3.10",
     "@material-ui/styles": "^4.11.4",

--- a/src/Components/Common/DateRangePicker.tsx
+++ b/src/Components/Common/DateRangePicker.tsx
@@ -1,10 +1,10 @@
 import { Box } from "@material-ui/core";
-import { Close } from "@material-ui/icons";
 import moment from "moment";
 import React from "react";
 import { DateRangePicker as DateRange } from "react-dates";
 import "react-dates/initialize";
 import "react-dates/lib/css/_datepicker.css";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 interface IDateRangePickerProps {
   label?: string;
@@ -55,7 +55,7 @@ export const DateRangePicker: React.FC<IDateRangePickerProps> = ({
         regular={size === "regular"}
         block
         displayFormat="DD/MM/yyyy"
-        customCloseIcon={<Close />}
+        customCloseIcon={<CareIcon className="care-l-multiply" />}
       />
     </Box>
   );

--- a/src/Components/Common/GLocationPicker.tsx
+++ b/src/Components/Common/GLocationPicker.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Wrapper, Status } from "@googlemaps/react-wrapper";
 import { deepEqual } from "../../Common/utils";
 import { isLatLngLiteral } from "@googlemaps/typescript-guards";
-import PersonPinIcon from "@material-ui/icons/PersonPin";
 import Spinner from "./Spinner";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import useConfig from "../../Common/hooks/useConfig";
@@ -222,7 +221,7 @@ const Map: React.FC<MapProps> = ({
               )
             }
           >
-            <PersonPinIcon />
+            <CareIcon className="care-l-user-location text-2xl fill-black" />
           </div>
         )}
       </>

--- a/src/Components/Common/LanguageSelector.tsx
+++ b/src/Components/Common/LanguageSelector.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { useTranslation } from "react-i18next";
 import { LANGUAGE_NAMES } from "../../Locale/config";
 import { classNames } from "../../Utils/utils";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 export const LanguageSelector = (props: any) => {
   const { i18n } = useTranslation();
@@ -38,7 +38,7 @@ export const LanguageSelector = (props: any) => {
         ))}
       </select>
       <div className="absolute right-0 mr-1 z-10 h-auto w-8 pointer-events-none">
-        <ExpandMoreIcon className={props.className} />
+        <CareIcon className={`care-l-angle-down text-xl ${props.className}`} />
       </div>
     </div>
   );

--- a/src/Components/Common/components/SelectMenu.tsx
+++ b/src/Components/Common/components/SelectMenu.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import { Listbox, Transition } from "@headlessui/react";
-import { Check, KeyboardArrowDown } from "@material-ui/icons";
+import CareIcon from "../../../CAREUI/icons/CareIcon";
 
 type Props<T> = {
   options: {
@@ -47,12 +47,12 @@ export default function SelectMenu<T>(props: Props<T>) {
               <div className="relative z-0 flex w-full">
                 <div className="relative flex-1 flex items-center py-2 pl-3 pr-4 border border-transparent rounded-l focus:outline-none focus:z-10">
                   {selected.value && (
-                    <Check className="h-5 w-5" aria-hidden="true" />
+                    <CareIcon className="h-5 w-5 care-l-check" />
                   )}
                   <p className="ml-2.5 text-sm font-medium">{selected.title}</p>
                 </div>
                 <div className="items-center p-2 rounded-r text-sm font-medium focus:outline-none focus:z-10">
-                  <KeyboardArrowDown className="h-5 w-5" aria-hidden="true" />
+                  <CareIcon className="h-5 w-5 care-l-angle-down" />
                 </div>
               </div>
             </Listbox.Button>
@@ -98,7 +98,7 @@ export default function SelectMenu<T>(props: Props<T>) {
                                 active ? "text-white" : "text-primary-500"
                               }`}
                             >
-                              <Check className="h-5 w-5" aria-hidden="true" />
+                              <CareIcon className="h-5 w-5 care-l-check text-xl" />
                             </span>
                           ) : null}
                         </div>

--- a/src/Components/Common/utils/HelpToolTip.tsx
+++ b/src/Components/Common/utils/HelpToolTip.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Tooltip from "@material-ui/core/Tooltip";
-import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
+import CareIcon from "../../../CAREUI/icons/CareIcon";
 
 export default function HelpToolTip(props: any) {
   const { text, link, place = "right" } = props;
@@ -23,7 +23,7 @@ export default function HelpToolTip(props: any) {
       arrow
       placement={place}
     >
-      <HelpOutlineIcon></HelpOutlineIcon>
+      <CareIcon className="care-l-question-circle text-2xl" />
     </Tooltip>
   );
 }

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -7,7 +7,6 @@ import {
 } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
 import * as Notification from "../../Utils/Notifications.js";
-import CropFreeIcon from "@material-ui/icons/CropFree";
 import PageTitle from "../Common/PageTitle";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { validateEmailAddress } from "../../Common/validation";
@@ -17,7 +16,6 @@ import {
 } from "../Common/HelperInputFields";
 import { AssetClass, AssetData, AssetType } from "../Assets/AssetTypes";
 import loadable from "@loadable/component";
-import { LocationOnOutlined } from "@material-ui/icons";
 import { navigate } from "raviger";
 import QrReader from "react-qr-reader";
 import { parseQueryParams } from "../../Utils/primitives";
@@ -31,6 +29,7 @@ import TextFormField from "../Form/FormFields/TextFormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 import useAppHistory from "../../Common/hooks/useAppHistory";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -399,7 +398,7 @@ const AssetCreate = (props: AssetProps) => {
         <section className="text-center">
           <h1 className="text-6xl flex items-center flex-col py-10">
             <div className="p-5 rounded-full flex items-center justify-center bg-gray-200 w-40 h-40">
-              <LocationOnOutlined fontSize="inherit" color="primary" />
+              <CareIcon className="care-l-map-marker text-green-600" />
             </div>
           </h1>
           <p className="text-gray-600">
@@ -692,7 +691,9 @@ const AssetCreate = (props: AssetProps) => {
                       margin="dense"
                       value={qrCodeId}
                       onChange={(e) => setQrCodeId(e.target.value)}
-                      actionIcon={<CropFreeIcon className="cursor-pointer" />}
+                      actionIcon={
+                        <CareIcon className="care-l-focus cursor-pointer text-lg" />
+                      }
                       action={() => setIsScannerActive(true)}
                       errors={state.errors.qr_code_id}
                     />

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -9,7 +9,6 @@ import {
   partialUpdateAssetBed,
   deleteAssetBed,
 } from "../../../Redux/actions";
-import RefreshIcon from "@material-ui/icons/Refresh";
 import { getCameraPTZ } from "../../../Common/constants";
 import {
   StreamStatus,
@@ -32,6 +31,7 @@ import { BedSelect } from "../../Common/BedSelect";
 import { BedModel } from "../models";
 import { TextInputField } from "../../Common/HelperInputFields";
 import useWindowDimensions from "../../../Common/hooks/useWindowDimensions";
+import CareIcon from "../../../CAREUI/icons/CareIcon";
 
 const LiveFeed = (props: any) => {
   const middlewareHostname =
@@ -637,7 +637,7 @@ const LiveFeed = (props: any) => {
                     fetchCameraPresets();
                   }}
                 >
-                  <RefreshIcon /> Refresh
+                  <CareIcon className="care-l-redo text-lg h-4" /> Refresh
                 </button>
               )}
             </div>

--- a/src/Components/Facility/Consultations/NutritionPlots.tsx
+++ b/src/Components/Facility/Consultations/NutritionPlots.tsx
@@ -3,12 +3,11 @@ import { useDispatch } from "react-redux";
 import { statusType, useAbortableEffect } from "../../../Common/utils";
 import { dailyRoundsAnalyse } from "../../../Redux/actions";
 import { LinePlot } from "./components/LinePlot";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import { StackedLinePlot } from "./components/StackedLinePlot";
 import Pagination from "../../Common/Pagination";
 import { PAGINATION_LIMIT } from "../../../Common/constants";
 import { formatDate } from "../../../Utils/utils";
+import CareIcon from "../../../CAREUI/icons/CareIcon";
 
 export const NutritionPlots = (props: any) => {
   const { facilityId, patientId, consultationId } = props;
@@ -191,7 +190,11 @@ export const NutritionPlots = (props: any) => {
           onClick={() => setShowIO(!showIO)}
         >
           <div> IO Balance Plots</div>
-          {showIO ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          {showIO ? (
+            <CareIcon className="care-l-angle-up text-2xl font-bold" />
+          ) : (
+            <CareIcon className="care-l-angle-down text-2xl font-bold" />
+          )}
         </div>
 
         <div
@@ -229,7 +232,11 @@ export const NutritionPlots = (props: any) => {
           onClick={() => setShowIntake(!showIntake)}
         >
           <div>Intake</div>
-          {showIntake ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          {showIntake ? (
+            <CareIcon className="care-l-angle-up text-2xl font-bold" />
+          ) : (
+            <CareIcon className="care-l-angle-down text-2xl font-bold" />
+          )}
         </div>
         <div className={showIntake ? "grid md:grid-cols-2 gap-4" : "hidden"}>
           <div className="pt-4 px-4 bg-white border rounded-lg md:col-span-2">
@@ -332,7 +339,11 @@ export const NutritionPlots = (props: any) => {
           onClick={() => setShowOutput(!showOutput)}
         >
           <div> Output</div>
-          {showOutput ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          {showOutput ? (
+            <CareIcon className="care-l-angle-up text-2xl font-bold" />
+          ) : (
+            <CareIcon className="care-l-angle-down text-2xl font-bold" />
+          )}
         </div>
         <div
           className={

--- a/src/Components/Facility/FacilityUsers.tsx
+++ b/src/Components/Facility/FacilityUsers.tsx
@@ -16,13 +16,13 @@ import { USER_TYPES, RESULTS_PER_PAGE_LIMIT } from "../../Common/constants";
 import { FacilityModel } from "../Facility/models";
 
 import { IconButton, CircularProgress } from "@material-ui/core";
-import CloseIcon from "@material-ui/icons/Close";
 import LinkFacilityDialog from "../Users/LinkFacilityDialog";
 import UserDeleteDialog from "../Users/UserDeleteDialog";
 import * as Notification from "../../Utils/Notifications.js";
 import UserDetails from "../Common/UserDetails";
 import UnlinkFacilityDialog from "../Users/UnlinkFacilityDialog";
 import { classNames } from "../../Utils/utils";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -246,7 +246,7 @@ export default function FacilityUsers(props: any) {
                     })
                   }
                 >
-                  <CloseIcon />
+                  <CareIcon className="care-l-multiply text-xl font-bold" />
                 </IconButton>
               </div>
             </div>

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -50,8 +50,6 @@ import { DupPatientModel } from "../Facility/models";
 import { PatientModel } from "./models";
 import TransferPatientDialog from "../Facility/TransferPatientDialog";
 import { validatePincode } from "../../Common/validation";
-import { InfoOutlined } from "@material-ui/icons";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { getPincodeDetails, includesIgnoreCase } from "../../Utils/utils";
 
 const Loading = loadable(() => import("../Common/Loading"));
@@ -1043,8 +1041,8 @@ export const PatientRegister = (props: PatientRegisterProps) => {
       <div className="mt-4">
         <div className="bg-purple-100 text-purple-800 p-4 font-semibold text-xs my-8 rounded mx-4">
           <div className="text-lg font-bold flex items-center mb-1">
-            <InfoOutlined className="mr-2" /> Please enter the correct date of
-            birth for the patient
+            <CareIcon className=" care-l-info-circle text-2xl font-bold mr-1" />{" "}
+            Please enter the correct date of birth for the patient
           </div>
           <p className="text-sm text-black font-normal">
             Each patient in the system is uniquely identifiable by the number
@@ -1486,7 +1484,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   <Card elevation={0} className="mb-8 rounded">
                     <AccordionV2
                       className="mt-2 lg:mt-0 md:mt-0 bg-white shadow-sm rounded-lg p-3 relative"
-                      expandIcon={<ExpandMoreIcon />}
+                      expandIcon={
+                        <CareIcon className="care-l-angle-down text-2xl font-bold" />
+                      }
                       title={
                         <h1 className="font-bold text-purple-500 text-left text-xl">
                           COVID Details

--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -1,5 +1,4 @@
 import { CircularProgress } from "@material-ui/core";
-import WarningRoundedIcon from "@material-ui/icons/WarningRounded";
 import { make as SlideOver } from "../Common/SlideOver.gen";
 import SampleFilter from "./SampleFilters";
 import { navigate } from "raviger";
@@ -26,6 +25,7 @@ import { formatDate } from "../../Utils/utils";
 import SearchInput from "../Form/SearchInput";
 import useFilters from "../../Common/hooks/useFilters";
 import { ExportButton } from "../Common/Export";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
@@ -232,7 +232,7 @@ export default function SampleViewAdmin() {
                       Contact:{" "}
                     </span>
                     Confirmed carrier
-                    <WarningRoundedIcon className="text-red-500"></WarningRoundedIcon>
+                    <CareIcon className="care-l-exclamation-triangle text-red-500 text-xl font-bold" />
                   </div>
                 )}
                 {item.patient_has_suspected_contact &&
@@ -242,7 +242,7 @@ export default function SampleViewAdmin() {
                         Contact:{" "}
                       </span>
                       Suspected carrier
-                      <WarningRoundedIcon className="text-yellow-500"></WarningRoundedIcon>
+                      <CareIcon className="care-l-exclamation-triangle text-xl font-bold text-yellow-500" />
                     </div>
                   )}
                 {item.has_sari && (
@@ -251,14 +251,14 @@ export default function SampleViewAdmin() {
                       SARI:{" "}
                     </span>
                     Severe Acute Respiratory illness
-                    <WarningRoundedIcon className="text-orange-500"></WarningRoundedIcon>
+                    <CareIcon className="care-l-exclamation-triangle text-xl font-bold text-orange-500" />
                   </div>
                 )}
                 {item.has_ari && !item.has_sari && (
                   <div>
                     <span className="font-semibold leading-relaxed">ARI: </span>
                     Acute Respiratory illness
-                    <WarningRoundedIcon className="text-yellow-500"></WarningRoundedIcon>
+                    <CareIcon className=" care-l-exclamation-triangle text-xl font-bold text-yellow-500" />
                   </div>
                 )}
               </div>

--- a/src/Components/Patient/UpdateStatusDialog.tsx
+++ b/src/Components/Patient/UpdateStatusDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogContent,
   DialogTitle,
 } from "@material-ui/core";
-import CloudUploadOutlineIcon from "@material-ui/icons/CloudUpload";
 import React, { useEffect, useState, useReducer } from "react";
 import axios from "axios";
 import {
@@ -19,6 +18,7 @@ import { createUpload } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
 import { header_content_type, LinearProgressWithLabel } from "./FileUpload";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 interface Props {
   sample: SampleTestModel;
@@ -241,7 +241,7 @@ const UpdateStatusDialog = (props: Props) => {
                   onClick={handleUpload}
                   disabled={uploadDone}
                 >
-                  <CloudUploadOutlineIcon>save</CloudUploadOutlineIcon>
+                  <CareIcon className="care-l-cloud-upload text-2xl font-bold" />
                   <span>Upload</span>
                 </Submit>
               </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #5049 
- Uninstalls `@material-ui/icons`

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
