### PR TITLE
Add loading spinner beside add button

### DIFF
--- a/src/Components/Users/SkillsSlideOver.Components.tsx
+++ b/src/Components/Users/SkillsSlideOver.Components.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import { classNames } from "../../Utils/utils";
+import ButtonV2 from "../Common/components/ButtonV2";
+import { SkillModel } from "./models";
+
+const SELECT_SKILLS_COPY = "Select and add some skills";
+
+export const AddSkillsPlaceholder = () => {
+  return (
+    <div className="mb-2 mt-2 flex flex-col justify-center align-middle content-center h-96">
+      <div className="w-full">
+        <img
+          src={`${process.env.PUBLIC_URL}/images/404.svg`}
+          alt="Error 404"
+          className="w-80 mx-auto"
+        />
+      </div>
+      <p className="text-lg font-semibold text-center text-primary pt-4">
+        {SELECT_SKILLS_COPY}
+      </p>
+    </div>
+  );
+};
+
+type SkillsArrayProps = {
+  isLoading: boolean;
+  skills: SkillModel[];
+  authorizeForAddSkill: boolean;
+  setDeleteSkill: (skill: SkillModel) => void;
+};
+
+export const SkillsArray = ({
+  isLoading,
+  skills,
+  authorizeForAddSkill,
+  setDeleteSkill,
+}: SkillsArrayProps) => {
+  return (
+    <React.Fragment>
+      {skills.map((skill, i) => (
+        <div
+          key={`facility_${i}`}
+          className={classNames(
+            "relative py-5 px-4 lg:px-8 hover:bg-gray-200 focus:bg-gray-200 transition ease-in-out duration-200 rounded md:rounded-lg cursor-pointer"
+          )}
+        >
+          <div className="flex justify-between">
+            <div className="text-lg font-bold">{skill.skill_object.name}</div>
+            <div>
+              <ButtonV2
+                size="small"
+                variant="danger"
+                ghost={true}
+                disabled={isLoading || !authorizeForAddSkill}
+                onClick={() => setDeleteSkill(skill)}
+              >
+                <CareIcon className="care-l-times text-lg" />
+              </ButtonV2>
+            </div>
+          </div>
+        </div>
+      ))}
+    </React.Fragment>
+  );
+};

