### PR TITLE
Add CSV support for the asset export, issue #5483

### DIFF
--- a/src/Common/hooks/useExport.tsx
+++ b/src/Common/hooks/useExport.tsx
@@ -8,6 +8,40 @@ interface CSVLinkProps {
   data: string;
 }
 
+interface FlattenedObject {
+  id: string;
+  status: string;
+  asset_type: string;
+  location_object_id: string;
+  location_object_facility_id: string;
+  location_object_facility_name: string;
+  location_object_created_date: string;
+  location_object_modified_date: string;
+  location_object_name: string;
+  location_object_description: string;
+  location_object_location_type: number;
+  created_date: string;
+  modified_date: string;
+  name: string;
+  description: string;
+  asset_class: string;
+  is_working: boolean;
+  not_working_reason: string;
+  serial_number: string;
+  warranty_details: string;
+  meta_asset_type?: string;
+  meta_local_ip_address?: string;
+  vendor_name: string;
+  support_name: string;
+  support_phone: string;
+  support_email: string;
+  qr_code_id?: string;
+  manufacturer: string;
+  warranty_amc_end_of_validity?: string;
+  last_serviced_on?: string;
+  notes: string;
+}
+
 export default function useExport() {
   const dispatch: any = useDispatch();
   const [isExporting, setIsExporting] = useState(false);
@@ -24,18 +58,65 @@ export default function useExport() {
 
   const getTimestamp = () => new Date().toISOString();
 
-  const exportCSV = async (
-    filenamePrefix: string,
-    action: any,
-    parse = (data: string) => data
-  ) => {
+  const flattenObject = (obj: any): FlattenedObject => {
+    const result: FlattenedObject = {
+      id: obj.id,
+      status: obj.status,
+      asset_type: obj.asset_type,
+      location_object_id: obj.location_object?.id || "",
+      location_object_facility_id: obj.location_object?.facility?.id || "",
+      location_object_facility_name: obj.location_object?.facility?.name || "",
+      location_object_created_date: obj.location_object?.created_date || "",
+      location_object_modified_date: obj.location_object?.modified_date || "",
+      location_object_name: obj.location_object?.name || "",
+      location_object_description: obj.location_object?.description || "",
+      location_object_location_type: obj.location_object?.location_type || 0,
+      created_date: obj.created_date,
+      modified_date: obj.modified_date,
+      name: obj.name,
+      description: obj.description,
+      asset_class: obj.asset_class,
+      is_working: obj.is_working,
+      not_working_reason: obj.not_working_reason,
+      serial_number: obj.serial_number,
+      warranty_details: obj.warranty_details,
+      meta_asset_type: obj.meta?.asset_type,
+      meta_local_ip_address: obj.meta?.local_ip_address,
+      vendor_name: obj.vendor_name,
+      support_name: obj.support_name,
+      support_phone: obj.support_phone,
+      support_email: obj.support_email,
+      qr_code_id: obj.qr_code_id,
+      manufacturer: obj.manufacturer,
+      warranty_amc_end_of_validity: obj.warranty_amc_end_of_validity,
+      last_serviced_on: obj.last_serviced_on,
+      notes: obj.notes,
+    };
+
+    return result;
+  };
+  const parseJSONtoCSV = (data: string) => {
+    const json = JSON.parse(data);
+    const flattened = json.map((obj: any) => flattenObject(obj));
+
+    const csvHeader = Object.keys(flattened[0]).join(",");
+    const csvRows = flattened.map((obj: any) => Object.values(obj).join(","));
+    const csv = [csvHeader, ...csvRows].join("\n");
+    return csv;
+  };
+
+  const exportCSV = async (filenamePrefix: string, action: any) => {
     setIsExporting(true);
 
     const filename = `${filenamePrefix}_${getTimestamp()}.csv`;
 
     const res = await dispatch(action);
     if (res.status === 200) {
-      setCsvLinkProps({ ...csvLinkProps, filename, data: parse(res.data) });
+      setCsvLinkProps({
+        ...csvLinkProps,
+        filename,
+        data: parseJSONtoCSV(JSON.stringify(res.data.results)),
+      });
       document.getElementById(csvLinkProps.id)?.click();
     }
 
@@ -73,13 +154,13 @@ export default function useExport() {
 
     switch (type) {
       case "csv":
-        exportCSV(filePrefix, action(), parse);
+        exportCSV(filePrefix, action());
         break;
       case "json":
         exportJSON(filePrefix, action(), parse);
         break;
       default:
-        exportCSV(filePrefix, action(), parse);
+        exportCSV(filePrefix, action());
     }
   };
 

--- a/src/Common/hooks/useExport.tsx
+++ b/src/Common/hooks/useExport.tsx
@@ -105,7 +105,11 @@ export default function useExport() {
     return csv;
   };
 
-  const exportCSV = async (filenamePrefix: string, action: any) => {
+  const exportCSV = async (
+    filenamePrefix: string,
+    action: any,
+    parse = (data: string) => data
+  ) => {
     setIsExporting(true);
 
     const filename = `${filenamePrefix}_${getTimestamp()}.csv`;
@@ -115,7 +119,7 @@ export default function useExport() {
       setCsvLinkProps({
         ...csvLinkProps,
         filename,
-        data: parseJSONtoCSV(JSON.stringify(res.data.results)),
+        data: parse(JSON.stringify(res.data.results)),
       });
       document.getElementById(csvLinkProps.id)?.click();
     }
@@ -154,13 +158,13 @@ export default function useExport() {
 
     switch (type) {
       case "csv":
-        exportCSV(filePrefix, action());
+        exportCSV(filePrefix, action(), parseJSONtoCSV);
         break;
       case "json":
         exportJSON(filePrefix, action(), parse);
         break;
       default:
-        exportCSV(filePrefix, action());
+        exportCSV(filePrefix, action(), parseJSONtoCSV);
     }
   };
 

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -323,7 +323,7 @@ const AssetsList = () => {
                         json: true,
                         limit: totalCount,
                       }),
-                    type: "json",
+                    type: "csv",
                     filePrefix: `assets_${facility?.name}`,
                     options: {
                       icon: <CareIcon className="care-l-export" />,


### PR DESCRIPTION
### WHAT
Fixes the issue of not being able to export csv files. The main issue was that there was no parser which could convert the json string from the response body to a suitable format for csv. So, I add a function that parses the json data to csv format.

## Proposed Changes

- Fixes #5483
- Changed default dowload type to CSV.  src/Components/Assets/AssetsList.tsx line 326.
- Added function to flatten response body for csv conversion. src/Common/hooks/useExport.tsx line 11 to 43 (interface) and line  61 to 94 (function)
- Added a parser function to parse the flattened json object. src/Components/useExport.tsx line 98 to 106.

## demonstration
- Go to https://care.coronasafe.in/assets?page=2&limit=18&search=
- Hit the Export Assets button
![image](https://github.com/coronasafe/care_fe/assets/76475829/5ae4ba47-801d-4a5f-8e33-433eeb82ad49)
- A sample downloaded CSV is given below [assets_undefined_2023-05-25T13_11_41.357Z.csv](https://github.com/coronasafe/care_fe/files/11565307/assets_undefined_2023-05-25T13_11_41.357Z.csv)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
- The function flattenObject in src/Common/hooks/useExport.tsx line 61 flattens the response body json data to a flat json.
- Next, the function parseJSONtoCSV in src/Components/useExport.tsx line 98 parses the given json object and convertes it to a comma separated string.
- We use parseJSONtoCSV as the default parser for exportFile function src/Components/useExport.tsx  151.
