### PR TITLE
Mark patient as expired only after discharge in shifting

### DIFF
--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -25,6 +25,7 @@ import { CircularProgress } from "@material-ui/core";
 import { ConsultationModel } from "../Facility/models.js";
 import DischargeModal from "../Facility/DischargeModal.js";
 import { FacilitySelect } from "../Common/FacilitySelect";
+import { FieldChangeEvent } from "../Form/FormFields/Utils.js";
 import { FieldLabel } from "../Form/FormFields/FormField";
 import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import { LegacySelectField } from "../Common/HelperInputFields";
@@ -213,10 +214,15 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
     dispatch({ type: "set_form", form });
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (discharged = false) => {
     const validForm = validateForm();
 
     if (validForm) {
+      if (!discharged && state.form.status === "PATIENT EXPIRED") {
+        setShowDischargeModal(true);
+        return;
+      }
+
       setIsLoading(true);
 
       const data: any = {
@@ -263,11 +269,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
           msg: t("shift_request_updated_successfully"),
         });
 
-        if (data.status === "PATIENT EXPIRED") {
-          setShowDischargeModal(true);
-        } else {
-          navigate(`/shifting/${props.id}`);
-        }
+        navigate(`/shifting/${props.id}`);
       } else {
         setIsLoading(false);
       }
@@ -322,9 +324,8 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
         consultationData={consultationData}
         discharge_reason="EXP"
         afterSubmit={() => {
-          navigate(
-            `/facility/${consultationData.facility}/patient/${consultationData.patient}/consultation/${consultationData.id}`
-          );
+          console.log("discharged");
+          handleSubmit(true);
         }}
       />
       <PageTitle
@@ -593,7 +594,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
 
               <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">
                 <Cancel onClick={() => goBack()} />
-                <Submit onClick={handleSubmit} />
+                <Submit onClick={() => handleSubmit()} />
               </div>
             </div>
           </CardContent>

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -320,7 +320,6 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
         consultationData={consultationData}
         discharge_reason="EXP"
         afterSubmit={() => {
-          console.log("discharged");
           handleSubmit(true);
         }}
       />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da7b2d6</samp>

Refactor the shifting details update component to improve the discharge confirmation logic for expired patients. Fix the type definition of the `handleChange` function in `ShiftDetailsUpdate.tsx`.

## Proposed Changes

- Fixes #5388 
- Mark the patient as expired only after discharge in shifting


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da7b2d6</samp>

*  Import `FieldChangeEvent` type to use in `handleChange` function ([link](https://github.com/coronasafe/care_fe/pull/5404/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fR28))
*  Modify `handleSubmit` function to accept `discharged` parameter and show `DischargeModal` if patient is not discharged and status is "PATIENT EXPIRED" ([link](https://github.com/coronasafe/care_fe/pull/5404/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL216-R225), [link](https://github.com/coronasafe/care_fe/pull/5404/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL266-R272))
*  Change `afterSubmit` callback of `DischargeModal` to call `handleSubmit` with `discharged` set to true ([link](https://github.com/coronasafe/care_fe/pull/5404/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL325-R328))
*  Change `onClick` handler of `Submit` to call `handleSubmit` without arguments ([link](https://github.com/coronasafe/care_fe/pull/5404/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL596-R597))
