### PR TITLE
Removed respiratory support badge when it is none

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -189,7 +189,7 @@ export default function PatientInfoCard(props: {
                     ?.ventilator_interface,
                 ],
               ].map((stat, i) => {
-                return stat[2] ? (
+                return stat[2] && stat[1] !== "NONE" ? (
                   <div
                     key={"patient_stat_" + i}
                     className="bg-gray-200 border-gray-500 border py-1 px-2 rounded-lg text-xs"


### PR DESCRIPTION
## Proposed Changes

- Fixes #5266
- Removed respiratory support badge when its value is 'NONE' in Patient Card

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