--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -117,9 +117,14 @@ export default ({ show, setShow, username }: IProps) => {
               <ButtonV2
                 disabled={!authorizeForAddSkill}
                 onClick={() => addSkill(username, selectedSkill)}
+                className="w-6rem"
               >
                 {/* Replace "Add" in button with CircularProgress */}
-                {isLoading ? <CircularProgress /> : t("add")}
+                {isLoading ? (
+                  <CircularProgress className="h-5 w-5" />
+                ) : (
+                  t("add")
+                )}
               </ButtonV2>
               {!authorizeForAddSkill && (
                 <span className="tooltip-text tooltip-bottom -translate-x-24 translate-y-2">

--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import SlideOverCustom from "../../CAREUI/interactive/SlideOver";
-import { classNames } from "../../Utils/utils";
 import { SkillModel, SkillObjectModel } from "../Users/models";
 import { SkillSelect } from "../Common/SkillSelect";
 import {
@@ -13,14 +12,21 @@ import * as Notification from "../../Utils/Notifications.js";
 import { useDispatch } from "react-redux";
 import ButtonV2 from "../Common/components/ButtonV2";
 import AuthorizeFor from "../../Utils/AuthorizeFor";
-import CareIcon from "../../CAREUI/icons/CareIcon";
 import { useIsAuthorized } from "../../Common/hooks/useIsAuthorized";
+import {
+  AddSkillsPlaceholder,
+  SkillsArray,
+} from "./SkillsSlideOver.Components";
+import Spinner from "../Common/Spinner";
 
 interface IProps {
   username: string;
   show: boolean;
   setShow: (show: boolean) => void;
 }
+
+const CONTACT_YOUR_ADMIN_COPY = "Contact your admin to add skills";
+const ADD_COPY = "Add";
 
 export default ({ show, setShow, username }: IProps) => {
   const [skills, setSkills] = useState<SkillModel[]>([]);
@@ -79,6 +85,8 @@ export default ({ show, setShow, username }: IProps) => {
     AuthorizeFor(["DistrictAdmin", "StateAdmin"])
   );
 
+  const hasSkills = useMemo(() => skills.length > 0, [skills]);
+
   return (
     <div className="col-span-4">
       {deleteSkill && (
@@ -113,56 +121,31 @@ export default ({ show, setShow, username }: IProps) => {
                 disabled={!authorizeForAddSkill}
                 onClick={() => addSkill(username, selectedSkill)}
               >
-                Add
+                {ADD_COPY}
               </ButtonV2>
+              {isLoading ? <Spinner /> : null}
               {!authorizeForAddSkill && (
                 <span className="tooltip-text tooltip-bottom -translate-x-24 translate-y-2">
-                  Contact your admin to add skills
+                  {CONTACT_YOUR_ADMIN_COPY}
                 </span>
               )}
             </div>
-            <div className="mb-2 mt-4">
-              {skills.length === 0 ? (
-                <div className="mb-2 mt-2 flex flex-col justify-center align-middle content-center h-96">
-                  <div className="w-full">
-                    <img
-                      src={`${process.env.PUBLIC_URL}/images/404.svg`}
-                      alt="Error 404"
-                      className="w-80 mx-auto"
-                    />
-                  </div>
-                  <p className="text-lg font-semibold text-center text-primary pt-4">
-                    Select and add some skills
-                  </p>
-                </div>
-              ) : (
-                skills.map((skill, i) => (
-                  <div
-                    key={`facility_${i}`}
-                    className={classNames(
-                      "relative py-5 px-4 lg:px-8 hover:bg-gray-200 focus:bg-gray-200 transition ease-in-out duration-200 rounded md:rounded-lg cursor-pointer"
-                    )}
-                  >
-                    <div className="flex justify-between">
-                      <div className="text-lg font-bold">
-                        {skill.skill_object.name}
-                      </div>
-                      <div>
-                        <ButtonV2
-                          size="small"
-                          variant="danger"
-                          ghost={true}
-                          disabled={isLoading || !authorizeForAddSkill}
-                          onClick={() => setDeleteSkill(skill)}
-                        >
-                          <CareIcon className="care-l-times text-lg" />
-                        </ButtonV2>
-                      </div>
-                    </div>
-                  </div>
-                ))
-              )}
-            </div>
+            {/* While loading skills, we want to hide the skills panel because we
+            are showing the loading spinner next to the add button */}
+            {isLoading ? null : (
+              <div className="mb-2 mt-4">
+                {hasSkills ? (
+                  <SkillsArray
+                    isLoading={isLoading}
+                    skills={skills}
+                    authorizeForAddSkill={authorizeForAddSkill}
+                    setDeleteSkill={setDeleteSkill}
+                  />
+                ) : (
+                  <AddSkillsPlaceholder />
+                )}
+              </div>
+            )}
           </div>
         </div>
       </SlideOverCustom>

--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -13,11 +13,9 @@ import { useDispatch } from "react-redux";
 import ButtonV2 from "../Common/components/ButtonV2";
 import AuthorizeFor from "../../Utils/AuthorizeFor";
 import { useIsAuthorized } from "../../Common/hooks/useIsAuthorized";
-import {
-  AddSkillsPlaceholder,
-  SkillsArray,
-} from "./SkillsSlideOver.Components";
-import Spinner from "../Common/Spinner";
+import { AddSkillsPlaceholder, SkillsArray } from "./SkillsSlideOverComponents";
+import { useTranslation } from "react-i18next";
+import CircularProgress from "../Common/components/CircularProgress";
 
 interface IProps {
   username: string;
@@ -25,10 +23,9 @@ interface IProps {
   setShow: (show: boolean) => void;
 }
 
-const CONTACT_YOUR_ADMIN_COPY = "Contact your admin to add skills";
-const ADD_COPY = "Add";
-
 export default ({ show, setShow, username }: IProps) => {
+  /* added const {t} hook here and relevant text to Common.json to avoid eslint error  */
+  const { t } = useTranslation();
   const [skills, setSkills] = useState<SkillModel[]>([]);
   const [selectedSkill, setSelectedSkill] = useState<SkillObjectModel | null>(
     null
@@ -121,18 +118,21 @@ export default ({ show, setShow, username }: IProps) => {
                 disabled={!authorizeForAddSkill}
                 onClick={() => addSkill(username, selectedSkill)}
               >
-                {ADD_COPY}
+                {/* Replace "Add" in button with CircularProgress */}
+                {isLoading ? <CircularProgress /> : t("add")}
               </ButtonV2>
-              {isLoading ? <Spinner /> : null}
               {!authorizeForAddSkill && (
                 <span className="tooltip-text tooltip-bottom -translate-x-24 translate-y-2">
-                  {CONTACT_YOUR_ADMIN_COPY}
+                  {t("contact_your_admin_to_add_skills")}
                 </span>
               )}
             </div>
-            {/* While loading skills, we want to hide the skills panel because we
-            are showing the loading spinner next to the add button */}
-            {isLoading ? null : (
+            {/* While loading skills, we display an additional circular progress to show we are fetching the information*/}
+            {isLoading ? (
+              <div className="mt-4 flex justify-center">
+                <CircularProgress />
+              </div>
+            ) : (
               <div className="mb-2 mt-4">
                 {hasSkills ? (
                   <SkillsArray

--- a/src/Components/Users/SkillsSlideOverComponents.tsx
+++ b/src/Components/Users/SkillsSlideOverComponents.tsx
@@ -1,12 +1,12 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { classNames } from "../../Utils/utils";
 import ButtonV2 from "../Common/components/ButtonV2";
 import { SkillModel } from "./models";
 
-const SELECT_SKILLS_COPY = "Select and add some skills";
-
 export const AddSkillsPlaceholder = () => {
+  const { t } = useTranslation();
   return (
     <div className="mb-2 mt-2 flex flex-col justify-center align-middle content-center h-96">
       <div className="w-full">
@@ -17,7 +17,7 @@ export const AddSkillsPlaceholder = () => {
         />
       </div>
       <p className="text-lg font-semibold text-center text-primary pt-4">
-        {SELECT_SKILLS_COPY}
+        {t("select_skills")}
       </p>
     </div>
   );

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -110,5 +110,8 @@
   "submit": "Submit",
   "camera": "Camera",
   "submitting": "Submitting",
-  "view_details": "View Details"
+  "view_details": "View Details",
+  "select_skills": "Select and add some skills",
+  "contact_your_admin_to_add_skills": "Contact your admin to add skills",
+  "add": "Add"
 }


### PR DESCRIPTION
## Proposed Changes
Hi, @coronasafe/code-reviewers !
- Fixes issue https://github.com/coronasafe/care_fe/issues/5119
- Implemented loading spinner next to add button in add user skills panel
- Refactored SkillsSlideOver component to make it easier to read
- Fixed eslint warnings 

<img width="1080" alt="LoadingSpinner" src="https://user-images.githubusercontent.com/109168765/226122030-2fb010df-e446-4701-9eed-fe9c3bd27d35.png">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.

- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
