### PR TITLE
Made ambulance no. not mandatory in shift request create

### DIFF
--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -88,10 +88,6 @@ export const ShiftCreate = (props: patientShiftProps) => {
       errorText: "Reason for shifting in mandatory",
       invalidText: "Please enter reason for shifting",
     },
-    ambulance_number: {
-      errorText: "Ambulance Number is required",
-      invalidText: "Please enter valid Ambulance Number",
-    },
   };
 
   if (wartime_shifting) {
@@ -515,7 +511,6 @@ export const ShiftCreate = (props: patientShiftProps) => {
               <div className="md:col-span-1">
                 <TextFormField
                   label="Ambulance No."
-                  required
                   name="ambulance_number"
                   placeholder="Ambulance No."
                   value={state.form.ambulance_number}

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -98,11 +98,6 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
     reason: {
       errorText: t("please_enter_a_reason_for_the_shift"),
     },
-
-    ambulance_number: {
-      errorText: "Ambulance Number is required",
-      invalidText: "Please enter valid Ambulance Number",
-    },
   };
 
   if (wartime_shifting) {
@@ -193,7 +188,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
     dispatch({ type: "set_form", form });
   };
 
-  const handleFormFieldChange = (event: FieldChangeEvent<unknown>) => {
+  const handleFormFieldChange = (event: any) => {
     dispatch({
       type: "set_form",
       form: { ...state.form, [event.name]: event.value },
@@ -570,7 +565,6 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
               <div className="md:col-span-1">
                 <TextFormField
                   label="Ambulance No."
-                  required
                   name="ambulance_number"
                   placeholder="Ambulance No."
                   value={state.form.ambulance_number}


### PR DESCRIPTION
### WHAT
copilot:summary

## Proposed Changes

- Fixes #5382 
- Made ambulance number field not mandatory in shift request create form

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
copilot:walkthrough
