### PR TITLE
Fixed excess scrolling issue in summary tab in patient consultation

### DIFF
--- a/src/Components/Facility/Consultations/PrimaryParametersPlot.tsx
+++ b/src/Components/Facility/Consultations/PrimaryParametersPlot.tsx
@@ -141,11 +141,11 @@ export const PrimaryParametersPlot = ({
   });
   return (
     <div>
-      <div className="grid grid-row-1 md:grid-cols-2 gap-4">
-        <div className="md:w-full w-screen m-2 pt-4 px-4 bg-white border rounded-lg shadow">
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className="md:w-full overflow-x-auto m-2 pt-4 px-4 bg-white border rounded-lg shadow">
           <StackedLinePlot title="BP" xData={dates} yData={BPData} />
         </div>
-        <div className="md:w-full w-screen pt-4 m-2 px-4 bg-white border rounded-lg shadow">
+        <div className="md:w-full overflow-x-auto pt-4 m-2 px-4 bg-white border rounded-lg shadow">
           <LinePlot
             title="Pulse"
             name="Pulse"
@@ -155,7 +155,7 @@ export const PrimaryParametersPlot = ({
             high={100}
           />
         </div>
-        <div className="md:w-full w-screen pt-4 m-2 px-4 bg-white border rounded-lg shadow">
+        <div className="md:w-full overflow-x-auto pt-4 m-2 px-4 bg-white border rounded-lg shadow">
           <LinePlot
             title="Temperature (F)"
             name="Temperature"
@@ -163,7 +163,7 @@ export const PrimaryParametersPlot = ({
             yData={yAxisData("temperature")}
           />
         </div>
-        <div className="md:w-full w-screen pt-4 m-2 px-4 bg-white border rounded-lg shadow">
+        <div className="md:w-full overflow-x-auto pt-4 m-2 px-4 bg-white border rounded-lg shadow">
           <LinePlot
             title="Resp"
             name="Resp"
@@ -171,10 +171,10 @@ export const PrimaryParametersPlot = ({
             yData={yAxisData("resp")}
           />
         </div>
-        <div className="md:w-full w-screen pt-4 m-2 px-4 bg-white border rounded-lg shadow">
+        <div className="md:w-full overflow-x-auto pt-4 m-2 px-4 bg-white border rounded-lg shadow">
           <StackedLinePlot title="Insulin" xData={dates} yData={InsulinData} />
         </div>
-        <div className="md:w-full w-screen pt-4 m-2 px-4 bg-white border rounded-lg shadow">
+        <div className="md:w-full overflow-x-auto pt-4 m-2 px-4 bg-white border rounded-lg shadow">
           <LinePlot
             title="SPO2 (%)"
             name="spo2"
@@ -184,7 +184,7 @@ export const PrimaryParametersPlot = ({
             high={100}
           />
         </div>
-        <div className="md:w-full w-screen pt-4 m-2 px-4 bg-white border rounded-lg shadow">
+        <div className="md:w-full overflow-x-auto pt-4 m-2 px-4 bg-white border rounded-lg shadow">
           <LinePlot
             title="Ventilator FIO2 (%)"
             name="fio2"
@@ -194,7 +194,7 @@ export const PrimaryParametersPlot = ({
             high={60}
           />
         </div>
-        <div className="md:w-full w-screen pt-4 m-2 px-4 bg-white border rounded-lg shadow h-80">
+        <div className="md:w-full overflow-x-auto pt-4 m-2 px-4 bg-white border rounded-lg shadow h-80">
           <h3 className="text-sm px-3 mb-2">Rhythm</h3>
           <div className="flow-root m-2 overflow-y-scroll h-64">
             <ul role="list" className="-mb-8">


### PR DESCRIPTION
## Proposed Changes

- Fixes #5117
- [x] the summary tab cards should be properly fit in mobile view.
- [x] the rhythm card should be fully visible in summary tab

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
