### PR TITLE
Add "Shift Patient" button to patient dashboard

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -663,6 +663,17 @@ export const ConsultationDetails = (props: any) => {
           <div className="w-full sm:w-min lg:absolute xl:right-0 -right-6 top-0 flex sm:flex-row sm:items-center flex-col space-y-1 sm:space-y-0 sm:divide-x-2">
             {patientData.is_active && (
               <div className="w-full flex flex-col sm:flex-row px-2">
+                <ButtonV2
+                  onClick={() =>
+                    navigate(
+                      `/facility/${patientData.facility}/patient/${patientData.id}/shift/new`
+                    )
+                  }
+                  className="w-full btn m-1 btn-primary hover:text-white"
+                >
+                  <CareIcon className="care-l-ambulance w-5 h-5" />
+                  Shift Patient
+                </ButtonV2>
                 <button
                   onClick={() => setShowDoctors(true)}
                   className="w-full btn m-1 btn-primary hover:text-white"


### PR DESCRIPTION
Fixes #5297

This PR adds a new "Shift Patient" button to the `ConsultationDetails` component, which allows healthcare providers to quickly and easily shift a patient to a new facility. The button is located in the top right-hand corner of the component and is only visible if the patient is currently active.

![image](https://user-images.githubusercontent.com/3626859/230908376-b6d504fd-8f1c-46e6-99aa-083c79b977a1.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
