### PR TITLE
Modify error message in the shift create form

### DIFF
--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -78,10 +78,10 @@ export const ShiftCreate = (props: patientShiftProps) => {
 
   let requiredFields: any = {
     refering_facility_contact_name: {
-      errorText: "Name of contact of the referring facility",
+      errorText: "Name of contact of the current facility",
     },
     refering_facility_contact_number: {
-      errorText: "Phone number of contact of the referring facility",
+      errorText: "Phone number of contact of the current facility",
       invalidText: "Please enter valid phone number",
     },
     reason: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8a9a59</samp>

Updated error messages for shift request form to use consistent terminology. Changed `referring facility` to `current facility` in `src/Components/Patient/ShiftCreate.tsx`.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8a9a59</samp>

*  Update error messages for required fields in shift request form ([link](https://github.com/coronasafe/care_fe/pull/5419/files?diff=unified&w=0#diff-7ec03dd8838e59d1d7ef0aa4f42c6ed82aa5f086d5d280b42617974f674f561fL81-R84))
