### PR TITLE
Permissions for 'Transfer to Rec. Facility button'

### DIFF
--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -2,7 +2,7 @@ import { CircularProgress } from "@material-ui/core";
 import { navigate } from "raviger";
 import moment from "moment";
 import React, { useCallback, useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { GENDER_TYPES, SAMPLE_TEST_STATUS } from "../../Common/constants";
 import loadable from "@loadable/component";
 import { statusType, useAbortableEffect } from "../../Common/utils";
@@ -64,6 +64,11 @@ export const PatientHome = (props: any) => {
   const [isConsultationLoading, setIsConsultationLoading] = useState(false);
   const [isSampleLoading, setIsSampleLoading] = useState(false);
   const [sampleFlag, callSampleList] = useState(false);
+  const rootState: any = useSelector((rootState) => rootState);
+  const { currentUser } = rootState;
+  const userHomeFacilityId = currentUser.data.home_facility;
+  const userType = currentUser.data.user_type;
+  const { t } = useTranslation();
   const [selectedStatus, setSelectedStatus] = useState<{
     status: number;
     sample: any;
@@ -651,16 +656,17 @@ export const PatientHome = (props: any) => {
                     </div>
                   </div>
                 )}
-                {patientData.is_vaccinated && patientData.last_vaccinated_date && (
-                  <div className="sm:col-span-1">
-                    <div className="text-sm leading-5 font-semibold text-zinc-400">
-                      Last Vaccinated on
+                {patientData.is_vaccinated &&
+                  patientData.last_vaccinated_date && (
+                    <div className="sm:col-span-1">
+                      <div className="text-sm leading-5 font-semibold text-zinc-400">
+                        Last Vaccinated on
+                      </div>
+                      <div className="mt-1 text-sm leading-5 font-medium">
+                        {formatDate(patientData.last_vaccinated_date)}
+                      </div>
                     </div>
-                    <div className="mt-1 text-sm leading-5 font-medium">
-                      {formatDate(patientData.last_vaccinated_date)}
-                    </div>
-                  </div>
-                )}
+                  )}
                 {patientData.countries_travelled &&
                   !!patientData.countries_travelled.length && (
                     <div className="sm:col-span-1">
@@ -933,15 +939,24 @@ export const PatientHome = (props: any) => {
                           All Details
                         </ButtonV2>
                       </div>
-                      {shift.status === "TRANSFER IN PROGRESS" &&
+                      {shift.status === "COMPLETED" &&
                         shift.assigned_facility && (
                           <div className="mt-2">
                             <ButtonV2
                               size="small"
                               className="w-full"
+                              disabled={
+                                !shift.patient_object.allow_transfer ||
+                                !(
+                                  ["DistrictAdmin", "StateAdmin"].includes(
+                                    userType
+                                  ) ||
+                                  userHomeFacilityId === shift.assigned_facility
+                                )
+                              }
                               onClick={() => setModalFor(shift.external_id)}
                             >
-                              TRANSFER TO RECEIVING FACILITY
+                              {t("transfer_to_receiving_facility")}
                             </ButtonV2>
                             <Modal
                               open={modalFor === shift.external_id}

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -18,7 +18,7 @@ import loadable from "@loadable/component";
 import moment from "moment";
 import { navigate } from "raviger";
 import useConfig from "../../Common/hooks/useConfig";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import useFilters from "../../Common/hooks/useFilters";
 import { useTranslation } from "react-i18next";
 
@@ -42,6 +42,10 @@ export default function ListView() {
     externalId: undefined,
     loading: false,
   });
+  const rootState: any = useSelector((rootState) => rootState);
+  const { currentUser } = rootState;
+  const userHomeFacilityId = currentUser.data.home_facility;
+  const userType = currentUser.data.user_type;
   const { t } = useTranslation();
 
   const handleTransferComplete = (shift: any) => {
@@ -239,27 +243,33 @@ export default function ListView() {
                 <i className="fas fa-eye mr-2" /> {t("all_details")}
               </ButtonV2>
             </div>
-            {shift.status === "TRANSFER IN PROGRESS" &&
-              shift.assigned_facility && (
-                <div className="mt-2">
-                  <ButtonV2
-                    className="w-full"
-                    onClick={() => setModalFor(shift.external_id)}
-                  >
-                    {t("transfer_to_receiving_facility")}
-                  </ButtonV2>
-                  <ConfirmDialogV2
-                    title={t("confirm_transfer_complete")}
-                    description={t("mark_transfer_complete_confirmation")}
-                    action="Confirm"
-                    show={modalFor === shift.external_id}
-                    onClose={() =>
-                      setModalFor({ externalId: undefined, loading: false })
-                    }
-                    onConfirm={() => handleTransferComplete(shift)}
-                  />
-                </div>
-              )}
+            {shift.status === "COMPLETED" && shift.assigned_facility && (
+              <div className="mt-2">
+                <ButtonV2
+                  className="w-full"
+                  disabled={
+                    !shift.patient_object.allow_transfer ||
+                    !(
+                      ["DistrictAdmin", "StateAdmin"].includes(userType) ||
+                      userHomeFacilityId === shift.assigned_facility
+                    )
+                  }
+                  onClick={() => setModalFor(shift.external_id)}
+                >
+                  {t("transfer_to_receiving_facility")}
+                </ButtonV2>
+                <ConfirmDialogV2
+                  title={t("confirm_transfer_complete")}
+                  description={t("mark_transfer_complete_confirmation")}
+                  action="Confirm"
+                  show={modalFor === shift.external_id}
+                  onClose={() =>
+                    setModalFor({ externalId: undefined, loading: false })
+                  }
+                  onConfirm={() => handleTransferComplete(shift)}
+                />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/Components/Shifting/ShiftingBoard.tsx
+++ b/src/Components/Shifting/ShiftingBoard.tsx
@@ -15,7 +15,7 @@ import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 import moment from "moment";
 import { navigate } from "raviger";
 import useConfig from "../../Common/hooks/useConfig";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 
 const limit = 14;
@@ -52,6 +52,10 @@ const ShiftCard = ({ shift, filter }: any) => {
     item: shift,
     collect: (monitor) => ({ isDragging: !!monitor.isDragging() }),
   }));
+  const rootState: any = useSelector((rootState) => rootState);
+  const { currentUser } = rootState;
+  const userHomeFacilityId = currentUser.data.home_facility;
+  const userType = currentUser.data.user_type;
   const { t } = useTranslation();
 
   const handleTransferComplete = (shift: any) => {
@@ -208,11 +212,18 @@ const ShiftCard = ({ shift, filter }: any) => {
               <i className="fas fa-eye mr-2" /> {t("all_details")}
             </button>
           </div>
-          {filter === "TRANSFER IN PROGRESS" && shift.assigned_facility && (
+          {filter === "COMPLETED" && shift.assigned_facility && (
             <div className="mt-2">
               <ButtonV2
                 variant="secondary"
                 className="w-full sm:whitespace-normal"
+                disabled={
+                  !shift.patient_object.allow_transfer ||
+                  !(
+                    ["DistrictAdmin", "StateAdmin"].includes(userType) ||
+                    userHomeFacilityId === shift.assigned_facility
+                  )
+                }
                 onClick={() => setModalFor(shift.external_id)}
               >
                 {t("transfer_to_receiving_facility")}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7603075</samp>

This pull request updates the shifting logic and UI for the patient and shifting components. It uses the global state for the user and facility data, and adds localization support for the transfer button text. It also restricts the transfer button visibility and functionality based on the shift status and the user's role and permissions.

## Proposed Changes

Fixes #5399 
The updates made to the code include importing 'useSelector' from 'react-redux', adding state variables to capture user details such as userType and userHomeFacilityId, and disabling the transfer button if the user is not authorized or if the transfer is not allowed. Additionally, changes were made to conditional statements to show the transfer button only if the filter is "COMPLETED" and the shift is assigned to a facility. 

The purpose of this implementation is to enable the transfer of patients when authorized and allow for restrictions when transferring is not allowed based on user type, facility assignment, or patient settings.

![image](https://user-images.githubusercontent.com/3626859/235452881-e41fafbb-b507-4f3d-a001-4924955d9598.png)
![image](https://user-images.githubusercontent.com/3626859/235452958-df67a7bd-8ff0-4bb5-9e8c-e5f5e2eb340d.png)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7603075</samp>

*  Import `useSelector` hook to access global state in `PatientHome`, `ListView`, and `ShiftCard` components ([link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL5-R5), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L21-R21), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L18-R18))
*  Declare and assign variables to get current user's data and home facility id from global state using `useSelector` hook in `PatientHome`, `ListView`, and `ShiftCard` components ([link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fR67-R71), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366R45-R48), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3R55-R58))
*  Replace hard-coded text with translation function `t` to support localization in `PatientHome` and `ListView` components ([link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL654-R669), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L242-R272))
*  Change condition for showing transfer button from `shift.status === "TRANSFER IN PROGRESS"` to `shift.status === "COMPLETED"` to allow transfers after shift is completed in `PatientHome`, `ListView`, and `ShiftCard` components ([link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL936-R942), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L242-R272), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L211-R226))
*  Add `disabled` prop for transfer button with condition that checks if patient is allowed to be transferred and if current user is authorized to transfer in `PatientHome`, `ListView`, and `ShiftCard` components ([link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL942-R959), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L242-R272), [link](https://github.com/coronasafe/care_fe/pull/5422/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L211-R226))
