### PR TITLE
Refactor patient category text: "Slightly Abnormal" to "Abnormal"

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -343,7 +343,7 @@ export const PATIENT_CATEGORIES: {
 }[] = [
   { id: "Comfort", text: "Comfort Care", twClass: "patient-comfort" },
   { id: "Stable", text: "Stable", twClass: "patient-stable" },
-  { id: "Moderate", text: "Slightly Abnormal", twClass: "patient-abnormal" },
+  { id: "Moderate", text: "Abnormal", twClass: "patient-abnormal" },
   { id: "Critical", text: "Critical", twClass: "patient-critical" },
 ];
 

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -76,7 +76,7 @@ export interface OptionsType {
 export type PatientCategory =
   | "Comfort Care"
   | "Stable"
-  | "Slightly Abnormal"
+  | "Abnormal"
   | "Critical";
 
 export interface ConsultationModel {

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -72,7 +72,7 @@ function TabPanel(props: TabPanelProps) {
 const PatientCategoryDisplayText: Record<PatientCategory, string> = {
   "Comfort Care": "COMFORT CARE",
   Stable: "STABLE",
-  "Slightly Abnormal": "ABNORMAL",
+  Abnormal: "ABNORMAL",
   Critical: "CRITICAL",
 };
 


### PR DESCRIPTION
Fixes #5198
Backend PR: https://github.com/coronasafe/care/pull/1233

`Slightly Abnormal` has been changed to `Abnormal` for consistency and clarity.

This change will ensure that the patient categories are accurately represented in the application and will provide a better user experience for healthcare professionals who rely on this information.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers