### PR TITLE
Made UI Responsive for Issue #5331

### DIFF
--- a/src/CAREUI/interactive/SlideOver.tsx
+++ b/src/CAREUI/interactive/SlideOver.tsx
@@ -90,7 +90,8 @@ export default function SlideOver({
                 className={classNames(
                   "bg-white md:rounded-xl flex flex-col",
                   directionClasses[slideFrom].proportions,
-                  dialogClass
+                  dialogClass,
+                  "p-6"
                 )}
               >
                 <div className="flex items-center p-2 gap-2 pt-4">


### PR DESCRIPTION
### WHAT
To make the page responsive

The Linked Facilities is now same as the Linked Skills after adding padding.
<img width="987" alt="Screenshot 2023-04-16 at 4 05 19 AM" src="https://user-images.githubusercontent.com/79076050/232256183-ed73f62d-c761-4f8b-aba0-19cc20ea1d23.png">
<img width="987" alt="Screenshot 2023-04-16 at 4 05 27 AM" src="https://user-images.githubusercontent.com/79076050/232256186-92f53f0c-beef-44db-9091-dff0f2d10488.png">



