### PR TITLE
Renames "Pending" to "Shifting Approval Pending"

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -137,7 +137,7 @@ export const FACILITY_TYPES: Array<OptionsType> = [
 ];
 
 export const SHIFTING_CHOICES_WARTIME: Array<OptionsType> = [
-  { id: 10, text: "PENDING" },
+  { id: 10, text: "PENDING", label: "SHIFTING APPROVAL PENDING" },
   { id: 15, text: "ON HOLD" },
   { id: 20, text: "APPROVED" },
   { id: 30, text: "REJECTED" },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b7ec60</samp>

Updated the `SHIFTING_CHOICES_WARTIME` constant to add labels for shifting statuses. Improved the UI of the shifting list page by showing more descriptive texts for each status.

## Proposed Changes

- Closes #5397 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b7ec60</samp>

* Add a label property to the first option of `SHIFTING_CHOICES_WARTIME` to display a more descriptive text for the shifting status in the shifting list page ([link](https://github.com/coronasafe/care_fe/pull/5421/files?diff=unified&w=0#diff-37705b30476b14631124ce42dd5c3500d43fbede16f0e91f9ae2905e4adc6376L140-R140))
