### PR TITLE
Fix 2260

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -675,7 +675,7 @@ export const CONSULTATION_TABS: Array<OptionsType> = [
   { id: 6, text: "ABG", desc: "ABG" },
   { id: 7, text: "NURSING", desc: "Nursing" },
   { id: 8, text: "NEUROLOGICAL_MONITORING", desc: "Neurological Monitoring" },
-  { id: 9, text: "VENTILATOR", desc: "Ventilator" },
+  { id: 9, text: "VENTILATOR", desc: "Respiratory Support" },
   { id: 10, text: "NUTRITION", desc: "Nutrition" },
   { id: 11, text: "PRESSURE_SORE", desc: "Pressure Sore" },
   { id: 12, text: "DIALYSIS", desc: "Dialysis" },

--- a/src/Components/CriticalCareRecording/Recording/CriticalCare__Recording.res
+++ b/src/Components/CriticalCareRecording/Recording/CriticalCare__Recording.res
@@ -11,7 +11,6 @@ type editor =
   | PressureSoreEditor
   | NursingCareEditor
   | MedicineEditor
-  | OthersEditor
 
 type state = {
   visibleEditor: option<editor>,
@@ -55,7 +54,6 @@ let editorNameToString = editor => {
   | PressureSoreEditor => "Pressure Sore"
   | NursingCareEditor => "Nursing Care"
   | MedicineEditor => "Medicine"
-  | OthersEditor => "Others"
   }
 }
 
@@ -221,13 +219,6 @@ let make = (~id, ~facilityId, ~patientId, ~consultationId, ~dailyRound) => {
                 id
                 consultationId
               />
-            | OthersEditor =>
-              <CriticalCare__OthersEditor
-                others={CriticalCare__DailyRound.others(state.dailyRound)}
-                updateCB={updateDailyRound(send, OthersEditor)}
-                id
-                consultationId
-              />
             }}
           </div>
         </div>
@@ -249,7 +240,6 @@ let make = (~id, ~facilityId, ~patientId, ~consultationId, ~dailyRound) => {
               PressureSoreEditor,
               NursingCareEditor,
               MedicineEditor,
-              OthersEditor,
             ])->React.array}
           </div>
           <Link

--- a/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
+++ b/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
@@ -9,6 +9,14 @@ open VentilatorParameters
 
 let reducer = (state: VentilatorParameters.state, action: VentilatorParameters.action) => {
   switch action {
+  | SetBilateralAirEntry(bilateral_air_entry) => {
+      ...state,
+      bilateral_air_entry: bilateral_air_entry,
+    }
+  | SetETCO2(etco2) => {
+      ...state,
+      etco2: etco2,
+    }
   | SetVentilatorInterface(ventilator_interface) => {
       ...state,
       ventilator_interface: ventilator_interface,
@@ -124,7 +132,8 @@ let makePayload = (state: VentilatorParameters.state) => {
     payload,
   )
   DictUtils.setOptionalNumber("ventilator_spo2", state.ventilator_spo2, payload)
-
+  DictUtils.setOptionalBool("bilateral_air_entry", state.bilateral_air_entry, payload)
+  DictUtils.setOptionalNumber("etco2", state.etco2, payload)
   payload
 }
 
@@ -185,6 +194,8 @@ let initialState: VentilatorParameters.t => VentilatorParameters.state = ventila
     ventilator_oxygen_modality_flow_rate: ventilatorParameters.ventilator_oxygen_modality_flow_rate,
     ventilator_fi02: ventilatorParameters.ventilator_fi02,
     ventilator_spo2: ventilatorParameters.ventilator_spo2,
+    etco2: ventilatorParameters.etco2,
+    bilateral_air_entry: ventilatorParameters.bilateral_air_entry,
     saving: false,
   }
 }

--- a/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
+++ b/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
@@ -7,6 +7,9 @@ external updateDailyRound: (string, string, Js.Json.t, _ => unit, _ => unit) => 
 
 open VentilatorParameters
 
