### PR TITLE
Added tooltip on occupancy chip in facility card

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -47,7 +47,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
 
   return (
     <div key={`usr_${facility.id}`} className="w-full">
-      <div className="block rounded-lg h-full overflow-clip bg-white shadow hover:border-primary-500">
+      <div className="block rounded-lg h-full bg-white shadow hover:border-primary-500">
         <div className="flex h-full">
           <Link
             href={`/facility/${facility.id}`}

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -164,7 +164,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                             : "bg-primary-100 button-primary-border"
                         }`}
                       >
-                        <span className="tooltip-text tooltip-top -translate-x-1/2">
+                        <span className="tooltip-text tooltip-right -translate-y-2">
                           Live Patients / Total beds
                         </span>{" "}
                         <CareIcon

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -158,13 +158,15 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                   <div className="flex justify-between w-full flex-wrap gap-2">
                     <div className="flex gap-2">
                       <div
-                        className={`flex items-center justify-center rounded-md text-xl h-[38px] w-fit px-2 ml-auto ${
+                        className={`flex items-center tooltip justify-center rounded-md text-xl h-[38px] w-fit px-2 ml-auto ${
                           facility.patient_count / facility.bed_count > 0.85
                             ? "bg-red-500 button-danger-border"
                             : "bg-primary-100 button-primary-border"
                         }`}
                       >
-                        {" "}
+                        <span className="tooltip-text tooltip-top -translate-x-1/2">
+                          Live Patients / Total beds
+                        </span>{" "}
                         <CareIcon
                           className={`care-l-bed text-${
                             facility.patient_count / facility.bed_count > 0.85


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc2898e</samp>

Added a tooltip feature to the facility card component to explain the bed occupancy ratio. Modified `FacilityCard.tsx` and added some CSS classes.

## Proposed Changes

- Fixes #5533 
- Added tooltip on occupancy chip with text "Live Patients / Total beds"

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc2898e</samp>

*  Add tooltip functionality to the facility card ratio element ([link](https://github.com/coronasafe/care_fe/pull/5539/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L161-R161), [link](https://github.com/coronasafe/care_fe/pull/5539/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L167-R169))
