### PR TITLE
fixed auto collapse the DateFormField after user clicks on a date

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, MutableRefObject } from "react";
 import {
   format,
   subMonths,
@@ -90,7 +90,11 @@ const DateInputV2: React.FC<Props> = ({
       );
   };
 
-  const setDateValue = (date: number) => () => {
+  type CloseFunction = (
+    focusableElement?: HTMLElement | MutableRefObject<HTMLElement | null>
+  ) => void;
+
+  const setDateValue = (date: number, close: CloseFunction) => () => {
     isDateWithinConstraints(date) &&
       onChange(
         new Date(
@@ -99,6 +103,7 @@ const DateInputV2: React.FC<Props> = ({
           date
         )
       );
+    close();
   };
 
   const getDayCount = (date: Date) => {
@@ -194,7 +199,7 @@ const DateInputV2: React.FC<Props> = ({
     <div>
       <div className="container mx-auto text-black">
         <Popover className="relative">
-          {({ open }) => (
+          {({ open, close }) => (
             <div
               onBlur={() => {
                 setIsOpen && setIsOpen(false);
@@ -310,7 +315,7 @@ const DateInputV2: React.FC<Props> = ({
                             className="aspect-square w-[14.26%]"
                           >
                             <div
-                              onClick={setDateValue(d)}
+                              onClick={setDateValue(d, close)}
                               className={classNames(
                                 "cursor-pointer flex items-center justify-center text-center h-full text-sm rounded leading-loose transition ease-in-out duration-100 text-black",
                                 value && isSelectedDate(d)


### PR DESCRIPTION
### WHAT
Fixed auto collapse the DateFormField after user clicks on a date by using close prop given by Headless UI.

## Proposed Changes

- Fixes #5280 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.


## Video
https://github.com/coronasafe/care_fe/assets/72242181/4796f3da-59bf-4359-b39e-32bd697f04be

