### PR TITLE
Add owner tag to thank you workflow

### DIFF
--- a/.github/workflows/thank-you.yml
+++ b/.github/workflows/thank-you.yml
@@ -31,16 +31,13 @@ jobs:
               repo: context.repo.repo,
             })
 
-            const { assignees } = result.data
-
-            if (assignees.length == 0) {
-              await github.rest.issues.createComment({ ...options, body: thankyouNote })
-              return
-            }
+            const { assignees, user } = result.data
 
             const assignees_tagged = assignees.map((user) => '@' + user.login).join(' ')
-            await github.rest.issues.createComment({
-              ...options,
-              body: `${assignees_tagged} ${thankyouNote}`,
-            })
+            const owner_tagged = '@' + user.login
 
+            if (assignees.length == 0) {
+              await github.rest.issues.createComment({ ...options, body: `${owner_tagged} ${thankyouNote}` })
+            } else {
+              await github.rest.issues.createComment({ ...options, body: `${assignees_tagged} ${owner_tagged} ${thankyouNote}` })
+            }


### PR DESCRIPTION
This PR updates the "Say thanks for the contributors" workflow to include a tag for the owner of the PR in the thank you note comment. This is to acknowledge the owner's contributions and show appreciation for their efforts.

This issue was initially reported by @rithviknishad 