### PR TITLE
Frontend changes for peacetime shifting

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -1,8 +1,8 @@
-import { PatientCategory } from "../Components/Facility/models";
-import { parsePhoneNumberFromString } from "libphonenumber-js";
-import moment from "moment";
 import { IConfig } from "./hooks/useConfig";
+import { PatientCategory } from "../Components/Facility/models";
 import { SortOption } from "../Components/Common/SortDropdown";
+import moment from "moment";
+import { parsePhoneNumberFromString } from "libphonenumber-js";
 
 export const RESULTS_PER_PAGE_LIMIT = 14;
 export const PAGINATION_LIMIT = 36;
@@ -146,6 +146,7 @@ export const SHIFTING_CHOICES: Array<OptionsType> = [
   { id: 60, text: "PATIENT TO BE PICKED UP" },
   { id: 70, text: "TRANSFER IN PROGRESS" },
   { id: 80, text: "COMPLETED" },
+  { id: 90, text: "PATIENT EXPIRED" },
 ];
 
 export const SHIFTING_VEHICLE_CHOICES: Array<OptionsType> = [

--- a/src/Common/hooks/useConfig.ts
+++ b/src/Common/hooks/useConfig.ts
@@ -55,6 +55,10 @@ export interface IConfig {
    * Env to enable HCX features
    */
   enable_hcx: boolean;
+  /**
+   * Env to toggle peacetime and wartime shifting
+   */
+  wartime_shifting: boolean;
 }
 
 const useConfig = () => {

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -1,80 +1,55 @@
-import { navigate } from "raviger";
-import { Button, CircularProgress } from "@material-ui/core";
-import moment from "moment";
-import { useCallback, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { statusType, useAbortableEffect } from "../../Common/utils";
 import * as Notification from "../../Utils/Notifications";
-import { getConsultation, getPatient, HCXActions } from "../../Redux/actions";
-import loadable from "@loadable/component";
-import { ConsultationModel, ICD11DiagnosisModel } from "./models";
-import { PatientModel } from "../Patient/models";
+
 import {
-  SYMPTOM_CHOICES,
   CONSULTATION_TABS,
-  OptionsType,
-  GENDER_TYPES,
   DISCHARGE_REASONS,
+  GENDER_TYPES,
+  OptionsType,
+  SYMPTOM_CHOICES,
 } from "../../Common/constants";
-import { FileUpload } from "../Patient/FileUpload";
-import { PrimaryParametersPlot } from "./Consultations/PrimaryParametersPlot";
-import { MedicineTables } from "./Consultations/MedicineTables";
+import { ConsultationModel, ICD11DiagnosisModel } from "./models";
+import { getConsultation, getPatient } from "../../Redux/actions";
+import { statusType, useAbortableEffect } from "../../Common/utils";
+import { useCallback, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
 import { ABGPlots } from "./Consultations/ABGPlots";
+import { Button } from "@material-ui/core";
+import ButtonV2 from "../Common/components/ButtonV2";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import Chip from "../../CAREUI/display/Chip";
 import { DailyRoundsList } from "./Consultations/DailyRoundsList";
-import { make as Link } from "../Common/components/Link.gen";
-import { NursingPlot } from "./Consultations/NursingPlot";
-import { NeurologicalTable } from "./Consultations/NeurologicalTables";
-import { VentilatorPlot } from "./Consultations/VentilatorPlot";
-import { NutritionPlots } from "./Consultations/NutritionPlots";
-import { PressureSoreDiagrams } from "./Consultations/PressureSoreDiagrams";
-import { DialysisPlots } from "./Consultations/DialysisPlots";
-import DoctorVideoSlideover from "./DoctorVideoSlideover";
-import { Feed } from "./Consultations/Feed";
-import { validateEmailAddress } from "../../Common/validation";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import { DialysisPlots } from "./Consultations/DialysisPlots";
+import DischargeModal from "./DischargeModal";
+import DoctorVideoSlideover from "./DoctorVideoSlideover";
+import { Feed } from "./Consultations/Feed";
+import { FileUpload } from "../Patient/FileUpload";
+import InvestigationTab from "./Investigations/investigationsTab";
 import { LegacyTextInputField } from "../Common/HelperInputFields";
-import { discharge, dischargePatient } from "../../Redux/actions";
+import { make as Link } from "../Common/components/Link.gen";
+import { MedicineTables } from "./Consultations/MedicineTables";
+import { NeurologicalTable } from "./Consultations/NeurologicalTables";
+import { NursingPlot } from "./Consultations/NursingPlot";
+import { NutritionPlots } from "./Consultations/NutritionPlots";
+import PatientInfoCard from "../Patient/PatientInfoCard";
+import { PatientModel } from "../Patient/models";
+import PatientVitalsCard from "../Patient/PatientVitalsCard";
+import { PressureSoreDiagrams } from "./Consultations/PressureSoreDiagrams";
+import { PrimaryParametersPlot } from "./Consultations/PrimaryParametersPlot";
 import ReadMore from "../Common/components/Readmore";
 import ResponsiveMedicineTable from "../Common/components/ResponsiveMedicineTables";
-import PatientInfoCard from "../Patient/PatientInfoCard";
-import PatientVitalsCard from "../Patient/PatientVitalsCard";
-import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
-import CareIcon from "../../CAREUI/icons/CareIcon";
-import DialogModal from "../Common/Dialog";
-import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
-import { SelectFormField } from "../Form/FormFields/SelectFormField";
-import DateFormField from "../Form/FormFields/DateFormField";
-import { FieldChangeEvent } from "../Form/FormFields/Utils";
-import TextFormField from "../Form/FormFields/TextFormField";
-import { FieldLabel } from "../Form/FormFields/FormField";
-import PrescriptionBuilder, {
-  PrescriptionType,
-} from "../Common/prescription-builder/PrescriptionBuilder";
-import PRNPrescriptionBuilder, {
-  PRNPrescriptionType,
-} from "../Common/prescription-builder/PRNPrescriptionBuilder";
+import { VentilatorPlot } from "./Consultations/VentilatorPlot";
+import { discharge } from "../../Redux/actions";
 import { formatDate } from "../../Utils/utils";
-import CreateClaimCard from "../HCX/CreateClaimCard";
-import { HCXClaimModel } from "../HCX/models";
-import ClaimDetailCard from "../HCX/ClaimDetailCard";
-import { useMessageListener } from "../../Common/hooks/useMessageListener";
-import Chip from "../../CAREUI/display/Chip";
-import InvestigationTab from "./Investigations/investigationsTab";
-import useConfig from "../../Common/hooks/useConfig";
-
-interface PreDischargeFormInterface {
-  discharge_reason: string;
-  discharge_notes: string;
-  discharge_date: string;
-  death_datetime: string | null;
-  death_confirmed_doctor: string | null;
-  discharge_prescription: PrescriptionType[];
-  discharge_prn_prescription: PRNPrescriptionType[];
-}
+import loadable from "@loadable/component";
+import moment from "moment";
+import { navigate } from "raviger";
+import { validateEmailAddress } from "../../Common/validation";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -90,12 +65,11 @@ export const ConsultationDetails = (props: any) => {
   const { currentUser } = state;
 
   const [consultationData, setConsultationData] = useState<ConsultationModel>(
-    {}
+    {} as ConsultationModel
   );
   const [patientData, setPatientData] = useState<PatientModel>({});
   const [open, setOpen] = useState(false);
   const [openDischargeDialog, setOpenDischargeDialog] = useState(false);
-  const [isSendingDischargeApi, setIsSendingDischargeApi] = useState(false);
 
   const initDischargeSummaryForm: { email: string } = {
     email: "",
@@ -104,63 +78,7 @@ export const ConsultationDetails = (props: any) => {
     initDischargeSummaryForm
   );
   const [errors, setErrors] = useState<any>({});
-  const [preDischargeForm, setPreDischargeForm] =
-    useState<PreDischargeFormInterface>({
-      discharge_reason: "",
-      discharge_notes: "",
-      discharge_date: "",
-      death_datetime: null,
-      death_confirmed_doctor: null,
-      discharge_prescription: [],
-      discharge_prn_prescription: [],
-    });
   const [showAutomatedRounds, setShowAutomatedRounds] = useState(true);
-
-  const [dischargePrescription, setDischargePrescription] = useState<
-    PrescriptionType[]
-  >([]);
-  const [dischargePRNPrescription, setDischargePRNPrescription] = useState<
-    PRNPrescriptionType[]
-  >([]);
-
-  const [latestClaim, setLatestClaim] = useState<HCXClaimModel>();
-  const [isCreateClaimLoading, setIsCreateClaimLoading] = useState(false);
-  const { enable_hcx } = useConfig();
-
-  const fetchLatestClaim = useCallback(async () => {
-    const res = await dispatch(
-      HCXActions.claims.list({
-        ordering: "-modified_date",
-        use: "claim",
-        consultation: consultationId,
-      })
-    );
-
-    if (res.data?.results?.length) {
-      setLatestClaim(res.data.results[0]);
-      if (isCreateClaimLoading)
-        Notification.Success({ msg: "Fetched Claim Approval Results" });
-    } else {
-      setLatestClaim(undefined);
-      if (isCreateClaimLoading)
-        Notification.Success({ msg: "Error Fetched Claim Approval Results" });
-    }
-    setIsCreateClaimLoading(false);
-  }, [consultationId, dispatch]);
-
-  useEffect(() => {
-    fetchLatestClaim();
-  }, [fetchLatestClaim]);
-
-  useMessageListener((data) => {
-    if (
-      data.type === "MESSAGE" &&
-      (data.from === "claim/on_submit" || data.from === "preauth/on_submit") &&
-      data.message === "success"
-    ) {
-      fetchLatestClaim();
-    }
-  });
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -228,58 +146,6 @@ export const ConsultationDetails = (props: any) => {
     }
   };
 
-  const handlePatientDischarge = async (value: boolean) => {
-    setIsSendingDischargeApi(true);
-    if (!preDischargeForm.discharge_reason) {
-      setErrors({
-        ...errors,
-        discharge_reason: "Please select a reason for discharge",
-      });
-      setIsSendingDischargeApi(false);
-      return;
-    }
-
-    if (
-      preDischargeForm.discharge_reason == "EXP" &&
-      !preDischargeForm.discharge_notes.trim()
-    ) {
-      setErrors({
-        ...errors,
-        discharge_notes: "Please enter the cause of death",
-      });
-      setIsSendingDischargeApi(false);
-      return;
-    }
-
-    const dischargeResponse = await dispatch(
-      dischargePatient(
-        {
-          ...preDischargeForm,
-          discharge: value,
-          discharge_date: moment(preDischargeForm.discharge_date).toISOString(
-            true
-          ),
-          discharge_prescription: dischargePrescription,
-          discharge_prn_prescription: dischargePRNPrescription,
-        },
-        { id: patientData.id }
-      )
-    );
-
-    setIsSendingDischargeApi(false);
-    if (dischargeResponse?.status === 200) {
-      const dischargeData = Object.assign({}, patientData);
-      dischargeData["discharge"] = value;
-      setPatientData(dischargeData);
-
-      Notification.Success({
-        msg: "Patient Discharged",
-      });
-      setOpenDischargeDialog(false);
-      window.location.reload();
-    }
-  };
-
   const handleDischargeSummaryFormChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
@@ -304,12 +170,6 @@ export const ConsultationDetails = (props: any) => {
     async (status: statusType) => {
       setIsLoading(true);
       const res = await dispatch(getConsultation(consultationId));
-      setPreDischargeForm((form) => {
-        return {
-          ...form,
-          discharge_date: new Date().toISOString(),
-        };
-      });
       if (!status.aborted) {
         if (res && res.data) {
           const data: ConsultationModel = {
@@ -416,15 +276,6 @@ export const ConsultationDetails = (props: any) => {
     ) : null;
   };
 
-  const handleDateChange = (e: FieldChangeEvent<Date>) => {
-    setPreDischargeForm((form) => {
-      return {
-        ...form,
-        discharge_date: e.value.toString(),
-      };
-    });
-  };
-
   return (
     <div>
       <Dialog open={open} onClose={handleDischargeSummary}>
@@ -478,175 +329,12 @@ export const ConsultationDetails = (props: any) => {
         </DialogActions>
       </Dialog>
 
-      <DialogModal
-        title={
-          <div>
-            <p>Discharge patient from CARE</p>
-            <span className="mt-1 flex gap-1 text-sm text-secondary-500 font-medium">
-              <CareIcon className="care-l-exclamation-triangle text-base" />
-              <p>Caution: this action is irreversible.</p>
-            </span>
-          </div>
-        }
+      <DischargeModal
         show={openDischargeDialog}
         onClose={handleDischargeClose}
-        className="md:max-w-3xl"
-      >
-        <div className="mt-6 flex flex-col">
-          <SelectFormField
-            required
-            label="Reason"
-            name="discharge_reason"
-            id="discharge_reason"
-            value={preDischargeForm.discharge_reason}
-            options={DISCHARGE_REASONS}
-            optionValue={({ id }) => id}
-            optionLabel={({ text }) => text}
-            onChange={(e) =>
-              setPreDischargeForm((prev) => ({
-                ...prev,
-                discharge_reason: e.value,
-              }))
-            }
-            error={errors?.discharge_reason}
-          />
-          <TextAreaFormField
-            required={preDischargeForm.discharge_reason == "EXP"}
-            label={
-              preDischargeForm.discharge_reason == "EXP"
-                ? "Cause of death"
-                : preDischargeForm.discharge_reason === "REC"
-                ? "Discharged Advice"
-                : "Notes"
-            }
-            name="discharge_notes"
-            value={preDischargeForm.discharge_notes}
-            onChange={(e) =>
-              setPreDischargeForm((prev) => ({
-                ...prev,
-                discharge_notes: e.value,
-              }))
-            }
-            error={errors?.discharge_notes}
-          />
-          {preDischargeForm.discharge_reason === "REC" && (
-            <div>
-              <DateFormField
-                label="Discharge Date"
-                name="discharge_date"
-                value={moment(preDischargeForm.discharge_date).toDate()}
-                min={moment(
-                  consultationData.admission_date ||
-                    consultationData.created_date
-                ).toDate()}
-                disableFuture={true}
-                required
-                onChange={handleDateChange}
-              />
-              <FieldLabel>Discharge Prescription</FieldLabel>
-              <div className="my-2">
-                <PrescriptionBuilder
-                  prescriptions={dischargePrescription}
-                  setPrescriptions={setDischargePrescription}
-                />
-              </div>
-              <div>
-                <FieldLabel>Discharge PRN Prescription</FieldLabel>
-                <PRNPrescriptionBuilder
-                  prescriptions={dischargePRNPrescription}
-                  setPrescriptions={setDischargePRNPrescription}
-                />
-              </div>
-            </div>
-          )}
-          {preDischargeForm.discharge_reason === "EXP" && (
-            <div>
-              <div>
-                Death Date and Time
-                <span className="text-danger-500">{" *"}</span>
-                <input
-                  type="datetime-local"
-                  className="w-[calc(100%-5px)] focus:ring-primary-500 focus:border-primary-500 block border border-gray-400 rounded py-2 px-4 text-sm bg-gray-100 hover:bg-gray-200 focus:outline-none focus:bg-white"
-                  value={preDischargeForm.death_datetime || ""}
-                  required
-                  min={consultationData.admission_date?.substring(0, 16)}
-                  max={moment(new Date()).format("YYYY-MM-DDThh:mm")}
-                  onChange={(e) => {
-                    setPreDischargeForm((form) => {
-                      return {
-                        ...form,
-                        death_datetime: e.target.value,
-                      };
-                    });
-                  }}
-                />
-              </div>
-              <TextFormField
-                name="death_confirmed_by"
-                label="Confirmed By"
-                value={preDischargeForm.death_confirmed_doctor || ""}
-                onChange={(e) => {
-                  setPreDischargeForm((form) => {
-                    return {
-                      ...form,
-                      death_confirmed_doctor: e.value,
-                    };
-                  });
-                }}
-                required
-                placeholder="Attending Doctor's Name and Designation"
-              />
-            </div>
-          )}
-          {["REF", "LAMA"].includes(preDischargeForm.discharge_reason) && (
-            <div>
-              <DateFormField
-                label="Date of Discharge"
-                name="discharge_date"
-                value={moment(preDischargeForm.discharge_date).toDate()}
-                min={moment(
-                  consultationData.admission_date ||
-                    consultationData.created_date
-                ).toDate()}
-                disableFuture={true}
-                required
-                onChange={handleDateChange}
-              />
-            </div>
-          )}
-        </div>
+        consultationData={consultationData}
+      />
 
-        {enable_hcx && (
-          // TODO: if policy and approved pre-auth exists
-          <div className="my-5 shadow rounded p-5">
-            <h2 className="mb-2">Claim Insurance</h2>
-            {latestClaim ? (
-              <ClaimDetailCard claim={latestClaim} />
-            ) : (
-              <CreateClaimCard
-                consultationId={consultationId}
-                patientId={patientId}
-                use="claim"
-                isCreating={isCreateClaimLoading}
-                setIsCreating={setIsCreateClaimLoading}
-              />
-            )}
-          </div>
-        )}
-
-        <div className="flex flex-col md:flex-row gap-2 pt-4 md:justify-end">
-          <Cancel onClick={handleDischargeClose} />
-          {isSendingDischargeApi ? (
-            <CircularProgress size={20} />
-          ) : (
-            <Submit
-              onClick={() => handlePatientDischarge(false)}
-              label="Confirm Discharge"
-              autoFocus
-            />
-          )}
-        </div>
-      </DialogModal>
       <div className="px-2 pb-2">
         <nav className="flex justify-between flex-wrap relative">
           <PageTitle

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -44,6 +44,7 @@ interface IProps {
   show: boolean;
   onClose: () => void;
   consultationData: ConsultationModel;
+  afterSubmit?: () => void;
   discharge_reason?: string;
   discharge_notes?: string;
   discharge_date?: string | null;
@@ -54,6 +55,10 @@ const DischargeModal = ({
   show,
   onClose,
   consultationData,
+  afterSubmit = () => {
+    onClose();
+    window.location.reload();
+  },
   discharge_reason = "",
   discharge_notes = "",
   discharge_date = new Date().toISOString(),
@@ -165,8 +170,8 @@ const DischargeModal = ({
       Notification.Success({
         msg: "Patient Discharged",
       });
-      onClose();
-      window.location.reload();
+
+      afterSubmit();
     }
   };
 

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -1,0 +1,356 @@
+import * as Notification from "../../Utils/Notifications";
+
+import { Cancel, Submit } from "../Common/components/ButtonV2";
+import PRNPrescriptionBuilder, {
+  PRNPrescriptionType,
+} from "../Common/prescription-builder/PRNPrescriptionBuilder";
+import PrescriptionBuilder, {
+  PrescriptionType,
+} from "../Common/prescription-builder/PrescriptionBuilder";
+import { useCallback, useEffect, useState } from "react";
+
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import { CircularProgress } from "@material-ui/core";
+import ClaimDetailCard from "../HCX/ClaimDetailCard";
+import { ConsultationModel } from "./models";
+import CreateClaimCard from "../HCX/CreateClaimCard";
+import { DISCHARGE_REASONS } from "../../Common/constants";
+import DateFormField from "../Form/FormFields/DateFormField";
+import DialogModal from "../Common/Dialog";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
+import { FieldLabel } from "../Form/FormFields/FormField";
+import { HCXActions } from "../../Redux/actions";
+import { HCXClaimModel } from "../HCX/models";
+import { SelectFormField } from "../Form/FormFields/SelectFormField";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
+import TextFormField from "../Form/FormFields/TextFormField";
+import { dischargePatient } from "../../Redux/actions";
+import moment from "moment";
+import useConfig from "../../Common/hooks/useConfig";
+import { useDispatch } from "react-redux";
+import { useMessageListener } from "../../Common/hooks/useMessageListener";
+
+interface PreDischargeFormInterface {
+  discharge_reason: string;
+  discharge_notes: string;
+  discharge_date: string | null;
+  death_datetime: string | null;
+  death_confirmed_doctor: string | null;
+  discharge_prescription: PrescriptionType[];
+  discharge_prn_prescription: PRNPrescriptionType[];
+}
+
+interface IProps {
+  show: boolean;
+  onClose: () => void;
+  consultationData: ConsultationModel;
+  discharge_reason?: string;
+  discharge_notes?: string;
+  discharge_date?: string | null;
+  death_datetime?: string | null;
+}
+
+const DischargeModal = ({
+  show,
+  onClose,
+  consultationData,
+  discharge_reason = "",
+  discharge_notes = "",
+  discharge_date = new Date().toISOString(),
+  death_datetime = null,
+}: IProps) => {
+  const { enable_hcx } = useConfig();
+  const dispatch: any = useDispatch();
+  const [preDischargeForm, setPreDischargeForm] =
+    useState<PreDischargeFormInterface>({
+      discharge_reason,
+      discharge_notes,
+      discharge_date,
+      death_datetime,
+      death_confirmed_doctor: null,
+      discharge_prescription: [],
+      discharge_prn_prescription: [],
+    });
+  const [dischargePrescription, setDischargePrescription] = useState<
+    PrescriptionType[]
+  >([]);
+  const [dischargePRNPrescription, setDischargePRNPrescription] = useState<
+    PRNPrescriptionType[]
+  >([]);
+  const [latestClaim, setLatestClaim] = useState<HCXClaimModel>();
+  const [isCreateClaimLoading, setIsCreateClaimLoading] = useState(false);
+  const [isSendingDischargeApi, setIsSendingDischargeApi] = useState(false);
+  const [errors, setErrors] = useState<any>({});
+
+  const fetchLatestClaim = useCallback(async () => {
+    const res = await dispatch(
+      HCXActions.claims.list({
+        ordering: "-modified_date",
+        use: "claim",
+        consultation: consultationData.id,
+      })
+    );
+
+    if (res.data?.results?.length) {
+      setLatestClaim(res.data.results[0]);
+      if (isCreateClaimLoading)
+        Notification.Success({ msg: "Fetched Claim Approval Results" });
+    } else {
+      setLatestClaim(undefined);
+      if (isCreateClaimLoading)
+        Notification.Success({ msg: "Error Fetched Claim Approval Results" });
+    }
+    setIsCreateClaimLoading(false);
+  }, [consultationData.id, dispatch]);
+
+  useEffect(() => {
+    fetchLatestClaim();
+  }, [fetchLatestClaim]);
+
+  useMessageListener((data) => {
+    if (
+      data.type === "MESSAGE" &&
+      (data.from === "claim/on_submit" || data.from === "preauth/on_submit") &&
+      data.message === "success"
+    ) {
+      fetchLatestClaim();
+    }
+  });
+
+  const handlePatientDischarge = async (value: boolean) => {
+    setIsSendingDischargeApi(true);
+    if (!preDischargeForm.discharge_reason) {
+      setErrors({
+        ...errors,
+        discharge_reason: "Please select a reason for discharge",
+      });
+      setIsSendingDischargeApi(false);
+      return;
+    }
+
+    if (
+      preDischargeForm.discharge_reason == "EXP" &&
+      !preDischargeForm.discharge_notes.trim()
+    ) {
+      setErrors({
+        ...errors,
+        discharge_notes: "Please enter the cause of death",
+      });
+      setIsSendingDischargeApi(false);
+      return;
+    }
+
+    const dischargeResponse = await dispatch(
+      dischargePatient(
+        {
+          ...preDischargeForm,
+          discharge: value,
+          discharge_date: moment(preDischargeForm.discharge_date).toISOString(
+            true
+          ),
+          discharge_prescription: dischargePrescription,
+          discharge_prn_prescription: dischargePRNPrescription,
+        },
+        { id: consultationData.patient }
+      )
+    );
+
+    setIsSendingDischargeApi(false);
+    if (dischargeResponse?.status === 200) {
+      // TODO: check this later
+      //   const dischargeData = Object.assign({}, patientData);
+      //   dischargeData["discharge"] = value;
+      //   setPatientData(dischargeData);
+
+      Notification.Success({
+        msg: "Patient Discharged",
+      });
+      onClose();
+      window.location.reload();
+    }
+  };
+
+  const handleDateChange = (e: FieldChangeEvent<Date>) => {
+    setPreDischargeForm((form) => {
+      return {
+        ...form,
+        discharge_date: e.value.toString(),
+      };
+    });
+  };
+
+  return (
+    <DialogModal
+      title={
+        <div>
+          <p>Discharge patient from CARE</p>
+          <span className="mt-1 flex gap-1 text-sm text-secondary-500 font-medium">
+            <CareIcon className="care-l-exclamation-triangle text-base" />
+            <p>Caution: this action is irreversible.</p>
+          </span>
+        </div>
+      }
+      show={show}
+      onClose={onClose}
+      className="md:max-w-3xl"
+    >
+      <div className="mt-6 flex flex-col">
+        <SelectFormField
+          required
+          label="Reason"
+          name="discharge_reason"
+          id="discharge_reason"
+          value={preDischargeForm.discharge_reason}
+          disabled={!!discharge_reason}
+          options={DISCHARGE_REASONS}
+          optionValue={({ id }) => id}
+          optionLabel={({ text }) => text}
+          onChange={(e) =>
+            setPreDischargeForm((prev) => ({
+              ...prev,
+              discharge_reason: e.value,
+            }))
+          }
+          error={errors?.discharge_reason}
+        />
+        <TextAreaFormField
+          required={preDischargeForm.discharge_reason == "EXP"}
+          label={
+            preDischargeForm.discharge_reason == "EXP"
+              ? "Cause of death"
+              : preDischargeForm.discharge_reason === "REC"
+              ? "Discharged Advice"
+              : "Notes"
+          }
+          name="discharge_notes"
+          value={preDischargeForm.discharge_notes}
+          onChange={(e) =>
+            setPreDischargeForm((prev) => ({
+              ...prev,
+              discharge_notes: e.value,
+            }))
+          }
+          error={errors?.discharge_notes}
+        />
+        {preDischargeForm.discharge_reason === "REC" && (
+          <div>
+            <DateFormField
+              label="Discharge Date"
+              name="discharge_date"
+              value={moment(preDischargeForm?.discharge_date).toDate()}
+              min={moment(
+                consultationData?.admission_date ||
+                  consultationData?.created_date
+              ).toDate()}
+              disableFuture={true}
+              required
+              onChange={handleDateChange}
+            />
+            <FieldLabel>Discharge Prescription</FieldLabel>
+            <div className="my-2">
+              <PrescriptionBuilder
+                prescriptions={dischargePrescription}
+                setPrescriptions={setDischargePrescription}
+              />
+            </div>
+            <div>
+              <FieldLabel>Discharge PRN Prescription</FieldLabel>
+              <PRNPrescriptionBuilder
+                prescriptions={dischargePRNPrescription}
+                setPrescriptions={setDischargePRNPrescription}
+              />
+            </div>
+          </div>
+        )}
+        {preDischargeForm.discharge_reason === "EXP" && (
+          <div>
+            <div>
+              Death Date and Time
+              <span className="text-danger-500">{" *"}</span>
+              <input
+                type="datetime-local"
+                className="w-[calc(100%-5px)] focus:ring-primary-500 focus:border-primary-500 block border border-gray-400 rounded py-2 px-4 text-sm bg-gray-100 hover:bg-gray-200 focus:outline-none focus:bg-white"
+                value={preDischargeForm.death_datetime || ""}
+                required
+                min={consultationData?.admission_date?.substring(0, 16)}
+                max={moment(new Date()).format("YYYY-MM-DDThh:mm")}
+                onChange={(e) => {
+                  setPreDischargeForm((form) => {
+                    return {
+                      ...form,
+                      death_datetime: e.target.value,
+                    };
+                  });
+                }}
+              />
+            </div>
+            <TextFormField
+              name="death_confirmed_by"
+              label="Confirmed By"
+              value={preDischargeForm.death_confirmed_doctor || ""}
+              onChange={(e) => {
+                setPreDischargeForm((form) => {
+                  return {
+                    ...form,
+                    death_confirmed_doctor: e.value,
+                  };
+                });
+              }}
+              required
+              placeholder="Attending Doctor's Name and Designation"
+            />
+          </div>
+        )}
+        {["REF", "LAMA"].includes(preDischargeForm.discharge_reason) && (
+          <div>
+            <DateFormField
+              label="Date of Discharge"
+              name="discharge_date"
+              value={moment(preDischargeForm.discharge_date).toDate()}
+              min={moment(
+                consultationData?.admission_date ||
+                  consultationData?.created_date
+              ).toDate()}
+              disableFuture={true}
+              required
+              onChange={handleDateChange}
+            />
+          </div>
+        )}
+      </div>
+
+      {enable_hcx && (
+        // TODO: if policy and approved pre-auth exists
+        <div className="my-5 shadow rounded p-5">
+          <h2 className="mb-2">Claim Insurance</h2>
+          {latestClaim ? (
+            <ClaimDetailCard claim={latestClaim} />
+          ) : (
+            <CreateClaimCard
+              consultationId={consultationData.id}
+              patientId={consultationData.patient}
+              use="claim"
+              isCreating={isCreateClaimLoading}
+              setIsCreating={setIsCreateClaimLoading}
+            />
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-col md:flex-row gap-2 pt-4 md:justify-end">
+        <Cancel onClick={onClose} />
+        {isSendingDischargeApi ? (
+          <CircularProgress size={20} />
+        ) : (
+          <Submit
+            onClick={() => handlePatientDischarge(false)}
+            label="Confirm Discharge"
+            autoFocus
+          />
+        )}
+      </div>
+    </DialogModal>
+  );
+};
+
+export default DischargeModal;

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -1,6 +1,6 @@
+import { AssignedToObjectModel } from "../Patient/models";
 import { PRNPrescriptionType } from "../Common/prescription-builder/PRNPrescriptionBuilder";
 import { ProcedureType } from "../Common/prescription-builder/ProcedureBuilder";
-import { AssignedToObjectModel } from "../Patient/models";
 
 export interface LocalBodyModel {
   name: string;
@@ -95,10 +95,10 @@ export interface ConsultationModel {
   history_of_present_illness?: string;
   facility?: number;
   facility_name?: string;
-  id?: number;
+  id: string;
   modified_date?: string;
   other_symptoms?: string;
-  patient?: number;
+  patient: string;
   prescribed_medication?: string;
   referred_to?: number | null;
   suggestion?: string;

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -1,32 +1,39 @@
 import React, { useState } from "react";
-import { navigate } from "raviger";
-import ListFilter from "./ListFilter";
-import ShiftingBoard from "./ShiftingBoard";
+
 import BadgesList from "./BadgesList";
-import { SHIFTING_CHOICES } from "../../Common/constants";
-import { downloadShiftRequests } from "../../Redux/actions";
-import loadable from "@loadable/component";
-import withScrolling from "react-dnd-scrolling";
-import { formatFilter } from "./Commons";
-import SearchInput from "../Form/SearchInput";
-import useFilters from "../../Common/hooks/useFilters";
 import { ExportButton } from "../Common/Export";
+import ListFilter from "./ListFilter";
+import { SHIFTING_CHOICES } from "../../Common/constants";
+import SearchInput from "../Form/SearchInput";
+import ShiftingBoard from "./ShiftingBoard";
+import { downloadShiftRequests } from "../../Redux/actions";
+import { formatFilter } from "./Commons";
+import loadable from "@loadable/component";
+import { navigate } from "raviger";
+import useConfig from "../../Common/hooks/useConfig";
+import useFilters from "../../Common/hooks/useFilters";
 import { useTranslation } from "react-i18next";
+import withScrolling from "react-dnd-scrolling";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const ScrollingComponent = withScrolling("div");
-const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text);
-
-const COMPLETED = ["COMPLETED", "REJECTED", "DESTINATION REJECTED"];
-const ACTIVE = shiftStatusOptions.filter(
-  (option) => !COMPLETED.includes(option)
-);
 
 export default function BoardView() {
   const { qParams, updateQuery, FilterBadges, advancedFilter } = useFilters({
     limit: -1,
   });
+  const { wartime_shifting } = useConfig();
+
+  const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text).filter(
+    (choice) => wartime_shifting || choice !== "PENDING"
+  );
+
+  const COMPLETED = ["COMPLETED", "REJECTED", "DESTINATION REJECTED"];
+  const ACTIVE = shiftStatusOptions.filter(
+    (option) => !COMPLETED.includes(option)
+  );
+
   const [boardFilter, setBoardFilter] = useState(ACTIVE);
   const [isLoading] = useState(false);
   const { t } = useTranslation();

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -1,29 +1,28 @@
-import React, { useEffect, useState } from "react";
-import { FacilitySelect } from "../Common/FacilitySelect";
-import { UserSelect } from "../Common/UserSelect2";
-import { navigate } from "raviger";
-import { LegacySelectField } from "../Common/HelperInputFields";
 import {
-  SHIFTING_FILTER_ORDER,
-  DISEASE_STATUS,
   BREATHLESSNESS_LEVEL,
+  DISEASE_STATUS,
+  SHIFTING_FILTER_ORDER,
 } from "../../Common/constants";
-import moment from "moment";
-import { getAnyFacility, getUserList } from "../../Redux/actions";
-import { useDispatch } from "react-redux";
-import { CircularProgress } from "@material-ui/core";
-import { SHIFTING_CHOICES } from "../../Common/constants";
 import { DateRangePicker, getDate } from "../Common/DateRangePicker";
-import parsePhoneNumberFromString from "libphonenumber-js";
-import useMergeState from "../../Common/hooks/useMergeState";
-import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
-import { FieldChangeEvent } from "../Form/FormFields/Utils";
-import useConfig from "../../Common/hooks/useConfig";
-import { useTranslation } from "react-i18next";
-import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
-import { FieldLabel } from "../Form/FormFields/FormField";
+import React, { useEffect, useState } from "react";
+import { getAnyFacility, getUserList } from "../../Redux/actions";
 
-const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text);
+import { CircularProgress } from "@material-ui/core";
+import { FacilitySelect } from "../Common/FacilitySelect";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
+import { FieldLabel } from "../Form/FormFields/FormField";
+import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
+import { LegacySelectField } from "../Common/HelperInputFields";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
+import { SHIFTING_CHOICES } from "../../Common/constants";
+import { UserSelect } from "../Common/UserSelect2";
+import moment from "moment";
+import { navigate } from "raviger";
+import parsePhoneNumberFromString from "libphonenumber-js";
+import useConfig from "../../Common/hooks/useConfig";
+import { useDispatch } from "react-redux";
+import useMergeState from "../../Common/hooks/useMergeState";
+import { useTranslation } from "react-i18next";
 
 const clearFilterState = {
   orgin_facility: "",
@@ -50,13 +49,17 @@ const clearFilterState = {
 };
 
 export default function ListFilter(props: any) {
-  const { kasp_enabled, kasp_string } = useConfig();
+  const { kasp_enabled, kasp_string, wartime_shifting } = useConfig();
   const { filter, onChange, closeFilter } = props;
   const [isOriginLoading, setOriginLoading] = useState(false);
   const [isShiftingLoading, setShiftingLoading] = useState(false);
   const [isAssignedLoading, setAssignedLoading] = useState(false);
   const [isAssignedUserLoading, setAssignedUserLoading] = useState(false);
   const { t } = useTranslation();
+
+  const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text).filter(
+    (choice) => wartime_shifting || choice !== "PENDING"
+  );
 
   const [filterState, setFilterState] = useMergeState({
     orgin_facility: filter.orgin_facility || "",

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -21,6 +21,8 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import { useCallback, useEffect, useReducer, useState } from "react";
 
 import { CircularProgress } from "@material-ui/core";
+import { ConsultationModel } from "../Facility/models.js";
+import DischargeModal from "../Facility/DischargeModal.js";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { FieldLabel } from "../Form/FormFields/FormField";
 import { LegacyErrorHelperText } from "../Common/HelperInputFields";
@@ -73,6 +75,10 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [assignedUser, SetAssignedUser] = useState(null);
   const [assignedUserLoading, setAssignedUserLoading] = useState(false);
+  const [consultationData, setConsultationData] = useState<ConsultationModel>(
+    {} as ConsultationModel
+  );
+  const [showDischargeModal, setShowDischargeModal] = useState(false);
   const { t } = useTranslation();
 
   const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text).filter(
@@ -210,7 +216,11 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
           msg: t("shift_request_updated_successfully"),
         });
 
-        navigate(`/shifting/${props.id}`);
+        if (data.status === "PATIENT EXPIRED") {
+          setShowDischargeModal(true);
+        } else {
+          navigate(`/shifting/${props.id}`);
+        }
       } else {
         setIsLoading(false);
       }
@@ -224,6 +234,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
       if (!status.aborted) {
         if (res && res.data) {
           const d = res.data;
+          setConsultationData(d.patient.last_consultation);
           d["initial_status"] = res.data.status;
           d["status"] = qParams.status || res.data.status;
           dispatch({ type: "set_form", form: d });
@@ -250,6 +261,12 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
 
   return (
     <div className="px-2 pb-2">
+      <DischargeModal
+        show={showDischargeModal}
+        onClose={() => setShowDischargeModal(false)}
+        consultationData={consultationData}
+        discharge_reason="EXP"
+      />
       <PageTitle
         title={t("update_shift_request")}
         backUrl={`/shifting/${props.id}`}

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -1,44 +1,44 @@
-import { useReducer, useState, useCallback, useEffect } from "react";
-import loadable from "@loadable/component";
-import { FacilitySelect } from "../Common/FacilitySelect";
-import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
-import { useDispatch } from "react-redux";
-import { navigate, useQueryParams } from "raviger";
-import { statusType, useAbortableEffect } from "../../Common/utils";
-import { getShiftDetails, updateShift, getUserList } from "../../Redux/actions";
-import { LegacySelectField } from "../Common/HelperInputFields";
-import {
-  SHIFTING_CHOICES,
-  FACILITY_TYPES,
-  SHIFTING_VEHICLE_CHOICES,
-  BREATHLESSNESS_LEVEL,
-} from "../../Common/constants";
-import { UserSelect } from "../Common/UserSelect";
-import { CircularProgress } from "@material-ui/core";
-import { useTranslation } from "react-i18next";
 
 import {
+  BREATHLESSNESS_LEVEL,
+  FACILITY_TYPES,
+  SHIFTING_CHOICES,
+  SHIFTING_VEHICLE_CHOICES,
+} from "../../Common/constants";
+import {
+  Box,
   Card,
   CardContent,
+  FormControlLabel,
   Radio,
   RadioGroup,
-  Box,
-  FormControlLabel,
 } from "@material-ui/core";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
-import useConfig from "../../Common/hooks/useConfig";
+import { getShiftDetails, getUserList, updateShift } from "../../Redux/actions";
+import { navigate, useQueryParams } from "raviger";
+import { statusType, useAbortableEffect } from "../../Common/utils";
+import { useCallback, useEffect, useReducer, useState } from "react";
+
+import { CircularProgress } from "@material-ui/core";
+import { FacilitySelect } from "../Common/FacilitySelect";
 import { FieldLabel } from "../Form/FormFields/FormField";
+import { LegacyErrorHelperText } from "../Common/HelperInputFields";
+import { LegacySelectField } from "../Common/HelperInputFields";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
+import { UserSelect } from "../Common/UserSelect";
+import loadable from "@loadable/component";
 import useAppHistory from "../../Common/hooks/useAppHistory";
+import useConfig from "../../Common/hooks/useConfig";
+import { useDispatch } from "react-redux";
+import { useTranslation } from "react-i18next";
+
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 interface patientShiftProps {
   id: string;
 }
-
-const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text);
 
 const initForm: any = {
   shifting_approving_facility_object: null,
@@ -67,13 +67,17 @@ const initialState = {
 
 export const ShiftDetailsUpdate = (props: patientShiftProps) => {
   const { goBack } = useAppHistory();
-  const { kasp_full_string } = useConfig();
+  const { kasp_full_string, wartime_shifting } = useConfig();
   const dispatchAction: any = useDispatch();
   const [qParams, _] = useQueryParams();
   const [isLoading, setIsLoading] = useState(true);
   const [assignedUser, SetAssignedUser] = useState(null);
   const [assignedUserLoading, setAssignedUserLoading] = useState(false);
   const { t } = useTranslation();
+
+  const shiftStatusOptions = SHIFTING_CHOICES.map((obj) => obj.text).filter(
+    (choice) => wartime_shifting || choice !== "PENDING"
+  );
 
   const requiredFields: any = {
     shifting_approving_facility_object: {

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -266,6 +266,11 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
         onClose={() => setShowDischargeModal(false)}
         consultationData={consultationData}
         discharge_reason="EXP"
+        afterSubmit={() => {
+          navigate(
+            `/facility/${consultationData.facility}/patient/${consultationData.patient}/consultation/${consultationData.id}`
+          );
+        }}
       />
       <PageTitle
         title={t("update_shift_request")}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b037f5</samp>

This pull request adds the feature to discharge expired patients from the shifting module and refactors some code to use the new CAREUI components and the `wartime_shifting` config property. It also sorts some imports and fixes a bug in the consultation model. The main files affected are `ShiftDetailsUpdate.tsx`, `DischargeModal.tsx`, `ConsultationDetails.tsx`, and `models.tsx`.

## Proposed Changes

- Fixes #5368 
- Refactored discharge summary into a new component
- Hiding the pending list and pending option in shifting module in peacetime mode (you can create an env for setting peacetime mode to true)
- When the patient expired is selected as status (also add this to status) and the changes are saved, Redirect the user to Discharge from the CARE pop-up window, with the reason for discharge "death" must come auto-populated and must not be editable.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b037f5</samp>

*  Add `DischargeModal` component to handle the discharge logic and UI for both consultation and shifting modules ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764R1-R356), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL481-R337), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fR264-R269))
*  Replace the `handlePatientDischarge` function and the `DialogModal` component for the discharge form with the `DischargeModal` component in the consultation module ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL231-L282), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL307-L312), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL481-R337))
*  Add `consultationData`, `showDischargeModal` and `setShowDischargeModal` states to the shifting module to store the consultation data and the flag to show the `DischargeModal` component ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL76-R87))
*  Show the `DischargeModal` component and store the consultation data if the shifting status is updated to "PATIENT EXPIRED" in the shifting module ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL209-R223), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fR237), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fR264-R269))
*  Add `wartime_shifting` property to the `IConfig` interface and the `useConfig` hook to toggle the shifting feature based on the environment variable ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-85ddd82d8d8242a8120ad7bf95ed40ce93b4290afb8e17e7c2370bfb2086dd71R58-R61), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-9bd3f042da788b477c58be6b5fe84715b43138511ba961eda57b3317333bfe18L53-R52), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL70-R72))
*  Filter out the "PENDING" option from the shifting status options if the `wartime_shifting` property is false ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-9bd3f042da788b477c58be6b5fe84715b43138511ba961eda57b3317333bfe18R60-R63))
*  Remove the `shiftStatusOptions` variable from the shifting module and use a local variable that depends on the `wartime_shifting` property ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL41-L42))
*  Add a new option for shifting status to handle the case of patient expired ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-37705b30476b14631124ce42dd5c3500d43fbede16f0e91f9ae2905e4adc6376R149))
*  Simplify the `preDischargeForm` state by removing the unused properties `dischargePrescription` and `dischargePRNPrescription` ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL107-R82))
*  Remove the `handleDateChange` function and use the `DateFormField` component instead ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL419-L427))
*  Initialize the `consultationData` and `patientData` states with an empty object casted as the respective model types to avoid type errors ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL93-R72))
*  Make the `id` and `patient` properties in the `ConsultationModel` interface mandatory as they are required for the discharge logic ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfL98-R101))
*  Sort the imports alphabetically and remove unused imports for better readability and consistency in various files ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-37705b30476b14631124ce42dd5c3500d43fbede16f0e91f9ae2905e4adc6376L1-R5), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL1-R21), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfL1-R3), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-fc18d7013fcb5787812d6865749dd91966308ccf3493ab227001b2ca0079f600L2-R36), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-9bd3f042da788b477c58be6b5fe84715b43138511ba961eda57b3317333bfe18L1-R26), [link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL1-R37))
*  Update the imports to use the new components from the CAREUI library in the consultation module ([link](https://github.com/coronasafe/care_fe/pull/5369/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL39-R53))
