### PR TITLE
ESLint: set `no-literal-string` only for JSX

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,9 @@
         "jsx-attributes": {
           "include": ["label", "placeholder", "error", "title"],
           "exclude": [".*"]
+        },
+        "callees": {
+          "exclude": [".*"]
         }
       }
     ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,7 +44,7 @@
     "i18next/no-literal-string": [
       "warn",
       {
-        "mode": "all",
+        "mode": "jsx-only",
         "jsx-attributes": {
           "include": ["label", "placeholder", "error", "title"],
           "exclude": [".*"]


### PR DESCRIPTION
## Proposed Changes:
- Currently no literal string warning is there even in places where it's not required (strings that's potentially not part of the UI)
- Set the rule only for text inside JSX, and exclude callees

### Before:
![image](https://user-images.githubusercontent.com/25143503/228525296-6e5fc43c-832d-4999-8a74-9d7d79c98b5a.png)

### After:
![image](https://user-images.githubusercontent.com/25143503/228526864-ec053c86-0340-4bd4-9b19-cd6b357cf0fe.png)




@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
