### PR TITLE
Hide CNS momentarily

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -87,7 +87,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                       {kasp_string}
                     </div>
                   )}
-                  <div className="flex items-center justify-between">
+                  {/* <div className="flex items-center justify-between">
                     <Link
                       href={`/facility/${facility.id}`}
                       className="float-left font-bold text-xl capitalize text-inherit hover:text-inherit"
@@ -102,7 +102,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                       <CareIcon className="care-l-monitor-heart-rate text-lg" />
                       <span>CNS</span>
                     </ButtonV2>
-                  </div>
+                  </div> */}
                 </div>
 
                 <div className="flex gap-1 flex-wrap mt-2">

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -620,7 +620,7 @@ export const FacilityHome = (props: any) => {
               </DropdownMenu>
             </div>
             <div className="flex flex-col justify-end">
-              <ButtonV2
+              {/* <ButtonV2
                 variant="primary"
                 ghost
                 border
@@ -629,7 +629,7 @@ export const FacilityHome = (props: any) => {
               >
                 <CareIcon className="care-l-monitor-heart-rate text-lg" />
                 <span>Central Nursing Station</span>
-              </ButtonV2>
+              </ButtonV2> */}
               <ButtonV2
                 variant="primary"
                 ghost


### PR DESCRIPTION
## Proposed Changes

- Problem: Discharged patients for a bed is being shown even though new patients have been admitted to those beds.
- To avoid confusion among doctors/nurses, buttons that take to CNS have been hidden momentarily.

cc: @aparnacoronasafe 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
