### PR TITLE
Mark all components from HelperInputFields as Deprecated

### DIFF
--- a/src/Components/Auth/ResetPassword.tsx
+++ b/src/Components/Auth/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ErrorHelperText } from "../Common/HelperInputFields";
+import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import { useDispatch } from "react-redux";
 import * as Notification from "../../Utils/Notifications.js";
 import { postResetPassword, checkResetToken } from "../../Redux/actions";
@@ -139,7 +139,7 @@ export const ResetPassword = (props: any) => {
                 onChange={handleChange}
                 error={errors.confirm}
               />
-              <ErrorHelperText error={errors.token} />
+              <LegacyErrorHelperText error={errors.token} />
             </div>
             <div className="sm:flex sm:justify-between grid p-4">
               <Cancel onClick={() => navigate("/login")} />

--- a/src/Components/Common/DiagnosisSelect.tsx
+++ b/src/Components/Common/DiagnosisSelect.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useDispatch } from "react-redux";
 import { listICD11Diagnosis } from "../../Redux/actions";
-import { AutoCompleteAsyncField } from "./HelperInputFields";
+import { LegacyAutoCompleteAsyncField } from "./HelperInputFields";
 import { debounce } from "lodash";
 import { ICD11DiagnosisModel } from "../Facility/models";
 
@@ -56,7 +56,7 @@ export const DiagnosisSelect = (props: DiagnosisSelectProps) => {
   );
 
   return (
-    <AutoCompleteAsyncField
+    <LegacyAutoCompleteAsyncField
       name={name}
       multiple={true}
       variant="outlined"

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -143,7 +143,10 @@ export const LegacyTextInputField = (props: TextFieldPropsExtended) => {
   );
 };
 