+let string_of_int = data => Belt.Option.mapWithDefault(data, "", Js.Int.toString)
+let int_of_string = data => data->Belt.Int.fromString
+
 let reducer = (state: VentilatorParameters.state, action: VentilatorParameters.action) => {
   switch action {
   | SetBilateralAirEntry(bilateral_air_entry) => {
@@ -213,6 +216,46 @@ let make = (~ventilatorParameters: VentilatorParameters.t, ~id, ~consultationId,
 
   <div>
     <CriticalCare__PageTitle title="Respiratory Support" />
+     <div>
+      <div className="px-5 my-10">
+        <div className=" text-xl font-bold my-2"> {str("Bilateral Air Entry")} </div>
+        <div className="flex md:flex-row flex-col md:space-y-0 space-y-2 space-x-0 md:space-x-4">
+          <Radio
+            key="bilateral-air-entry-yes"
+            id="bilateral-air-entry-yes"
+            label="Yes"
+            checked={switch state.bilateral_air_entry {
+              | Some(bae) => bae
+              | None => false
+            }}
+            onChange={_ => send(SetBilateralAirEntry(Some(true)))}
+          />
+          
+          <Radio
+            key="bilateral-air-entry-no"
+            id="bilateral-air-entry-no"
+            label="No"
+            checked={switch state.bilateral_air_entry {
+              | Some(bae) => !bae
+              | None => false
+            }}
+            onChange={_ => send(SetBilateralAirEntry(Some(false)))}
+          />
+        </div>
+      </div>
+      <Slider
+        title={"EtCO2 (mm Hg)"}
+        start={"0"}
+        end={"200"}
+        interval={"20"}
+        step={1.0}
+        value={string_of_int(state.etco2)}
+        setValue={s => send(SetETCO2(int_of_string(s)))}
+        getLabel={getStatus(35.0, "Low", 45.0, "High")}
+        hasError={ValidationUtils.isInputInRangeInt(0, 200, state.etco2)}
+      />
+    </div>
+
     <div className="py-6">
       <div className="mb-6">
         <h4> {str("Respiratory Support")} </h4>

--- a/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor__Invasive.res
+++ b/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor__Invasive.res
@@ -94,6 +94,16 @@ let silderOptionArray = [
     "min": 90.0,
     "max": 100.0,
   },
+  {
+    "title": "EtCO2 (mm Hg)",
+    "start": "0",
+    "end": "200",
+    "interval": "20",
+    "step": 1.0,
+    "id": "etco2",
+    "min": 35.0,
+    "max": 45.0,
+  }
 ]
 
 @react.component
@@ -102,6 +112,34 @@ let make = (~state: VentilatorParameters.state, ~send: VentilatorParameters.acti
   let (parentVentilatorMode, setParentVentilatorMode) = React.useState(() => defaultChecked)
 
   <div>
+    <div>
+      <div className="my-10">
+        <div className=" text-xl font-bold my-2"> {str("Bilateral Air Entry")} </div>
+        <div className="flex md:flex-row flex-col md:space-y-0 space-y-2 space-x-0 md:space-x-4">
+          <Radio
+            key="bilateral-air-entry-yes"
+            id="bilateral-air-entry-yes"
+            label="Yes"
+            checked={switch state.bilateral_air_entry {
+              | Some(bae) => bae
+              | None => false
+            }}
+            onChange={_ => send(SetBilateralAirEntry(Some(true)))}
+          />
+          
+          <Radio
+            key="bilateral-air-entry-no"
+            id="bilateral-air-entry-no"
+            label="No"
+            checked={switch state.bilateral_air_entry {
+              | Some(bae) => !bae
+              | None => false
+            }}
+            onChange={_ => send(SetBilateralAirEntry(Some(false)))}
+          />
+        </div>
+      </div>
+    </div>
     <h4 className="mb-4"> {str("Ventilator Mode")} </h4>
     <div className="mb-4">
       <Radio
@@ -192,6 +230,7 @@ let make = (~state: VentilatorParameters.state, ~send: VentilatorParameters.acti
           | "ventilator_tidal_volume" => state.ventilator_tidal_volume
           | "ventilator_fi02" => state.ventilator_fi02
           | "ventilator_spo2" => state.ventilator_spo2
+          | "etco2" => state.etco2
           | _ => None
           }
 
@@ -208,6 +247,7 @@ let make = (~state: VentilatorParameters.state, ~send: VentilatorParameters.acti
             | "ventilator_tidal_volume" => SetTidalVolume(s)
             | "ventilator_fi02" => SetFIO2(s)
             | "ventilator_spo2" => SetSPO2(s)
+            | "etco2" => SetETCO2(s)
             }
           <Slider
             key={`non-invasive-${option["id"]}`}

--- a/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor__Invasive.res
+++ b/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor__Invasive.res
@@ -94,16 +94,6 @@ let silderOptionArray = [
     "min": 90.0,
     "max": 100.0,
   },
-  {
-    "title": "EtCO2 (mm Hg)",
-    "start": "0",
-    "end": "200",
-    "interval": "20",
-    "step": 1.0,
-    "id": "etco2",
-    "min": 35.0,
-    "max": 45.0,
-  }
 ]
 
 @react.component
@@ -112,34 +102,6 @@ let make = (~state: VentilatorParameters.state, ~send: VentilatorParameters.acti
   let (parentVentilatorMode, setParentVentilatorMode) = React.useState(() => defaultChecked)
 
   <div>
-    <div>
-      <div className="my-10">
-        <div className=" text-xl font-bold my-2"> {str("Bilateral Air Entry")} </div>
-        <div className="flex md:flex-row flex-col md:space-y-0 space-y-2 space-x-0 md:space-x-4">
-          <Radio
-            key="bilateral-air-entry-yes"
-            id="bilateral-air-entry-yes"
-            label="Yes"
-            checked={switch state.bilateral_air_entry {
-              | Some(bae) => bae
-              | None => false
-            }}
-            onChange={_ => send(SetBilateralAirEntry(Some(true)))}
-          />
-          
-          <Radio
-            key="bilateral-air-entry-no"
-            id="bilateral-air-entry-no"
-            label="No"
-            checked={switch state.bilateral_air_entry {
-              | Some(bae) => !bae
-              | None => false
-            }}
-            onChange={_ => send(SetBilateralAirEntry(Some(false)))}
-          />
-        </div>
-      </div>
-    </div>
     <h4 className="mb-4"> {str("Ventilator Mode")} </h4>
     <div className="mb-4">
       <Radio
@@ -230,7 +192,6 @@ let make = (~state: VentilatorParameters.state, ~send: VentilatorParameters.acti
           | "ventilator_tidal_volume" => state.ventilator_tidal_volume
           | "ventilator_fi02" => state.ventilator_fi02
           | "ventilator_spo2" => state.ventilator_spo2
-          | "etco2" => state.etco2
           | _ => None
           }
 
@@ -247,7 +208,6 @@ let make = (~state: VentilatorParameters.state, ~send: VentilatorParameters.acti
             | "ventilator_tidal_volume" => SetTidalVolume(s)
             | "ventilator_fi02" => SetFIO2(s)
             | "ventilator_spo2" => SetSPO2(s)
-            | "etco2" => SetETCO2(s)
             }
           <Slider
             key={`non-invasive-${option["id"]}`}

--- a/src/Components/CriticalCareRecording/types/CriticalCare__VentilatorParameters.res
+++ b/src/Components/CriticalCareRecording/types/CriticalCare__VentilatorParameters.res
@@ -158,6 +158,8 @@ type t = {
   ventilator_oxygen_modality_flow_rate: option<int>,
   ventilator_fi02: option<int>,
   ventilator_spo2: option<int>,
+  bilateral_air_entry: option<bool>,
+  etco2: option<int>,
 }
 
 let ventilatorInterface = t => t.ventilator_interface
@@ -202,6 +204,8 @@ type state = {
   ventilator_oxygen_modality_flow_rate: option<int>,
   ventilator_fi02: option<int>,
   ventilator_spo2: option<int>,
+  bilateral_air_entry: option<bool>,
+  etco2: option<int>,
   saving: bool,
 }
 
@@ -219,6 +223,8 @@ type action =
   | SetOxygenModalityFlowRate(option<int>)
   | SetFIO2(option<int>)
   | SetSPO2(option<int>)
+  | SetBilateralAirEntry(option<bool>)
+  | SetETCO2(option<int>)
   | SetSaving
   | ClearSaving
 
@@ -236,6 +242,8 @@ let make = (
   ~ventilator_oxygen_modality_flow_rate,
   ~ventilator_fi02,
   ~ventilator_spo2,
+  ~bilateral_air_entry,
+  ~etco2,
 ) => {
   ventilator_interface: ventilator_interface,
   ventilator_mode: ventilator_mode,
@@ -250,6 +258,8 @@ let make = (
   ventilator_oxygen_modality_flow_rate: ventilator_oxygen_modality_flow_rate,
   ventilator_fi02: ventilator_fi02,
   ventilator_spo2: ventilator_spo2,
+  bilateral_air_entry: bilateral_air_entry,
+  etco2: etco2,
 }
 
 let makeFromJs = dailyRound => {
@@ -269,6 +279,8 @@ let makeFromJs = dailyRound => {
     ~ventilator_oxygen_modality_flow_rate=dailyRound["ventilator_oxygen_modality_flow_rate"]->Js.Nullable.toOption,
     ~ventilator_fi02=dailyRound["ventilator_fi02"]->Js.Nullable.toOption,
     ~ventilator_spo2=dailyRound["ventilator_spo2"]->Js.Nullable.toOption,
+    ~bilateral_air_entry=dailyRound["bilateral_air_entry"]->Js.Nullable.toOption,
+    ~etco2=dailyRound["etco2"]->Js.Nullable.toOption,
   )
 }
 

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -90,7 +90,7 @@ export const ConsultationDetails = (props: any) => {
   const { currentUser } = state;
 
   const [consultationData, setConsultationData] = useState<ConsultationModel>(
-    {}
+    {} as any
   );
   const [patientData, setPatientData] = useState<PatientModel>({});
   const [open, setOpen] = useState(false);

--- a/src/Components/Facility/Consultations/VentilatorPlot.tsx
+++ b/src/Components/Facility/Consultations/VentilatorPlot.tsx
@@ -7,6 +7,7 @@ import Pagination from "../../Common/Pagination";
 import { PAGINATION_LIMIT } from "../../../Common/constants";
 import { formatDate } from "../../../Utils/utils";
 
+/*
 interface ModalityType {
   id: number;
   type: string;
@@ -24,18 +25,17 @@ const modality: Array<ModalityType> = [
     normal_rate_high: 15,
   },
 ];
+*/
 
 export const VentilatorPlot = (props: any) => {
-  const { facilityId, patientId, consultationId } = props;
+  const { consultationId } = props;
   const dispatch: any = useDispatch();
-  const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState({});
   const [currentPage, setCurrentPage] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
 
   const fetchDailyRounds = useCallback(
     async (status: statusType) => {
-      setIsLoading(true);
       const res = await dispatch(
         dailyRoundsAnalyse(
           {
@@ -62,7 +62,6 @@ export const VentilatorPlot = (props: any) => {
           setResults(res.data.results);
           setTotalCount(res.data.count);
         }
-        setIsLoading(false);
       }
     },
     [consultationId, dispatch, currentPage]
@@ -75,7 +74,7 @@ export const VentilatorPlot = (props: any) => {
     [currentPage]
   );
 
-  const handlePagination = (page: number, limit: number) => {
+  const handlePagination = (page: number) => {
     setCurrentPage(page);
   };
 
@@ -178,6 +177,16 @@ export const VentilatorPlot = (props: any) => {
             yData={yAxisData("etco2")}
             low={35}
             high={45}
+          />
+        </div>
+        <div className="pt-4 px-4 bg-white border rounded-lg shadow">
+          <LinePlot
+            title="Bilateral Air Entry"
+            name="Bilateral Air Entry"
+            xData={dates}
+            yData={yAxisData("bilateral_air_entry")}
+            low={0}
+            high={1}
           />
         </div>
         <div className="pt-4 px-4 bg-white border rounded-lg shadow">

--- a/src/Components/Facility/Consultations/VentilatorPlot.tsx
+++ b/src/Components/Facility/Consultations/VentilatorPlot.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { statusType, useAbortableEffect } from "../../../Common/utils";
 import { dailyRoundsAnalyse } from "../../../Redux/actions";
@@ -6,6 +6,7 @@ import { LinePlot } from "./components/LinePlot";
 import Pagination from "../../Common/Pagination";
 import { PAGINATION_LIMIT } from "../../../Common/constants";
 import { formatDate } from "../../../Utils/utils";
+import BinaryChronologicalChart from "./components/BinaryChronologicalChart";
 
 /*
 interface ModalityType {
@@ -50,6 +51,7 @@ export const VentilatorPlot = (props: any) => {
               "ventilator_fi02",
               "ventilator_spo2",
               "etco2",
+              "bilateral_air_entry",
               "ventilator_oxygen_modality_oxygen_rate",
               "ventilator_oxygen_modality_flow_rate",
             ],
@@ -59,6 +61,7 @@ export const VentilatorPlot = (props: any) => {
       );
       if (!status.aborted) {
         if (res && res.data) {
+          console.log(res);
           setResults(res.data.results);
           setTotalCount(res.data.count);
         }
@@ -87,6 +90,19 @@ export const VentilatorPlot = (props: any) => {
       .map((p: any) => p[name])
       .reverse();
   };
+
+  const bilateral = Object.values(results)
+    .map((p: any, i) => {
+      return {
+        value: p.bilateral_air_entry,
+        timestamp: Object.keys(results)[i],
+      };
+    })
+    .filter((p) => p.value !== null);
+
+  useEffect(() => {
+    console.log(bilateral);
+  }, [bilateral]);
 
   return (
     <div>
@@ -180,13 +196,11 @@ export const VentilatorPlot = (props: any) => {
           />
         </div>
         <div className="pt-4 px-4 bg-white border rounded-lg shadow">
-          <LinePlot
+          <BinaryChronologicalChart
             title="Bilateral Air Entry"
-            name="Bilateral Air Entry"
-            xData={dates}
-            yData={yAxisData("bilateral_air_entry")}
-            low={0}
-            high={1}
+            data={bilateral}
+            trueName="Yes"
+            falseName="No"
           />
         </div>
         <div className="pt-4 px-4 bg-white border rounded-lg shadow">

--- a/src/Components/Facility/Consultations/components/BinaryChronologicalChart.tsx
+++ b/src/Components/Facility/Consultations/components/BinaryChronologicalChart.tsx
@@ -1,0 +1,67 @@
+import moment from "moment";
+import CareIcon from "../../../../CAREUI/icons/CareIcon";
+
+export default function BinaryChronologicalChart(props: {
+  data: {
+    value: boolean;
+    timestamp: string;
+    notes?: string;
+  }[];
+  trueName?: string;
+  falseName?: string;
+  title: string;
+}) {
+  const { data, title, trueName = "true", falseName = "false" } = props;
+
+  return (
+    <div className="overflow-x-auto bg-white">
+      <h3 className="text-sm px-3 mb-2">{title}</h3>
+      <div className="flow-root m-2 overflow-y-scroll h-64">
+        <ul role="list" className="">
+          {data.map((entry, i) => (
+            <li key={i}>
+              <div className="relative pb-8">
+                <span
+                  className="absolute top-4 left-4 -ml-px h-full w-0.5 bg-gray-200"
+                  aria-hidden="true"
+                />
+                <div className="relative flex space-x-3">
+                  <div>
+                    <span
+                      className={`h-8 w-8 rounded-full flex items-center justify-center ring-8 ring-white ${
+                        entry.value ? " text-green-500 " : " text-red-500 "
+                      }`}
+                    >
+                      {entry.value ? (
+                        <CareIcon className="care-l-check-circle text-xl" />
+                      ) : (
+                        <CareIcon className="care-l-times-circle text-xl" />
+                      )}
+                    </span>
+                  </div>
+                  <div className="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
+                    <div>
+                      <p
+                        className={`text-sm ${
+                          entry.value ? " text-green-500 " : " text-red-500 "
+                        }`}
+                      >
+                        <span className="mr-5">
+                          {entry.value ? trueName : falseName}
+                        </span>
+                        <span>{entry.notes}</span>
+                      </p>
+                    </div>
+                    <div className="whitespace-nowrap text-right text-sm text-gray-500">
+                      <p>{moment(entry.timestamp).format("lll")}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0023f44</samp>

This pull request adds two new fields to the ventilator parameters form for invasive ventilation mode: `bilateral_air_entry` and `etco2`. These fields are used to record and display the patient's air entry and end-tidal carbon dioxide levels. The changes affect the type definitions, the component state and actions, and the functions to create and parse the ventilator parameters object in `CriticalCare__VentilatorParameters.res` and `CriticalCare__VentilatorParametersEditor.res`.

## Proposed Changes

- Fixes #2260 
- moved etco2 and bilateral_air_entry to respiratory support

![image](https://user-images.githubusercontent.com/23238460/232962300-5b08555b-22f2-4d5d-961a-ef17bd6dcdb8.png)
![image](https://user-images.githubusercontent.com/23238460/232962373-d6d2770c-fe61-43f4-b0e6-04b88513f5a1.png)
![image](https://user-images.githubusercontent.com/23238460/232962426-077712f5-61d7-4c23-bf35-61c09f28c327.png)



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0023f44</samp>

*  Add two new fields to the ventilator parameters form for invasive ventilation mode: bilateral air entry and EtCO2 ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR161-R162), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR207-R208), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR226-R227), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR245-R246), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR261-R262), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR282-R283), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14R97-R106), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14R115-R142), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-d87205b509f4d11a0ac60ff34e9eaec19d747ca0b553fc1d8227844299953727R12-R19), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-d87205b509f4d11a0ac60ff34e9eaec19d747ca0b553fc1d8227844299953727L127-R136), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-d87205b509f4d11a0ac60ff34e9eaec19d747ca0b553fc1d8227844299953727R197-R198))
  * Update the type definitions of `CriticalCare__VentilatorParameters.t`, `CriticalCare__VentilatorParameters.state`, and `CriticalCare__VentilatorParameters.action` in `CriticalCare__VentilatorParameters.res` to include the new fields as optional values ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR161-R162), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR207-R208), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR226-R227))
  * Update the make function and the fromDailyRound function of `CriticalCare__VentilatorParameters.t` in `CriticalCare__VentilatorParameters.res` to create and convert the new fields from the given arguments and the daily round object ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR245-R246), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR261-R262), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-1a71244c6fc319aa54cde9c03663b552ce9472e4fbd02aefdd01a00766247c6fR282-R283))
  * Update the reducer function in `CriticalCare__VentilatorParametersEditor.res` to handle the new actions for setting the values of the new fields in the state ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-d87205b509f4d11a0ac60ff34e9eaec19d747ca0b553fc1d8227844299953727R12-R19))
  * Update the getPayload function in `CriticalCare__VentilatorParametersEditor.res` to include the new fields in the payload dictionary if they are present in the state ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-d87205b509f4d11a0ac60ff34e9eaec19d747ca0b553fc1d8227844299953727L127-R136))
  * Update the initialState function in `CriticalCare__VentilatorParametersEditor.res` to set the values of the new fields in the state from the ventilatorParameters prop ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-d87205b509f4d11a0ac60ff34e9eaec19d747ca0b553fc1d8227844299953727R197-R198))
  * Update the render function of `CriticalCare__VentilatorParametersEditor__Invasive.res` to display the new fields in the form with the appropriate properties and validations ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14R97-R106), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14R115-R142))
  * Update the getValue and setValue functions of `CriticalCare__VentilatorParametersEditor__Invasive.res` to return and update the values of the new fields from the state ([link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14R233), [link](https://github.com/coronasafe/care_fe/pull/5349/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14R250))
