### PR TITLE
Consultation Form: Minor fixes for action field

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -280,12 +280,14 @@ export const ConsultationForm = (props: any) => {
         if (res.data) {
           setPatientName(res.data.name);
           setFacilityName(res.data.facility_object.name);
-          dispatch({
-            type: "set_form_field",
-            field: "action",
-            value: TELEMEDICINE_ACTIONS.find((a) => a.id === res.data.action)
-              ?.text,
-          });
+          if (isUpdate) {
+            dispatch({
+              type: "set_form_field",
+              field: "action",
+              value: TELEMEDICINE_ACTIONS.find((a) => a.id === res.data.action)
+                ?.text,
+            });
+          }
         }
       } else {
         setPatientName("");

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -98,7 +98,7 @@ type FormDetails = {
   prn_prescription: PRNPrescriptionType[];
   investigation: InvestigationType[];
   is_telemedicine: BooleanStrings;
-  action: string | null;
+  action?: string;
   assigned_to: string;
   assigned_to_object: UserModel | null;
   special_instruction: string;
@@ -147,7 +147,7 @@ const initForm: FormDetails = {
   prn_prescription: [],
   investigation: [],
   is_telemedicine: "false",
-  action: null,
+  action: undefined,
   assigned_to: "",
   assigned_to_object: null,
   special_instruction: "",

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -341,7 +341,7 @@ export const ConsultationForm = (props: any) => {
             death_datetime: res.data?.death_datetime || "",
             death_confirmed_doctor: res.data?.death_confirmed_doctor || "",
           };
-          dispatch({ type: "set_form", form: formData });
+          dispatch({ type: "set_form", form: { ...state.form, ...formData } });
           setBed(formData.bed);
         } else {
           goBack();

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -293,7 +293,7 @@ export const ConsultationForm = (props: any) => {
       }
     }
     fetchPatientName();
-  }, [dispatchAction, patientId, state.form]);
+  }, [dispatchAction, patientId]);
 
   const hasSymptoms =
     !!state.form.symptoms.length && !state.form.symptoms.includes(1);
@@ -1282,6 +1282,7 @@ export const ConsultationForm = (props: any) => {
                                 {...selectField("review_interval")}
                                 label="Review After"
                                 options={REVIEW_AT_CHOICES}
+                                position="above"
                               />
                             </div>
                             <div className="flex-1" ref={fieldRef["action"]}>

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -114,7 +114,8 @@ type FormDetails = {
 
 type Action =
   | { type: "set_form"; form: FormDetails }
-  | { type: "set_error"; errors: FormDetails };
+  | { type: "set_error"; errors: FormDetails }
+  | { type: "set_form_field"; field: keyof FormDetails; value: any };
 
 const initForm: FormDetails = {
   symptoms: [],
@@ -189,13 +190,22 @@ const consultationFormReducer = (state = initialState, action: Action) => {
     case "set_form": {
       return {
         ...state,
-        form: action.form,
+        form: { ...state.form, ...action.form },
       };
     }
     case "set_error": {
       return {
         ...state,
         errors: action.errors,
+      };
+    }
+    case "set_form_field": {
+      return {
+        ...state,
+        form: {
+          ...state.form,
+          [action.field]: action.value,
+        },
       };
     }
   }
@@ -271,12 +281,10 @@ export const ConsultationForm = (props: any) => {
           setPatientName(res.data.name);
           setFacilityName(res.data.facility_object.name);
           dispatch({
-            type: "set_form",
-            form: {
-              ...state.form,
-              action: TELEMEDICINE_ACTIONS.find((a) => a.id === res.data.action)
-                ?.text,
-            },
+            type: "set_form_field",
+            field: "action",
+            value: TELEMEDICINE_ACTIONS.find((a) => a.id === res.data.action)
+              ?.text,
           });
         }
       } else {
@@ -285,7 +293,7 @@ export const ConsultationForm = (props: any) => {
       }
     }
     fetchPatientName();
-  }, [dispatchAction, patientId]);
+  }, [dispatchAction, patientId, state.form]);
 
   const hasSymptoms =
     !!state.form.symptoms.length && !state.form.symptoms.includes(1);
@@ -341,7 +349,7 @@ export const ConsultationForm = (props: any) => {
             death_datetime: res.data?.death_datetime || "",
             death_confirmed_doctor: res.data?.death_confirmed_doctor || "",
           };
-          dispatch({ type: "set_form", form: { ...state.form, ...formData } });
+          dispatch({ type: "set_form", form: formData });
           setBed(formData.bed);
         } else {
           goBack();

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -98,7 +98,7 @@ type FormDetails = {
   prn_prescription: PRNPrescriptionType[];
   investigation: InvestigationType[];
   is_telemedicine: BooleanStrings;
-  action: string;
+  action: string | null;
   assigned_to: string;
   assigned_to_object: UserModel | null;
   special_instruction: string;
@@ -147,7 +147,7 @@ const initForm: FormDetails = {
   prn_prescription: [],
   investigation: [],
   is_telemedicine: "false",
-  action: "PENDING",
+  action: null,
   assigned_to: "",
   assigned_to_object: null,
   special_instruction: "",
@@ -1272,7 +1272,7 @@ export const ConsultationForm = (props: any) => {
                               <SelectFormField
                                 {...field("action")}
                                 label="Action"
-                                required
+                                position="above"
                                 options={TELEMEDICINE_ACTIONS}
                                 optionLabel={(option) => option.desc}
                                 optionValue={(option) => option.text}

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -270,6 +270,14 @@ export const ConsultationForm = (props: any) => {
         if (res.data) {
           setPatientName(res.data.name);
           setFacilityName(res.data.facility_object.name);
+          dispatch({
+            type: "set_form",
+            form: {
+              ...state.form,
+              action: TELEMEDICINE_ACTIONS.find((a) => a.id === res.data.action)
+                ?.text,
+            },
+          });
         }
       } else {
         setPatientName("");


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3e8fea</samp>

Fixed a bug in the consultation form and improved its layout. The `action` field can now be properly edited and displayed in `src/Components/Facility/ConsultationForm.tsx`.

## Proposed Changes

- Fixes #5335

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3e8fea</samp>

*  Allow null values for the action field in the consultation form and avoid setting a default value ([link](https://github.com/coronasafe/care_fe/pull/5340/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL101-R101), [link](https://github.com/coronasafe/care_fe/pull/5340/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL150-R150))
*  Display the label above the action select field instead of inside it ([link](https://github.com/coronasafe/care_fe/pull/5340/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL1275-R1275))
