### PR TITLE
Fix syntax error in label-wip.yml workflow file

### DIFF
--- a/.github/workflows/label-wip.yml
+++ b/.github/workflows/label-wip.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-linked-issues
     permissions: write-all
-    if: github.repository == 'coronasafe/care_fe' && 'join(needs.check-linked-issues.outputs.linked_issues) != ''
+    if: github.repository == 'coronasafe/care_fe' && needs.check-linked-issues.outputs.linked_issues.length > 0
     steps:
       - name: Label
         uses: actions/github-script@v6


### PR DESCRIPTION
Fixed a syntax error in the `label-wip.yml` workflow file, which was preventing the workflow from running correctly. The error was in the `if` condition of the `label-issues` job, where the expression used to check whether the `linked_issues` output of the `check-linked-issues` job was not empty was incorrect. The `length` function was used instead to correctly check the length of the `linked_issues` string.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers