### PR TITLE
fix padding below bed select field in consultation form

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1065,7 +1065,7 @@ export const ConsultationForm = (props: any) => {
                       </div>
 
                       {!isUpdate && (
-                        <div className="col-span-6" ref={fieldRef["bed"]}>
+                        <div className="col-span-6 mb-6" ref={fieldRef["bed"]}>
                           <FieldLabel>Bed</FieldLabel>
                           <BedSelect
                             name="bed"
@@ -1080,6 +1080,7 @@ export const ConsultationForm = (props: any) => {
                       )}
                     </>
                   )}
+
                   <div className="col-span-6" ref={fieldRef["ip_no"]}>
                     <TextFormField
                       {...field("ip_no")}


### PR DESCRIPTION
## Proposed Changes

- fixes padding below bed select field in consultation form

### Before: 
![image](https://user-images.githubusercontent.com/25143503/228522451-103a1afc-438b-4b25-afca-a4d23d98d797.png)

### After:
![image](https://user-images.githubusercontent.com/25143503/228522629-27c3796d-9b4a-4123-9b70-907a906e8b76.png)



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
