### PR TITLE
fixes respiratory support filters and adds badge

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -204,6 +204,7 @@ export const PatientManager = () => {
     last_consultation_is_telemedicine:
       qParams.last_consultation_is_telemedicine || undefined,
     is_antenatal: qParams.is_antenatal || undefined,
+    ventilator_interface: qParams.ventilator_interface || undefined,
   };
 
   useEffect(() => {
@@ -312,6 +313,7 @@ export const PatientManager = () => {
     qParams.last_vaccinated_date_after,
     qParams.last_consultation_is_telemedicine,
     qParams.is_antenatal,
+    qParams.ventilator_interface,
   ]);
 
   const getTheCategoryFromId = () => {
@@ -841,6 +843,12 @@ export const PatientManager = () => {
             ordering(),
             value("Category", "category", getTheCategoryFromId()),
             badge("Disease Status", "disease_status"),
+            value(
+              "Respiratory Support",
+              "ventilator_interface",
+              qParams.ventilator_interface &&
+                t(`RESPIRATORY_SUPPORT_${qParams.ventilator_interface}`)
+            ),
             value(
               "Gender",
               "gender",

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -116,5 +116,9 @@
   "select_skills": "Select and add some skills",
   "contact_your_admin_to_add_skills": "Contact your admin to add skills",
   "add": "Add",
-  "sort_by": "Sort By"
+  "sort_by": "Sort By",
+  "RESPIRATORY_SUPPORT_UNKNOWN": "None",
+  "RESPIRATORY_SUPPORT_OXYGEN_SUPPORT": "O2 Support",
+  "RESPIRATORY_SUPPORT_NON_INVASIVE": "NIV",
+  "RESPIRATORY_SUPPORT_INVASIVE": "IV"
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38322f4</samp>

This pull request adds a new feature to filter and sort patients by their respiratory support type in the `ManagePatients` component. It also updates the `Common` locale file with the translation keys and values for the respiratory support types.

## Proposed Changes

- Fixes #5361
@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38322f4</samp>

*  Add `ventilator_interface` property to `PatientManager` component to filter patients by respiratory support type ([link](https://github.com/coronasafe/care_fe/pull/5360/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R207))
*  Update patient data from API whenever `ventilator_interface` filter value changes ([link](https://github.com/coronasafe/care_fe/pull/5360/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R316))
*  Display respiratory support type of each patient in a new column of the patient table ([link](https://github.com/coronasafe/care_fe/pull/5360/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R847-R852))
*  Add translation keys and values for respiratory support types to `Common.json` file ([link](https://github.com/coronasafe/care_fe/pull/5360/files?diff=unified&w=0#diff-38a71477ce052dd5f81bf55434622f86d274a8dc6a8af1a03fb444588aec4296R119-R122))
