### PR TITLE
disables asset class field in asset update

### DIFF
--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -31,6 +31,7 @@ import useAppHistory from "../../Common/hooks/useAppHistory";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { LocationSelect } from "../Common/LocationSelect";
 import { FieldLabel } from "../Form/FormFields/FormField";
+import { useTranslation } from "react-i18next";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -97,6 +98,7 @@ type AssetFormSection =
 
 const AssetCreate = (props: AssetProps) => {
   const { goBack } = useAppHistory();
+  const { t } = useTranslation();
   const { facilityId, assetId } = props;
 
   let assetTypeInitial: AssetType;
@@ -572,6 +574,8 @@ const AssetCreate = (props: AssetProps) => {
                     {/* Asset Class */}
                     <div ref={fieldRef["asset_class"]} className="flex-1">
                       <SelectFormField
+                        disabled={!!props.assetId}
+                        placeholder={props.assetId ? t("none") : undefined}
                         name="asset_class"
                         label="Asset Class"
                         value={asset_class}

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -132,6 +132,7 @@
   "contact_your_admin_to_add_skills": "Contact your admin to add skills",
   "add": "Add",
   "sort_by": "Sort By",
+  "none": "None",
   "RESPIRATORY_SUPPORT_UNKNOWN": "None",
   "RESPIRATORY_SUPPORT_OXYGEN_SUPPORT": "O2 Support",
   "RESPIRATORY_SUPPORT_NON_INVASIVE": "NIV",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e074d60</samp>

This pull request improves the AssetCreate component by adding internationalization support and a better UI for the input field. It also updates the `Common.json` file with a new translation string.

## Proposed Changes

- Fixes #5564

![image](https://github.com/coronasafe/care_fe/assets/25143503/70f849ec-dc99-4412-b308-57298e7a1643)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e074d60</samp>

* Import the `useTranslation` hook from `react-i18next` to enable internationalization of the AssetCreate component ([link](https://github.com/coronasafe/care_fe/pull/5565/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073R34))
* Destructure the `t` function from the hook and assign it to a variable to access the translation strings from `Common.json` ([link](https://github.com/coronasafe/care_fe/pull/5565/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073R101))
* Modify the `disabled` and `placeholder` props of the `InputField` component to conditionally render based on the `assetId` prop ([link](https://github.com/coronasafe/care_fe/pull/5565/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073R577-R578))
* Add the translation string for "None" to the `Common.json` file under the `en` locale ([link](https://github.com/coronasafe/care_fe/pull/5565/files?diff=unified&w=0#diff-38a71477ce052dd5f81bf55434622f86d274a8dc6a8af1a03fb444588aec4296R135))
