### PR TITLE
Sachdevavaibhav/#4945

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, MutableRefObject } from "react";
 import {
   format,
   subMonths,
@@ -90,7 +90,11 @@ const DateInputV2: React.FC<Props> = ({
       );
   };
 
-  const setDateValue = (date: number) => () => {
+  type CloseFunction = (
+    focusableElement?: HTMLElement | MutableRefObject<HTMLElement | null>
+  ) => void;
+
+  const setDateValue = (date: number, close: CloseFunction) => () => {
     isDateWithinConstraints(date) &&
       onChange(
         new Date(
@@ -99,6 +103,7 @@ const DateInputV2: React.FC<Props> = ({
           date
         )
       );
+    close();
   };
 
   const getDayCount = (date: Date) => {
@@ -194,7 +199,7 @@ const DateInputV2: React.FC<Props> = ({
     <div>
       <div className="container mx-auto text-black">
         <Popover className="relative">
-          {({ open }) => (
+          {({ open, close }) => (
             <div
               onBlur={() => {
                 setIsOpen && setIsOpen(false);
@@ -310,7 +315,7 @@ const DateInputV2: React.FC<Props> = ({
                             className="aspect-square w-[14.26%]"
                           >
                             <div
-                              onClick={setDateValue(d)}
+                              onClick={setDateValue(d, close)}
                               className={classNames(
                                 "cursor-pointer flex items-center justify-center text-center h-full text-sm rounded leading-loose transition ease-in-out duration-100 text-black",
                                 value && isSelectedDate(d)

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -10,10 +10,7 @@ import * as Notification from "../../Utils/Notifications.js";
 import PageTitle from "../Common/PageTitle";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { validateEmailAddress } from "../../Common/validation";
-import {
-  LegacyActionTextInputField,
-  LegacyErrorHelperText,
-} from "../Common/HelperInputFields";
+import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import { AssetClass, AssetData, AssetType } from "../Assets/AssetTypes";
 import loadable from "@loadable/component";
 import { navigate } from "raviger";
@@ -677,23 +674,24 @@ const AssetCreate = (props: AssetProps) => {
                     />
                   </div>
                   {/* Asset QR ID */}
-                  <div className="col-span-6">
-                    <label htmlFor="asset-qr-id">Asset QR ID</label>
-                    <LegacyActionTextInputField
-                      id="qr_code_id"
-                      fullWidth
-                      name="qr_code_id"
-                      placeholder=""
-                      variant="outlined"
-                      margin="dense"
-                      value={qrCodeId}
-                      onChange={(e) => setQrCodeId(e.target.value)}
-                      actionIcon={
-                        <CareIcon className="care-l-focus cursor-pointer text-lg" />
-                      }
-                      action={() => setIsScannerActive(true)}
-                      errors={state.errors.qr_code_id}
-                    />
+                  <div className="col-span-6 flex flex-row items-center gap-3">
+                    <div className="w-full">
+                      <TextFormField
+                        id="qr_code_id"
+                        name="qr_code_id"
+                        placeholder=""
+                        label="Asset QR ID"
+                        value={qrCodeId}
+                        onChange={(e) => setQrCodeId(e.value)}
+                        error={state.errors.qr_code_id}
+                      />
+                    </div>
+                    <div
+                      className="flex items-center justify-self-end ml-1 mt-1 border border-gray-400 rounded px-4 h-10 cursor-pointer hover:bg-gray-200"
+                      onClick={() => setIsScannerActive(true)}
+                    >
+                      <CareIcon className="care-l-focus cursor-pointer text-lg" />
+                    </div>
                     <LegacyErrorHelperText error={state.errors.qr_id} />
                   </div>
                 </div>


### PR DESCRIPTION
### WHAT
Working on #4945 
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5739e28</samp>

Improved date input component by closing popover after selection. Updated `setDateValue` function and `DateInputV2.tsx` file.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5739e28</samp>

* Import `MutableRefObject` type from `react` to use as parameter type for `close` function ([link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL1-R1))
* Modify `setDateValue` function to accept `close` function as second parameter and invoke it after `onChange` callback ([link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL93-R97), [link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bR106))
* Destructure `close` function from `Popover` component props and pass it to `setDateValue` function ([link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL197-R202))
* Pass `close` function to `setDateValue` function inside `onClick` handler of `div` element that renders each date in calendar ([link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL313-R318))
* Close popover component after user selects or clicks on a date from `DateInputV2` component ([link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL93-R97), [link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bR106), [link](https://github.com/coronasafe/care_fe/pull/5551/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL313-R318))
