### PR TITLE
Fixed icon missing issue in the linked skills slideover

### DIFF
--- a/src/Components/Users/SkillsSlideOverComponents.tsx
+++ b/src/Components/Users/SkillsSlideOverComponents.tsx
@@ -11,7 +11,7 @@ export const AddSkillsPlaceholder = () => {
     <div className="mb-2 mt-2 flex flex-col justify-center align-middle content-center h-96">
       <div className="w-full">
         <img
-          src={`${import.meta.env.VITE_PUBLIC_URL}/images/404.svg`}
+          src={`${import.meta.env.REACT_PUBLIC_URL}/images/404.svg`}
           alt="Error 404"
           className="w-80 mx-auto"
         />


### PR DESCRIPTION
## Proposed Changes

- Fixes #5258 
Fixed icon missing issue in the linked skills slideover
![image](https://user-images.githubusercontent.com/59426397/230490384-0579d8ca-8f98-4c06-a1b8-9026e9ad5917.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
