### PR TITLE
Hide the history of illness field when brought by dead is selected

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -890,19 +890,19 @@ export const ConsultationForm = (props: any) => {
                           />
                         </div>
                       )}
+                      <div
+                        className="col-span-6"
+                        ref={fieldRef["history_of_present_illness"]}
+                      >
+                        <TextAreaFormField
+                          {...field("history_of_present_illness")}
+                          label="History of present illness"
+                          placeholder="Optional information"
+                        />
+                      </div>
                     </>
                   )}
 
-                  <div
-                    className="col-span-6"
-                    ref={fieldRef["history_of_present_illness"]}
-                  >
-                    <TextAreaFormField
-                      {...field("history_of_present_illness")}
-                      label="History of present illness"
-                      placeholder="Optional information"
-                    />
-                  </div>
                   <div
                     className="col-span-6"
                     ref={fieldRef["examination_details"]}


### PR DESCRIPTION
## Proposed Changes

- Fixes #5169 
Hide the history of illness field when brought by dead is selected
![image](https://user-images.githubusercontent.com/59426397/228016364-2bf0dbeb-8d87-42f2-9f95-293e994abef1.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
