### PR TITLE
Show all locations in CNS page by default and added a cancel button to setLoaction Modal

### DIFF
--- a/src/Components/Facility/FacilityCNS.tsx
+++ b/src/Components/Facility/FacilityCNS.tsx
@@ -148,6 +148,7 @@ export default function FacilityCNS({ facilityId }: { facilityId: string }) {
                 border
                 onClick={() => setShowSelectLocation(true)}
               >
+                <CareIcon className="care-l-location-point text-lg" />
                 Change Location
               </ButtonV2>
               <ButtonV2
@@ -278,9 +279,10 @@ export default function FacilityCNS({ facilityId }: { facilityId: string }) {
                 (currentPage - 1) * PER_PAGE_LIMIT,
                 currentPage * PER_PAGE_LIMIT
               )
-              .map(({ patient, socketUrl }) => (
+              .map(({ patient, socketUrl, asset }) => (
                 <MonitorCard
                   key={patient.id}
+                  location={asset.location_object}
                   facilityId={facilityId}
                   patient={patient}
                   socketUrl={socketUrl}
@@ -292,9 +294,10 @@ export default function FacilityCNS({ facilityId }: { facilityId: string }) {
                 (currentPage - 1) * PER_PAGE_LIMIT,
                 currentPage * PER_PAGE_LIMIT
               )
-              .map(({ patient, socketUrl }) => (
+              .map(({ patient, socketUrl, asset }) => (
                 <MonitorCard
                   key={patient.id}
+                  location={asset.location_object}
                   facilityId={facilityId}
                   patient={patient}
                   socketUrl={socketUrl}

--- a/src/Components/Facility/FacilityCNS.tsx
+++ b/src/Components/Facility/FacilityCNS.tsx
@@ -1,8 +1,7 @@
-import { Link, navigate } from "raviger";
+import { navigate } from "raviger";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import CareIcon from "../../CAREUI/icons/CareIcon";
-import { GENDER_TYPES } from "../../Common/constants";
 import {
   getAllPatient,
   getPermittedFacility,
@@ -15,11 +14,11 @@ import Page from "../Common/components/Page";
 import Loading from "../Common/Loading";
 import Pagination from "../Common/Pagination";
 import { PatientModel } from "../Patient/models";
-import PatientVitalsCard from "../Patient/PatientVitalsCard";
 import { FacilityModel } from "./models";
 import AutocompleteFormField from "../Form/FormFields/Autocomplete";
 import { uniqBy } from "lodash";
 import DialogModal from "../Common/Dialog";
+import { MonitorCard } from "./MonitorCard";
 
 interface Monitor {
   patient: PatientModel;
@@ -273,37 +272,32 @@ export default function FacilityCNS({ facilityId }: { facilityId: string }) {
         </div>
       )}
       <div className="mt-4 grid grid-cols-1 lg:grid-cols-3 gap-1">
-        {monitors
-          ?.filter((m) =>
-            defaultShowAllLocation
-              ? true
-              : m.asset.location_object.id === location?.id
-          )
-          ?.slice(
-            (currentPage - 1) * PER_PAGE_LIMIT,
-            currentPage * PER_PAGE_LIMIT
-          )
-          .map(({ patient, socketUrl }) => (
-            <div key={patient.id} className="group p-2 rounded-lg bg-black">
-              <div className="flex flex-wrap gap-4 text-white w-full tracking-wider p-2">
-                <Link
-                  href={`/facility/${facilityId}/patient/${patient.id}/consultation/${patient.last_consultation?.id}`}
-                  className="font-bold uppercase text-white"
-                >
-                  {patient.name}
-                </Link>
-                <span>
-                  {patient.age}y |{" "}
-                  {GENDER_TYPES.find((g) => g.id === patient.gender)?.icon}
-                </span>
-                <span className="flex-1 flex items-center justify-end gap-2 text-end">
-                  <CareIcon className="care-l-bed text-lg" />
-                  {patient.last_consultation?.current_bed?.bed_object?.name}
-                </span>
-              </div>
-              <PatientVitalsCard socketUrl={socketUrl} shrinked />
-            </div>
-          ))}
+        {defaultShowAllLocation
+          ? monitors
+              ?.slice(
+                (currentPage - 1) * PER_PAGE_LIMIT,
+                currentPage * PER_PAGE_LIMIT
+              )
+              .map(({ patient, socketUrl }) => (
+                <MonitorCard
+                  facilityId={facilityId}
+                  patient={patient}
+                  socketUrl={socketUrl}
+                />
+              ))
+          : monitors
+              ?.filter((m) => m.asset.location_object.id === location?.id)
+              ?.slice(
+                (currentPage - 1) * PER_PAGE_LIMIT,
+                currentPage * PER_PAGE_LIMIT
+              )
+              .map(({ patient, socketUrl }) => (
+                <MonitorCard
+                  facilityId={facilityId}
+                  patient={patient}
+                  socketUrl={socketUrl}
+                />
+              ))}
       </div>
     </Page>
   );

--- a/src/Components/Facility/FacilityCNS.tsx
+++ b/src/Components/Facility/FacilityCNS.tsx
@@ -280,6 +280,7 @@ export default function FacilityCNS({ facilityId }: { facilityId: string }) {
               )
               .map(({ patient, socketUrl }) => (
                 <MonitorCard
+                  key={patient.id}
                   facilityId={facilityId}
                   patient={patient}
                   socketUrl={socketUrl}
@@ -293,6 +294,7 @@ export default function FacilityCNS({ facilityId }: { facilityId: string }) {
               )
               .map(({ patient, socketUrl }) => (
                 <MonitorCard
+                  key={patient.id}
                   facilityId={facilityId}
                   patient={patient}
                   socketUrl={socketUrl}

--- a/src/Components/Facility/MonitorCard.tsx
+++ b/src/Components/Facility/MonitorCard.tsx
@@ -1,0 +1,39 @@
+import { GENDER_TYPES } from "../../Common/constants";
+import { Link } from "raviger";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import { PatientModel } from "../Patient/models";
+import PatientVitalsCard from "../Patient/PatientVitalsCard";
+
+interface MonitorCardProps {
+  facilityId: string;
+  patient: PatientModel;
+  socketUrl: string;
+}
+
+export const MonitorCard = ({
+  facilityId,
+  patient,
+  socketUrl,
+}: MonitorCardProps) => {
+  return (
+    <div key={patient.id} className="group p-2 rounded-lg bg-black">
+      <div className="flex flex-wrap gap-4 text-white w-full tracking-wider p-2">
+        <Link
+          href={`/facility/${facilityId}/patient/${patient.id}/consultation/${patient.last_consultation?.id}`}
+          className="font-bold uppercase text-white"
+        >
+          {patient.name}
+        </Link>
+        <span>
+          {patient.age}y |{" "}
+          {GENDER_TYPES.find((g) => g.id === patient.gender)?.icon}
+        </span>
+        <span className="flex-1 flex items-center justify-end gap-2 text-end">
+          <CareIcon className="care-l-bed text-lg" />
+          {patient.last_consultation?.current_bed?.bed_object?.name}
+        </span>
+      </div>
+      <PatientVitalsCard socketUrl={socketUrl} shrinked />
+    </div>
+  );
+};

--- a/src/Components/Facility/MonitorCard.tsx
+++ b/src/Components/Facility/MonitorCard.tsx
@@ -3,17 +3,20 @@ import { Link } from "raviger";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { PatientModel } from "../Patient/models";
 import PatientVitalsCard from "../Patient/PatientVitalsCard";
+import { AssetLocationObject } from "../Assets/AssetTypes";
 
 interface MonitorCardProps {
   facilityId: string;
   patient: PatientModel;
   socketUrl: string;
+  location: AssetLocationObject;
 }
 
 export const MonitorCard = ({
   facilityId,
   patient,
   socketUrl,
+  location,
 }: MonitorCardProps) => {
   return (
     <div key={patient.id} className="group p-2 rounded-lg bg-black">
@@ -31,6 +34,10 @@ export const MonitorCard = ({
         <span className="flex-1 flex items-center justify-end gap-2 text-end">
           <CareIcon className="care-l-bed text-lg" />
           {patient.last_consultation?.current_bed?.bed_object?.name}
+        </span>
+        <span className="flex-2 flex items-center justify-end gap-2 text-end">
+          <CareIcon className="care-l-location-point text-lg" />
+          {location.name}
         </span>
       </div>
       <PatientVitalsCard socketUrl={socketUrl} shrinked />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 095b7b2</samp>

This pull request enhances the facility CNS page by adding a location filter option and improving the UI and speed of the page components. It modifies the `FacilityCNS.tsx` file and some related components.

## Proposed Changes

- Fixes #5346
- Show all locations in CNS page by default
![image](https://user-images.githubusercontent.com/59426397/233870611-439614a0-a6a8-4220-9935-5d08cd901a5f.png)
- Added a show all location button
![image](https://user-images.githubusercontent.com/59426397/233870704-57177227-8fb5-4b67-8e8e-5eba4cee3f5b.png)

- Fixes #5351 
-  Added a cancel button to setLoaction Modal
![image](https://user-images.githubusercontent.com/59426397/233870714-258bc546-65f6-46f5-8c78-133b2cdfab56.png)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 095b7b2</samp>

*  Add a new state variable to store the user preference for viewing all monitors or only the selected location ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8R39))
*  Change the initial value of the state variable that controls the location selection modal to avoid showing it on every page load ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L48-R49))
*  Modify the page title to reflect the user preference and the selected location ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L134-R139))
*  Conditionally render the options section based on the presence of monitors and add a "Go Back" button if there are none ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L140-R190))
*  Update the pagination data to match the total count of monitors based on the user preference and the selected location ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L178-R204))
*  Simplify and enhance the location selection modal to remove unnecessary messages and add new buttons for "Show All Locations", "Confirm", and "Cancel" ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L186-R216), [link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L225-R266))
*  Filter the main grid of monitors based on the user preference and the selected location ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L240-R281))
*  Import the `Cancel` component from `../Common/components/ButtonV2` to use in the location selection modal ([link](https://github.com/coronasafe/care_fe/pull/5378/files?diff=unified&w=0#diff-ad41f23b1187ec4f7000793014b0380c568fd2951cc72df118dd990b6513d7e8L13-R13))
