### PR TITLE
Remove '_' from asset status in asset page filters

### DIFF
--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -169,7 +169,7 @@ function AssetFilter(props: any) {
         label="Asset Status"
         errorClassName="hidden"
         options={["ACTIVE", "TRANSFER_IN_PROGRESS"]}
-        optionLabel={(o) => o}
+        optionLabel={(o) => o.replace(/_/g, " ")}
         optionValue={(o) => o}
         value={asset_status}
         onChange={({ value }) => setAssetStatus(value)}

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -50,6 +50,7 @@ const AssetsList = () => {
   const [totalCount, setTotalCount] = useState(0);
   const [facility, setFacility] = useState<FacilityModel>();
   const [asset_type, setAssetType] = useState<string>();
+  const [status, setStatus] = useState<string>();
   const [facilityName, setFacilityName] = useState<string>();
   const [asset_class, setAssetClass] = useState<string>();
   const [locationName, setLocationName] = useState<string>();
@@ -110,6 +111,10 @@ const AssetsList = () => {
   useEffect(() => {
     setAssetType(qParams.asset_type);
   }, [qParams.asset_type]);
+
+  useEffect(() => {
+    setStatus(qParams.status);
+  }, [qParams.status]);
 
   useEffect(() => {
     setAssetClass(qParams.asset_class);
@@ -390,7 +395,7 @@ const AssetsList = () => {
               badge("Name/Serial No./QR ID", "search"),
               value("Asset Type", "asset_type", asset_type || ""),
               value("Asset Class", "asset_class", asset_class || ""),
-              badge("Status", "status"),
+              value("Status", "status", status?.replace(/_/g, " ") || ""),
               value("Location", "location", locationName || ""),
             ]}
           />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c87931c</samp>

This pull request adds a feature to filter assets by status on the assets list page. It also improves the status label formatting in the `AssetFilter` component and the `AssetsList.tsx` file.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c87931c</samp>

*  Modify the status labels in the asset filter component to replace underscores with spaces for readability and consistency ([link](https://github.com/coronasafe/care_fe/pull/5444/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L172-R172))
*  Add a new state variable `status` to the `AssetsList` component to store the selected status filter value from the query parameters ([link](https://github.com/coronasafe/care_fe/pull/5444/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R53))
*  Update the `status` state variable whenever the `qParams.status` changes using a `useEffect` hook to keep them in sync ([link](https://github.com/coronasafe/care_fe/pull/5444/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R116-R119))
*  Display the status value as a regular text instead of a badge in the `AssetCard` component and replace underscores with spaces for consistency with the other values ([link](https://github.com/coronasafe/care_fe/pull/5444/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L393-R398))
