### PR TITLE
Made the button with cross icon not appear in pressure sore preview mode

### DIFF
--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreEditor.res
@@ -271,6 +271,7 @@ let renderBody = (state, send, title, partPaths, substr) => {
                   ),
                 )}
               </div>
+              {state.previewMode ? React.null :  <div>
               {switch selectedPart {
               | Some(p) =>
                 <i
@@ -281,6 +282,7 @@ let renderBody = (state, send, title, partPaths, substr) => {
                 />
               | None => React.null
               }}
+              </div>}
             </div>
           </div>
         }, partPaths)->React.array}


### PR DESCRIPTION
## Proposed Changes

- Fixes #4894 
- The cross button in pressure sore will not appear in preview mode as well as in the consultation.

### Screenshot
![image](https://user-images.githubusercontent.com/40627011/227990078-aff88fe7-841e-48e6-8184-08163e512af4.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
