### PR TITLE
Fixed bed type chip allignment in bed select dropdown

### DIFF
--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -117,13 +117,15 @@ const AutoCompleteAsync = (props: Props) => {
                     value={item}
                   >
                     {({ selected }) => (
-                      <div className="flex justify-between align-center">
-                        {optionLabel(item)}
-                        {optionLabelChip(item) && (
-                          <div className="px-2 mt-1 sm:mt-0 text-center bg-secondary-100 h-fit max-w-fit rounded-full text-xs text-gray-900 border border-secondary-400">
-                            {optionLabelChip(item)}
-                          </div>
-                        )}
+                      <div className="flex justify-between items-center">
+                        <div className="flex gap-2 items-center">
+                          {optionLabel(item)}
+                          {optionLabelChip(item) && (
+                            <div className="px-2 mt-1 sm:mt-0 text-center bg-secondary-100 h-fit max-w-fit rounded-full text-xs text-gray-900 border border-secondary-400">
+                              {optionLabelChip(item)}
+                            </div>
+                          )}
+                        </div>
                         {selected && (
                           <CareIcon className="care-l-check text-lg" />
                         )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f87a04a</samp>

Improved the UI of the `AutoCompleteAsync` component by fixing the alignment of the option label and chip. Modified the file `src/Components/Form/AutoCompleteAsync.tsx` to use a flex container and the items-center class.

## Proposed Changes

- Fixes #5520 
- Fixed bed type chip allignment in bed select dropdown

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f87a04a</samp>

*  Align option label and chip horizontally with check icon in `AutoCompleteAsync` component ([link](https://github.com/coronasafe/care_fe/pull/5526/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8L120-R128))
*  Add flex container with gap to wrap label and chip in `AutoCompleteAsync` component ([link](https://github.com/coronasafe/care_fe/pull/5526/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8L120-R128))
*  Change align-center class to items-center to fix vertical alignment in `AutoCompleteAsync` component ([link](https://github.com/coronasafe/care_fe/pull/5526/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8L120-R128))
