### PR TITLE
fix(resource): cant submit resource request

### DIFF
--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -221,7 +221,7 @@ export default function ResourceCreate(props: resourceProps) {
   return (
     <div className="px-2 pb-2">
       <PageTitle
-        title={t("create_title")}
+        title={t("create_resource_request")}
         crumbsReplacements={{
           [facilityId]: { name: facilityName },
           resource: { style: "pointer-events-none" },

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -1,29 +1,16 @@
 import { useReducer, useState, useEffect } from "react";
 import loadable from "@loadable/component";
 import { FacilitySelect } from "../Common/FacilitySelect";
-import {
-  LegacyTextInputField,
-  LegacyMultilineInputField,
-  LegacyErrorHelperText,
-  LegacySelectField,
-} from "../Common/HelperInputFields";
 import * as Notification from "../../Utils/Notifications.js";
 import { useDispatch } from "react-redux";
 import { navigate } from "raviger";
 import {
+  OptionsType,
   RESOURCE_CATEGORY_CHOICES,
   RESOURCE_SUBCATEGORIES,
 } from "../../Common/constants";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
-import {
-  Card,
-  CardContent,
-  InputLabel,
-  Radio,
-  RadioGroup,
-  Box,
-  FormControlLabel,
-} from "@material-ui/core";
+import { Card, CardContent } from "@material-ui/core";
 import { phonePreg } from "../../Common/validation";
 
 import { createResource, getAnyFacility } from "../../Redux/actions";
@@ -31,6 +18,13 @@ import { Cancel, Submit } from "../Common/components/ButtonV2";
 import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
 import { FieldChangeEvent } from "../Form/FormFields/Utils";
 import useAppHistory from "../../Common/hooks/useAppHistory";
+import { useTranslation } from "react-i18next";
+import TextFormField from "../Form/FormFields/TextFormField";
+import { SelectFormField } from "../Form/FormFields/SelectFormField";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
+import RadioFormField from "../Form/FormFields/RadioFormField";
+import { FieldLabel } from "../Form/FormFields/FormField";
+
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -91,6 +85,7 @@ const initialState = {
 export default function ResourceCreate(props: resourceProps) {
   const { goBack } = useAppHistory();
   const { facilityId } = props;
+  const { t } = useTranslation();
 
   const dispatchAction: any = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
@@ -134,9 +129,9 @@ export default function ResourceCreate(props: resourceProps) {
     const errors = { ...initError };
     let isInvalidForm = false;
     Object.keys(requiredFields).forEach((field) => {
-      const phoneNumber = parsePhoneNumberFromString(state.form[field]);
       switch (field) {
-        case "refering_facility_contact_number":
+        case "refering_facility_contact_number": {
+          const phoneNumber = parsePhoneNumberFromString(state.form[field]);
           if (!state.form[field]) {
             errors[field] = requiredFields[field].errorText;
             isInvalidForm = true;
@@ -148,6 +143,7 @@ export default function ResourceCreate(props: resourceProps) {
             isInvalidForm = true;
           }
           return;
+        }
         default:
           if (!state.form[field]) {
             errors[field] = requiredFields[field].errorText;
@@ -160,9 +156,9 @@ export default function ResourceCreate(props: resourceProps) {
     return !isInvalidForm;
   };
 
-  const handleChange = (e: any) => {
+  const handleChange = (e: FieldChangeEvent<string>) => {
     const form = { ...state.form };
-    const { name, value } = e.target;
+    const { name, value } = e;
     form[name] = value;
     dispatch({ type: "set_form", form });
   };
@@ -225,7 +221,7 @@ export default function ResourceCreate(props: resourceProps) {
   return (
     <div className="px-2 pb-2">
       <PageTitle
-        title={"Create Resource Request"}
+        title={t("create_title")}
         crumbsReplacements={{
           [facilityId]: { name: facilityName },
           resource: { style: "pointer-events-none" },
@@ -236,33 +232,26 @@ export default function ResourceCreate(props: resourceProps) {
         <Card>
           <CardContent>
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
-              <div>
-                <InputLabel>Name of Contact Person at Facility*</InputLabel>
-                <LegacyTextInputField
-                  fullWidth
-                  name="refering_facility_contact_name"
-                  variant="outlined"
-                  margin="dense"
-                  value={state.form.refering_facility_contact_name}
-                  onChange={handleChange}
-                  errors={state.errors.refering_facility_contact_name}
-                />
-              </div>
-
-              <div>
-                <PhoneNumberFormField
-                  label="Contact person phone"
-                  name="refering_facility_contact_number"
-                  required
-                  onlyIndia
-                  value={state.form.refering_facility_contact_number}
-                  onChange={handleFormFieldChange}
-                  error={state.errors.refering_facility_contact_number}
-                />
-              </div>
+              <TextFormField
+                required
+                label={t("contact_person")}
+                name="refering_facility_contact_name"
+                value={state.form.refering_facility_contact_name}
+                onChange={handleChange}
+                error={state.errors.refering_facility_contact_name}
+              />
+              <PhoneNumberFormField
+                label={t("contact_phone")}
+                name="refering_facility_contact_number"
+                required
+                onlyIndia
+                value={state.form.refering_facility_contact_number}
+                onChange={handleFormFieldChange}
+                error={state.errors.refering_facility_contact_number}
+              />
 
               <div className="md:col-span-2">
-                <InputLabel>Name of approving facility*</InputLabel>
+                <FieldLabel required>{t("approving_facility")}</FieldLabel>
                 <FacilitySelect
                   multiple={false}
                   facilityType={1500}
@@ -275,104 +264,67 @@ export default function ResourceCreate(props: resourceProps) {
                 />
               </div>
 
-              <div>
-                <InputLabel>Category</InputLabel>
-                <LegacySelectField
-                  name="category"
-                  variant="outlined"
-                  fullWidth
-                  margin="dense"
-                  optionArray={true}
-                  value={state.form.category}
-                  options={RESOURCE_CATEGORY_CHOICES}
-                  onChange={handleChange}
-                  className="bg-white h-14 mt-2 shadow-sm md:text-sm md:leading-5"
-                />
-              </div>
+              <SelectFormField
+                label={t("category")}
+                name="category"
+                required
+                value={state.form.category}
+                options={RESOURCE_CATEGORY_CHOICES}
+                optionLabel={(option: string) => option}
+                optionValue={(option: string) => option}
+                onChange={({ value }) => handleValueChange(value, "category")}
+              />
+              <SelectFormField
+                label={t("sub_category")}
+                name="sub_category"
+                required
+                value={state.form.sub_category}
+                options={RESOURCE_SUBCATEGORIES}
+                optionLabel={(option: OptionsType) => option.text}
+                optionValue={(option: OptionsType) => option.id}
+                onChange={({ value }) =>
+                  handleValueChange(value, "sub_category")
+                }
+              />
 
-              <div>
-                <InputLabel>Subcategory</InputLabel>
-                <LegacySelectField
-                  name="sub_category"
-                  variant="outlined"
-                  margin="dense"
-                  fullWidth
-                  value={state.form.sub_category}
-                  options={RESOURCE_SUBCATEGORIES}
-                  onChange={handleChange}
-                  className="bg-white h-14 mt-2 shadow-sm md:text-sm md:leading-5"
-                />
-              </div>
+              <TextFormField
+                label={t("request_title")}
+                name="title"
+                placeholder={t("request_title_placeholder")}
+                value={state.form.title}
+                onChange={handleChange}
+                error={state.errors.title}
+              />
 
-              <div className="md:col-span-1">
-                <InputLabel>Request Title*</InputLabel>
-                <LegacyTextInputField
-                  rows={5}
-                  name="title"
-                  variant="outlined"
-                  margin="dense"
-                  type="text"
-                  placeholder="Type your title here"
-                  value={state.form.title}
-                  onChange={handleChange}
-                  errors={state.errors.title}
-                />
-              </div>
-
-              <div className="md:col-span-1">
-                <div className="w-full">
-                  <InputLabel>Required Quantity</InputLabel>
-                  <LegacyTextInputField
-                    name="requested_quantity"
-                    variant="outlined"
-                    margin="dense"
-                    type="number"
-                    value={state.form.required_quantity}
-                    onChange={handleChange}
-                    errors=""
-                  />
-                </div>
-              </div>
+              <TextFormField
+                label={t("required_quantity")}
+                name="requested_quantity"
+                value={state.form.required_quantity}
+                onChange={handleChange}
+              />
 
               <div className="md:col-span-2">
-                <InputLabel>Description of request*</InputLabel>
-                <LegacyMultilineInputField
-                  rows={5}
+                <TextAreaFormField
+                  label={t("request_description")}
                   name="reason"
-                  variant="outlined"
-                  margin="dense"
-                  type="text"
-                  placeholder="Type your description here"
+                  rows={5}
+                  required
+                  placeholder={t("request_description_placeholder")}
                   value={state.form.reason}
                   onChange={handleChange}
-                  errors={state.errors.reason}
+                  error={state.errors.reason}
                 />
               </div>
 
-              <div>
-                <InputLabel>Is this an emergency?</InputLabel>
-                <RadioGroup
-                  aria-label="emergency"
-                  name="emergency"
-                  value={state.form.emergency === "true"}
-                  onChange={handleChange}
-                  style={{ padding: "0px 5px" }}
-                >
-                  <Box>
-                    <FormControlLabel
-                      value={true}
-                      control={<Radio />}
-                      label="Yes"
-                    />
-                    <FormControlLabel
-                      value={false}
-                      control={<Radio />}
-                      label="No"
-                    />
-                  </Box>
-                </RadioGroup>
-                <LegacyErrorHelperText error={state.errors.emergency} />
-              </div>
+              <RadioFormField
+                label={t("is_this_an_emergency")}
+                name="emergency"
+                options={[true, false]}
+                optionDisplay={(o) => (o ? t("yes") : t("no"))}
+                optionValue={(o) => String(o)}
+                value={state.form.emergency}
+                onChange={handleChange}
+              />
 
               <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">
                 <Cancel onClick={() => goBack()} />

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -6,6 +6,8 @@
   "footer_body": "CoronaSafe Network is an open-source public utility designed by a multi-disciplinary team of innovators and volunteers. CoronaSafe CARE is a Digital Public Good recognised by the United Nations.",
   "reset": "Reset",
   "downloads": "Downloads",
+  "category": "Category",
+  "sub_category": "Sub Category",
   "download_type": "Download Type",
   "state": "State",
   "district": "District",

--- a/src/Locale/en/Resource.json
+++ b/src/Locale/en/Resource.json
@@ -1,0 +1,11 @@
+{
+  "create_title": "Create Resource Request",
+  "contact_person": "Name of Contact Person at Facility",
+  "approving_facility": "Name of Approving Facility",
+  "contact_phone": "Contact Person Number",
+  "request_title": "Request Title",
+  "request_title_placeholder": "Type your title here",
+  "required_quantity": "Required Quantity",
+  "request_description": "Description of Request",
+  "request_description_placeholder": "Type your description here"
+}

--- a/src/Locale/en/Resource.json
+++ b/src/Locale/en/Resource.json
@@ -1,5 +1,5 @@
 {
-  "create_title": "Create Resource Request",
+  "create_resource_request": "Create Resource Request",
   "contact_person": "Name of Contact Person at Facility",
   "approving_facility": "Name of Approving Facility",
   "contact_phone": "Contact Person Number",

--- a/src/Locale/en/index.js
+++ b/src/Locale/en/index.js
@@ -10,6 +10,7 @@ import Shifting from "./Shifting.json";
 import Notifications from "./Notifications.json";
 import ExternalResult from "./ExternalResult.json";
 import CoverImageEdit from "./CoverImageEdit.json";
+import Resource from "./Resource.json";
 import SortOptions from "./SortOptions.json";
 
 export default {
@@ -24,6 +25,7 @@ export default {
   ...Facility,
   ...Hub,
   ...Notifications,
+  ...Resource,
   ...Shifting,
   SortOptions,
 };


### PR DESCRIPTION
# Bug Fix

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e08fdd</samp>

Refactored the resource creation form and added localization support. The form now uses custom components and the `useTranslation` hook to render the fields and labels in the user's preferred language. The code was also cleaned up and the types and styles were enhanced. The English locale file was updated with the resource-related strings from `Resource.json`.

## Proposed Changes

- Updates `form validation` logic
- Replaces MUI with tailwind components

## Associated Issue

- Fixes #5440

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug/test a new feature.
- [ ] Update product [documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care)
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep the screenshot or demo video for the changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e08fdd</samp>

*  Remove unused imports from `ResourceCreate.tsx` to clean up the code and avoid unnecessary dependencies ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL4-R13))
*  Add imports of custom form components and translation hook to `ResourceCreate.tsx` to improve the form functionality and appearance ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aR21-R27))
*  Initialize the translation hook with `const { t } = useTranslation();` in `ResourceCreate.tsx` to access the translation function for the form labels and title ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aR88))
*  Move the phone number parsing statement inside the relevant case block in the `validateForm` function in `ResourceCreate.tsx` to avoid unnecessary parsing of other fields ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL137-R134), [link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aR146))
*  Change the `handleChange` function parameter type to `FieldChangeEvent<string>` in `ResourceCreate.tsx` to use the custom type for the form field change event ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL163-R161))
*  Replace the `PageTitle` component prop with the translation function for the page title in `ResourceCreate.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL228-R224))
*  Replace the legacy form components with the custom form components and use the translation function for the field labels in `ResourceCreate.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL239-R254), [link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL278-R327))
*  Import the `Resource.json` file to `index.js` in the English locale to include the resource-related translation strings ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-f5a5abfe6011db80ae7ac7d25eb216e76c5fc78a79e46b1b32be04d3853c4271R13))
*  Spread the `Resource` object to the `en` object in the English locale to include the resource-related translation strings ([link](https://github.com/coronasafe/care_fe/pull/5443/files?diff=unified&w=0#diff-f5a5abfe6011db80ae7ac7d25eb216e76c5fc78a79e46b1b32be04d3853c4271R28))
