### PR TITLE
buttons width  bug fixed in mobile view of file section in patient consultation page

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1582,7 +1582,7 @@ export const FileUpload = (props: FileUploadProps) => {
                     <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
                       {({ isAuthorized }) =>
                         isAuthorized ? (
-                          <label className="font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1 button-size-default justify-center button-shape-square button-primary-default">
+                          <label className="w-full font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1 button-size-default justify-center button-shape-square button-primary-default">
                             <CareIcon className="care-l-file-upload-alt text-lg" />
                             {t("choose_file")}
                             <input
@@ -1597,7 +1597,10 @@ export const FileUpload = (props: FileUploadProps) => {
                         )
                       }
                     </AuthorizedChild>
-                    <ButtonV2 onClick={() => setModalOpenForCamera(true)}>
+                    <ButtonV2
+                      onClick={() => setModalOpenForCamera(true)}
+                      className="w-full"
+                    >
                       <CareIcon className="care-l-camera text-lg mr-2" />
                       Open Camera
                     </ButtonV2>
@@ -1605,6 +1608,7 @@ export const FileUpload = (props: FileUploadProps) => {
                       authorizeFor={NonReadOnlyUsers}
                       disabled={!file || !uploadFileName || !isActive}
                       onClick={() => handleUpload({ status })}
+                      className="w-full"
                     >
                       <CareIcon className="care-l-cloud-upload text-lg" />
                       {t("upload")}

--- a/src/Utils/VoiceRecorder.tsx
+++ b/src/Utils/VoiceRecorder.tsx
@@ -67,6 +67,7 @@ export const VoiceRecorder = (props: any) => {
               <ButtonV2
                 onClick={startRecording}
                 authorizeFor={NonReadOnlyUsers}
+                className="w-full"
               >
                 <CareIcon className="care-l-microphone text-lg" />
                 {t("record")}


### PR DESCRIPTION
buttons width  bug fixed in the mobile view of file section in the patient consultation page

### WHAT
In the file tab of patient consultation page, all the buttons are not in full width during responsive view
![image](https://github.com/coronasafe/care_fe/assets/97228857/9db30885-9e7d-4822-bbaf-51529d87df1e)


## Proposed Changes
![image](https://github.com/coronasafe/care_fe/assets/97228857/b768ee94-a8f9-4043-aa5c-3f6cc847d0c9)
![image](https://github.com/coronasafe/care_fe/assets/97228857/44e8aa6d-95b4-4431-bf19-fea3c462f7b0)




- Fixes #5540 


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f370d3a</samp>

*  Make file upload, camera, and voice recording buttons fill the available width of the parent container for better layout and alignment ([link](https://github.com/coronasafe/care_fe/pull/5548/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1585-R1585), [link](https://github.com/coronasafe/care_fe/pull/5548/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1600-R1603), [link](https://github.com/coronasafe/care_fe/pull/5548/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R1611), [link](https://github.com/coronasafe/care_fe/pull/5548/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcR70))
