### PR TITLE
Refactor discharge badge on Patient Dashboard

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -535,7 +535,10 @@ export const ConsultationDetails = (props: any) => {
                 label="Discharge Date"
                 name="discharge_date"
                 value={moment(preDischargeForm.discharge_date).toDate()}
-                min={moment(consultationData.admission_date).toDate()}
+                min={moment(
+                  consultationData.admission_date ||
+                    consultationData.created_date
+                ).toDate()}
                 disableFuture={true}
                 required
                 onChange={handleDateChange}
@@ -601,7 +604,10 @@ export const ConsultationDetails = (props: any) => {
                 label="Date of Discharge"
                 name="discharge_date"
                 value={moment(preDischargeForm.discharge_date).toDate()}
-                min={moment(consultationData.admission_date).toDate()}
+                min={moment(
+                  consultationData.admission_date ||
+                    consultationData.created_date
+                ).toDate()}
                 disableFuture={true}
                 required
                 onChange={handleDateChange}
@@ -906,7 +912,7 @@ export const ConsultationDetails = (props: any) => {
                         {consultationData.discharge_reason === "REC" && (
                           <div className="grid gap-4">
                             <div>
-                              Date {" - "}
+                              Discharge Date {" - "}
                               <span className="font-semibold">
                                 {consultationData.discharge_date
                                   ? formatDate(consultationData.discharge_date)
@@ -985,14 +991,6 @@ export const ConsultationDetails = (props: any) => {
                         {consultationData.discharge_reason === "EXP" && (
                           <div className="grid gap-4">
                             <div>
-                              Discharge Date {" - "}
-                              <span className="font-semibold">
-                                {consultationData.discharge_date
-                                  ? formatDate(consultationData.discharge_date)
-                                  : "--:--"}
-                              </span>
-                            </div>
-                            <div>
                               Date of Death {" - "}
                               <span className="font-semibold">
                                 {consultationData.death_datetime
@@ -1020,7 +1018,7 @@ export const ConsultationDetails = (props: any) => {
                         ) && (
                           <div className="grid gap-4">
                             <div>
-                              Date {" - "}
+                              Discharge Date {" - "}
                               <span className="font-semibold">
                                 {consultationData.discharge_date
                                   ? formatDate(consultationData.discharge_date)

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -210,7 +210,12 @@ export default function PatientInfoCard(props: {
                       )?.text
                     }{" "}
                     on{" "}
-                    {moment(consultation?.admission_date).format("DD/MM/YYYY")},
+                    {consultation?.suggestion === "A"
+                      ? moment(consultation?.admission_date).format(
+                          "DD/MM/YYYY"
+                        )
+                      : moment(consultation?.created_date).format("DD/MM/YYYY")}
+                    ,
                     {consultation?.discharge_reason === "EXP" ? (
                       <span>
                         {" "}

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -199,29 +199,39 @@ export default function PatientInfoCard(props: {
                 );
               })}
             </div>
-            <div className="flex gap-4 text-sm mt-3 px-3 py-1 font-medium bg-cyan-300">
-              <div>
-                {
-                  CONSULTATION_SUGGESTION.find(
-                    (suggestion) => suggestion.id === consultation?.suggestion
-                  )?.text
-                }{" "}
-                on{" "}
-                {consultation?.suggestion === "A"
-                  ? moment(consultation?.admission_date).format("DD/MM/YYYY")
-                  : consultation?.suggestion === "DD"
-                  ? moment(consultation?.death_datetime).format("DD/MM/YYYY")
-                  : moment(consultation?.created_date).format("DD/MM/YYYY")}
+            {patient.is_active === false && (
+              <div className="flex gap-4 text-sm mt-3 px-3 py-1 font-medium bg-cyan-300">
+                <div>
+                  <span>
+                    {
+                      CONSULTATION_SUGGESTION.find(
+                        (suggestion) =>
+                          suggestion.id === consultation?.suggestion
+                      )?.text
+                    }{" "}
+                    on{" "}
+                    {moment(consultation?.admission_date).format("DD/MM/YYYY")},
+                    {consultation?.discharge_reason === "EXP" ? (
+                      <span>
+                        {" "}
+                        Expired on{" "}
+                        {moment(consultation?.death_datetime).format(
+                          "DD/MM/YYYY"
+                        )}
+                      </span>
+                    ) : (
+                      <span>
+                        {" "}
+                        Discharged on{" "}
+                        {moment(consultation?.discharge_date).format(
+                          "DD/MM/YYYY"
+                        )}
+                      </span>
+                    )}
+                  </span>
+                </div>
               </div>
-              {patient.is_active === false &&
-                consultation?.suggestion !== "OP" &&
-                consultation?.suggestion !== "DD" && (
-                  <div>
-                    Discharged on{" "}
-                    {moment(consultation?.discharge_date).format("DD/MM/YYYY")}
-                  </div>
-                )}
-            </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a48c63</samp>

This pull request improves the display of consultation and patient information in the frontend. It fixes the discharge date display and validation in `ConsultationDetails.tsx`, and hides unnecessary fields for active patients in `PatientInfoCard.tsx`.

## Proposed Changes

- Fixes #5315


**When the discharge reason is expired,**
- [x] the patient dashboard to show "Admitted on XYZ, Expired on DD/MM/YYYY(date given in the pop up discharge form)"
 In the Discharge details card in the patient dashboard, remove Discharge date

- [x] Add data validation to the date field in the discharge pop-up form: the date cannot be before the Admission date if there is an admission date (if not, date of consultation filed) or after the current date. Allow date of consultation/ Admission date.
When the discharge reason is referred,

**When the discharge reason is Recovered, Referred or LAMA**

 - [x] the patient dashboard to show "Admitted on XYZ, discharged on DD/MM/YYYY(date given in the pop up discharge form)"
 In the Discharge details card in the patient dashboard, rename date to "discharge date and show the date given in the pop up discharge form"

- [x] In data validation to the date field in the discharge pop-up form: the date cannot be before the admission date (if there is no admission date, then the date of Consultation filed )or after the current date. Allow date of consultation/ Admission date.


![image](https://user-images.githubusercontent.com/3626859/231965855-8d2d581b-bf7b-4b52-bbca-f09c38d110b9.png)
![image](https://user-images.githubusercontent.com/3626859/231965867-151bcedd-4cb2-4a30-99af-c1fc11727cef.png)
![image](https://user-images.githubusercontent.com/3626859/231965884-4d9ffe30-1857-47a0-a175-bf8acee0cfbc.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a48c63</samp>

*  Add fallback values for minimum discharge date in consultation details and discharge form to prevent invalid dates ([link](https://github.com/coronasafe/care_fe/pull/5333/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL538-R541), [link](https://github.com/coronasafe/care_fe/pull/5333/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL604-R610))
*  Add labels for discharge date in consultation details and summary cards to improve clarity ([link](https://github.com/coronasafe/care_fe/pull/5333/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL909-R915), [link](https://github.com/coronasafe/care_fe/pull/5333/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL1023-R1021))
*  Remove redundant display of discharge date in consultation details and summary cards to avoid duplication ([link](https://github.com/coronasafe/care_fe/pull/5333/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL988-L995), [link](https://github.com/coronasafe/care_fe/pull/5333/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL1023-R1021))
*  Show consultation suggestion, admission date, discharge date, and death date only for inactive patients in patient info card to avoid showing irrelevant or outdated information ([link](https://github.com/coronasafe/care_fe/pull/5333/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L202-R234))
