### PR TITLE
Added OP number to patient consultation form

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -689,7 +689,7 @@ export const ConsultationDetails = (props: any) => {
           <div className="border rounded-lg bg-white shadow h-full text-black w-full">
             <PatientInfoCard
               patient={patientData}
-              ip_no={consultationData.ip_no}
+              consultation={consultationData}
               fetchPatientData={fetchData}
             />
 

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -94,6 +94,7 @@ type FormDetails = {
   prescribed_medication: string;
   consultation_notes: string;
   ip_no: string;
+  op_no: string;
   procedure: ProcedureType[];
   discharge_advice: PrescriptionType[];
   prn_prescription: PRNPrescriptionType[];
@@ -141,6 +142,7 @@ const initForm: FormDetails = {
   prescribed_medication: "",
   consultation_notes: "",
   ip_no: "",
+  op_no: "",
   procedure: [],
   discharge_advice: [],
   prn_prescription: [],
@@ -303,6 +305,7 @@ export const ConsultationForm = (props: any) => {
                   ?.id || "Comfort"
               : "Comfort",
             ip_no: res.data.ip_no ? res.data.ip_no : "",
+            op_no: res.data.op_no ? res.data.op_no : "",
             verified_by: res.data.verified_by ? res.data.verified_by : "",
             OPconsultation: res.data.consultation_notes,
             is_telemedicine: `${res.data.is_telemedicine}`,
@@ -377,6 +380,16 @@ export const ConsultationForm = (props: any) => {
             invalidForm = true;
           } else if (!state.form[field].replace(/\s/g, "").length) {
             errors[field] = "IP can not be empty";
+            invalidForm = true;
+          }
+          return;
+        case "op_no":
+          if (state.form.suggestion === "A") return;
+          if (!state.form[field]) {
+            errors[field] = "OP Number is required as person is not admitted";
+            invalidForm = true;
+          } else if (!state.form[field].replace(/\s/g, "").length) {
+            errors[field] = "OP can not be empty";
             invalidForm = true;
           }
           return;
@@ -619,6 +632,7 @@ export const ConsultationForm = (props: any) => {
         prescribed_medication: state.form.prescribed_medication,
         discharge_date: state.form.discharge_date,
         ip_no: state.form.ip_no,
+        op_no: state.form.op_no,
         icd11_diagnoses: state.form.icd11_diagnoses_object.map((o) => o.id),
         icd11_provisional_diagnoses:
           state.form.icd11_provisional_diagnoses_object.map((o) => o.id),
@@ -1096,14 +1110,23 @@ export const ConsultationForm = (props: any) => {
                       )}
                     </>
                   )}
-
-                  <div className="col-span-6" ref={fieldRef["ip_no"]}>
-                    <TextFormField
-                      {...field("ip_no")}
-                      label="IP Number"
-                      required={state.form.suggestion === "A"}
-                    />
-                  </div>
+                  {state.form.suggestion !== "A" ? (
+                    <div className="col-span-6 mb-6" ref={fieldRef["op_no"]}>
+                      <TextFormField
+                        {...field("op_no")}
+                        label="OP Number"
+                        required={state.form.suggestion !== "A"}
+                      />
+                    </div>
+                  ) : (
+                    <div className="col-span-6 mb-6" ref={fieldRef["ip_no"]}>
+                      <TextFormField
+                        {...field("ip_no")}
+                        label="IP Number"
+                        required={state.form.suggestion === "A"}
+                      />
+                    </div>
+                  )}
                 </div>
 
                 <div className="grid grid-cols-1 gap-4 gap-x-6">

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -383,16 +383,6 @@ export const ConsultationForm = (props: any) => {
             invalidForm = true;
           }
           return;
-        case "op_no":
-          if (state.form.suggestion === "A") return;
-          if (!state.form[field]) {
-            errors[field] = "OP Number is required as person is not admitted";
-            invalidForm = true;
-          } else if (!state.form[field].replace(/\s/g, "").length) {
-            errors[field] = "OP can not be empty";
-            invalidForm = true;
-          }
-          return;
         case "other_symptoms":
           if (isOtherSymptomsSelected && !state.form[field]) {
             errors[field] = "Please enter the other symptom details";
@@ -1112,11 +1102,7 @@ export const ConsultationForm = (props: any) => {
                   )}
                   {state.form.suggestion !== "A" ? (
                     <div className="col-span-6 mb-6" ref={fieldRef["op_no"]}>
-                      <TextFormField
-                        {...field("op_no")}
-                        label="OP Number"
-                        required={state.form.suggestion !== "A"}
-                      />
+                      <TextFormField {...field("op_no")} label="OP Number" />
                     </div>
                   ) : (
                     <div className="col-span-6 mb-6" ref={fieldRef["ip_no"]}>

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -100,6 +100,8 @@ export interface ConsultationModel {
   referred_to?: number | null;
   suggestion?: string;
   ip_no?: string;
+  op_no?: string;
+  consultation_status?: number;
   is_kasp?: boolean;
   kasp_enabled_date?: string;
   diagnosis?: string;

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -4,7 +4,7 @@ import { PatientModel } from "./models";
 import DialogModal from "../Common/Dialog";
 import Beds from "../Facility/Consultations/Beds";
 import { useState } from "react";
-import { PatientCategory } from "../Facility/models";
+import { ConsultationModel, PatientCategory } from "../Facility/models";
 import {
   CONSULTATION_SUGGESTION,
   DISCHARGE_REASONS,
@@ -19,14 +19,16 @@ import useConfig from "../../Common/hooks/useConfig";
 
 export default function PatientInfoCard(props: {
   patient: PatientModel;
-  ip_no?: string | undefined;
+  consultation?: ConsultationModel;
   fetchPatientData?: (state: { aborted: boolean }) => void;
 }) {
   const [open, setOpen] = useState(false);
   const { enable_hcx } = useConfig();
 
   const patient = props.patient;
-  const ip_no = props.ip_no;
+  const consultation = props.consultation;
+  const ip_no = consultation?.ip_no;
+  const op_no = consultation?.op_no;
 
   const category: PatientCategory | undefined =
     patient?.last_consultation?.category;
@@ -141,13 +143,14 @@ export default function PatientInfoCard(props: {
                 ></i>
                 {patient.facility_object?.name}
               </Link>
-              {ip_no && (
-                <span className="md:col-span-2 capitalize pl-2">
-                  <span className="badge badge-pill badge-primary">
-                    {`IP: ${ip_no}`}
-                  </span>
+
+              <span className="md:col-span-2 capitalize pl-2">
+                <span className="badge badge-pill badge-primary">
+                  {consultation?.suggestion !== "A"
+                    ? `OP: ${op_no}`
+                    : `IP: ${ip_no}`}
                 </span>
-              )}
+              </span>
             </div>
             {!patient.is_active && (
               <p className="bg-red-100 text-red-600 inline-block rounded-lg px-2 py-1 my-1 text-sm">

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -144,13 +144,15 @@ export default function PatientInfoCard(props: {
                 {patient.facility_object?.name}
               </Link>
 
-              <span className="md:col-span-2 capitalize pl-2">
-                <span className="badge badge-pill badge-primary">
-                  {consultation?.suggestion !== "A"
-                    ? `OP: ${op_no}`
-                    : `IP: ${ip_no}`}
+              {(consultation?.suggestion === "A" || op_no) && (
+                <span className="md:col-span-2 capitalize pl-2">
+                  <span className="badge badge-pill badge-primary">
+                    {consultation?.suggestion !== "A"
+                      ? `OP: ${op_no}`
+                      : `IP: ${ip_no}`}
+                  </span>
                 </span>
-              </span>
+              )}
             </div>
             {!patient.is_active && (
               <p className="bg-red-100 text-red-600 inline-block rounded-lg px-2 py-1 my-1 text-sm">


### PR DESCRIPTION
## Proposed Changes

- Fixes #4877 
- Requires OP number instead of IP number incase decision after consultation is not Admission

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

![image](https://user-images.githubusercontent.com/23238460/230330854-6c4b2bd5-cabe-4ea9-b8bc-80c2ff0f8e03.png)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
