### PR TITLE
Update Treatment Plan icon in Consultation Form

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -61,6 +61,7 @@ import DateFormField from "../Form/FormFields/DateFormField";
 import useConfig from "../../Common/hooks/useConfig";
 import useAppHistory from "../../Common/hooks/useAppHistory";
 import useVisibility from "../../Utils/useVisibility";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -230,12 +231,12 @@ export const ConsultationForm = (props: any) => {
 
   const sections = {
     "Consultation Details": {
-      iconClass: "fa-solid fa-suitcase-medical",
+      iconClass: "care-l-medkit",
       visible: consultationDetailsVisible,
       ref: consultationDetailsRef,
     },
     "Treatment Plan": {
-      iconClass: "fa-solid fa-prescription",
+      iconClass: "care-l-clipboard-alt",
       visible: treatmentPlanVisible,
       ref: treatmentPlanRef,
     },
@@ -751,7 +752,7 @@ export const ConsultationForm = (props: any) => {
         className="col-span-6 flex flex-row items-center mb-6 -ml-2"
         ref={section.ref as LegacyRef<HTMLDivElement>}
       >
-        <i className={`${section.iconClass} text-lg mr-3`} />
+        <CareIcon className={`${section.iconClass} text-xl mr-3`} />
         <label className="font-bold text-lg text-gray-900">
           {sectionTitle}
         </label>
@@ -826,7 +827,7 @@ export const ConsultationForm = (props: any) => {
                   setCurrentSection(sectionTitle as ConsultationFormSection);
                 }}
               >
-                <i className={`${section.iconClass} text-sm`} />
+                <CareIcon className={`${section.iconClass} text-lg`} />
                 <span>{sectionTitle}</span>
               </button>
             );


### PR DESCRIPTION
## Proposed Changes

- Fixes #5172
- Use CareIcon instead of FontAwesome for Consultation Details

![image](https://user-images.githubusercontent.com/25143503/227984759-9a7d1b9a-a095-46f9-8c94-25f38d72758a.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
