### PR TITLE
Center aligned loader on samples page

### DIFF
--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -306,7 +306,11 @@ export default function SampleViewAdmin() {
   }
 
   if (isLoading || !sample) {
-    manageSamples = <Loading />;
+    manageSamples = (
+      <div className="flex justify-center w-full">
+        <Loading />
+      </div>
+    );
   } else if (sample && sample.length) {
     manageSamples = (
       <>


### PR DESCRIPTION
Fixes #5142 

Center-aligned the loader on the samples page
http://localhost:4000/sample
![image](https://user-images.githubusercontent.com/70687348/226817319-52035168-d9a3-47ac-860b-940b6dc70b93.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
