### PR TITLE
Fixed malfunction of filters

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -48,6 +48,7 @@ const AssetsList = () => {
   const [totalCount, setTotalCount] = useState(0);
   const [facility, setFacility] = useState<FacilityModel>();
   const [asset_type, setAssetType] = useState<string>();
+  const [facilityName, setFacilityName] = useState<string>();
   const [asset_class, setAssetClass] = useState<string>();
   const [locationName, setLocationName] = useState<string>();
   const [importAssetModalOpen, setImportAssetModalOpen] = useState(false);
@@ -118,6 +119,14 @@ const AssetsList = () => {
     },
     [dispatch, fetchData]
   );
+  useEffect(() => {
+    async function fetchFacilityName() {
+      if (!qParams.facility) return setFacilityName("");
+      const res = await dispatch(getAnyFacility(qParams.facility, "facility"));
+      setFacilityName(res?.data?.name);
+    }
+    fetchFacilityName();
+  }, [dispatch, qParams.facility]);
 
   const fetchFacility = useCallback(
     async (status: statusType) => {
@@ -367,14 +376,14 @@ const AssetsList = () => {
           </div>
         </div>
       </div>
-      <AssetFilter {...advancedFilter} />
+      <AssetFilter {...advancedFilter} key={window.location.search} />
       {isLoading ? (
         <Loading />
       ) : (
         <>
           <FilterBadges
             badges={({ badge, value }) => [
-              value("Facility", ["facility", "location"], facility?.name || ""),
+              value("Facility", "facility", facilityName || ""),
               badge("Name/Serial No./QR ID", "search"),
               value("Asset Type", "asset_type", asset_type || ""),
               value("Asset Class", "asset_class", asset_class || ""),

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -334,7 +334,11 @@ export default function ResultList() {
         </table>
       </div>
       <Pagination totalCount={totalCount} />
-      <ListFilter {...advancedFilter} dataList={lsgWardData} />
+      <ListFilter
+        {...advancedFilter}
+        dataList={lsgWardData}
+        key={window.location.search}
+      />
     </div>
   );
 }

--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -258,7 +258,7 @@ export const HospitalList = () => {
         </div>
       </div>
 
-      <FacilityFilter {...advancedFilter} />
+      <FacilityFilter {...advancedFilter} key={window.location.search} />
       <FilterBadges
         badges={({ badge, value, kasp }) => [
           badge("Facility/District Name", "search"),

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -874,7 +874,7 @@ export const PatientManager = () => {
         />
       </div>
       <div>
-        <PatientFilter {...advancedFilter} />
+        <PatientFilter {...advancedFilter} key={window.location.search} />
         <NavTabs
           onChange={(tab) => updateQuery({ is_active: tab ? "False" : "True" })}
           options={[

--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -378,7 +378,7 @@ export default function SampleViewAdmin() {
           </div>
 
           <AdvancedFilterButton onClick={() => advancedFilter.setShow(true)} />
-          <SampleFilter {...advancedFilter} />
+          <SampleFilter {...advancedFilter} key={window.location.search} />
         </div>
         <FilterBadges
           badges={({ badge, value }) => [

--- a/src/Components/Resource/BadgesList.tsx
+++ b/src/Components/Resource/BadgesList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { getAnyFacility } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
+import { SHIFTING_FILTER_ORDER } from "../../Common/constants";
 
 export default function BadgesList(props: any) {
   const { appliedFilters, FilterBadges } = props;
@@ -43,10 +44,24 @@ export default function BadgesList(props: any) {
     fetchData();
   }, [dispatch, appliedFilters.assigned_facility]);
 
+  const getDescShiftingFilterOrder = (ordering: any) => {
+    let desc = "";
+    SHIFTING_FILTER_ORDER.map((item: any) => {
+      if (item.text === ordering) {
+        desc = item.desc;
+      }
+    });
+    return desc;
+  };
+
   return (
     <FilterBadges
       badges={({ badge, value, boolean, dateRange }: any) => [
-        badge("Ordering", "ordering"),
+        value(
+          "Ordering",
+          "ordering",
+          getDescShiftingFilterOrder(appliedFilters.ordering)
+        ),
         badge("Status", "status"),
         boolean("Emergency", "emergency", {
           trueValue: "yes",

--- a/src/Components/Resource/ListView.tsx
+++ b/src/Components/Resource/ListView.tsx
@@ -248,7 +248,11 @@ export default function ListView() {
           </div>
         )}
       </div>
-      <ListFilter {...advancedFilter} showResourceStatus={true} />
+      <ListFilter
+        {...advancedFilter}
+        showResourceStatus={true}
+        key={window.location.search}
+      />
     </div>
   );
 }

--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -112,7 +112,7 @@ export default function BoardView() {
           )}
         </div>
       </ScrollingComponent>
-      <ListFilter {...advancedFilter} />
+      <ListFilter {...advancedFilter} key={window.location.search} />
     </div>
   );
 }

--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { getUserList, getAnyFacility } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
+import { SHIFTING_FILTER_ORDER } from "../../Common/constants";
 
 export default function BadgesList(props: any) {
   const { qParams, FilterBadges } = props;
@@ -63,6 +64,15 @@ export default function BadgesList(props: any) {
     }
     fetchData();
   }, [dispatch, qParams.assigned_facility]);
+  const getDescShiftingFilterOrder = (ordering: any) => {
+    let desc = "";
+    SHIFTING_FILTER_ORDER.map((item: any) => {
+      if (item.text === ordering) {
+        desc = item.desc;
+      }
+    });
+    return desc;
+  };
 
   return (
     <FilterBadges
@@ -82,6 +92,7 @@ export default function BadgesList(props: any) {
         phoneNumber(t("phone_no"), "patient_phone_number"),
         badge(t("patient_name"), "patient_name"),
         ...dateRange(t("created"), "created_date"),
+        ...dateRange(t("modified"), "modified_date"),
         badge(t("disease_status"), "disease_status"),
         badge(t("breathlessness_level"), "breathlessness_level"),
         value(t("assigned_to"), "assigned_to", assignedUsername),
@@ -95,6 +106,11 @@ export default function BadgesList(props: any) {
           t("shifting_approval_facility"),
           "shifting_approving_facility",
           approvingFacilityName
+        ),
+        value(
+          t("ordering"),
+          "ordering",
+          getDescShiftingFilterOrder(qParams.ordering)
         ),
       ]}
     />

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -118,7 +118,7 @@ export default function BoardView() {
           )}
         </div>
       </ScrollingComponent>
-      <ListFilter {...advancedFilter} />
+      <ListFilter {...advancedFilter} key={window.location.search} />
     </div>
   );
 }

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -339,7 +339,11 @@ export default function ListView() {
           </div>
         )}
       </div>
-      <ListFilter showShiftingStatus={true} {...advancedFilter} />
+      <ListFilter
+        showShiftingStatus={true}
+        {...advancedFilter}
+        key={window.location.search}
+      />
     </Page>
   );
 }

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -470,7 +470,7 @@ export default function ManageUsers() {
             {userTypes.length && addUser}
           </div>
 
-          <UserFilter {...advancedFilter} />
+          <UserFilter {...advancedFilter} key={window.location.search} />
         </div>
       </div>
 

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -24,6 +24,7 @@
   "no": "No",
   "status": "Status",
   "created": "Created",
+  "modified": "Modified",
   "updated": "Updated",
   "assigned_to": "Assigned to",
   "cancel": "Cancel",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58bab83</samp>

This pull request adds or improves filtering and ordering features for various data types, such as assets, shifting, resources, samples, patients, and users. It also fixes a bug where the filter values were not reset when the query parameters changed. It does so by adding a `key` prop to the filter components, which is set to the current window location search string, and by using constants and functions to map the query values to more descriptive texts. The changes affect several files, such as `AssetsList.tsx`, `BadgesList.tsx`, `FacilityFilter.tsx`, `ListFilter.tsx`, and `UserFilter.tsx`.

## Proposed Changes

- Fixes #5257 
Fixed malfunction of filters


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58bab83</samp>

*  Add a `key` prop to various filter components to ensure they are re-rendered when the query parameters change and the filter values are reset accordingly ([link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L370-R379), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-3ff48bac32004c8412fdd842f678d61ab738bbada999fa8d9fa1da73f760ea11L337-R341), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-8e39f154ccf13c9dedd0f968d21a0abbde450e88df9724a4e7d4264d487a7846L261-R261), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L885-R885), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL381-R381), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-9b8688043522f05d85d852d6a8b0a6d4ee406f772f626d435136c5e357b91d00L251-R255), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-72363d4a4cc81142bd2db278c3c1e17ee14614fc4be0af317cc60db25f4be79cL115-R115), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-fc18d7013fcb5787812d6865749dd91966308ccf3493ab227001b2ca0079f600L121-R121), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L342-R346), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121L473-R473))
*  Add a new state variable `facilityName` to store the fetched name of the selected facility in the `AssetsList` component and use it to display the facility name badge ([link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R51), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R122-R129), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L377-R386))
*  Add a new function `getDescShiftingFilterOrder` to display the ordering filter badge for shifting data with a more descriptive text instead of the query parameter value, using the `SHIFTING_FILTER_ORDER` constant ([link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-e39ede2a5c09938bbd4d5e3d09dbad6f332fc3c70a7059544d94227d6abac960R4), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-e39ede2a5c09938bbd4d5e3d09dbad6f332fc3c70a7059544d94227d6abac960L46-R64), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfR5), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfR67-R75), [link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfR110-R114))
*  Add a new date range filter option for the modified date of the shifting data in the `BadgesList` component ([link](https://github.com/coronasafe/care_fe/pull/5362/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfR95))
