### PR TITLE
Fix search input on various pages

### DIFF
--- a/cypress/e2e/external_results_spec/external_result.cy.ts
+++ b/cypress/e2e/external_results_spec/external_result.cy.ts
@@ -19,9 +19,9 @@ describe("Edit Profile Testing", () => {
     cy.awaitUrl("/external_results");
   });
 
-  it("Search by Patient name", () => {
+  it("Search by Sample name", () => {
     cy.intercept(/\/api\/v1\/external_result/).as("external_result");
-    cy.get("[name='patient_name_search']").type("akhil");
+    cy.get("[name='name']").type("akhil");
     cy.wait("@external_result").then((interception) => {
       expect(interception.response.statusCode).to.equal(200);
     });

--- a/cypress/e2e/sample_test_spec/sample_test.cy.ts
+++ b/cypress/e2e/sample_test_spec/sample_test.cy.ts
@@ -22,7 +22,7 @@ describe("Sample List", () => {
 
   it("Search by Patient Name", () => {
     cy.intercept(/\/api\/v1\/test_sample/).as("test_sample");
-    cy.get("[name='patient_name_search']").type("Test");
+    cy.get("[name='patient_name']").type("Test");
     cy.wait("@test_sample").then((interception) => {
       expect(interception.response.statusCode).to.equal(200);
     });

--- a/cypress/e2e/shifting_spec/shifting.cy.ts
+++ b/cypress/e2e/shifting_spec/shifting.cy.ts
@@ -25,7 +25,7 @@ describe("Shifting Page", () => {
   });
 
   it("search patient", () => {
-    cy.get("[name='patient_name_search']").type("Akhil");
+    cy.get("[name='patient_name']").type("Akhil");
     cy.url().should("include", "Akhil");
   });
 

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -262,11 +262,10 @@ export default function ResultList() {
         />
         <div className="mt-2">
           <SearchInput
-            label="Search by name"
-            name="patient_name_search"
+            name="name"
             onChange={(e) => updateQuery({ [e.name]: e.value })}
             value={qParams.name}
-            placeholder="Search patient"
+            placeholder="Search by name"
           />
           <div className="text-sm font-medium my-2">Search by number</div>
           <div className="w-full max-w-sm">

--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -363,13 +363,13 @@ export default function SampleViewAdmin() {
 
           <div className="w-full flex flex-col gap-3">
             <SearchInput
-              name="patient_name_search"
+              name="patient_name"
               value={qParams.patient_name}
               onChange={(e) => updateQuery({ [e.name]: e.value })}
               placeholder="Search patient"
             />
             <SearchInput
-              name="district_name_search"
+              name="district_name"
               value={qParams.district_name}
               onChange={(e) => updateQuery({ [e.name]: e.value })}
               placeholder="Search by district"

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -52,7 +52,7 @@ export default function BoardView() {
         </div>
         <div className="w-full flex pt-2 lg:space-x-4 items-center flex-col lg:flex-row justify-between">
           <SearchInput
-            name="patient_name_search"
+            name="patient_name"
             value={qParams.patient_name}
             onChange={(e) => updateQuery({ [e.name]: e.value })}
             placeholder={t("search_patient")}


### PR DESCRIPTION
Fixes #5276 

Fixes search input on the following pages:
- Samples page
- Shifting Board view
- External results page

![image](https://user-images.githubusercontent.com/3626859/230672110-1bc90908-1cd9-483e-8cf6-4f946ab2cca5.png)

![image](https://user-images.githubusercontent.com/3626859/230672191-6a60eb80-162b-46d2-b6f5-bae5765afb41.png)

![image](https://user-images.githubusercontent.com/3626859/230672239-4a0a8f2a-8d52-4a8a-9c31-b6d4b9f56c35.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers