### PR TITLE
Fix for Rhythm field not updating in Daily Rounds

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -918,7 +918,13 @@ export const DailyRounds = (props: any) => {
                           <SelectField
                             name="rhythm"
                             variant="standard"
-                            value={state.form.rhythm}
+                            value={
+                              RHYTHM_CHOICES.find(
+                                (choice) =>
+                                  choice.text.toUpperCase() ===
+                                  state.form.rhythm
+                              )?.id
+                            }
                             options={RHYTHM_CHOICES}
                             onChange={handleChange}
                             errors={state.errors.rhythm}


### PR DESCRIPTION
Fixes #5075

This PR fixes an issue where the Rhythm field in Daily Rounds was not being updated in the frontend, and always defaulting to "Unknown" even if a value for it was set.

![image](https://user-images.githubusercontent.com/3626859/224025391-fdb09047-9297-42a5-b796-38b977e8165c.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
