### PR TITLE
Added support for hcx communication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "raviger": "^4.1.2",
         "react": "18.2.0",
         "react-copy-to-clipboard": "^5.0.3",
-        "react-csv": "^2.1.9",
+        "react-csv": "^2.2.2",
         "react-csv-reader": "^3.5.2",
         "react-dates": "^21.8.0",
         "react-dnd": "^16.0.1",
@@ -14348,9 +14348,9 @@
       }
     },
     "node_modules/react-csv": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.1.9.tgz",
-      "integrity": "sha512-p/2TakszTfa1qDCkcyGKa+3L+K5sARyNnE4pQ01p206WsD1qugcWfnM22MoUgFzVK2CPGzJPtiWpfPiM2OlJWw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz",
+      "integrity": "sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw=="
     },
     "node_modules/react-csv-reader": {
       "version": "3.5.2",
@@ -27949,9 +27949,9 @@
       }
     },
     "react-csv": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.1.9.tgz",
-      "integrity": "sha512-p/2TakszTfa1qDCkcyGKa+3L+K5sARyNnE4pQ01p206WsD1qugcWfnM22MoUgFzVK2CPGzJPtiWpfPiM2OlJWw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz",
+      "integrity": "sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw=="
     },
     "react-csv-reader": {
       "version": "3.5.2",

--- a/src/CAREUI/icons/CareIcon.tsx
+++ b/src/CAREUI/icons/CareIcon.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import { transformIcons } from "./icon";
+import { useEffect } from "react";
 
 export interface CareIconProps {
   className?: string | undefined;
@@ -13,10 +13,13 @@ export interface CareIconProps {
  *
  * @see [icon library](https://iconscout.com/unicons/)
  */
-export default function CareIcon({ className }: CareIconProps) {
+export default function CareIcon({
+  className,
+  ...rest
+}: CareIconProps & React.HTMLAttributes<HTMLSpanElement>) {
   useEffect(() => transformIcons(), [className]);
   return (
-    <span key={className}>
+    <span {...rest} key={className}>
       <i className={`care ${className}`} />
     </span>
   );

--- a/src/Common/hooks/useConfig.ts
+++ b/src/Common/hooks/useConfig.ts
@@ -64,7 +64,7 @@ export interface IConfig {
 const useConfig = () => {
   const state: any = useSelector((state) => state);
   const { config } = state;
-  return config.data as IConfig;
+  return { ...config.data, enable_hcx: true } as IConfig;
 };
 
 export default useConfig;

--- a/src/Components/Facility/ConsultationClaims.tsx
+++ b/src/Components/Facility/ConsultationClaims.tsx
@@ -1,13 +1,15 @@
-import { useCallback, useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
-import { HCXActions } from "../../Redux/actions";
-import PageTitle from "../Common/PageTitle";
-import ClaimDetailCard from "../HCX/ClaimDetailCard";
-import CreateClaimCard from "../HCX/CreateClaimCard";
-import { HCXClaimModel } from "../HCX/models";
-import { useMessageListener } from "../../Common/hooks/useMessageListener";
-import { navigate } from "raviger";
 import * as Notification from "../../Utils/Notifications";
+
+import { useCallback, useEffect, useState } from "react";
+
+import ClaimCard from "../HCX/ClaimCard";
+import CreateClaimCard from "../HCX/CreateClaimCard";
+import { HCXActions } from "../../Redux/actions";
+import { HCXClaimModel } from "../HCX/models";
+import PageTitle from "../Common/PageTitle";
+import { navigate } from "raviger";
+import { useDispatch } from "react-redux";
+import { useMessageListener } from "../../Common/hooks/useMessageListener";
 
 interface Props {
   facilityId: string;
@@ -83,7 +85,7 @@ export default function ConsultationClaims({
         <div className="flex flex-col gap-8 w-full max-w-3xl mx-auto">
           {claims?.map((claim) => (
             <div className="p-8 bg-white rounded-lg">
-              <ClaimDetailCard claim={claim} />
+              <ClaimCard claim={claim} />
             </div>
           ))}
         </div>

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { CircularProgress } from "@material-ui/core";
-import ClaimDetailCard from "../HCX/ClaimDetailCard";
+import ClaimCard from "../HCX/ClaimCard";
 import { ConsultationModel } from "./models";
 import CreateClaimCard from "../HCX/CreateClaimCard";
 import { DISCHARGE_REASONS } from "../../Common/constants";
@@ -329,7 +329,7 @@ const DischargeModal = ({
         <div className="my-5 shadow rounded p-5">
           <h2 className="mb-2">Claim Insurance</h2>
           {latestClaim ? (
-            <ClaimDetailCard claim={latestClaim} />
+            <ClaimCard claim={latestClaim} />
           ) : (
             <CreateClaimCard
               consultationId={consultationData.id}

--- a/src/Components/HCX/ClaimCard.tsx
+++ b/src/Components/HCX/ClaimCard.tsx
@@ -1,0 +1,42 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+import ClaimCardCommunication from "./ClaimCardCommunication";
+import ClaimCardInfo from "./ClaimCardInfo";
+import { HCXClaimModel } from "./models";
+
+interface IProps {
+  claim: HCXClaimModel;
+}
+
+export default function ClaimCard({ claim }: IProps) {
+  const [showMessages, setShowMessages] = useState(false);
+  const [containerDimensions, setContainerDimensions] = useState({
+    width: 0,
+    height: 0,
+  });
+  const cardContainerRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (cardContainerRef.current) {
+      setContainerDimensions({
+        width: cardContainerRef.current.offsetWidth,
+        height: cardContainerRef.current.offsetHeight,
+      });
+    }
+  }, [cardContainerRef]);
+
+  console.log(containerDimensions);
+
+  return showMessages ? (
+    <div style={{ ...containerDimensions }} className="px-6 lg:px-8 relative">
+      <ClaimCardCommunication claim={claim} setShowMessages={setShowMessages} />
+    </div>
+  ) : (
+    <div
+      ref={cardContainerRef}
+      className="px-6 lg:px-8" // TODO: add a card flip animation
+    >
+      <ClaimCardInfo claim={claim} setShowMessages={setShowMessages} />
+    </div>
+  );
+}

--- a/src/Components/HCX/ClaimCardCommunication.tsx
+++ b/src/Components/HCX/ClaimCardCommunication.tsx
@@ -1,0 +1,171 @@
+import { HCXClaimModel, HCXCommunicationModel } from "./models";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import ButtonV2 from "../Common/components/ButtonV2";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import { HCXActions } from "../../Redux/actions";
+import SendCommunicationModal from "./SendCommunicationModal";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
+import { classNames } from "../../Utils/utils";
+import { useDispatch } from "react-redux";
+
+interface IProps {
+  claim: HCXClaimModel;
+  setShowMessages: (show: boolean) => void;
+}
+
+interface IMessage {
+  type?: string;
+  data?: string;
+  user?: string | null;
+  index?: number;
+}
+
+export default function ClaimCardCommunication({
+  claim,
+  setShowMessages,
+}: IProps) {
+  const dispatch = useDispatch<any>();
+  const [messages, setMessages] = useState<IMessage[]>([]);
+  const [responses, setResponses] = useState<IMessage[]>([]);
+  const [inputText, setInputText] = useState("");
+  const [createdCommunication, setCreatedCommunication] =
+    useState<HCXCommunicationModel>();
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const fetchCommunications = useCallback(async () => {
+    const response = await dispatch(
+      HCXActions.communications.list({
+        claim: claim.id,
+        ordering: "created_date",
+      })
+    );
+
+    if (response.status === 200 && response.data) {
+      response.data.results?.forEach(
+        (communication: HCXCommunicationModel, i: number) => {
+          communication.content?.forEach((content) =>
+            setMessages((prev) => [
+              ...prev,
+              { ...content, user: communication.created_by, index: i },
+            ])
+          );
+        }
+      );
+    }
+  }, [claim.id, dispatch]);
+
+  const handleSubmit = async () => {
+    const response = await dispatch(
+      HCXActions.communications.create({
+        claim: claim.id,
+        content: responses.map((response) => ({
+          type: response.type as string,
+          data: response.data as string,
+        })),
+      })
+    );
+
+    console.log(response, response.status);
+    if (response.status === 201) {
+      setCreatedCommunication(response.data); //TODO: check if this is correct
+    }
+  };
+
+  useEffect(() => {
+    fetchCommunications();
+  }, [fetchCommunications, createdCommunication]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [responses]);
+
+  return (
+    <div className="flex flex-col justify-end h-full">
+      {createdCommunication && (
+        <SendCommunicationModal
+          communication={createdCommunication}
+          show
+          onClose={() => {
+            setCreatedCommunication(undefined);
+            setResponses([]);
+          }}
+        />
+      )}
+      <div className="flex justify-end">
+        <CareIcon
+          onClick={() => setShowMessages(false)}
+          className="care-l-info-circle w-7 h-7 text-gray-600 cursor-pointer hover:text-gray-800"
+        />
+      </div>
+
+      <div className="overflow-y-auto w-full h-full my-3">
+        {messages.map((message) => (
+          <div
+            className={classNames(
+              "flex mb-4",
+              message.user ? "justify-end" : "justify-start"
+            )}
+          >
+            <p
+              className={classNames(
+                "ml-2 py-3 px-4 text-white",
+                message.user
+                  ? "bg-blue-400 rounded-bl-3xl rounded-tl-3xl rounded-tr-xl"
+                  : "bg-gray-500 rounded-br-3xl rounded-tr-3xl rounded-tl-xl"
+              )}
+            >
+              {message.data}
+            </p>
+          </div>
+        ))}
+
+        {responses.map((message, i) => (
+          <div className="flex mb-4 justify-end">
+            <p
+              onClick={() =>
+                setResponses((prev) => prev.filter((_, j) => i !== j))
+              }
+              className="group relative flex items-center justify-center gap-2 ml-2 py-3 px-4 text-white bg-blue-400 rounded-bl-3xl rounded-tl-3xl rounded-tr-xl hover:bg-red-400"
+            >
+              <span className="group-hover:opacity-40 group-hover:line-through">
+                {message.data}
+              </span>
+              <CareIcon className="care-l-trash text-xl font-bold hidden group-hover:block group-hover:absolute top-1/3 left-1/2" />
+            </p>
+          </div>
+        ))}
+
+        <div ref={bottomRef} />
+      </div>
+      <div className="flex items-center gap-3 w-full m-auto">
+        <TextAreaFormField
+          name="message"
+          value={inputText}
+          onChange={(e) => setInputText(e.value)}
+          placeholder="Enter a message"
+          rows={1}
+          className="w-full -mb-3"
+        />
+        {inputText.length || !responses.length ? (
+          <ButtonV2
+            onClick={() => {
+              setResponses((prev) => [
+                ...prev,
+                { type: "text", data: inputText },
+              ]);
+              setInputText("");
+            }}
+            disabled={!inputText.length}
+          >
+            Add
+          </ButtonV2>
+        ) : (
+          <ButtonV2 disabled={!responses.length} onClick={handleSubmit}>
+            Submit
+          </ButtonV2>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/Components/HCX/ClaimCardInfo.tsx
+++ b/src/Components/HCX/ClaimCardInfo.tsx
@@ -1,11 +1,14 @@
 import { classNames, formatCurrency, formatDate } from "../../Utils/utils";
-import { HCXClaimModel } from "../HCX/models";
+
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import { HCXClaimModel } from "./models";
 
 interface IProps {
   claim: HCXClaimModel;
+  setShowMessages: (show: boolean) => void;
 }
 
-export default function ClaimDetailCard({ claim }: IProps) {
+export default function ClaimCardInfo({ claim, setShowMessages }: IProps) {
   const status =
     claim.outcome === "Processing Complete"
       ? claim.error_text
@@ -14,7 +17,7 @@ export default function ClaimDetailCard({ claim }: IProps) {
       : "Pending";
 
   return (
-    <div className="px-6 lg:px-8">
+    <>
       <div className="sm:flex sm:items-center">
         <div className="sm:flex-auto">
           <h1 className="text-xl font-semibold text-gray-700">
@@ -29,7 +32,12 @@ export default function ClaimDetailCard({ claim }: IProps) {
             .
           </p>
         </div>
-        <div className="mt-4 sm:mt-0 sm:ml-16 flex items-center justify-center gap-3">
+        <div className="mt-4 sm:mt-0 sm:ml-16 flex flex-row-reverse items-center justify-center gap-3">
+          <CareIcon
+            onClick={() => setShowMessages(true)}
+            className="care-l-comment-alt-message w-7 h-7 text-gray-600 cursor-pointer hover:text-gray-800"
+          />
+
           {claim.use && (
             <span className="font-bold text-sm p-1 px-2 rounded shadow bg-primary-100 text-primary-500">
               {claim.use}
@@ -157,6 +165,6 @@ export default function ClaimDetailCard({ claim }: IProps) {
           {claim.error_text}
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/src/Components/HCX/SendCommunicationModal.tsx
+++ b/src/Components/HCX/SendCommunicationModal.tsx
@@ -1,0 +1,60 @@
+import * as Notification from "../../Utils/Notifications";
+
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import DialogModal from "../Common/Dialog";
+import { FileUpload } from "../Patient/FileUpload";
+import { HCXActions } from "../../Redux/actions";
+import { HCXCommunicationModel } from "./models";
+import { Submit } from "../Common/components/ButtonV2";
+import { useDispatch } from "react-redux";
+import { useState } from "react";
+
+interface Props {
+  communication: HCXCommunicationModel;
+  show: boolean;
+  onClose: () => void;
+}
+
+export default function SendCommunicationModal({
+  communication,
+  ...props
+}: Props) {
+  const dispatch = useDispatch<any>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+
+    const res = await dispatch(HCXActions.sendCommunication(communication.id!));
+    if (res.data) {
+      Notification.Success({ msg: "Message Sent" });
+      props.onClose();
+    }
+
+    setIsLoading(false);
+  };
+
+  return (
+    <DialogModal
+      show={props.show}
+      onClose={props.onClose}
+      title="Add supporting documents"
+      className="w-full max-w-screen-lg"
+      titleAction={
+        <Submit disabled={isLoading} onClick={handleSubmit}>
+          {isLoading && <CareIcon className="care-l-spinner animate-spin" />}
+          {isLoading ? "Sending Message" : "Send Message"}
+        </Submit>
+      }
+    >
+      <div className="p-4 pt-8">
+        <FileUpload
+          type="COMMUNICATION"
+          communicationId={communication.id!}
+          hideBack
+          unspecified
+        />
+      </div>
+    </DialogModal>
+  );
+}

--- a/src/Components/HCX/models.ts
+++ b/src/Components/HCX/models.ts
@@ -37,6 +37,18 @@ export interface HCXPolicyModel {
   modified_date?: string;
 }
 
+export interface HCXCommunicationModel {
+  id?: string;
+  identifier?: string;
+  claim?: string;
+  claim_object?: HCXClaimModel;
+  content?: { type: string; data: string }[];
+  created_by?: string | null;
+  last_modified_by?: string | null;
+  created_date?: string;
+  modified_date?: string;
+}
+
 export interface HCXItemModel {
   id: string;
   name: string;

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1,40 +1,42 @@
-import axios from "axios";
+import * as Notification from "../../Utils/Notifications.js";
+
+import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
 import { CircularProgress, InputLabel } from "@material-ui/core";
-import loadable from "@loadable/component";
-import React, { useCallback, useState, useEffect, useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { statusType, useAbortableEffect } from "../../Common/utils";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
-  viewUpload,
-  retrieveUpload,
   createUpload,
-  getPatient,
   editUpload,
+  getPatient,
+  retrieveUpload,
+  viewUpload,
 } from "../../Redux/actions";
+import { statusType, useAbortableEffect } from "../../Common/utils";
+import { useDispatch, useSelector } from "react-redux";
+
+import AuthorizedChild from "../../CAREUI/misc/AuthorizedChild";
+import Box from "@material-ui/core/Box";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import DialogModal from "../Common/Dialog";
 import { FileUploadModel } from "./models";
+import HeadedTabs from "../Common/HeadedTabs";
 import { LegacyTextInputField } from "../Common/HelperInputFields";
 import LinearProgress from "@material-ui/core/LinearProgress";
-import Typography from "@material-ui/core/Typography";
-import Box from "@material-ui/core/Box";
-import * as Notification from "../../Utils/Notifications.js";
-import { VoiceRecorder } from "../../Utils/VoiceRecorder";
 import Modal from "@material-ui/core/Modal";
+import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import Pagination from "../Common/Pagination";
 import { RESULTS_PER_PAGE_LIMIT } from "../../Common/constants";
-import imageCompression from "browser-image-compression";
-import { formatDate } from "../../Utils/utils";
-import { useTranslation } from "react-i18next";
-import HeadedTabs from "../Common/HeadedTabs";
-import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
-import DialogModal from "../Common/Dialog";
-import CareIcon from "../../CAREUI/icons/CareIcon";
-import TextFormField from "../Form/FormFields/TextFormField";
-import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import RecordMeta from "../../CAREUI/display/RecordMeta";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
+import TextFormField from "../Form/FormFields/TextFormField";
+import Typography from "@material-ui/core/Typography";
+import { VoiceRecorder } from "../../Utils/VoiceRecorder";
 import Webcam from "react-webcam";
+import axios from "axios";
+import { formatDate } from "../../Utils/utils";
+import imageCompression from "browser-image-compression";
+import loadable from "@loadable/component";
+import { useTranslation } from "react-i18next";
 import useWindowDimensions from "../../Common/hooks/useWindowDimensions";
-import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
-import AuthorizedChild from "../../CAREUI/misc/AuthorizedChild";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -96,6 +98,7 @@ interface FileUploadProps {
   unspecified: boolean;
   sampleId?: number;
   claimId?: string;
+  communicationId?: string;
 }
 
 interface URLS {
@@ -137,6 +140,7 @@ export const FileUpload = (props: FileUploadProps) => {
     unspecified,
     sampleId,
     claimId,
+    communicationId,
   } = props;
   const id = patientId;
   const dispatch: any = useDispatch();
@@ -286,12 +290,14 @@ export const FileUpload = (props: FileUploadProps) => {
     CONSULTATION: "Upload Consultation Files",
     SAMPLE_MANAGEMENT: "Upload Sample Report",
     CLAIM: "Upload Supporting Info",
+    COMMUNICATION: "Upload Supporting Info",
   };
   const VIEW_HEADING: { [index: string]: string } = {
     PATIENT: "View Patient Files",
     CONSULTATION: "View Consultation Files",
     SAMPLE_MANAGEMENT: "View Sample Report",
     CLAIM: "Supporting Info",
+    COMMUNICATION: "Supporting Info",
   };
 
   const handleClose = () => {
@@ -315,6 +321,8 @@ export const FileUpload = (props: FileUploadProps) => {
         return sampleId;
       case "CLAIM":
         return claimId;
+      case "COMMUNICATION":
+        return communicationId;
     }
   };
 

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -1,4 +1,8 @@
-import { HCXClaimModel, HCXPolicyModel } from "../Components/HCX/models";
+import {
+  HCXClaimModel,
+  HCXCommunicationModel,
+  HCXPolicyModel,
+} from "../Components/HCX/models";
 import { fireRequest, fireRequestForFiles } from "./fireRequest";
 
 export const getConfig = () => {
@@ -891,6 +895,31 @@ export const HCXActions = {
     },
   },
 
+  communications: {
+    list(params: object) {
+      return fireRequest("listHCXCommunications", [], params);
+    },
+    create(obj: HCXCommunicationModel) {
+      return fireRequest("createHCXCommunication", [], obj);
+    },
+    read(id: string) {
+      return fireRequest("getHCXCommunication", [], {}, { external_id: id });
+    },
+    update(id: string, obj: HCXCommunicationModel) {
+      return fireRequest("updateHCXCommunication", [], obj, {
+        external_id: id,
+      });
+    },
+    partialUpdate(id: string, obj: Partial<HCXCommunicationModel>) {
+      return fireRequest("partialUpdateHCXCommunication", [], obj, {
+        external_id: id,
+      });
+    },
+    delete(id: string) {
+      return fireRequest("deleteHCXCommunication", [], {}, { external_id: id });
+    },
+  },
+
   preauths: {
     list(consultation: string) {
       return fireRequest(
@@ -909,5 +938,9 @@ export const HCXActions = {
 
   makeClaim(claim: string) {
     return fireRequest("hcxMakeClaim", [], { claim });
+  },
+
+  sendCommunication(communication: string) {
+    return fireRequest("hcxSendCommunication", [], { communication });
   },
 };

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -880,6 +880,41 @@ const routes: Routes = {
     path: "/api/v1/hcx/make_claim/",
     method: "POST",
   },
+
+  listHCXCommunications: {
+    path: "/api/v1/hcx/communication/",
+    method: "GET",
+  },
+
+  createHCXCommunication: {
+    path: "/api/v1/hcx/communication/",
+    method: "POST",
+  },
+
+  getHCXCommunication: {
+    path: "/api/v1/hcx/communication/{external_id}/",
+    method: "GET",
+  },
+
+  updateHCXCommunication: {
+    path: "/api/v1/hcx/communication/{external_id}/",
+    method: "PUT",
+  },
+
+  partialUpdateHCXCommunication: {
+    path: "/api/v1/hcx/communication/{external_id}/",
+    method: "PATCH",
+  },
+
+  deleteHCXCommunication: {
+    path: "/api/v1/hcx/communication/{external_id}/",
+    method: "DELETE",
+  },
+
+  hcxSendCommunication: {
+    path: "/api/v1/hcx/send_communication/",
+    method: "POST",
+  },
 };
 
 export default routes;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,20 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
 import { VitePWA } from "vite-plugin-pwa";
-import { resolve } from "path";
+import { defineConfig } from "vite";
 import { promises as fs } from "fs";
-
+import react from "@vitejs/plugin-react-swc";
+import { resolve } from "path";
 
 export default defineConfig({
   envPrefix: "REACT_",
   plugins: [
     react(),
     VitePWA({
-      strategies: 'injectManifest',
-      srcDir: 'src',
-      filename: 'service-worker.ts',
+      strategies: "injectManifest",
+      srcDir: "src",
+      filename: "service-worker.ts",
       injectRegister: null,
       injectManifest: {
-        maximumFileSizeToCacheInBytes: 7000000
+        maximumFileSizeToCacheInBytes: 7000000,
       },
       manifest: {
         name: "Care",
@@ -38,7 +37,7 @@ export default defineConfig({
             src: "https://cdn.coronasafe.network/care-manifest/images/icons/icon-512x512.png",
             sizes: "512x512",
             type: "image/png",
-          }
+          },
         ],
       },
     }),
@@ -74,7 +73,7 @@ export default defineConfig({
     port: 4000,
     proxy: {
       "/api": {
-        target: "https://careapi.coronasafe.in",
+        target: "https://local.kha.vin",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f5ca89</samp>

The pull request adds a new feature for managing HCX claims and communications in the frontend. It introduces a new `ClaimCard` component that displays the claim details and allows the user to toggle the communication view. It also adds new actions, types, and API endpoints for interacting with the HCX server. It updates the UI and functionality of the existing `DischargeModal` and `FileUpload` components to use the new feature. It also makes some minor style and configuration changes in `vite.config.ts` and `useConfig.ts`.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f5ca89</samp>

*  Enable HCX features in the UI by always returning `enable_hcx: true` in the `useConfig` hook ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-85ddd82d8d8242a8120ad7bf95ed40ce93b4290afb8e17e7c2370bfb2086dd71L67-R67))
*  Add `ClaimCard` component to render claim information and communication in a compact and interactive design ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-f9b4357447504c321553fe8e4493620306fca07232463c5d55341bc0ecf2c2feR1-R42))
*  Replace `ClaimDetailCard` component with `ClaimCard` component in `ConsultationClaims` and `DischargeModal` components ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-fee4043b456d40aa1b59177878c6a94594a8bf578d04d2966fb4deffff9f45b4L86-R88), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L14-R14), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L332-R332))
*  Rename `ClaimDetailCard` component to `ClaimCardInfo` and move it to `src/Components/HCX/ClaimCardInfo.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-fd5f3602142e86836559df3c6d3c80b14b3cd6f32d260c4f4b2a2f21de1116c1L2-R11))
*  Modify `ClaimCardInfo` component to remove unnecessary `div` wrappers, add `CareIcon` component to toggle communication view, and change `flex` direction ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-fd5f3602142e86836559df3c6d3c80b14b3cd6f32d260c4f4b2a2f21de1116c1L17-R20), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-fd5f3602142e86836559df3c6d3c80b14b3cd6f32d260c4f4b2a2f21de1116c1L32-R40), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-fd5f3602142e86836559df3c6d3c80b14b3cd6f32d260c4f4b2a2f21de1116c1L160-R168))
*  Add `ClaimCardCommunication` component to render messages and responses related to a claim, and allow adding, deleting, and submitting responses ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-fa17dbc622d2665009e26a790198307999b6c8b4492a1bf417915f14e53ad281R1-R171))
*  Add `SendCommunicationModal` component to render a modal dialog for uploading supporting documents and sending communication to HCX server ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-75ad71b487ae1994c1156f523bbf8467352dc4226211609b24590753ca975c07R1-R60))
*  Add `HCXCommunicationModel` interface to define the shape of the communication object ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-85ceca8e056645987380e5f45d62da65607c1d46e3772d96543077cc818a2457R40-R51))
*  Add `communications` object to `HCXActions` to define actions for creating, reading, updating, deleting, and listing communications ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eR898-R922))
*  Add `sendCommunication` function to `HCXActions` to dispatch request to HCX server with communication id as payload ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eR942-R945))
*  Add API endpoints for HCX communication features to `src/Redux/api.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR883-R917))
*  Modify `FileUpload` component to accept `communicationId` prop and filter file uploads by communication ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R101), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R143), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R293), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R300), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R324-R325))
*  Reorder imports alphabetically in `CareIcon`, `ConsultationClaims`, `FileUpload`, and `vite.config.ts` ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-9bbaedced0a7c77495fc04cdb72e39bea9ef315234027f4eab7402ba8a90af53L1-R2), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-fee4043b456d40aa1b59177878c6a94594a8bf578d04d2966fb4deffff9f45b4L1-R12), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1-R39), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL1-R6))
*  Fix minor formatting issues in `vite.config.ts` ([link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL13-R17), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL41-R40), [link](https://github.com/coronasafe/care_fe/pull/5473/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL77-R76))