-export const ActionTextInputField = (props: ActionTextFieldProps) => {
+/**
+ * Deprecated. Use `TextFormField` instead.
+ */
+export const LegacyActionTextInputField = (props: ActionTextFieldProps) => {
   const { onChange, type, errors, onKeyDown } = props;
   const inputType = type === "number" || type === "float" ? "text" : type;
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -191,7 +191,10 @@ export const LegacyActionTextInputField = (props: ActionTextFieldProps) => {
   );
 };
 
-export const MultilineInputField = (props: TextFieldPropsExtended) => {
+/**
+ * Deprecated. Use `TextAreaFormField` instead.
+ */
+export const LegacyMultilineInputField = (props: TextFieldPropsExtended) => {
   const { errors } = props;
   return (
     <div>

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -227,7 +227,10 @@ export const LegacyDateTimeFiled = (props: DateInputFieldProps) => {
   );
 };
 
-export const DateInputField = (props: DateInputFieldProps) => {
+/**
+ * Deprecated. Use `DateFormField` instead.
+ */
+export const LegacyDateInputField = (props: DateInputFieldProps) => {
   const {
     value,
     onChange,

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -567,7 +567,7 @@ export const LegacyAutoCompleteAsyncField = (
 /**
  * Deprecated. Use `PhoneNumberFormField` instead.
  */
-export const PhoneNumberField = (props: any) => {
+export const LegacyPhoneNumberField = (props: any) => {
   const {
     label,
     placeholder,

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -204,7 +204,10 @@ export const LegacyMultilineInputField = (props: TextFieldPropsExtended) => {
   );
 };
 
-export const DateTimeFiled = (props: DateInputFieldProps) => {
+/**
+ * Deprecated. Use `TextFormField` with `type="datetime-local"` instead.
+ */
+export const LegacyDateTimeFiled = (props: DateInputFieldProps) => {
   const { label, errors, onChange, value, margin, disabled, ...restProps } =
     props;
   return (

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -24,7 +24,6 @@ import {
   DatePickerProps,
   KeyboardDatePicker,
   KeyboardDateTimePicker,
-  KeyboardTimePicker,
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
@@ -261,24 +260,6 @@ export const LegacyDateInputField = (props: DateInputFieldProps) => {
         {...restProps}
       />
       <ErrorHelperText error={errors} />
-    </MuiPickersUtilsProvider>
-  );
-};
-
-export const TimeInputField = (props: any) => {
-  const { value, onChange, label } = props;
-  return (
-    <MuiPickersUtilsProvider utils={DateFnsUtils}>
-      <KeyboardTimePicker
-        margin="normal"
-        id="time-picker"
-        label={label}
-        value={value}
-        onChange={onChange}
-        KeyboardButtonProps={{
-          "aria-label": "change time",
-        }}
-      />
     </MuiPickersUtilsProvider>
   );
 };

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -357,7 +357,10 @@ export const LegacySelectField = (props: DefaultSelectInputProps) => {
   );
 };
 
-export const MultiSelectField = (props: MultiSelectInputProps) => {
+/**
+ * Deprecated. Use `MultiSelectFormField` instead.
+ */
+export const LegacyMultiSelectField = (props: MultiSelectInputProps) => {
   const {
     errors,
     options,

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -97,12 +97,6 @@ interface CheckboxProps extends Omit<FormControlLabelProps, "control"> {
   label: string;
 }
 
-interface OptionsProps {
-  options: Array<{ id: number | string; text: string }>;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
-  values: Array<{ answerId: number }>;
-}
-
 /**
  * Deprecated. Use `TextFormField` instead.
  */
@@ -277,31 +271,6 @@ export const LegacyErrorHelperText = (props: { error?: string }) => {
     >
       {error}
     </span>
-  );
-};
-
-export const ShowCheckboxOptions = (props: OptionsProps) => {
-  const { options, onChange, values } = props;
-  return (
-    <div>
-      {options.map((opt: any, i: number) => {
-        const checked = values.indexOf(opt.id) > -1;
-        return (
-          <div key={i}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={checked}
-                  value={opt.id}
-                  onChange={onChange}
-                />
-              }
-              label={opt.text}
-            />
-          </div>
-        );
-      })}
-    </div>
   );
 };
 

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -436,7 +436,10 @@ export const LegacyMultiSelectField = (props: MultiSelectInputProps) => {
   );
 };
 
-export const CheckboxField = (props: CheckboxProps) => {
+/**
+ * Deprecated.
+ */
+export const LegacyCheckboxField = (props: CheckboxProps) => {
   const { onChange, checked, name, style } = props;
   return (
     <FormControlLabel

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -450,52 +450,6 @@ export const LegacyCheckboxField = (props: CheckboxProps) => {
   );
 };
 
-interface AutoCompleteMultiFieldProps {
-  id: string;
-  options: Array<any>;
-  label: string;
-  variant: string;
-  placeholder: string;
-  errors?: string;
-  value: any;
-  onChange: (e: any, selected: any) => void;
-}
-
-export const AutoCompleteMultiField = (props: AutoCompleteMultiFieldProps) => {
-  const {
-    id,
-    options,
-    label,
-    variant,
-    placeholder,
-    errors = "",
-    onChange,
-    value,
-  } = props;
-  return (
-    <>
-      <Autocomplete
-        multiple
-        freeSolo
-        id={id}
-        options={options}
-        onChange={onChange}
-        value={value}
-        filterSelectedOptions
-        renderInput={(params: any) => (
-          <TextField
-            {...params}
-            variant={variant}
-            label={label}
-            placeholder={placeholder}
-          />
-        )}
-      />
-      <LegacyErrorHelperText error={errors} />
-    </>
-  );
-};
-
 interface AutoCompleteAsyncFieldProps {
   multiple?: boolean;
   className?: string;

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -477,7 +477,18 @@ interface AutoCompleteAsyncFieldProps {
   disabled?: boolean;
 }
 
-export const AutoCompleteAsyncField = (props: AutoCompleteAsyncFieldProps) => {
+/**
+ * Deprecated.
+ *
+ * Alternatives:
+ * - Use `useAsyncOptions` hook along with `AutocompleteFormField` or
+ * `AutocompleteMultiSelectFormField` instead.
+ * - Use `AutocompleteAsync` component directly.
+ *
+ */
+export const LegacyAutoCompleteAsyncField = (
+  props: AutoCompleteAsyncFieldProps
+) => {
   const {
     name,
     margin,

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -299,7 +299,10 @@ export const LegacyNativeSelectField = (props: any) => {
   );
 };
 
-export const SelectField = (props: DefaultSelectInputProps) => {
+/**
+ * Deprecated. Use `SelectFormField` instead.
+ */
+export const LegacySelectField = (props: DefaultSelectInputProps) => {
   const {
     options,
     optionArray,

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -274,7 +274,10 @@ export const LegacyErrorHelperText = (props: { error?: string }) => {
   );
 };
 
-export const NativeSelectField = (props: any) => {
+/**
+ * Deprecated. Use `SelectFormField` instead.
+ */
+export const LegacyNativeSelectField = (props: any) => {
   const { options, variant, label, optionKey, optionValue, ...others } = props;
   return (
     <FormControl style={{ width: "100%" }} variant={variant} margin="dense">

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -10,7 +10,6 @@ import {
   ListItemText,
   MenuItem,
   NativeSelect,
-  Radio,
   Select,
   TextField,
   TextFieldProps,
@@ -278,28 +277,6 @@ export const LegacyErrorHelperText = (props: { error?: string }) => {
     >
       {error}
     </span>
-  );
-};
-
-export const ShowRadioOptions = (props: OptionsProps) => {
-  const { options, onChange, values } = props;
-  return (
-    <div>
-      {options.map((opt: any, i: number) => {
-        const checked = values.findIndex((val: any) => val.answerId == opt.id);
-        return (
-          <div key={i}>
-            <Radio
-              checked={checked !== -1}
-              name="radioBtn"
-              value={opt.id}
-              onChange={onChange}
-            />{" "}
-            {opt.text}
-          </div>
-        );
-      })}
-    </div>
   );
 };
 

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -137,7 +137,7 @@ export const LegacyTextInputField = (props: TextFieldPropsExtended) => {
         onChange={handleChange}
         onKeyDown={handleKeyDown}
       />
-      <ErrorHelperText error={errors} />
+      <LegacyErrorHelperText error={errors} />
     </div>
   );
 };
@@ -185,7 +185,7 @@ export const LegacyActionTextInputField = (props: ActionTextFieldProps) => {
           </div>
         )}
       </div>
-      <ErrorHelperText error={errors} />
+      <LegacyErrorHelperText error={errors} />
     </div>
   );
 };
@@ -198,7 +198,7 @@ export const LegacyMultilineInputField = (props: TextFieldPropsExtended) => {
   return (
     <div>
       <TextField {...props} multiline fullWidth />
-      <ErrorHelperText error={errors} />
+      <LegacyErrorHelperText error={errors} />
     </div>
   );
 };
@@ -221,7 +221,7 @@ export const LegacyDateTimeFiled = (props: DateInputFieldProps) => {
         disabled={disabled}
         {...restProps}
       />
-      <ErrorHelperText error={errors} />
+      <LegacyErrorHelperText error={errors} />
     </MuiPickersUtilsProvider>
   );
 };
@@ -259,12 +259,16 @@ export const LegacyDateInputField = (props: DateInputFieldProps) => {
         }}
         {...restProps}
       />
-      <ErrorHelperText error={errors} />
+      <LegacyErrorHelperText error={errors} />
     </MuiPickersUtilsProvider>
   );
 };
 
-export const ErrorHelperText = (props: { error?: string }) => {
+/**
+ * Deprecated. Set `error` on the `FormField` component instead.
+ * Or use `FieldError` to break out of the design.
+ */
+export const LegacyErrorHelperText = (props: { error?: string }) => {
   const { error } = props;
   return (
     <span
@@ -396,7 +400,7 @@ export const SelectField = (props: DefaultSelectInputProps) => {
             })}
         </Select>
       </FormControl>
-      {!!errors && <ErrorHelperText error={errors} />}
+      {!!errors && <LegacyErrorHelperText error={errors} />}
     </>
   );
 };
@@ -472,7 +476,7 @@ export const MultiSelectField = (props: MultiSelectInputProps) => {
           })}
         </Select>
       </FormControl>
-      {!!errors && <ErrorHelperText error={errors} />}
+      {!!errors && <LegacyErrorHelperText error={errors} />}
     </>
   );
 };
@@ -529,7 +533,7 @@ export const AutoCompleteMultiField = (props: AutoCompleteMultiFieldProps) => {
           />
         )}
       />
-      <ErrorHelperText error={errors} />
+      <LegacyErrorHelperText error={errors} />
     </>
   );
 };
@@ -632,7 +636,7 @@ export const AutoCompleteAsyncField = (props: AutoCompleteAsyncFieldProps) => {
           />
         )}
       />
-      <ErrorHelperText error={errors} />
+      <LegacyErrorHelperText error={errors} />
     </>
   );
 };
@@ -710,7 +714,7 @@ export const PhoneNumberField = (props: any) => {
           <CareIcon className="care-l-multiply" />
         </ButtonV2>
       </div>
-      {errors && <ErrorHelperText error={errors} />}
+      {errors && <LegacyErrorHelperText error={errors} />}
     </>
   );
 };

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -105,7 +105,10 @@ interface OptionsProps {
   values: Array<{ answerId: number }>;
 }
 
-export const TextInputField = (props: TextFieldPropsExtended) => {
+/**
+ * Deprecated. Use `TextFormField` instead.
+ */
+export const LegacyTextInputField = (props: TextFieldPropsExtended) => {
   const { onChange, type, errors, onKeyDown } = props;
   const inputType = type === "number" || type === "float" ? "text" : type;
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/Components/Common/UserSelect.tsx
+++ b/src/Components/Common/UserSelect.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { getFacilityUsers } from "../../Redux/actions";
-import { AutoCompleteAsyncField } from "../Common/HelperInputFields";
+import { LegacyAutoCompleteAsyncField } from "../Common/HelperInputFields";
 import { UserModel } from "../Users/models";
 
 export const UserSelect = (props: any) => {
@@ -49,7 +49,7 @@ export const UserSelect = (props: any) => {
   }, [dispatchAction, facilityId]);
 
   return (
-    <AutoCompleteAsyncField
+    <LegacyAutoCompleteAsyncField
       freeSolo={false}
       multiple={multiple}
       variant="outlined"

--- a/src/Components/Common/UserSelect2.tsx
+++ b/src/Components/Common/UserSelect2.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import { getUserList } from "../../Redux/actions";
-import { AutoCompleteAsyncField } from "../Common/HelperInputFields";
+import { LegacyAutoCompleteAsyncField } from "../Common/HelperInputFields";
 import { UserModel } from "../Users/models";
 import { debounce } from "lodash";
 interface UserSelectProps {
@@ -74,7 +74,7 @@ export const UserSelect = (props: UserSelectProps) => {
   );
 
   return (
-    <AutoCompleteAsyncField
+    <LegacyAutoCompleteAsyncField
       name={name}
       multiple={multiple}
       variant="outlined"

--- a/src/Components/Common/components/Switch.tsx
+++ b/src/Components/Common/components/Switch.tsx
@@ -1,5 +1,5 @@
 import { FieldLabel } from "../../Form/FormFields/FormField";
-import { ErrorHelperText } from "../HelperInputFields";
+import { LegacyErrorHelperText } from "../HelperInputFields";
 
 type SwitchProps<T> = {
   name?: string;
@@ -51,7 +51,7 @@ export default function SwitchV2<T>(props: SwitchProps<T>) {
           );
         })}
       </ul>
-      <ErrorHelperText error={props.error} />
+      <LegacyErrorHelperText error={props.error} />
     </div>
   );
 }

--- a/src/Components/DeathReport/DeathReport.tsx
+++ b/src/Components/DeathReport/DeathReport.tsx
@@ -5,7 +5,7 @@ import { getPatient } from "../../Redux/actions";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { GENDER_TYPES } from "../../Common/constants";
 import {
-  TextInputField,
+  LegacyTextInputField,
   MultilineInputField,
 } from "../Common/HelperInputFields";
 import { InputLabel } from "@material-ui/core";
@@ -299,7 +299,7 @@ export default function PrintDeathReport(props: { id: string }) {
             <div className="grid grid-cols-1 mt-4 gap-10">
               <div>
                 <InputLabel htmlFor="name">Name</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="name"
                   id="name"
                   variant="outlined"
@@ -314,7 +314,7 @@ export default function PrintDeathReport(props: { id: string }) {
             <div className="grid grid-cols-2 mt-4 gap-10">
               <div>
                 <InputLabel htmlFor="age">Age</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="age"
                   id="age"
                   variant="outlined"
@@ -327,7 +327,7 @@ export default function PrintDeathReport(props: { id: string }) {
               </div>
               <div>
                 <InputLabel htmlFor="gender">Gender</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="gender"
                   id="gender"
                   variant="outlined"
@@ -355,7 +355,7 @@ export default function PrintDeathReport(props: { id: string }) {
             <div className="grid grid-cols-2 mt-4 gap-10">
               <div>
                 <InputLabel htmlFor="phone_number">Phone Number</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="phone_number"
                   id="phone_number"
                   variant="outlined"
@@ -370,7 +370,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="is_declared_positive">
                   Whether declared positive
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="is_declared_positive"
                   id="is_declared_positive"
                   variant="outlined"
@@ -387,7 +387,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="date_declared_positive">
                   Date of declaring positive
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="date_declared_positive"
                   id="date_declared_positive"
                   variant="outlined"
@@ -402,7 +402,7 @@ export default function PrintDeathReport(props: { id: string }) {
               </div>
               <div>
                 <InputLabel htmlFor="test_type">Type of test done</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="test_type"
                   id="test_type"
                   variant="outlined"
@@ -419,7 +419,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="date_of_test">
                   Date of sample collection for Covid testing
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="date_of_test"
                   id="date_of_test"
                   variant="outlined"
@@ -434,7 +434,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="date_of_result">
                   Covid confirmation date
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="date_of_result"
                   id="date_of_result"
                   variant="outlined"
@@ -449,7 +449,7 @@ export default function PrintDeathReport(props: { id: string }) {
               </div>
               <div className="col-span-1">
                 <InputLabel htmlFor="srf_id">SRF ID</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="srf_id"
                   id="srf_id"
                   variant="outlined"
@@ -466,7 +466,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="hospital_tested_in">
                   Hospital in which patient tested for SARS COV 2
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="hospital_tested_in"
                   id="hospital_tested_in"
                   variant="outlined"
@@ -481,7 +481,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="hospital_died_in">
                   Name of the hospital in which the patient died
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="hospital_died_in"
                   id="hospital_died_in"
                   variant="outlined"
@@ -498,7 +498,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="date_of_admission">
                   Date of admission
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="date_of_admission"
                   id="date_of_admission"
                   variant="outlined"
@@ -511,7 +511,7 @@ export default function PrintDeathReport(props: { id: string }) {
               </div>
               <div>
                 <InputLabel htmlFor="date_of_death">Date of death</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="date_of_death"
                   id="date_of_death"
                   variant="outlined"
@@ -528,7 +528,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="comorbidities">
                   Mention the co-morbidities if present
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="comorbidities"
                   id="comorbidities"
                   variant="outlined"
@@ -543,7 +543,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="history_clinical_course">
                   History and clinical course in the hospital
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="history_clinical_course"
                   id="history_clinical_course"
                   variant="outlined"
@@ -560,7 +560,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="brought_dead">
                   Whether brought dead
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="brought_dead"
                   id="brought_dead"
                   variant="outlined"
@@ -575,7 +575,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="home_or_cfltc">
                   If yes was the deceased brought from home/CFLTC
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="home_or_cfltc"
                   id="home_or_cfltc"
                   variant="outlined"
@@ -592,7 +592,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="is_vaccinated">
                   Whether vaccinated
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="is_vaccinated"
                   id="is_vaccinated"
                   variant="outlined"
@@ -607,7 +607,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="kottayam_confirmation_sent">
                   Whether NIV/IUBCR Kottayam confirmation sent
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="kottayam_confirmation_sent"
                   id="kottayam_confirmation_sent"
                   variant="outlined"
@@ -624,7 +624,7 @@ export default function PrintDeathReport(props: { id: string }) {
                 <InputLabel htmlFor="kottayam_sample_date">
                   Sample sent to NIV/IUCBR Kottayam on
                 </InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="kottayam_sample_date"
                   id="kottayam_sample_date"
                   variant="outlined"
@@ -637,7 +637,7 @@ export default function PrintDeathReport(props: { id: string }) {
               </div>
               <div>
                 <InputLabel htmlFor="cause_of_death">Cause of death</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="cause_of_death"
                   id="cause_of_death"
                   variant="outlined"

--- a/src/Components/DeathReport/DeathReport.tsx
+++ b/src/Components/DeathReport/DeathReport.tsx
@@ -6,7 +6,7 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import { GENDER_TYPES } from "../../Common/constants";
 import {
   LegacyTextInputField,
-  MultilineInputField,
+  LegacyMultilineInputField,
 } from "../Common/HelperInputFields";
 import { InputLabel } from "@material-ui/core";
 import moment from "moment";
@@ -341,7 +341,7 @@ export default function PrintDeathReport(props: { id: string }) {
             </div>
             <div className="grid grid-cols-1 mt-4">
               <InputLabel htmlFor="address">Address</InputLabel>
-              <MultilineInputField
+              <LegacyMultilineInputField
                 name="address"
                 id="address"
                 variant="outlined"

--- a/src/Components/ExternalResult/ExternalResultLocalbodySelector.tsx
+++ b/src/Components/ExternalResult/ExternalResultLocalbodySelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import { useTranslation } from "react-i18next";
 import { FieldLabel } from "../Form/FormFields/FormField";
 
@@ -25,7 +25,7 @@ export const ExternalResultLocalbodySelector = (props: any) => {
           <FieldLabel id="local_body-label" required={true}>
             {t("local_body")}
           </FieldLabel>
-          <SelectField
+          <LegacySelectField
             name="local_body"
             variant="outlined"
             margin="dense"
@@ -42,7 +42,7 @@ export const ExternalResultLocalbodySelector = (props: any) => {
             {t("Ward")}
           </FieldLabel>
           {wards && (
-            <SelectField
+            <LegacySelectField
               name="ward"
               variant="outlined"
               margin="dense"

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import {
-  AutoCompleteAsyncField,
+  LegacyAutoCompleteAsyncField,
   LegacyTextInputField,
 } from "../Common/HelperInputFields";
 import { DateRangePicker, getDate } from "../Common/DateRangePicker";
@@ -193,7 +193,7 @@ export default function ListFilter(props: any) {
       <div className="flex flex-wrap gap-2">
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">{t("lsg")}</span>
-          <AutoCompleteAsyncField
+          <LegacyAutoCompleteAsyncField
             multiple={true}
             name="local_bodies"
             options={lsgList}
@@ -215,7 +215,7 @@ export default function ListFilter(props: any) {
       <div className="flex flex-wrap gap-2">
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">{t("Ward")}</span>
-          <AutoCompleteAsyncField
+          <LegacyAutoCompleteAsyncField
             multiple={true}
             name="wards"
             options={filterWards()}

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import {
   AutoCompleteAsyncField,
-  TextInputField,
+  LegacyTextInputField,
 } from "../Common/HelperInputFields";
 import { DateRangePicker, getDate } from "../Common/DateRangePicker";
 import { getAllLocalBodyByDistrict } from "../../Redux/actions";
@@ -283,7 +283,7 @@ export default function ListFilter(props: any) {
       </div>
       <div className="w-full flex-none">
         <span className="text-sm font-semibold">{t("srf_id")}</span>
-        <TextInputField
+        <LegacyTextInputField
           id="srf_id"
           name="srf_id"
           variant="outlined"

--- a/src/Components/ExternalResult/ResultUpdate.tsx
+++ b/src/Components/ExternalResult/ResultUpdate.tsx
@@ -18,7 +18,10 @@ import {
   externalResult,
   partialUpdateExternalResult,
 } from "../../Redux/actions";
-import { MultilineInputField, SelectField } from "../Common/HelperInputFields";
+import {
+  LegacyMultilineInputField,
+  SelectField,
+} from "../Common/HelperInputFields";
 import { navigate } from "raviger";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
@@ -246,7 +249,7 @@ export default function UpdateResult(props: any) {
           <div className="px-4 py-5 grid gap-4 grid-cols-1 md:grid-cols-2">
             <div data-testid="current-address">
               <InputLabel id="address-label">Current Address*</InputLabel>
-              <MultilineInputField
+              <LegacyMultilineInputField
                 rows={2}
                 name="address"
                 variant="outlined"

--- a/src/Components/ExternalResult/ResultUpdate.tsx
+++ b/src/Components/ExternalResult/ResultUpdate.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../Redux/actions";
 import {
   LegacyMultilineInputField,
-  SelectField,
+  LegacySelectField,
 } from "../Common/HelperInputFields";
 import { navigate } from "raviger";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
@@ -266,7 +266,7 @@ export default function UpdateResult(props: any) {
               {isLocalbodyLoading ? (
                 <CircularProgress size={20} />
               ) : (
-                <SelectField
+                <LegacySelectField
                   name="local_body"
                   variant="outlined"
                   margin="dense"
@@ -288,7 +288,7 @@ export default function UpdateResult(props: any) {
               {isWardLoading ? (
                 <CircularProgress size={20} />
               ) : (
-                <SelectField
+                <LegacySelectField
                   name="ward"
                   variant="outlined"
                   margin="dense"

--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -10,7 +10,7 @@ import {
   updateFacilityBed,
 } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import { LOCATION_BED_TYPES } from "../../Common/constants";
 import { navigate } from "raviger";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
@@ -183,7 +183,7 @@ export const AddBedForm = (props: BedFormProps) => {
                   <FieldLabel required id="bedType">
                     Bed Type
                   </FieldLabel>
-                  <SelectField
+                  <LegacySelectField
                     id="bed-type"
                     fullWidth
                     name="bed_type"

--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -10,7 +10,10 @@ import {
   getInventorySummary,
 } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { SelectField, LegacyTextInputField } from "../Common/HelperInputFields";
+import {
+  LegacySelectField,
+  LegacyTextInputField,
+} from "../Common/HelperInputFields";
 import { InventoryItemsModel } from "./models";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
@@ -230,7 +233,7 @@ export const AddInventoryForm = (props: any) => {
                   <InputLabel id="inventory_name_label">
                     Inventory Name
                   </InputLabel>
-                  <SelectField
+                  <LegacySelectField
                     name="id"
                     variant="outlined"
                     margin="dense"
@@ -247,7 +250,7 @@ export const AddInventoryForm = (props: any) => {
                   <InputLabel id="inventory_description_label">
                     Status:
                   </InputLabel>
-                  <SelectField
+                  <LegacySelectField
                     name="isIncoming"
                     variant="outlined"
                     margin="dense"
@@ -276,7 +279,7 @@ export const AddInventoryForm = (props: any) => {
                 </div>
                 <div>
                   <InputLabel id="unit">Unit</InputLabel>
-                  <SelectField
+                  <LegacySelectField
                     name="unit"
                     margin="dense"
                     variant="outlined"

--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -10,7 +10,7 @@ import {
   getInventorySummary,
 } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { SelectField, TextInputField } from "../Common/HelperInputFields";
+import { SelectField, LegacyTextInputField } from "../Common/HelperInputFields";
 import { InventoryItemsModel } from "./models";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
@@ -264,7 +264,7 @@ export const AddInventoryForm = (props: any) => {
                 </div>
                 <div>
                   <InputLabel id="quantity">Quantity</InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="quantity"
                     variant="outlined"
                     margin="dense"

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -12,7 +12,7 @@ import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { validateEmailAddress } from "../../Common/validation";
 import {
   LegacyActionTextInputField,
-  ErrorHelperText,
+  LegacyErrorHelperText,
 } from "../Common/HelperInputFields";
 import { AssetClass, AssetData, AssetType } from "../Assets/AssetTypes";
 import loadable from "@loadable/component";
@@ -660,7 +660,9 @@ const AssetCreate = (props: AssetProps) => {
                         setNotWorkingReason(e.target.value)
                       }
                     />
-                    <ErrorHelperText error={state.errors.not_working_reason} />
+                    <LegacyErrorHelperText
+                      error={state.errors.not_working_reason}
+                    />
                   </div>
                   {/* Divider */}
                   <div className="col-span-6">
@@ -691,7 +693,7 @@ const AssetCreate = (props: AssetProps) => {
                       action={() => setIsScannerActive(true)}
                       errors={state.errors.qr_code_id}
                     />
-                    <ErrorHelperText error={state.errors.qr_id} />
+                    <LegacyErrorHelperText error={state.errors.qr_id} />
                   </div>
                 </div>
                 <div className="grid grid-cols-6 gap-x-6">
@@ -739,7 +741,7 @@ const AssetCreate = (props: AssetProps) => {
                       type="date"
                       min={moment().format("YYYY-MM-DD")}
                     />
-                    <ErrorHelperText
+                    <LegacyErrorHelperText
                       error={state.errors.warranty_amc_end_of_validity}
                     />
                   </div>
@@ -855,7 +857,9 @@ const AssetCreate = (props: AssetProps) => {
                       type="date"
                       max={moment(new Date()).format("YYYY-MM-DD")}
                     />
-                    <ErrorHelperText error={state.errors.last_serviced_on} />
+                    <LegacyErrorHelperText
+                      error={state.errors.last_serviced_on}
+                    />
                   </div>
 
                   {/* Notes */}
@@ -874,7 +878,7 @@ const AssetCreate = (props: AssetProps) => {
                         setNotes(e.target.value)
                       }
                     />
-                    <ErrorHelperText error={state.errors.notes} />
+                    <LegacyErrorHelperText error={state.errors.notes} />
                   </div>
                 </div>
 

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -11,7 +11,7 @@ import PageTitle from "../Common/PageTitle";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { validateEmailAddress } from "../../Common/validation";
 import {
-  ActionTextInputField,
+  LegacyActionTextInputField,
   ErrorHelperText,
 } from "../Common/HelperInputFields";
 import { AssetClass, AssetData, AssetType } from "../Assets/AssetTypes";
@@ -676,7 +676,7 @@ const AssetCreate = (props: AssetProps) => {
                   {/* Asset QR ID */}
                   <div className="col-span-6">
                     <label htmlFor="asset-qr-id">Asset QR ID</label>
-                    <ActionTextInputField
+                    <LegacyActionTextInputField
                       id="qr_code_id"
                       fullWidth
                       name="qr_code_id"

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -37,7 +37,7 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import { TextInputField } from "../Common/HelperInputFields";
+import { LegacyTextInputField } from "../Common/HelperInputFields";
 import { discharge, dischargePatient } from "../../Redux/actions";
 import ReadMore from "../Common/components/Readmore";
 import ViewInvestigationSuggestions from "./Investigations/InvestigationSuggestions";
@@ -456,7 +456,7 @@ export const ConsultationDetails = (props: any) => {
               Fill email input with my email.
             </a>
           </div>
-          <TextInputField
+          <LegacyTextInputField
             type="email"
             name="email"
             label="email"

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
 import { FacilitySelect } from "../Common/FacilitySelect";
-import { ErrorHelperText } from "../Common/HelperInputFields";
+import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import { BedModel, FacilityModel } from "./models";
 import { OnlineUsersSelect } from "../Common/OnlineUsersSelect";
 import { UserModel } from "../Users/models";
@@ -297,7 +297,7 @@ export const ConsultationForm = (props: any) => {
             admitted_to: res.data.admitted_to ? res.data.admitted_to : "",
             category: res.data.category
               ? PATIENT_CATEGORIES.find((i) => i.text === res.data.category)
-                ?.id || "Comfort"
+                  ?.id || "Comfort"
               : "Comfort",
             ip_no: res.data.ip_no ? res.data.ip_no : "",
             verified_by: res.data.verified_by ? res.data.verified_by : "",
@@ -815,8 +815,9 @@ export const ConsultationForm = (props: any) => {
             const section = sections[sectionTitle as ConsultationFormSection];
             return (
               <button
-                className={`rounded-l-lg flex items-center justify-start gap-3 px-5 py-3 w-full font-medium ${isCurrent ? "bg-white text-primary-500" : "bg-transparent"
-                  } hover:bg-white hover:tracking-wider transition-all duration-100 ease-in`}
+                className={`rounded-l-lg flex items-center justify-start gap-3 px-5 py-3 w-full font-medium ${
+                  isCurrent ? "bg-white text-primary-500" : "bg-transparent"
+                } hover:bg-white hover:tracking-wider transition-all duration-100 ease-in`}
                 onClick={() => {
                   section.ref.current?.scrollIntoView({
                     behavior: "smooth",
@@ -935,7 +936,7 @@ export const ConsultationForm = (props: any) => {
                       {Math.sqrt(
                         (Number(state.form.weight) *
                           Number(state.form.height)) /
-                        3600
+                          3600
                       ).toFixed(2)}{" "}
                       m<sup>2</sup>
                     </div>
@@ -1101,7 +1102,7 @@ export const ConsultationForm = (props: any) => {
                               investigations={InvestigationAdvice}
                               setInvestigations={setInvestigationAdvice}
                             />
-                            <ErrorHelperText
+                            <LegacyErrorHelperText
                               error={state.errors.investigation}
                             />
                           </div>
@@ -1116,7 +1117,7 @@ export const ConsultationForm = (props: any) => {
                               prescriptions={dischargeAdvice}
                               setPrescriptions={setDischargeAdvice}
                             />
-                            <ErrorHelperText
+                            <LegacyErrorHelperText
                               error={state.errors.discharge_advice}
                             />
                           </div>
@@ -1131,7 +1132,7 @@ export const ConsultationForm = (props: any) => {
                               prescriptions={PRNAdvice}
                               setPrescriptions={setPRNAdvice}
                             />
-                            <ErrorHelperText
+                            <LegacyErrorHelperText
                               error={state.errors.prn_prescription}
                             />
                           </div>
@@ -1146,7 +1147,9 @@ export const ConsultationForm = (props: any) => {
                               procedures={procedures}
                               setProcedures={setProcedures}
                             />
-                            <ErrorHelperText error={state.errors.procedure} />
+                            <LegacyErrorHelperText
+                              error={state.errors.procedure}
+                            />
                           </div>
                           <div
                             className="col-span-6"
@@ -1193,7 +1196,9 @@ export const ConsultationForm = (props: any) => {
                                   />
                                 </Box>
                               </RadioGroup>
-                              <ErrorHelperText error={state.errors.is_kasp} />
+                              <LegacyErrorHelperText
+                                error={state.errors.is_kasp}
+                              />
                             </div>
                           )}
                           <div
@@ -1240,7 +1245,7 @@ export const ConsultationForm = (props: any) => {
                                 />
                               </Box>
                             </RadioGroup>
-                            <ErrorHelperText
+                            <LegacyErrorHelperText
                               error={state.errors.is_telemedicine}
                             />
                           </div>

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -29,7 +29,7 @@ import { AxiosError } from "axios";
 import { isNull } from "lodash";
 import { BedSelect } from "../../Common/BedSelect";
 import { BedModel } from "../models";
-import { TextInputField } from "../../Common/HelperInputFields";
+import { LegacyTextInputField } from "../../Common/HelperInputFields";
 import useWindowDimensions from "../../../Common/hooks/useWindowDimensions";
 import CareIcon from "../../../CAREUI/icons/CareIcon";
 
@@ -347,7 +347,7 @@ const LiveFeed = (props: any) => {
               </div>
               <div>
                 <InputLabel id="location">Preset Name</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="name"
                   id="location"
                   variant="outlined"

--- a/src/Components/Facility/DoctorCapacity.tsx
+++ b/src/Components/Facility/DoctorCapacity.tsx
@@ -4,7 +4,7 @@ import { DOCTOR_SPECIALIZATION } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { createDoctor, getDoctor, listDoctor } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { ErrorHelperText } from "../Common/HelperInputFields";
+import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import { DoctorModal, OptionsType } from "./models";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import SelectMenuV2 from "../Form/SelectMenuV2";
@@ -230,7 +230,7 @@ export const DoctorCapacity = (props: DoctorCapacityProps) => {
                 }
                 disabled={!!id}
               />
-              <ErrorHelperText error={state.errors.area} />
+              <LegacyErrorHelperText error={state.errors.area} />
             </div>
             <div>
               <TextFormField

--- a/src/Components/Facility/FacilityFilter/LocalBodySelect.tsx
+++ b/src/Components/Facility/FacilityFilter/LocalBodySelect.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { getLocalbodyByDistrict } from "../../../Redux/actions";
-import { AutoCompleteAsyncField } from "../../Common/HelperInputFields";
+import { LegacyAutoCompleteAsyncField } from "../../Common/HelperInputFields";
 
 interface LocalBodySelectProps {
   name: string;
@@ -81,7 +81,7 @@ function LocalBodySelect(props: LocalBodySelectProps) {
   }, [dispatchAction, district, selected]);
 
   return (
-    <AutoCompleteAsyncField
+    <LegacyAutoCompleteAsyncField
       name={name}
       multiple={multiple}
       variant="outlined"

--- a/src/Components/Facility/FacilityFilter/index.tsx
+++ b/src/Components/Facility/FacilityFilter/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { navigate } from "raviger";
-import { SelectField } from "../../Common/HelperInputFields";
+import { LegacySelectField } from "../../Common/HelperInputFields";
 import { CircularProgress } from "@material-ui/core";
 import { FACILITY_TYPES } from "../../../Common/constants";
 import { getStates, getDistrictByState } from "../../../Redux/actions";
@@ -128,7 +128,7 @@ function FacilityFilter(props: any) {
             {isStateLoading ? (
               <CircularProgress size={20} />
             ) : (
-              <SelectField
+              <LegacySelectField
                 name="state"
                 variant="outlined"
                 margin="dense"
@@ -147,7 +147,7 @@ function FacilityFilter(props: any) {
             {isDistrictLoading ? (
               <CircularProgress size={20} />
             ) : (
-              <SelectField
+              <LegacySelectField
                 name="district"
                 variant="outlined"
                 margin="dense"
@@ -175,7 +175,7 @@ function FacilityFilter(props: any) {
 
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">Facility type</span>
-          <SelectField
+          <LegacySelectField
             name="facility_type"
             variant="outlined"
             margin="dense"
@@ -190,7 +190,7 @@ function FacilityFilter(props: any) {
           <span className="text-sm font-semibold">
             {kasp_string} Empanelled
           </span>
-          <SelectField
+          <LegacySelectField
             name="kasp_empanelled"
             variant="outlined"
             margin="dense"

--- a/src/Components/Facility/Investigations/InvestigationTable.tsx
+++ b/src/Components/Facility/Investigations/InvestigationTable.tsx
@@ -14,7 +14,7 @@ import { createStyles, withStyles } from "@material-ui/styles";
 import React from "react";
 import { useState } from "react";
 import {
-  SelectField,
+  LegacySelectField,
   LegacyTextInputField,
 } from "../../Common/HelperInputFields";
 import _ from "lodash";
@@ -60,7 +60,7 @@ const TestRow = ({ data, onChange, showForm, value, isChanged }: any) => {
       >
         {showForm ? (
           data?.investigation_object?.investigation_type === "Choice" ? (
-            <SelectField
+            <LegacySelectField
               name="preferred_vehicle_choice"
               variant="outlined"
               optionArray={true}

--- a/src/Components/Facility/Investigations/InvestigationTable.tsx
+++ b/src/Components/Facility/Investigations/InvestigationTable.tsx
@@ -13,7 +13,10 @@ import {
 import { createStyles, withStyles } from "@material-ui/styles";
 import React from "react";
 import { useState } from "react";
-import { SelectField, TextInputField } from "../../Common/HelperInputFields";
+import {
+  SelectField,
+  LegacyTextInputField,
+} from "../../Common/HelperInputFields";
 import _ from "lodash";
 import { classNames } from "../../../Utils/utils";
 
@@ -157,7 +160,7 @@ export const InvestigationTable = ({
         </div>
       </div>
       <InputLabel className="mt-4">Search Test</InputLabel>
-      <TextInputField
+      <LegacyTextInputField
         value={searchFilter}
         placeholder="Search test"
         errors=""

--- a/src/Components/Facility/Investigations/Reports/index.tsx
+++ b/src/Components/Facility/Investigations/Reports/index.tsx
@@ -8,7 +8,7 @@ import {
   listInvestigations,
   getPatient,
 } from "../../../../Redux/actions";
-import { MultiSelectField } from "../../../Common/HelperInputFields";
+import { LegacyMultiSelectField } from "../../../Common/HelperInputFields";
 import PageTitle from "../../../Common/PageTitle";
 import { Button, ButtonGroup, Checkbox, TextField } from "@material-ui/core";
 import Loading from "../../../Common/Loading";
@@ -345,7 +345,7 @@ const InvestigationReports = ({ id }: any) => {
             <InputLabel required id="investigation-group-label">
               Select Investigation Groups
             </InputLabel>
-            <MultiSelectField
+            <LegacyMultiSelectField
               id="investigation-group-label"
               options={investigationGroups}
               value={selectedGroup}

--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -6,7 +6,6 @@ import {
   TableHead,
   TableRow,
   TableBody,
-  Theme,
   InputLabel,
   Typography,
   Box,
@@ -15,17 +14,17 @@ import { SelectField } from "../../Common/HelperInputFields";
 import { createStyles, makeStyles, withStyles } from "@material-ui/styles";
 import React from "react";
 import { useState } from "react";
-import { TextInputField } from "../../Common/HelperInputFields";
+import { LegacyTextInputField } from "../../Common/HelperInputFields";
 import _ from "lodash";
 
-const useStyle = makeStyles((theme: Theme) => ({
+const useStyle = makeStyles(() => ({
   tableCell: {
     paddingTop: 0,
     paddingBottom: 0,
   },
 }));
 
-const StyledTableRow = withStyles((theme: Theme) =>
+const StyledTableRow = withStyles(() =>
   createStyles({
     root: {
       "&:nth-of-type(odd)": {
@@ -107,7 +106,7 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
       )}
       <br />
       <InputLabel>Search Test</InputLabel>
-      <TextInputField
+      <LegacyTextInputField
         value={searchFilter}
         placeholder="Search test"
         errors=""

--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   Box,
 } from "@material-ui/core";
-import { SelectField } from "../../Common/HelperInputFields";
+import { LegacySelectField } from "../../Common/HelperInputFields";
 import { createStyles, makeStyles, withStyles } from "@material-ui/styles";
 import React from "react";
 import { useState } from "react";
@@ -45,7 +45,7 @@ const TestRow = ({ data, value, onChange }: any) => {
       <TableCell className={className.tableCell}>{data.name}</TableCell>
       <TableCell className={className.tableCell} align="right">
         {data.investigation_type === "Choice" ? (
-          <SelectField
+          <LegacySelectField
             name="preferred_vehicle_choice"
             variant="outlined"
             optionArray={true}

--- a/src/Components/Facility/Investigations/index.tsx
+++ b/src/Components/Facility/Investigations/index.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useReducer, useState } from "react";
-import { MultiSelectField } from "../../Common/HelperInputFields";
 import { TestTable } from "./Table";
 import { useDispatch } from "react-redux";
 import Autocomplete from "@material-ui/lab/Autocomplete";
-import { Checkbox, TextField, InputLabel } from "@material-ui/core";
+import { Checkbox, TextField } from "@material-ui/core";
 import {
   createInvestigation,
   listInvestigationGroups,
@@ -57,7 +56,7 @@ const testFormReducer = (state = initialState, action: any) => {
   }
 };
 
-let listOfInvestigations = (
+const listOfInvestigations = (
   group_id: string,
   investigations: InvestigationType[]
 ) => {
@@ -66,7 +65,7 @@ let listOfInvestigations = (
   );
 };
 
-let findGroup = (group_id: string, groups: Group[]) => {
+const findGroup = (group_id: string, groups: Group[]) => {
   return groups.find((g) => g.external_id === group_id);
 };
 
@@ -75,7 +74,7 @@ const Investigation = (props: {
   patientId: string;
   facilityId: string;
 }) => {
-  const { consultationId, patientId, facilityId } = props;
+  const { patientId, facilityId } = props;
 
   const dispatch: any = useDispatch();
   const [selectedGroup, setSelectedGroup] = useState<string[]>([]);
@@ -140,12 +139,12 @@ const Investigation = (props: {
   }, [props.consultationId]);
 
   const initialiseForm = () => {
-    let investigationsArray = selectedGroup.map((group_id: string) => {
+    const investigationsArray = selectedGroup.map((group_id: string) => {
       return listOfInvestigations(group_id, investigations);
     });
 
-    let flatInvestigations = investigationsArray.flat();
-    let form: any = {};
+    const flatInvestigations = investigationsArray.flat();
+    const form: any = {};
 
     flatInvestigations.forEach(
       (i: InvestigationType) =>
@@ -163,7 +162,7 @@ const Investigation = (props: {
     setState({ type: "set_form", form });
   };
 
-  const handleSubmit = async (e: any) => {
+  const handleSubmit = async () => {
     initialiseForm();
     if (!saving) {
       setSaving(true);

--- a/src/Components/Facility/SetInventoryForm.tsx
+++ b/src/Components/Facility/SetInventoryForm.tsx
@@ -5,7 +5,10 @@ import loadable from "@loadable/component";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getItems, setMinQuantity, getAnyFacility } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { SelectField, LegacyTextInputField } from "../Common/HelperInputFields";
+import {
+  LegacySelectField,
+  LegacyTextInputField,
+} from "../Common/HelperInputFields";
 import { InventoryItemsModel } from "./models";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
@@ -155,7 +158,7 @@ export const SetInventoryForm = (props: any) => {
                   <InputLabel id="inventory_name_label">
                     Inventory Name
                   </InputLabel>
-                  <SelectField
+                  <LegacySelectField
                     name="id"
                     variant="outlined"
                     margin="dense"

--- a/src/Components/Facility/SetInventoryForm.tsx
+++ b/src/Components/Facility/SetInventoryForm.tsx
@@ -5,7 +5,7 @@ import loadable from "@loadable/component";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getItems, setMinQuantity, getAnyFacility } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { SelectField, TextInputField } from "../Common/HelperInputFields";
+import { SelectField, LegacyTextInputField } from "../Common/HelperInputFields";
 import { InventoryItemsModel } from "./models";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
@@ -171,7 +171,7 @@ export const SetInventoryForm = (props: any) => {
 
                 <div>
                   <InputLabel id="inventory_name_label">Unit</InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="id"
                     variant="outlined"
                     margin="dense"
@@ -183,7 +183,7 @@ export const SetInventoryForm = (props: any) => {
 
                 <div className="md:col-span-2">
                   <InputLabel id="quantity">Item Min Quantity</InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     fullWidth
                     name="quantity"
                     variant="outlined"

--- a/src/Components/Facility/TriageForm.tsx
+++ b/src/Components/Facility/TriageForm.tsx
@@ -12,7 +12,7 @@ import {
   getTriageInfo,
 } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { TextInputField } from "../Common/HelperInputFields";
+import { LegacyTextInputField } from "../Common/HelperInputFields";
 import { PatientStatsModel } from "./models";
 import ButtonV2 from "../Common/components/ButtonV2";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
@@ -329,7 +329,7 @@ export const TriageForm = (props: triageFormProps) => {
                   <InputLabel id="num-patients-visited-label">
                     Patients Visited in Triage
                   </InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="num_patients_visited"
                     variant="outlined"
                     margin="dense"
@@ -346,7 +346,7 @@ export const TriageForm = (props: triageFormProps) => {
                   <InputLabel id="num-patients-home-quarantine-label">
                     Patients in Home Quarantine
                   </InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="num_patients_home_quarantine"
                     variant="outlined"
                     margin="dense"
@@ -363,7 +363,7 @@ export const TriageForm = (props: triageFormProps) => {
                   <InputLabel id="num-patients-isolation-label">
                     Suspected Isolated
                   </InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="num_patients_isolation"
                     variant="outlined"
                     margin="dense"
@@ -380,7 +380,7 @@ export const TriageForm = (props: triageFormProps) => {
                   <InputLabel id="num-patient-referred-label">
                     Patients Referred
                   </InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="num_patient_referred"
                     variant="outlined"
                     margin="dense"
@@ -397,7 +397,7 @@ export const TriageForm = (props: triageFormProps) => {
                   <InputLabel id="num-patient-referred-label">
                     Confirmed Positive
                   </InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="num_patient_confirmed_positive"
                     variant="outlined"
                     margin="dense"

--- a/src/Components/Form/FormFields/PhoneNumberFormField.tsx
+++ b/src/Components/Form/FormFields/PhoneNumberFormField.tsx
@@ -1,4 +1,4 @@
-import { PhoneNumberField } from "../../Common/HelperInputFields";
+import { LegacyPhoneNumberField } from "../../Common/HelperInputFields";
 import FormField from "./FormField";
 import { FormFieldBaseProps, useFormFieldPropsResolver } from "./Utils";
 
@@ -15,7 +15,7 @@ const PhoneNumberFormField = (props: Props) => {
   const field = useFormFieldPropsResolver(props as any);
   return (
     <FormField field={field}>
-      <PhoneNumberField
+      <LegacyPhoneNumberField
         name={field.name}
         disabled={field.disabled}
         value={field.value}

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -24,7 +24,7 @@ import {
   LegacySelectField,
   LegacyErrorHelperText,
   LegacyDateTimeFiled,
-  MultiSelectField,
+  LegacyMultiSelectField,
   AutoCompleteAsyncField,
 } from "../Common/HelperInputFields";
 import {
@@ -617,7 +617,7 @@ export const DailyRounds = (props: any) => {
 
                     <div className="md:col-span-2">
                       <FieldLabel id="symptoms-label">Symptoms</FieldLabel>
-                      <MultiSelectField
+                      <LegacyMultiSelectField
                         name="additional_symptoms"
                         variant="outlined"
                         value={state.form.additional_symptoms}

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -21,7 +21,7 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   LegacyNativeSelectField,
   CheckboxField,
-  SelectField,
+  LegacySelectField,
   LegacyErrorHelperText,
   LegacyDateTimeFiled,
   MultiSelectField,
@@ -527,7 +527,7 @@ export const DailyRounds = (props: any) => {
                   />
                 </div>
                 <div className="w-full md:w-1/3">
-                  <SelectField
+                  <LegacySelectField
                     className=""
                     name="rounds_type"
                     variant="standard"
@@ -550,7 +550,7 @@ export const DailyRounds = (props: any) => {
                   />
                 </div>
                 <div className="w-full md:w-1/3">
-                  <SelectField
+                  <LegacySelectField
                     name="patient_category"
                     variant="standard"
                     margin="dense"
@@ -661,7 +661,7 @@ export const DailyRounds = (props: any) => {
                       <FieldLabel id="review_interval-label">
                         Review After{" "}
                       </FieldLabel>
-                      <SelectField
+                      <LegacySelectField
                         name="review_interval"
                         variant="standard"
                         value={state.form.review_interval || prevReviewInterval}
@@ -913,7 +913,7 @@ export const DailyRounds = (props: any) => {
                           <FieldLabel className="flex flex-row justify-between">
                             Rhythm
                           </FieldLabel>
-                          <SelectField
+                          <LegacySelectField
                             name="rhythm"
                             variant="standard"
                             value={

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -25,7 +25,7 @@ import {
   LegacyErrorHelperText,
   LegacyDateTimeFiled,
   LegacyMultiSelectField,
-  AutoCompleteAsyncField,
+  LegacyAutoCompleteAsyncField,
 } from "../Common/HelperInputFields";
 import {
   createDailyReport,
@@ -706,7 +706,7 @@ export const DailyRounds = (props: any) => {
                                 Systolic
                                 {getStatus(100, "Low", 140, "High", "systolic")}
                               </FieldLabel>
-                              <AutoCompleteAsyncField
+                              <LegacyAutoCompleteAsyncField
                                 name="systolic"
                                 multiple={false}
                                 variant="standard"
@@ -735,7 +735,7 @@ export const DailyRounds = (props: any) => {
                                 Diastolic{" "}
                                 {getStatus(50, "Low", 90, "High", "diastolic")}
                               </FieldLabel>
-                              <AutoCompleteAsyncField
+                              <LegacyAutoCompleteAsyncField
                                 name="diastolic"
                                 multiple={false}
                                 variant="standard"
@@ -772,7 +772,7 @@ export const DailyRounds = (props: any) => {
                               "pulse"
                             )}
                           </FieldLabel>
-                          <AutoCompleteAsyncField
+                          <LegacyAutoCompleteAsyncField
                             name="pulse"
                             multiple={false}
                             variant="standard"
@@ -813,7 +813,7 @@ export const DailyRounds = (props: any) => {
                           </FieldLabel>
                           <div className="flex flex-row">
                             <div className="grow mr-2">
-                              <AutoCompleteAsyncField
+                              <LegacyAutoCompleteAsyncField
                                 name="temperature"
                                 multiple={false}
                                 variant="standard"
@@ -857,7 +857,7 @@ export const DailyRounds = (props: any) => {
                             {"Respiratory Rate (bpm) *"}
                             {getStatus(12, "Low", 16, "High", "resp")}
                           </FieldLabel>
-                          <AutoCompleteAsyncField
+                          <LegacyAutoCompleteAsyncField
                             name="resp"
                             multiple={false}
                             variant="standard"
@@ -889,7 +889,7 @@ export const DailyRounds = (props: any) => {
                               "ventilator_spo2"
                             )}
                           </FieldLabel>
-                          <AutoCompleteAsyncField
+                          <LegacyAutoCompleteAsyncField
                             name="ventilator_spo2"
                             multiple={false}
                             variant="standard"

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -22,7 +22,7 @@ import {
   NativeSelectField,
   CheckboxField,
   SelectField,
-  ErrorHelperText,
+  LegacyErrorHelperText,
   LegacyDateTimeFiled,
   MultiSelectField,
   AutoCompleteAsyncField,
@@ -587,7 +587,7 @@ export const DailyRounds = (props: any) => {
                       />
                     </Box>
                   </RadioGroup>
-                  <ErrorHelperText error={state.errors.clone_last} />
+                  <LegacyErrorHelperText error={state.errors.clone_last} />
                 </div>
               )}
               {(state.form.clone_last === "false" || id) && (
@@ -624,7 +624,7 @@ export const DailyRounds = (props: any) => {
                         options={symptomChoices}
                         onChange={handleSymptomChange}
                       />
-                      <ErrorHelperText
+                      <LegacyErrorHelperText
                         error={state.errors.additional_symptoms}
                       />
                     </div>
@@ -654,7 +654,7 @@ export const DailyRounds = (props: any) => {
                         options={TELEMEDICINE_ACTIONS}
                         onChange={handleChange}
                       />
-                      <ErrorHelperText error={state.errors.action} />
+                      <LegacyErrorHelperText error={state.errors.action} />
                     </div>
 
                     <div className="flex-1">

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
-  NativeSelectField,
+  LegacyNativeSelectField,
   CheckboxField,
   SelectField,
   LegacyErrorHelperText,
@@ -645,7 +645,7 @@ export const DailyRounds = (props: any) => {
 
                     <div className="flex-1">
                       <FieldLabel id="action-label">Action </FieldLabel>
-                      <NativeSelectField
+                      <LegacyNativeSelectField
                         name="action"
                         variant="outlined"
                         value={state.form.action}

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -23,7 +23,7 @@ import {
   CheckboxField,
   SelectField,
   ErrorHelperText,
-  DateTimeFiled,
+  LegacyDateTimeFiled,
   MultiSelectField,
   AutoCompleteAsyncField,
 } from "../Common/HelperInputFields";
@@ -515,7 +515,7 @@ export const DailyRounds = (props: any) => {
             <CardContent>
               <div className="flex flex-col md:flex-row gap-4">
                 <div className="w-full md:w-1/3">
-                  <DateTimeFiled
+                  <LegacyDateTimeFiled
                     label="Measured At"
                     margin="dense"
                     value={state.form.taken_at}

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -20,7 +20,7 @@ import {
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   LegacyNativeSelectField,
-  CheckboxField,
+  LegacyCheckboxField,
   LegacySelectField,
   LegacyErrorHelperText,
   LegacyDateTimeFiled,
@@ -678,7 +678,7 @@ export const DailyRounds = (props: any) => {
                       </div>
                     </div>
                     <div>
-                      <CheckboxField
+                      <LegacyCheckboxField
                         checked={state.form.recommend_discharge}
                         onChange={handleCheckboxFieldChange}
                         name="recommend_discharge"

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -12,7 +12,7 @@ import {
   editUpload,
 } from "../../Redux/actions";
 import { FileUploadModel } from "./models";
-import { TextInputField } from "../Common/HelperInputFields";
+import { LegacyTextInputField } from "../Common/HelperInputFields";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
@@ -1309,7 +1309,7 @@ export const FileUpload = (props: FileUploadProps) => {
               <InputLabel id="spo2-label">
                 Enter Audio File Name (optional)
               </InputLabel>
-              <TextInputField
+              <LegacyTextInputField
                 name="consultation_audio_file"
                 variant="outlined"
                 margin="dense"
@@ -1372,7 +1372,7 @@ export const FileUpload = (props: FileUploadProps) => {
               </div>
               <div>
                 <InputLabel id="spo2-label">Enter File Name*</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="consultation_file"
                   variant="outlined"
                   margin="dense"

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DISEASE_STATUS } from "../../Common/constants";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 
 const diseaseStatusOptions = ["Show All", ...DISEASE_STATUS];
 
@@ -18,7 +18,7 @@ export const PatientFilter = (props: PatientFilterProps) => {
   return (
     <div className="md:flex sticky top-0 bg-gray-100">
       <div className="w-56 flex items-center">
-        <SelectField
+        <LegacySelectField
           name="disease_status"
           variant="outlined"
           margin="dense"

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -26,7 +26,7 @@ import { SampleTestCard } from "./SampleTestCard";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import { ErrorHelperText } from "../Common/HelperInputFields";
+import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import Modal from "@material-ui/core/Modal";
 import Chip from "../../CAREUI/display/Chip";
 import { classNames, formatDate } from "../../Utils/utils";
@@ -1481,7 +1481,7 @@ export const PatientHome = (props: any) => {
               user_type={"Volunteer"}
               outline={false}
             />
-            <ErrorHelperText error={errors.assignedVolunteer} />
+            <LegacyErrorHelperText error={errors.assignedVolunteer} />
           </div>
 
           <DialogActions>

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -43,7 +43,7 @@ import {
   CheckboxField,
   LegacyDateInputField,
   LegacyErrorHelperText,
-  SelectField,
+  LegacySelectField,
   LegacyTextInputField,
 } from "../Common/HelperInputFields";
 import DuplicatePatientDialog from "../Facility/DuplicatePatientDialog";
@@ -1398,7 +1398,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                           >
                             Nationality
                           </FieldLabel>
-                          <SelectField
+                          <LegacySelectField
                             labelId="nationality"
                             name="nationality"
                             variant="outlined"
@@ -1641,7 +1641,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                   >
                                     Vaccine Name
                                   </FieldLabel>
-                                  <SelectField
+                                  <LegacySelectField
                                     labelId="vaccine_name"
                                     name="vaccine_name"
                                     variant="outlined"
@@ -1802,7 +1802,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             >
                               COVID Disease Status
                             </FieldLabel>
-                            <SelectField
+                            <LegacySelectField
                               labelId="disease_status"
                               name="disease_status"
                               variant="outlined"
@@ -1822,7 +1822,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             >
                               COVID Test Type
                             </FieldLabel>
-                            <SelectField
+                            <LegacySelectField
                               labelId="test_type"
                               name="test_type"
                               variant="outlined"

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -40,7 +40,7 @@ import {
 import * as Notification from "../../Utils/Notifications.js";
 import AlertDialog from "../Common/AlertDialog";
 import {
-  CheckboxField,
+  LegacyCheckboxField,
   LegacyDateInputField,
   LegacyErrorHelperText,
   LegacySelectField,
@@ -1059,7 +1059,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     return (
       <div key={textField}>
         <div>
-          <CheckboxField
+          <LegacyCheckboxField
             checked={state.form.medical_history.includes(id)}
             onChange={(e) => handleMedicalCheckboxChange(e, id)}
             name={checkboxField}
@@ -1344,7 +1344,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             error={state.errors.permanent_address}
                           />
 
-                          <CheckboxField
+                          <LegacyCheckboxField
                             checked={sameAddress}
                             onChange={() => setSameAddress(!sameAddress)}
                             label="Same as Current Address"

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -42,7 +42,7 @@ import AlertDialog from "../Common/AlertDialog";
 import {
   CheckboxField,
   LegacyDateInputField,
-  ErrorHelperText,
+  LegacyErrorHelperText,
   SelectField,
   LegacyTextInputField,
 } from "../Common/HelperInputFields";
@@ -1629,7 +1629,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                       />
                                     </div>
                                   </RadioGroup>
-                                  <ErrorHelperText
+                                  <LegacyErrorHelperText
                                     error={state.errors.number_of_doses}
                                   />
                                 </div>
@@ -2052,7 +2052,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                               return renderMedicalHistory(i.id, i.text);
                             })}
                           </div>
-                          <ErrorHelperText
+                          <LegacyErrorHelperText
                             error={state.errors.medical_history}
                           />
                         </div>

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -44,7 +44,7 @@ import {
   DateInputField,
   ErrorHelperText,
   SelectField,
-  TextInputField,
+  LegacyTextInputField,
 } from "../Common/HelperInputFields";
 import DuplicatePatientDialog from "../Facility/DuplicatePatientDialog";
 import { DupPatientModel } from "../Facility/models";
@@ -1156,7 +1156,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                   <FieldLabel htmlFor="care-external-results-id" required>
                     Enter Care External Results Id
                   </FieldLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     id="care-external-results-id"
                     name="care-external-results-id"
                     variant="outlined"
@@ -1380,7 +1380,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                           <FieldLabel htmlFor="village" id="name-label">
                             Village
                           </FieldLabel>
-                          <TextInputField
+                          <LegacyTextInputField
                             id="village"
                             name="village"
                             variant="outlined"
@@ -1516,7 +1516,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             >
                               Passport Number
                             </FieldLabel>
-                            <TextInputField
+                            <LegacyTextInputField
                               id="passport_no"
                               name="passport_no"
                               variant="outlined"
@@ -1585,7 +1585,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                   >
                                     COWIN ID
                                   </FieldLabel>
-                                  <TextInputField
+                                  <LegacyTextInputField
                                     id="covin_id"
                                     name="covin_id"
                                     variant="outlined"
@@ -1777,7 +1777,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                 >
                                   Name / Cluster of Contact
                                 </FieldLabel>
-                                <TextInputField
+                                <LegacyTextInputField
                                   id="cluster_name"
                                   name="cluster_name"
                                   variant="outlined"
@@ -1838,7 +1838,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             <FieldLabel id="srf_id-label" htmlFor="srf_id">
                               SRF Id for COVID Test
                             </FieldLabel>
-                            <TextInputField
+                            <LegacyTextInputField
                               id="srf_id"
                               name="srf_id"
                               variant="outlined"
@@ -1909,7 +1909,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             <FieldLabel id="test_id-label" htmlFor="test_id">
                               COVID Positive ID issued by ICMR
                             </FieldLabel>
-                            <TextInputField
+                            <LegacyTextInputField
                               id="test_id"
                               name="test_id"
                               variant="outlined"
@@ -1969,7 +1969,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             >
                               Number Of Primary Contacts for COVID
                             </FieldLabel>
-                            <TextInputField
+                            <LegacyTextInputField
                               id="number_of_primary_contacts"
                               name="number_of_primary_contacts"
                               variant="outlined"
@@ -1987,7 +1987,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             >
                               Number Of Secondary Contacts for COVID
                             </FieldLabel>
-                            <TextInputField
+                            <LegacyTextInputField
                               id="number_of_secondary_contacts"
                               name="number_of_secondary_contacts"
                               variant="outlined"

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -41,7 +41,7 @@ import * as Notification from "../../Utils/Notifications.js";
 import AlertDialog from "../Common/AlertDialog";
 import {
   CheckboxField,
-  DateInputField,
+  LegacyDateInputField,
   ErrorHelperText,
   SelectField,
   LegacyTextInputField,
@@ -1661,7 +1661,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                   >
                                     Last Date of Vaccination
                                   </FieldLabel>
-                                  <DateInputField
+                                  <LegacyDateInputField
                                     id="last_vaccinated_date"
                                     fullWidth={true}
                                     value={state.form.last_vaccinated_date}
@@ -1752,7 +1752,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                 >
                                   Estimate date of contact
                                 </FieldLabel>
-                                <DateInputField
+                                <LegacyDateInputField
                                   fullWidth={true}
                                   id="estimated_contact_date"
                                   value={state.form.estimated_contact_date}
@@ -1888,7 +1888,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                 <FieldLabel id="date_declared_positive-label">
                                   Date Patient is Declared Positive for COVID
                                 </FieldLabel>
-                                <DateInputField
+                                <LegacyDateInputField
                                   fullWidth={true}
                                   value={state.form.date_declared_positive}
                                   onChange={(date) =>
@@ -1928,7 +1928,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             >
                               Date of Sample given for COVID Test
                             </FieldLabel>
-                            <DateInputField
+                            <LegacyDateInputField
                               fullWidth={true}
                               id="date_of_test"
                               value={state.form.date_of_test}
@@ -1948,7 +1948,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                             >
                               Date of Result for COVID Test
                             </FieldLabel>
-                            <DateInputField
+                            <LegacyDateInputField
                               fullWidth={true}
                               id="date_of_result"
                               value={state.form.date_of_result}

--- a/src/Components/Patient/SampleFilters.tsx
+++ b/src/Components/Patient/SampleFilters.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import {
   SAMPLE_TEST_STATUS,
   SAMPLE_TEST_RESULT,
@@ -79,7 +79,7 @@ export default function UserFilter(props: any) {
       <div className="flex flex-wrap gap-2">
         <div className="w-full flex-none">
           <div className="text-sm font-semibold">Status</div>
-          <SelectField
+          <LegacySelectField
             name="status"
             variant="outlined"
             margin="dense"
@@ -97,7 +97,7 @@ export default function UserFilter(props: any) {
 
         <div className="w-full flex-none">
           <div className="text-sm font-semibold">Result</div>
-          <SelectField
+          <LegacySelectField
             name="result"
             variant="outlined"
             margin="dense"
@@ -110,7 +110,7 @@ export default function UserFilter(props: any) {
 
         <div className="w-full flex-none">
           <div className="text-sm font-semibold">Sample Test Type</div>
-          <SelectField
+          <LegacySelectField
             name="sample_type"
             variant="outlined"
             margin="dense"

--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -13,7 +13,7 @@ import * as Notification from "../../Utils/Notifications.js";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   CheckboxField,
-  SelectField,
+  LegacySelectField,
   LegacyTextInputField,
 } from "../Common/HelperInputFields";
 import { SampleTestModel, FacilityNameModel } from "./models";
@@ -278,7 +278,7 @@ export const SampleTest = (props: any) => {
                 <div className="space-y-4">
                   <div>
                     <FieldLabel>Sample Test Type*</FieldLabel>
-                    <SelectField
+                    <LegacySelectField
                       name="sample_type"
                       variant="outlined"
                       margin="dense"
@@ -306,7 +306,7 @@ export const SampleTest = (props: any) => {
                 <div className="row-span-3 space-y-4">
                   <div>
                     <FieldLabel>ICMR Category (for COVID Test)</FieldLabel>
-                    <SelectField
+                    <LegacySelectField
                       name="icmr_category"
                       variant="outlined"
                       margin="dense"
@@ -360,7 +360,7 @@ export const SampleTest = (props: any) => {
                   </div>
                   <div className="mt-4 w-full">
                     <FieldLabel>Testing Facility Name</FieldLabel>
-                    <SelectField
+                    <LegacySelectField
                       name="testing_facility"
                       variant="outlined"
                       margin="dense"

--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -14,7 +14,7 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   CheckboxField,
   SelectField,
-  TextInputField,
+  LegacyTextInputField,
 } from "../Common/HelperInputFields";
 import { SampleTestModel, FacilityNameModel } from "./models";
 import Typography from "@material-ui/core/Typography";
@@ -349,7 +349,7 @@ export const SampleTest = (props: any) => {
                 <div className="space-y-4">
                   <div>
                     <FieldLabel required>Label</FieldLabel>
-                    <TextInputField
+                    <LegacyTextInputField
                       name="icmr_label"
                       variant="outlined"
                       margin="dense"
@@ -401,7 +401,7 @@ export const SampleTest = (props: any) => {
               <div className="mt-4 grid gap-4 grid-cols-1 md:grid-cols-2">
                 <div>
                   <FieldLabel>Doctor's Name</FieldLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="doctor_name"
                     variant="outlined"
                     margin="dense"

--- a/src/Components/Patient/SampleTest.tsx
+++ b/src/Components/Patient/SampleTest.tsx
@@ -12,7 +12,7 @@ import {
 import * as Notification from "../../Utils/Notifications.js";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
-  CheckboxField,
+  LegacyCheckboxField,
   LegacySelectField,
   LegacyTextInputField,
 } from "../Common/HelperInputFields";
@@ -375,7 +375,7 @@ export const SampleTest = (props: any) => {
                     />
                   </div>
                   <div className="flex items-center">
-                    <CheckboxField
+                    <LegacyCheckboxField
                       checked={state.form.isFastTrack}
                       onChange={handleCheckboxFieldChange}
                       name="isFastTrack"
@@ -411,7 +411,7 @@ export const SampleTest = (props: any) => {
                   />
                 </div>
                 <div className="flex items-center">
-                  <CheckboxField
+                  <LegacyCheckboxField
                     checked={state.form.is_atypical_presentation}
                     onChange={handleCheckboxFieldChange}
                     name="is_atypical_presentation"
@@ -464,7 +464,7 @@ export const SampleTest = (props: any) => {
               </div>
               <div className="mt-4 grid gap-4 grid-cols-1 md:grid-cols-2">
                 <div className="flex items-center">
-                  <CheckboxField
+                  <LegacyCheckboxField
                     checked={state.form.has_sari}
                     onChange={handleCheckboxFieldChange}
                     name="has_sari"
@@ -472,7 +472,7 @@ export const SampleTest = (props: any) => {
                   />
                 </div>
                 <div className="flex items-center">
-                  <CheckboxField
+                  <LegacyCheckboxField
                     checked={state.form.has_ari}
                     onChange={handleCheckboxFieldChange}
                     name="has_ari"
@@ -480,7 +480,7 @@ export const SampleTest = (props: any) => {
                   />
                 </div>
                 <div className="flex items-center">
-                  <CheckboxField
+                  <LegacyCheckboxField
                     checked={state.form.is_unusual_course}
                     onChange={handleCheckboxFieldChange}
                     name="is_unusual_course"

--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -3,7 +3,7 @@ import loadable from "@loadable/component";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import {
   LegacyErrorHelperText,
-  SelectField,
+  LegacySelectField,
 } from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
 import { useDispatch } from "react-redux";
@@ -381,7 +381,7 @@ export const ShiftCreate = (props: patientShiftProps) => {
                 <FieldLabel>
                   Preferred Vehicle <span className="text-red-500">*</span>
                 </FieldLabel>
-                <SelectField
+                <LegacySelectField
                   name="preferred_vehicle_choice"
                   variant="outlined"
                   margin="dense"
@@ -398,7 +398,7 @@ export const ShiftCreate = (props: patientShiftProps) => {
                   Preferred Facility Type{" "}
                   <span className="text-red-500">*</span>
                 </FieldLabel>
-                <SelectField
+                <LegacySelectField
                   name="assigned_facility_type"
                   variant="outlined"
                   margin="dense"
@@ -415,7 +415,7 @@ export const ShiftCreate = (props: patientShiftProps) => {
                   Severity of Breathlessness{" "}
                   <span className="text-red-500">*</span>
                 </FieldLabel>
-                <SelectField
+                <LegacySelectField
                   name="breathlessness_level"
                   variant="outlined"
                   margin="dense"

--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -1,7 +1,10 @@
 import { useReducer, useState, useEffect } from "react";
 import loadable from "@loadable/component";
 import { FacilitySelect } from "../Common/FacilitySelect";
-import { ErrorHelperText, SelectField } from "../Common/HelperInputFields";
+import {
+  LegacyErrorHelperText,
+  SelectField,
+} from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
 import { useDispatch } from "react-redux";
 import { navigate } from "raviger";
@@ -334,7 +337,7 @@ export const ShiftCreate = (props: patientShiftProps) => {
                     />
                   </Box>
                 </RadioGroup>
-                <ErrorHelperText error={state.errors.emergency} />
+                <LegacyErrorHelperText error={state.errors.emergency} />
               </div>
 
               <div>
@@ -359,7 +362,7 @@ export const ShiftCreate = (props: patientShiftProps) => {
                     />
                   </Box>
                 </RadioGroup>
-                <ErrorHelperText error={state.errors.is_up_shift} />
+                <LegacyErrorHelperText error={state.errors.is_up_shift} />
               </div>
 
               {/* <div>

--- a/src/Components/Patient/UpdateStatusDialog.tsx
+++ b/src/Components/Patient/UpdateStatusDialog.tsx
@@ -11,7 +11,7 @@ import {
   SAMPLE_TEST_RESULT,
   SAMPLE_FLOW_RULES,
 } from "../../Common/constants";
-import { CheckboxField, SelectField } from "../Common/HelperInputFields";
+import { CheckboxField, LegacySelectField } from "../Common/HelperInputFields";
 import { SampleTestModel } from "./models";
 import * as Notification from "../../Utils/Notifications.js";
 import { createUpload } from "../../Redux/actions";
@@ -195,7 +195,7 @@ const UpdateStatusDialog = (props: Props) => {
           <div className="md:col-span-2">{currentStatus?.desc}</div>
           <div className="font-semibold leading-relaxed">New Status :</div>
           <div className="md:col-span-2">
-            <SelectField
+            <LegacySelectField
               name="status"
               variant="standard"
               optionValue="desc"
@@ -210,7 +210,7 @@ const UpdateStatusDialog = (props: Props) => {
                 Result :
               </div>
               <div className="md:col-span-2">
-                <SelectField
+                <LegacySelectField
                   name="result"
                   variant="standard"
                   value={state.form.result}

--- a/src/Components/Patient/UpdateStatusDialog.tsx
+++ b/src/Components/Patient/UpdateStatusDialog.tsx
@@ -11,7 +11,10 @@ import {
   SAMPLE_TEST_RESULT,
   SAMPLE_FLOW_RULES,
 } from "../../Common/constants";
-import { CheckboxField, LegacySelectField } from "../Common/HelperInputFields";
+import {
+  LegacyCheckboxField,
+  LegacySelectField,
+} from "../Common/HelperInputFields";
 import { SampleTestModel } from "./models";
 import * as Notification from "../../Utils/Notifications.js";
 import { createUpload } from "../../Redux/actions";
@@ -248,7 +251,7 @@ const UpdateStatusDialog = (props: Props) => {
             </>
           )}
           <div className="md:col-span-3">
-            <CheckboxField
+            <LegacyCheckboxField
               checked={state.form.confirm}
               onChange={(e: any) =>
                 handleChange(e.target.name, e.target.checked)

--- a/src/Components/Resource/ListFilter.tsx
+++ b/src/Components/Resource/ListFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { FacilitySelect } from "../Common/FacilitySelect";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import { RESOURCE_FILTER_ORDER } from "../../Common/constants";
 import moment from "moment";
 import { getAnyFacility } from "../../Redux/actions";
@@ -165,7 +165,7 @@ export default function ListFilter(props: any) {
         {props.showResourceStatus && (
           <div className="w-full flex-none">
             <span className="text-sm font-semibold">Status</span>
-            <SelectField
+            <LegacySelectField
               name="status"
               variant="outlined"
               margin="dense"
@@ -234,7 +234,7 @@ export default function ListFilter(props: any) {
         </div>
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">Ordering</span>
-          <SelectField
+          <LegacySelectField
             name="ordering"
             variant="outlined"
             margin="dense"
@@ -249,7 +249,7 @@ export default function ListFilter(props: any) {
 
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">Is emergency case</span>
-          <SelectField
+          <LegacySelectField
             name="emergency"
             variant="outlined"
             margin="dense"

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -2,7 +2,7 @@ import { useReducer, useState, useEffect } from "react";
 import loadable from "@loadable/component";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import {
-  TextInputField,
+  LegacyTextInputField,
   MultilineInputField,
   ErrorHelperText,
   SelectField,
@@ -238,7 +238,7 @@ export default function ResourceCreate(props: resourceProps) {
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
               <div>
                 <InputLabel>Name of Contact Person at Facility*</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   fullWidth
                   name="refering_facility_contact_name"
                   variant="outlined"
@@ -306,7 +306,7 @@ export default function ResourceCreate(props: resourceProps) {
 
               <div className="md:col-span-1">
                 <InputLabel>Request Title*</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   rows={5}
                   name="title"
                   variant="outlined"
@@ -322,7 +322,7 @@ export default function ResourceCreate(props: resourceProps) {
               <div className="md:col-span-1">
                 <div className="w-full">
                   <InputLabel>Required Quantity</InputLabel>
-                  <TextInputField
+                  <LegacyTextInputField
                     name="requested_quantity"
                     variant="outlined"
                     margin="dense"

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -3,7 +3,7 @@ import loadable from "@loadable/component";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import {
   LegacyTextInputField,
-  MultilineInputField,
+  LegacyMultilineInputField,
   ErrorHelperText,
   SelectField,
 } from "../Common/HelperInputFields";
@@ -336,7 +336,7 @@ export default function ResourceCreate(props: resourceProps) {
 
               <div className="md:col-span-2">
                 <InputLabel>Description of request*</InputLabel>
-                <MultilineInputField
+                <LegacyMultilineInputField
                   rows={5}
                   name="reason"
                   variant="outlined"

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -4,7 +4,7 @@ import { FacilitySelect } from "../Common/FacilitySelect";
 import {
   LegacyTextInputField,
   LegacyMultilineInputField,
-  ErrorHelperText,
+  LegacyErrorHelperText,
   SelectField,
 } from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
@@ -371,7 +371,7 @@ export default function ResourceCreate(props: resourceProps) {
                     />
                   </Box>
                 </RadioGroup>
-                <ErrorHelperText error={state.errors.emergency} />
+                <LegacyErrorHelperText error={state.errors.emergency} />
               </div>
 
               <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -5,7 +5,7 @@ import {
   LegacyTextInputField,
   LegacyMultilineInputField,
   LegacyErrorHelperText,
-  SelectField,
+  LegacySelectField,
 } from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
 import { useDispatch } from "react-redux";
@@ -277,7 +277,7 @@ export default function ResourceCreate(props: resourceProps) {
 
               <div>
                 <InputLabel>Category</InputLabel>
-                <SelectField
+                <LegacySelectField
                   name="category"
                   variant="outlined"
                   fullWidth
@@ -292,7 +292,7 @@ export default function ResourceCreate(props: resourceProps) {
 
               <div>
                 <InputLabel>Subcategory</InputLabel>
-                <SelectField
+                <LegacySelectField
                   name="sub_category"
                   variant="outlined"
                   margin="dense"

--- a/src/Components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/Components/Resource/ResourceDetailsUpdate.tsx
@@ -5,7 +5,7 @@ import { FacilitySelect } from "../Common/FacilitySelect";
 import {
   LegacyTextInputField,
   LegacyMultilineInputField,
-  ErrorHelperText,
+  LegacyErrorHelperText,
 } from "../Common/HelperInputFields";
 
 import * as Notification from "../../Utils/Notifications.js";
@@ -370,7 +370,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
                     />
                   </Box>
                 </RadioGroup>
-                <ErrorHelperText error={state.errors.emergency} />
+                <LegacyErrorHelperText error={state.errors.emergency} />
               </div>
 
               <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">

--- a/src/Components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/Components/Resource/ResourceDetailsUpdate.tsx
@@ -4,7 +4,7 @@ import loadable from "@loadable/component";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import {
   LegacyTextInputField,
-  MultilineInputField,
+  LegacyMultilineInputField,
   ErrorHelperText,
 } from "../Common/HelperInputFields";
 
@@ -335,7 +335,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
 
               <div className="md:col-span-2">
                 <InputLabel>Description of request*</InputLabel>
-                <MultilineInputField
+                <LegacyMultilineInputField
                   rows={5}
                   name="reason"
                   variant="outlined"

--- a/src/Components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/Components/Resource/ResourceDetailsUpdate.tsx
@@ -17,7 +17,7 @@ import {
   updateResource,
   getUserList,
 } from "../../Redux/actions";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import { RESOURCE_CHOICES } from "../../Common/constants";
 import { UserSelect } from "../Common/UserSelect";
 import { CircularProgress } from "@material-ui/core";
@@ -235,7 +235,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
               <div className="md:col-span-1">
                 <InputLabel>Status</InputLabel>
-                <SelectField
+                <LegacySelectField
                   name="status"
                   variant="outlined"
                   margin="dense"

--- a/src/Components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/Components/Resource/ResourceDetailsUpdate.tsx
@@ -3,7 +3,7 @@ import loadable from "@loadable/component";
 
 import { FacilitySelect } from "../Common/FacilitySelect";
 import {
-  TextInputField,
+  LegacyTextInputField,
   MultilineInputField,
   ErrorHelperText,
 } from "../Common/HelperInputFields";
@@ -294,7 +294,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
               </div>
               <div>
                 <InputLabel>Required Quantity</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="requested_quantity"
                   variant="outlined"
                   margin="dense"
@@ -306,7 +306,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
               </div>
               <div>
                 <InputLabel>Approved Quantity</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   name="assigned_quantity"
                   variant="outlined"
                   margin="dense"
@@ -320,7 +320,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
 
               <div className="md:col-span-2">
                 <InputLabel>Request Title*</InputLabel>
-                <TextInputField
+                <LegacyTextInputField
                   rows={5}
                   name="title"
                   variant="outlined"

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { UserSelect } from "../Common/UserSelect2";
 import { navigate } from "raviger";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import {
   SHIFTING_FILTER_ORDER,
   DISEASE_STATUS,
@@ -249,7 +249,7 @@ export default function ListFilter(props: any) {
         {props.showShiftingStatus && (
           <div className="w-full flex-none">
             <span className="text-sm font-semibold">{t("status")}</span>
-            <SelectField
+            <LegacySelectField
               name="status"
               variant="outlined"
               margin="dense"
@@ -341,7 +341,7 @@ export default function ListFilter(props: any) {
 
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">{t("ordering")}</span>
-          <SelectField
+          <LegacySelectField
             name="ordering"
             variant="outlined"
             margin="dense"
@@ -358,7 +358,7 @@ export default function ListFilter(props: any) {
           <span className="text-sm font-semibold">
             {t("is_emergency_case")}
           </span>
-          <SelectField
+          <LegacySelectField
             name="emergency"
             variant="outlined"
             margin="dense"
@@ -375,7 +375,7 @@ export default function ListFilter(props: any) {
             <span className="text-sm font-semibold">{`${t(
               "is"
             )} ${kasp_string}`}</span>
-            <SelectField
+            <LegacySelectField
               name="is_kasp"
               variant="outlined"
               margin="dense"
@@ -390,7 +390,7 @@ export default function ListFilter(props: any) {
 
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">{t("is_upshift_case")}</span>
-          <SelectField
+          <LegacySelectField
             name="is_up_shift"
             variant="outlined"
             margin="dense"
@@ -404,7 +404,7 @@ export default function ListFilter(props: any) {
 
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">{t("disease_status")}</span>
-          <SelectField
+          <LegacySelectField
             name="disease_status"
             variant="outlined"
             margin="dense"
@@ -418,7 +418,7 @@ export default function ListFilter(props: any) {
 
         <div className="w-full flex-none">
           <span className="text-sm font-semibold">{t("is_antenatal")}</span>
-          <SelectField
+          <LegacySelectField
             name="is_antenatal"
             variant="outlined"
             margin="dense"
@@ -434,7 +434,7 @@ export default function ListFilter(props: any) {
           <span className="text-sm font-semibold">
             {t("breathlessness_level")}
           </span>
-          <SelectField
+          <LegacySelectField
             name="breathlessness_level"
             variant="outlined"
             margin="dense"

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from "react-redux";
 import { navigate, useQueryParams } from "raviger";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getShiftDetails, updateShift, getUserList } from "../../Redux/actions";
-import { SelectField } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import {
   SHIFTING_CHOICES,
   FACILITY_TYPES,
@@ -256,7 +256,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
               <div className="md:col-span-1">
                 <FieldLabel>{t("status")}</FieldLabel>
-                <SelectField
+                <LegacySelectField
                   name="status"
                   variant="outlined"
                   margin="dense"
@@ -394,7 +394,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
               </div>
               <div className="md:col-span-1">
                 <FieldLabel>{t("preferred_vehicle")}</FieldLabel>
-                <SelectField
+                <LegacySelectField
                   name="preferred_vehicle_choice"
                   variant="outlined"
                   margin="dense"
@@ -408,7 +408,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
               </div>
               <div className="md:col-span-1">
                 <FieldLabel>{t("preferred_facility_type")}*</FieldLabel>
-                <SelectField
+                <LegacySelectField
                   name="assigned_facility_type"
                   variant="outlined"
                   margin="dense"
@@ -422,7 +422,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
               </div>
               <div className="md:col-span-1">
                 <FieldLabel>{t("severity_of_breathlessness")}*</FieldLabel>
-                <SelectField
+                <LegacySelectField
                   name="breathlessness_level"
                   variant="outlined"
                   margin="dense"

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -1,7 +1,7 @@
 import { useReducer, useState, useCallback, useEffect } from "react";
 import loadable from "@loadable/component";
 import { FacilitySelect } from "../Common/FacilitySelect";
-import { ErrorHelperText } from "../Common/HelperInputFields";
+import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
 import { useDispatch } from "react-redux";
 import { navigate, useQueryParams } from "raviger";
@@ -338,7 +338,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
                     />
                   </Box>
                 </RadioGroup>
-                <ErrorHelperText error={state.errors.emergency} />
+                <LegacyErrorHelperText error={state.errors.emergency} />
               </div>
 
               <div>
@@ -365,7 +365,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
                     />
                   </Box>
                 </RadioGroup>
-                <ErrorHelperText error={state.errors.is_kasp} />
+                <LegacyErrorHelperText error={state.errors.is_kasp} />
               </div>
 
               <div>
@@ -390,7 +390,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
                     />
                   </Box>
                 </RadioGroup>
-                <ErrorHelperText error={state.errors.is_up_shift} />
+                <LegacyErrorHelperText error={state.errors.is_up_shift} />
               </div>
               <div className="md:col-span-1">
                 <FieldLabel>{t("preferred_vehicle")}</FieldLabel>


### PR DESCRIPTION
## Proposed Changes

- Renames all components to `Legacy<ComponentName>` in `HelperInputFields.tsx` to explicitly prevent usage in favour of new components.
- Removes unused legacy components.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
