### PR TITLE
Added admit patient button in completed shifting cards

### DIFF
--- a/src/Common/utils.tsx
+++ b/src/Common/utils.tsx
@@ -1,6 +1,7 @@
+import { OptionsType, USER_TYPES, UserRole } from "./constants";
+
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect } from "react";
-import { OptionsType } from "./constants";
 
 export interface statusType {
   aborted?: boolean;
@@ -68,4 +69,10 @@ export const deepEqual = (x: any, y: any): boolean => {
   }
 
   return false;
+};
+
+export const checkAuthority = (type: UserRole, cutoff: UserRole) => {
+  const userAuthority = USER_TYPES.indexOf(type);
+  const cutoffAuthority = USER_TYPES.indexOf(cutoff);
+  return userAuthority >= cutoffAuthority;
 };

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -37,6 +37,7 @@
   "last_modified": "Last Modified",
   "patient_address": "Patient Address",
   "all_details": "All Details",
+  "admit_patient": "Admit Patient",
   "confirm": "Confirm",
   "refresh_list": "Refresh List",
   "last_edited": "Last Edited",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0676157</samp>

This pull request adds a feature to admit a patient to a facility after a completed shift in the shifting board component. It also refactors some imports and adds a utility function to check user authority in `src/Common/utils.tsx`. It updates the `Common.json` file with a new translation key for the admit button.

## Proposed Changes

- Fixes #5399 
- Added admit patient button in completed shifting cards


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0676157</samp>

*  Add `checkAuthority` utility function to compare user role with cutoff role ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-f1b9b06c04dce5b6de1b9d6697e14b969d718382fd56c2649714883940a2f8d7R73-R78))
*  Import `checkAuthority` function and `transferPatient` action in `ShiftingBoard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L15-R22))
*  Import `Notification` functions and `react-redux` hooks in `ShiftingBoard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L1-R2), [link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L8-R11))
*  Select `state` and `currentUser` from redux store in `ShiftingBoard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3R48-R49))
*  Add `isPatientTransfering` state variable to manage loading and disabled state of admit patient button ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3R60))
*  Add conditional rendering of admit patient button to `ShiftCard` component in `ShiftingBoard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3R212-R254))
*  Dispatch `transferPatient` action and display notification messages on button click in `ShiftingBoard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3R212-R254))
*  Add translation key and value for "admit_patient" in `Common.json` ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-38a71477ce052dd5f81bf55434622f86d274a8dc6a8af1a03fb444588aec4296R40))
*  Remove `console.log(shift)` statement from `ShiftingBoard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5405/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3R71-R73))
