### PR TITLE
Fixed misalignment of pain scale slider in critical care

### DIFF
--- a/src/Components/CriticalCareRecording/Pain/CriticalCare__PainInputModal.res
+++ b/src/Components/CriticalCareRecording/Pain/CriticalCare__PainInputModal.res
@@ -93,6 +93,7 @@ let getStatus = (min, minText, max, maxText, val) => {
                 <div>
                   <Slider
                     title={""}
+                    className="px-0 py-5 m-0"
                     disabled={previewMode}
                     start={"0"}
                     end={"5"}
@@ -110,7 +111,7 @@ let getStatus = (min, minText, max, maxText, val) => {
                     hasError={ValidationUtils.isInputInRangeInt(0, 5, Belt.Float.toString(painScale)->Belt.Int.fromString)}
                   />
                   <div className="mt-2">
-                    <label className="block font-medium text-black text-left">
+                    <label className="block font-medium text-black text-left mb-1">
                       {str("Description")}
                     </label>
                     <textarea


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b917e0</samp>

Improved the UI of the `CriticalCare__PainInputModal` component for recording pain scores. Applied consistent styling and spacing to the modal elements.

## Proposed Changes

- Fixes #5446 
- Fixed misalignment of pain scale slider in vitals critical care

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b917e0</samp>

*  Add a modal component for recording pain scores for critical care patients (`src/Components/CriticalCareRecording/Pain/CriticalCare__PainInputModal.res`)
  * Apply some padding and margin styles to the input field wrapper and the description label to improve the layout ([link](https://github.com/coronasafe/care_fe/pull/5450/files?diff=unified&w=0#diff-bbae45def66441f7ec9a4fce87d2116c1789682a70d0abd98ffb399113bab632R96), [link](https://github.com/coronasafe/care_fe/pull/5450/files?diff=unified&w=0#diff-bbae45def66441f7ec9a4fce87d2116c1789682a70d0abd98ffb399113bab632L113-R114))
