### PR TITLE
Add severity category sort options

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -168,6 +168,8 @@ export const SHIFTING_FILTER_ORDER: Array<OptionsType> = [
 export const PATIENT_SORT_OPTIONS: SortOption[] = [
   { isAscending: false, value: "-created_date" },
   { isAscending: true, value: "created_date" },
+  { isAscending: false, value: "-category_severity" },
+  { isAscending: true, value: "category_severity" },
   { isAscending: false, value: "-modified_date" },
   { isAscending: true, value: "modified_date" },
   {

--- a/src/Components/Common/components/Menu.tsx
+++ b/src/Components/Common/components/Menu.tsx
@@ -35,7 +35,7 @@ export default function DropdownMenu({
           <CareIcon className="ml-2 -mr-1 care-l-angle-down text-lg" />
         </Menu.Button>
         <DropdownTransition>
-          <Menu.Items className="z-10 absolute right-0 mt-2 py-1 min-w-full sm:min-w-[250px] origin-top-right rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+          <Menu.Items className="md:w-max z-10 absolute right-0 mt-2 py-1 min-w-full sm:min-w-[250px] origin-top-right rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
             <>{props.children}</>
           </Menu.Items>
         </DropdownTransition>

--- a/src/Locale/en/SortOptions.json
+++ b/src/Locale/en/SortOptions.json
@@ -1,6 +1,8 @@
 {
     "-created_date": "Latest created date first",
     "created_date": "Oldest created date first",
+    "-category_severity": "Highest Severity category first",
+    "category_severity": "Lowest Severity category first",
     "-modified_date": "Latest updated date first",
     "modified_date": "Oldest updated date first",
     "facility__name,last_consultation__current_bed__bed__name": "Bed No. 1-N",


### PR DESCRIPTION
Fixes #5197
Backend PR: https://github.com/coronasafe/care/pull/1235

This PR adds new patient sort options to the application. Specifically, it allows sorting patients by their severity category, from High to Low or Low to High.

The new sort options are included in the `PATIENT_SORT_OPTIONS` array in the `constants.tsx` file, and their corresponding localization strings are added to the `SortOptions.json` file in the `Locale/en`
directory.

This enhancement will enable users to easily sort patients by severity level, providing better visibility and management of patient care.

![image](https://user-images.githubusercontent.com/3626859/228858268-bc46314e-e99b-41c4-8a33-1409ae07776a.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
