### PR TITLE
fix: made notes consultation specific

### DIFF
--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -428,9 +428,15 @@ export const transferPatient = (params: object, pathParam: object) => {
 export const getPatientNotes = (
   patientId: string,
   limit: number,
-  offset: number
+  offset: number,
+  consultation?: string
 ) => {
-  return fireRequest("getPatientNotes", [], { limit, offset }, { patientId });
+  return fireRequest(
+    "getPatientNotes",
+    [],
+    { limit, offset, consultation },
+    { patientId }
+  );
 };
 export const addPatientNote = (patientId: string, params: object) => {
   return fireRequest("addPatientNote", [], params, { patientId });

--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -132,7 +132,26 @@ export default function AppRouter() {
     "/facility/:facilityId/patient/:patientId/notes": ({
       facilityId,
       patientId,
-    }: any) => <PatientNotes patientId={patientId} facilityId={facilityId} />,
+    }: {
+      facilityId: string;
+      patientId: string;
+    }) => <PatientNotes patientId={patientId} facilityId={facilityId} />,
+    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/notes":
+      ({
+        facilityId,
+        patientId,
+        consultationId,
+      }: {
+        facilityId: string;
+        patientId: string;
+        consultationId: string;
+      }) => (
+        <PatientNotes
+          patientId={patientId}
+          facilityId={facilityId}
+          consultationId={consultationId}
+        />
+      ),
     "/facility/:facilityId/patient/:patientId/files": ({
       facilityId,
       patientId,


### PR DESCRIPTION
# Bug Fix

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 216ff35</samp>

The pull request adds the functionality to view and manage notes for specific consultations of a patient. It modifies the `PatientNotes` component, the `getPatientNotes` action, and the `Link` component in `ConsultationDetails` to pass and use the `consultationId` parameter. It also adds a new route to the `AppRouter` component to render the `PatientNotes` component with the relevant props.

## Proposed Changes

- Adds consultation specific notes

## Associated Issue

- Required by coronasafe/care#1210

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 216ff35</samp>

*  Add a new route to access the notes page of a specific consultation for a patient ([link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-54de9c6ab4bf014bd5f50afa466003ba1a5ae1537a615261440d158cd59187f1L134-R153))
*  Modify the `href` attribute of the `Link` component to include the `consultationId` parameter ([link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL398-R398))
*  Update the `PatientNotes` component to receive and use the `consultationId` prop ([link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL17-R22), [link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL26-R28), [link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cR38-R40), [link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL41-R51), [link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cR99), [link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cR126-R132))
*  Convert the `fetchPatientName` function to an async arrow function and wrap it in an IIFE ([link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL66-R76), [link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cR83), [link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL78-R89))
*  Add the `consultation` parameter to the `getPatientNotes` and `addPatientNote` actions ([link](https://github.com/coronasafe/care_fe/pull/5429/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eL420-R428))
