### PR TITLE
Disables multiple buttons for read only users

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -346,12 +346,13 @@ const AssetManage = (props: AssetManageProps) => {
               )}
               {checkAuthority(user_type, "DistrictAdmin") && (
                 <ButtonV2
+                  authorizeFor={NonReadOnlyUsers}
                   onClick={() => setShowDeleteDialog(true)}
-                  variant={"danger"}
+                  variant="danger"
                   className="inline-flex"
                 >
                   <CareIcon className="care-l-trash h-4" />
-                  <span className="md:hidden">Delete</span>
+                  <span className="md:hidden">{t("delete")}</span>
                 </ButtonV2>
               )}
             </div>

--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from "react-i18next";
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 import * as Notification from "../../Utils/Notifications.js";
+import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 
 interface AssetManageProps {
   assetId: string;
@@ -324,9 +325,10 @@ const AssetManage = (props: AssetManageProps) => {
                   )
                 }
                 id="update-asset"
+                authorizeFor={NonReadOnlyUsers}
               >
                 <CareIcon className="care-l-pen h-4 mr-1" />
-                Update
+                {t("update")}
               </ButtonV2>
               {asset?.asset_class && (
                 <ButtonV2
@@ -336,9 +338,10 @@ const AssetManage = (props: AssetManageProps) => {
                     )
                   }
                   id="configure-asset"
+                  authorizeFor={NonReadOnlyUsers}
                 >
                   <CareIcon className="care-l-setting h-4" />
-                  Configure
+                  {t("configure")}
                 </ButtonV2>
               )}
               {checkAuthority(user_type, "DistrictAdmin") && (

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -20,7 +20,7 @@ import useFilters from "../../Common/hooks/useFilters";
 import { FacilityModel } from "../Facility/models";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { useIsAuthorized } from "../../Common/hooks/useIsAuthorized";
-import AuthorizeFor from "../../Utils/AuthorizeFor";
+import AuthorizeFor, { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import ButtonV2 from "../Common/components/ButtonV2";
 import FacilitiesSelectDialogue from "../ExternalResult/FacilitiesSelectDialogue";
 import ExportMenu from "../Common/Export";
@@ -28,10 +28,12 @@ import CountBlock from "../../CAREUI/display/Count";
 import AssetImportModal from "./AssetImportModal";
 import Page from "../Common/components/Page";
 import { AdvancedFilterButton } from "../../CAREUI/interactive/FiltersSlideover";
+import { useTranslation } from "react-i18next";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
 const AssetsList = () => {
+  const { t } = useTranslation();
   const {
     qParams,
     updateQuery,
@@ -361,6 +363,7 @@ const AssetsList = () => {
           </div>
           <div className="flex flex-col md:flex-row w-full">
             <ButtonV2
+              authorizeFor={NonReadOnlyUsers}
               className="w-full inline-flex items-center justify-center"
               onClick={() => {
                 if (qParams.facility) {
@@ -371,7 +374,7 @@ const AssetsList = () => {
               }}
             >
               <CareIcon className="care-l-plus-circle text-lg" />
-              <span>Create Asset</span>
+              <span>{t("create_asset")}</span>
             </ButtonV2>
           </div>
         </div>

--- a/src/Components/Common/components/ButtonV2.tsx
+++ b/src/Components/Common/components/ButtonV2.tsx
@@ -111,47 +111,51 @@ const ButtonV2 = ({
     `button-shape-${circle ? "circle" : "square"}`,
     ghost ? `button-${variant}-ghost` : `button-${variant}-default`,
     border && `button-${variant}-border`,
-    shadow && "shadow enabled:hover:shadow-lg"
+    shadow && "shadow enabled:hover:shadow-lg",
+    tooltip && "tooltip"
   );
 
-  if (authorizeFor) {
-    <AuthorizedChild authorizeFor={authorizeFor}>
-      {({ isAuthorized }) => (
-        <button
-          {...props}
-          disabled={disabled || !isAuthorized || loading}
-          className={className}
-        >
-          {children}
-        </button>
-      )}
-    </AuthorizedChild>;
+  if (tooltip) {
+    children = (
+      <>
+        {tooltip && (
+          <span className={classNames("tooltip-text", tooltipClassName)}>
+            {tooltip}
+          </span>
+        )}
+        {children}
+      </>
+    );
   }
 
   if (href && !(disabled || loading)) {
     return (
-      <Link
-        {...(props as any)}
-        href={href}
-        target={target}
-        className={className}
-      >
-        {children}
+      <Link href={href} target={target}>
+        <button {...props} disabled={disabled || loading} className={className}>
+          {children}
+        </button>
       </Link>
     );
   }
 
+  if (authorizeFor) {
+    return (
+      <AuthorizedChild authorizeFor={authorizeFor}>
+        {({ isAuthorized }) => (
+          <button
+            {...props}
+            disabled={disabled || !isAuthorized || loading}
+            className={className}
+          >
+            {children}
+          </button>
+        )}
+      </AuthorizedChild>
+    );
+  }
+
   return (
-    <button
-      {...props}
-      disabled={disabled || loading}
-      className={classNames(className, tooltip && "tooltip")}
-    >
-      {tooltip && (
-        <span className={classNames("tooltip-text", tooltipClassName)}>
-          {tooltip}
-        </span>
-      )}
+    <button {...props} disabled={disabled || loading} className={className}>
       {children}
     </button>
   );

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -50,12 +50,15 @@ import loadable from "@loadable/component";
 import moment from "moment";
 import { navigate } from "raviger";
 import { validateEmailAddress } from "../../Common/validation";
+import { useTranslation } from "react-i18next";
+import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const symptomChoices = [...SYMPTOM_CHOICES];
 
 export const ConsultationDetails = (props: any) => {
+  const { t } = useTranslation();
   const { facilityId, patientId, consultationId } = props;
   const tab = props.tab.toUpperCase();
   const dispatch: any = useDispatch();
@@ -1322,6 +1325,7 @@ export const ConsultationDetails = (props: any) => {
               />
               <div className="pt-6">
                 <ButtonV2
+                  authorizeFor={NonReadOnlyUsers}
                   disabled={!patientData.is_active}
                   onClick={() =>
                     navigate(
@@ -1330,7 +1334,7 @@ export const ConsultationDetails = (props: any) => {
                   }
                 >
                   <CareIcon className="care-l-plus" />
-                  <span>Log Lab Result</span>
+                  <span>{t("log_lab_results")}</span>
                 </ButtonV2>
               </div>
             </div>

--- a/src/Components/Facility/Investigations/index.tsx
+++ b/src/Components/Facility/Investigations/index.tsx
@@ -12,6 +12,7 @@ import {
 import * as Notification from "../../../Utils/Notifications.js";
 import { navigate, useQueryParams } from "raviger";
 import loadable from "@loadable/component";
+import { useTranslation } from "react-i18next";
 
 const Loading = loadable(() => import("../../Common/Loading"));
 const PageTitle = loadable(() => import("../../Common/PageTitle"));
@@ -74,6 +75,7 @@ const Investigation = (props: {
   patientId: string;
   facilityId: string;
 }) => {
+  const { t } = useTranslation();
   const { patientId, facilityId } = props;
   const [{ investigations: queryInvestigationsRaw = undefined }] =
     useQueryParams();
@@ -282,7 +284,7 @@ const Investigation = (props: {
   return (
     <div className="max-w-7xl mx-auto px-4">
       <PageTitle
-        title={"Log Lab Result"}
+        title={t("log_lab_results")}
         crumbsReplacements={{
           [facilityId]: { name: facilityName },
           [patientId]: { name: patientName },

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -31,6 +31,7 @@ import CareIcon from "../../CAREUI/icons/CareIcon";
 import TextFormField from "../Form/FormFields/TextFormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import RecordMeta from "../../CAREUI/display/RecordMeta";
+import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -1389,24 +1390,24 @@ export const FileUpload = (props: FileUploadProps) => {
                   <LinearProgressWithLabel value={uploadPercent} />
                 ) : (
                   <div className="flex flex-col gap-2 md:flex-row justify-between md:items-center items-stretch">
-                    <label className="flex items-center btn btn-primary">
-                      <i className="fas fa-file-arrow-down mr-2" /> Choose file
+                    <ButtonV2 authorizeFor={NonReadOnlyUsers}>
+                      <CareIcon className="care-l-file-upload-alt text-lg" />
+                      {t("choose_file")}
                       <input
                         title="changeFile"
                         onChange={onFileChange}
                         type="file"
                         hidden
                       />
-                    </label>
-                    <button
-                      className="btn btn-primary"
+                    </ButtonV2>
+                    <ButtonV2
+                      authorizeFor={NonReadOnlyUsers}
                       disabled={!file || !uploadFileName || !isActive}
-                      onClick={() => {
-                        handleUpload({ status });
-                      }}
+                      onClick={() => handleUpload({ status })}
                     >
-                      <i className="fas fa-cloud-arrow-up mr-2" /> Upload
-                    </button>
+                      <CareIcon className="care-l-cloud-upload text-lg" />
+                      {t("upload")}
+                    </ButtonV2>
                   </div>
                 )}
                 {file && (

--- a/src/Locale/en/Asset.json
+++ b/src/Locale/en/Asset.json
@@ -1,0 +1,3 @@
+{
+    "create_asset": "Create Asset"
+}

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -20,12 +20,16 @@
   "care": "CARE",
   "something_went_wrong": "Something went wrong..!",
   "stop": "Stop",
+  "record": "Record",
+  "recording": "Recording",
   "yes": "Yes",
   "no": "No",
   "status": "Status",
   "created": "Created",
   "modified": "Modified",
   "updated": "Updated",
+  "update": "Update",
+  "configure": "Configure",
   "assigned_to": "Assigned to",
   "cancel": "Cancel",
   "clear": "Clear",
@@ -104,6 +108,7 @@
   "recommended_aspect_ratio_for": "Recommended aspect ratio for",
   "drag_drop_image_to_upload": "Drag & drop image to upload",
   "upload_an_image": "Upload an image",
+  "upload": "Upload",
   "uploading": "Uploading",
   "switch": "Switch",
   "capture": "Capture",
@@ -121,5 +126,6 @@
   "RESPIRATORY_SUPPORT_UNKNOWN": "None",
   "RESPIRATORY_SUPPORT_OXYGEN_SUPPORT": "O2 Support",
   "RESPIRATORY_SUPPORT_NON_INVASIVE": "NIV",
-  "RESPIRATORY_SUPPORT_INVASIVE": "IV"
+  "RESPIRATORY_SUPPORT_INVASIVE": "IV",
+  "choose_file": "Choose File"
 }

--- a/src/Locale/en/Consultation.json
+++ b/src/Locale/en/Consultation.json
@@ -2,6 +2,7 @@
     "no_consultation_updates": "No consultation updates",
     "consultation_updates": "Consultation updates",
     "update_log": "Update Log",
+    "log_lab_results": "Log Lab Results",
     "no_log_update_delta": "No changes since previous log update",
     "virtual_nursing_assistant": "Virtual Nursing Assistant"
 }

--- a/src/Locale/en/index.js
+++ b/src/Locale/en/index.js
@@ -1,4 +1,5 @@
 import Auth from "./Auth.json";
+import Asset from "./Asset.json";
 import Common from "./Common.json";
 import Consultation from "./Consultation.json";
 import Entities from "./Entities.json";
@@ -13,6 +14,7 @@ import SortOptions from "./SortOptions.json";
 
 export default {
   ...Auth,
+  ...Asset,
   ...Common,
   ...Consultation,
   ...CoverImageEdit,

--- a/src/Utils/VoiceRecorder.tsx
+++ b/src/Utils/VoiceRecorder.tsx
@@ -3,7 +3,10 @@ import useRecorder from "./useRecorder";
 import { useEffect, useState } from "react";
 import ButtonV2 from "../Components/Common/components/ButtonV2";
 import CareIcon from "../CAREUI/icons/CareIcon";
+import { NonReadOnlyUsers } from "./AuthorizeFor";
+import { useTranslation } from "react-i18next";
 export const VoiceRecorder = (props: any) => {
+  const { t } = useTranslation();
   const { createAudioBlob, confirmAudioBlobExists, reset, setResetRecording } =
     props;
   const [
@@ -40,8 +43,8 @@ export const VoiceRecorder = (props: any) => {
           <>
             <div className="space-x-2 flex">
               <div className="bg-gray-100 p-2 text-primary-700">
-                <i className="fas fa-microphone-alt animate-pulse mr-2"></i>
-                Recording...
+                <CareIcon className="care-l-record-audio animate-pulse mr-2" />
+                {t("recording") + "..."}
               </div>
               <ButtonV2
                 onClick={() => {
@@ -49,8 +52,8 @@ export const VoiceRecorder = (props: any) => {
                   confirmAudioBlobExists();
                 }}
               >
-                <CareIcon className={"care-l-microphone-slash text-lg"} />
-                Stop
+                <CareIcon className="care-l-microphone-slash text-lg" />
+                {t("stop")}
               </ButtonV2>
             </div>
             <div className="mx-3">
@@ -61,9 +64,12 @@ export const VoiceRecorder = (props: any) => {
         ) : (
           <div>
             {!audioURL && (
-              <ButtonV2 onClick={startRecording}>
-                <CareIcon className={"care-l-microphone text-lg"} />
-                Record
+              <ButtonV2
+                onClick={startRecording}
+                authorizeFor={NonReadOnlyUsers}
+              >
+                <CareIcon className="care-l-microphone text-lg" />
+                {t("record")}
               </ButtonV2>
             )}
           </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e393f6e</samp>

This pull request adds authorization and localization features to several components in the frontend of the care application. It uses the `NonReadOnlyUsers` constant to restrict some actions to users with write permissions, and the `useTranslation` hook and the `t` function to display text in different languages. It also updates some UI elements to use custom buttons and icons. It affects the files `AssetManage.tsx`, `AssetsList.tsx`, `ConsultationDetails.tsx`, `Investigations/index.tsx`, `FileUpload.tsx`, `en/index.js`, and `VoiceRecorder.tsx`.

## Proposed Changes

- Fixes #5424
- Fixes `ButtonV2`'s authorization for user roles not returned.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e393f6e</samp>

*  Restrict asset and consultation update, configure, and filter buttons to users with write permissions using `NonReadOnlyUsers` constant and `authorizeFor` prop ([link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20R28), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L327-R331), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L339-R344), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L23-R23), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R366), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR53-R54), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR1328), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R34), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1392-R1395), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1400-R1410), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcL6-R9), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcL64-R72))
* Replace hard-coded texts with calls to `t` function for internationalization and localization in `AssetManage.tsx`, `AssetsList.tsx`, `ConsultationDetails.tsx`, `Investigations/index.tsx`, `FileUpload.tsx`, and `VoiceRecorder.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L327-R331), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L339-R344), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L31-R36),  [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L374-R377), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR61), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL1333-R1337), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR1328), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4R15), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4R78), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4L285-R287), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1392-R1395), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1400-R1410), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcL43-R47), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcL52-R56), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcL64-R72))
* Add `Asset` JSON file to `en` locale module for asset-related translations ([link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-f5a5abfe6011db80ae7ac7d25eb216e76c5fc78a79e46b1b32be04d3853c4271R2), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-f5a5abfe6011db80ae7ac7d25eb216e76c5fc78a79e46b1b32be04d3853c4271R17))
* Replace font-awesome icons with custom `CareIcon` components in `FileUpload.tsx` and `VoiceRecorder.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1392-R1395), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1400-R1410), [link](https://github.com/coronasafe/care_fe/pull/5425/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcL43-R47))
