### PR TITLE
Add patient name and bed number to Patient ordering

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -171,6 +171,20 @@ export const PATIENT_FILTER_ORDER: (OptionsType & { order: string })[] = [
   { id: 4, text: "-modified_date", desc: "Modified Date", order: "Descending" },
   { id: 5, text: "review_time", desc: "Review Time", order: "Ascending" },
   { id: 6, text: "-review_time", desc: "Review Time", order: "Descending" },
+  { id: 7, text: "name", desc: "Patient Name", order: "Ascending" },
+  { id: 8, text: "-name", desc: "Patient Name", order: "Descending" },
+  {
+    id: 7,
+    text: "facility__name,last_consultation__current_bed__bed__name",
+    desc: "Bed Number",
+    order: "Ascending",
+  },
+  {
+    id: 8,
+    text: "facility__name,-last_consultation__current_bed__bed__name",
+    desc: "Bed Number",
+    order: "Descending",
+  },
 ];
 
 export const getBedTypes = ({


### PR DESCRIPTION
Fixes #5094

- When using the bed number ordering, the entries are also grouped by the facility name as mentioned in the issue

![image](https://user-images.githubusercontent.com/3626859/224698286-7ecff8e2-4642-43d5-955b-4f79819d5b68.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
