### PR TITLE
fix choose file button not working in consultation files

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -34,6 +34,7 @@ import RecordMeta from "../../CAREUI/display/RecordMeta";
 import Webcam from "react-webcam";
 import useWindowDimensions from "../../Common/hooks/useWindowDimensions";
 import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
+import AuthorizedChild from "../../CAREUI/misc/AuthorizedChild";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -1578,26 +1579,28 @@ export const FileUpload = (props: FileUploadProps) => {
                   <LinearProgressWithLabel value={uploadPercent} />
                 ) : (
                   <div className="flex flex-col md:flex-row gap-2 items-center justify-start md:justify-end">
-                    <ButtonV2 authorizeFor={NonReadOnlyUsers}>
-                      <CareIcon className="care-l-file-upload-alt text-lg" />
-                      {t("choose_file")}
-                      <input
-                        title="changeFile"
-                        onChange={onFileChange}
-                        type="file"
-                        hidden
-                      />
+                    <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
+                      {({ isAuthorized }) =>
+                        isAuthorized ? (
+                          <label className="font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1 button-size-default justify-center button-shape-square">
+                            <CareIcon className="care-l-file-upload-alt text-lg" />
+                            {t("choose_file")}
+                            <input
+                              title="changeFile"
+                              onChange={onFileChange}
+                              type="file"
+                              hidden
+                            />
+                          </label>
+                        ) : (
+                          <></>
+                        )
+                      }
+                    </AuthorizedChild>
+                    <ButtonV2 onClick={() => setModalOpenForCamera(true)}>
+                      <CareIcon className="care-l-camera text-lg mr-2" />
+                      Open Camera
                     </ButtonV2>
-                    <ButtonV2
-                        onClick={() => {
-                          setModalOpenForCamera(true);
-                        }}
-                        className="btn btn-primary"
-                      >
-                        {/* <i className="fas fa-cloud-arrow-up mr-2"></i> */}
-                        <CareIcon className="care-l-camera text-lg mr-2" />
-                        Open Camera
-                      </ButtonV2>
                     <ButtonV2
                       authorizeFor={NonReadOnlyUsers}
                       disabled={!file || !uploadFileName || !isActive}

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1582,7 +1582,7 @@ export const FileUpload = (props: FileUploadProps) => {
                     <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
                       {({ isAuthorized }) =>
                         isAuthorized ? (
-                          <label className="font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1 button-size-default justify-center button-shape-square">
+                          <label className="font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1 button-size-default justify-center button-shape-square button-primary-default">
                             <CareIcon className="care-l-file-upload-alt text-lg" />
                             {t("choose_file")}
                             <input


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b677ad</samp>

This file enhances the file upload feature for patient details by adding authorization checks and improving the UI. It uses the `AuthorizedChild` component and modifies the button style.

## Proposed Changes

- Fixes #5445

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b677ad</samp>

*  Restrict file upload button to authorized users ([link](https://github.com/coronasafe/care_fe/pull/5447/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R37), [link](https://github.com/coronasafe/care_fe/pull/5447/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1581-R1604))
  - Import `AuthorizedChild` component from `../../CAREUI/misc/AuthorizedChild` in `FileUpload.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5447/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R37))
  - Wrap file upload button with `AuthorizedChild` component and pass `NonReadOnlyUsers` as `roles` prop ([link](https://github.com/coronasafe/care_fe/pull/5447/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1581-R1604))
  - Remove `authorizeFor` prop from camera button and adjust file upload button style ([link](https://github.com/coronasafe/care_fe/pull/5447/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1581-R1604))
