### PR TITLE
Fix death_report_spec, facility_spec and user_spec

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -24,8 +24,8 @@ jobs:
           path: care
 
       - name: Run docker compose up on care 🐳
-        run: cd care && touch .env && make docker_config_file=docker-compose.pre-built.yaml up && cd .. && sleep 30s
-        # Voluntarily kept 30 seconds delay to wait for migrations to complete.
+        run: cd care && touch .env && make docker_config_file=docker-compose.pre-built.yaml up && cd .. && sleep 60s
+        # Voluntarily kept 60 seconds delay to wait for migrations to complete.
 
       - name: Run Django collectstatic and load dummy data on care 🐍
         run: |

--- a/cypress/e2e/death_report_spec/death_report.cy.ts
+++ b/cypress/e2e/death_report_spec/death_report.cy.ts
@@ -1,4 +1,4 @@
-import { cy, it, describe, before, beforeEach } from "local-cypress";
+import { before, beforeEach, cy, describe, it } from "local-cypress";
 
 const user = { username: "devdistrictadmin", password: "Coronasafe@123" };
 const address = "C-106,\nSector-H,\nAliganj,\nLucknow,\nUttar Pradesh";
@@ -12,9 +12,10 @@ describe("Death Report", () => {
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.awaitUrl("/");
+    cy.intercept("**/api/v1/patient/**").as("getPatients");
     cy.get("a").contains("Patients").click({ force: true });
     cy.url().should("include", "/patients");
-    cy.contains("Details").click();
+    cy.wait("@getPatients").get("a[data-cy=patient]").first().click();
     cy.url().then((url) => {
       const patient_id = url.split("/")[6];
       cy.visit(`/death_report/${patient_id}`, {
@@ -35,14 +36,24 @@ describe("Death Report", () => {
     cy.get("textarea[name='address']").clear().type(address);
     cy.get("input[name='phone_number']").clear().type("+919919266674");
     cy.get("input[name='is_declared_positive']").clear().type("No");
-    cy.get("input[name='date_declared_positive']").clear().type("2021-12-01");
+    cy.get("input[name='date_declared_positive']")
+      .clear({ force: true })
+      .type("2021-12-01", { force: true });
     cy.get("input[name='test_type']").clear().type("Rapid Antigen");
-    cy.get("input[name='date_of_test']").clear().type("2021-12-01");
-    cy.get("input[name='date_of_result']").clear().type("2021-12-01");
+    cy.get("input[name='date_of_test']")
+      .clear({ force: true })
+      .type("2021-12-01", { force: true });
+    cy.get("input[name='date_of_result']")
+      .clear({ force: true })
+      .type("2021-12-01", { force: true });
     cy.get("input[name='hospital_tested_in']").clear().type("Apollo Hospital");
     cy.get("input[name='hospital_died_in']").clear().type("Apollo Hospital");
-    cy.get("input[name='date_of_admission']").clear().type("2021-12-01");
-    cy.get("input[name='date_of_death']").clear().type("2021-12-01");
+    cy.get("input[name='date_of_admission']")
+      .clear({ force: true })
+      .type("2021-12-01", { force: true });
+    cy.get("input[name='date_of_death']")
+      .clear({ force: true })
+      .type("2021-12-01", { force: true });
     cy.get("input[name='comorbidities']").clear().type("awesomeness");
     cy.get("input[name='history_clinical_course']")
       .clear()
@@ -51,7 +62,9 @@ describe("Death Report", () => {
     cy.get("input[name='home_or_cfltc']").clear().type("-");
     cy.get("input[name='is_vaccinated']").clear().type("Yes");
     cy.get("input[name='kottayam_confirmation_sent']").clear().type("Yes");
-    cy.get("input[name='kottayam_sample_date']").clear().type("2021-12-01");
+    cy.get("input[name='kottayam_sample_date']")
+      .clear({ force: true })
+      .type("2021-12-01", { force: true });
     cy.get("input[name='cause_of_death']")
       .clear()
       .type("Too awesome for earth");

--- a/cypress/e2e/facility_spec/facility.cy.ts
+++ b/cypress/e2e/facility_spec/facility.cy.ts
@@ -73,7 +73,7 @@ class facility {
 
     cy.get("input[id=pincode]").should("exist").clear().type(pincode);
 
-    cy.get("input[id=phone_number]").should("exist").type(phone);
+    cy.get("input[name=phone_number]").should("exist").type(phone);
 
     cy.get("input[id=oxygen_capacity]").clear().type(oxygen_capacity);
     cy.get("input[id=expected_oxygen_requirement]")

--- a/cypress/e2e/users_spec/user_crud.cy.ts
+++ b/cypress/e2e/users_spec/user_crud.cy.ts
@@ -187,9 +187,6 @@ describe("Edit Profile Testing", () => {
 
   it("Invalid Whatsapp Number of " + username, () => {
     const whatsapp_num = "11111-11111";
-
-    cy.get(".flag-dropdown").last().find(".arrow").click();
-    cy.get("li[data-flag-key='flag_no_84']").click();
     cy.get("[placeholder='WhatsApp Number']")
       .focus()
       .type(`${backspace}${whatsapp_num}`)
@@ -207,9 +204,6 @@ describe("Edit Profile Testing", () => {
 
   it("Valid Whatsapp Number of " + username, () => {
     const whatsapp_num = "91111-11111";
-
-    cy.get(".flag-dropdown").last().find(".arrow").click();
-    cy.get("li[data-flag-key='flag_no_84']").click();
     cy.get("[placeholder='WhatsApp Number']")
       .focus()
       .type(`${backspace}${whatsapp_num}`)
@@ -227,9 +221,6 @@ describe("Edit Profile Testing", () => {
 
   it("Invalid Phone Number of " + username, () => {
     const phone_num = "11111-11111";
-
-    cy.get(".flag-dropdown").first().find(".arrow").click();
-    cy.get("li[data-flag-key='flag_no_84']").click();
     cy.get("[placeholder='Phone Number']")
       .focus()
       .type(`${backspace}${phone_num}`)
@@ -247,9 +238,6 @@ describe("Edit Profile Testing", () => {
 
   it("Valid Phone Number of " + username, () => {
     const phone_num = "99999-99999";
-
-    cy.get(".flag-dropdown").first().find(".arrow").click();
-    cy.get("li[data-flag-key='flag_no_84']").click();
     cy.get("[placeholder='Phone Number']")
       .focus()
       .type(`${backspace}${phone_num}`)

--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -1,23 +1,25 @@
-import { useState, useEffect, MutableRefObject } from "react";
+import { MutableRefObject, useEffect, useState } from "react";
 import {
-  format,
-  subMonths,
   addMonths,
-  subYears,
   addYears,
-  isEqual,
-  getDaysInMonth,
+  format,
   getDay,
+  getDaysInMonth,
+  isEqual,
+  subMonths,
+  subYears,
 } from "date-fns";
+
+import CareIcon from "../../CAREUI/icons/CareIcon";
 import { Popover } from "@headlessui/react";
 import { classNames } from "../../Utils/utils";
-import CareIcon from "../../CAREUI/icons/CareIcon";
 
 type DatePickerType = "date" | "month" | "year";
 export type DatePickerPosition = "LEFT" | "RIGHT" | "CENTER";
 
 interface Props {
   id?: string;
+  name?: string;
   className?: string;
   value: Date | undefined;
   min?: Date;
@@ -34,6 +36,7 @@ const DAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
 const DateInputV2: React.FC<Props> = ({
   id,
+  name,
   className,
   value,
   min,
@@ -215,6 +218,7 @@ const DateInputV2: React.FC<Props> = ({
                 <input type="hidden" name="date" />
                 <input
                   id={id}
+                  name={name}
                   type="text"
                   readOnly
                   disabled={disabled}

--- a/src/Components/Common/HelperInputFields.tsx
+++ b/src/Components/Common/HelperInputFields.tsx
@@ -686,7 +686,7 @@ export const LegacyPhoneNumberField = (props: any) => {
             country={undefined}
             enableLongNumbers={true}
             buttonClass="hidden"
-            inputProps={{ id, name, maxLength }}
+            inputProps={{ id, name: enableTollFree ? name : "", maxLength }}
           />
           <ButtonV2
             className="mt-[2px]"
@@ -718,7 +718,7 @@ export const LegacyPhoneNumberField = (props: any) => {
             disabled={disabled}
             autoFormat={!turnOffAutoFormat}
             enableLongNumbers={true}
-            inputProps={{ id, name, maxLength }}
+            inputProps={{ id, name: enableTollFree ? "" : name, maxLength }}
             {...countryRestriction}
           />
           <ButtonV2

--- a/src/Components/Form/FormFields/DateFormField.tsx
+++ b/src/Components/Form/FormFields/DateFormField.tsx
@@ -1,7 +1,8 @@
-import { classNames } from "../../../Utils/utils";
 import DateInputV2, { DatePickerPosition } from "../../Common/DateInputV2";
-import FormField from "./FormField";
 import { FormFieldBaseProps, useFormFieldPropsResolver } from "./Utils";
+
+import FormField from "./FormField";
+import { classNames } from "../../../Utils/utils";
 
 type Props = FormFieldBaseProps<Date> & {
   placeholder?: string;
@@ -33,6 +34,7 @@ const DateFormField = (props: Props) => {
       <DateInputV2
         className={classNames(field.error && "border-red-500")}
         id={field.id}
+        name={field.name}
         value={field.value}
         onChange={field.handleChange}
         disabled={field.disabled}

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -1,48 +1,49 @@
-import loadable from "@loadable/component";
-import { Link, navigate } from "raviger";
-import { parsePhoneNumberFromString } from "libphonenumber-js";
-import moment from "moment";
-import React, { useEffect, useState, useCallback } from "react";
-import { useDispatch } from "react-redux";
-import SwipeableViews from "react-swipeable-views";
-import FacilitiesSelectDialogue from "../ExternalResult/FacilitiesSelectDialogue";
-import { Tooltip } from "@material-ui/core";
+import * as Notification from "../../Utils/Notifications.js";
 
-import {
-  getAllPatient,
-  getDistrict,
-  getLocalBody,
-  getAnyFacility,
-} from "../../Redux/actions";
-import NavTabs from "../Common/NavTabs";
 import {
   ADMITTED_TO,
   GENDER_TYPES,
   PATIENT_CATEGORIES,
-  RESPIRATORY_SUPPORT,
   PATIENT_SORT_OPTIONS,
+  RESPIRATORY_SUPPORT,
   TELEMEDICINE_ACTIONS,
 } from "../../Common/constants";
-import PatientFilter from "./PatientFilter";
-import { parseOptionId } from "../../Common/utils";
-import { statusType, useAbortableEffect } from "../../Common/utils";
-import Chip from "../../CAREUI/display/Chip";
 import { FacilityModel, PatientCategory } from "../Facility/models";
-import SearchInput from "../Form/SearchInput";
-import useFilters from "../../Common/hooks/useFilters";
-import FilterBadge from "../../CAREUI/display/FilterBadge";
-import CareIcon from "../../CAREUI/icons/CareIcon";
-import ButtonV2 from "../Common/components/ButtonV2";
-import { ExportMenu } from "../Common/Export";
-import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
-import { FieldChangeEvent } from "../Form/FormFields/Utils";
-import RecordMeta from "../../CAREUI/display/RecordMeta";
-import DoctorVideoSlideover from "../Facility/DoctorVideoSlideover";
-import CountBlock from "../../CAREUI/display/Count";
-import { useTranslation } from "react-i18next";
-import * as Notification from "../../Utils/Notifications.js";
+import { Link, navigate } from "raviger";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  getAllPatient,
+  getAnyFacility,
+  getDistrict,
+  getLocalBody,
+} from "../../Redux/actions";
+import { statusType, useAbortableEffect } from "../../Common/utils";
+
 import { AdvancedFilterButton } from "../../CAREUI/interactive/FiltersSlideover";
+import ButtonV2 from "../Common/components/ButtonV2";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import Chip from "../../CAREUI/display/Chip";
+import CountBlock from "../../CAREUI/display/Count";
+import DoctorVideoSlideover from "../Facility/DoctorVideoSlideover";
+import { ExportMenu } from "../Common/Export";
+import FacilitiesSelectDialogue from "../ExternalResult/FacilitiesSelectDialogue";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
+import FilterBadge from "../../CAREUI/display/FilterBadge";
+import NavTabs from "../Common/NavTabs";
+import PatientFilter from "./PatientFilter";
+import PhoneNumberFormField from "../Form/FormFields/PhoneNumberFormField";
+import RecordMeta from "../../CAREUI/display/RecordMeta";
+import SearchInput from "../Form/SearchInput";
 import SortDropdownMenu from "../Common/SortDropdown";
+import SwipeableViews from "react-swipeable-views";
+import { Tooltip } from "@material-ui/core";
+import loadable from "@loadable/component";
+import moment from "moment";
+import { parseOptionId } from "../../Common/utils";
+import { parsePhoneNumberFromString } from "libphonenumber-js";
+import { useDispatch } from "react-redux";
+import useFilters from "../../Common/hooks/useFilters";
+import { useTranslation } from "react-i18next";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -492,6 +493,7 @@ export const PatientManager = () => {
       return (
         <Link
           key={`usr_${patient.id}`}
+          data-cy="patient"
           href={patientUrl}
           className={`relative w-full cursor-pointer p-4 pl-5 hover:pl-5 rounded-lg bg-white shadow text-black ring-2 ring-opacity-0 hover:ring-opacity-100 transition-all duration-200 ease-in-out group ${categoryClass}-ring overflow-hidden`}
         >


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70a3ead</samp>

The pull request improves the test code for death report and user CRUD operations, fixes bugs and adds features to some common components, and adds name attributes to date inputs. It also sorts imports alphabetically in several files for consistency and adds `data-cy` attributes for testing.

## Proposed Changes

- Fix death_report_spec, facility_spec and user_spec

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70a3ead</samp>

*  Sort imports alphabetically in `cypress/e2e/death_report_spec/death_report.cy.ts`, `src/Components/Common/DateInputV2.tsx`, `src/Components/Form/FormFields/DateFormField.tsx`, and `src/Components/Patient/ManagePatients.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-75b5acdff6ee9f24dbdab837264b7c727f5a0a6e9bbaab55dbce16f89b0d6c9fL1-R1), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL1-R15), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-edd3d02a61529b620ebb6665c63339d9aa4b9ec64ee989ebb46e62dcad8d5870L1-R6), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L1-R46))
*  Use intercept and wait for API call to get patients list and click on first patient link in `cypress/e2e/death_report_spec/death_report.cy.ts` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-75b5acdff6ee9f24dbdab837264b7c727f5a0a6e9bbaab55dbce16f89b0d6c9fL15-R18))
*  Use `force` option to clear and type date inputs in `cypress/e2e/death_report_spec/death_report.cy.ts` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-75b5acdff6ee9f24dbdab837264b7c727f5a0a6e9bbaab55dbce16f89b0d6c9fL38-R56), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-75b5acdff6ee9f24dbdab837264b7c727f5a0a6e9bbaab55dbce16f89b0d6c9fL54-R67))
*  Add `name` prop to `Props` interface and pass it to `input` element in `src/Components/Common/DateInputV2.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bR22), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bR39), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bR221))
*  Pass `name` prop to `DateInputV2` component in `src/Components/Form/FormFields/DateFormField.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-edd3d02a61529b620ebb6665c63339d9aa4b9ec64ee989ebb46e62dcad8d5870R37))
*  Conditionally set `name` attribute for phone number inputs in `src/Components/Common/HelperInputFields.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-6d6ddd2689858ca12b7f23de6110fe80fa360e0adf05945a19ef6def218ab097L689-R689), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-6d6ddd2689858ca12b7f23de6110fe80fa360e0adf05945a19ef6def218ab097L721-R721))
*  Add `data-cy` attribute to patient link element in `src/Components/Patient/ManagePatients.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R496))
*  Copy and modify code from `cypress/e2e/facility_spec/facility.cy.ts` to use `name` attribute instead of `id` for phone number input in `cypress/e2e/death_report_spec/death_report.cy.ts` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-8f83566c5ff03dc3e5b39f6886960f41f769619afd2ad4818387c4335fb88453L76-R76))
*  Remove irrelevant and error-causing code for flag dropdown element in `cypress/e2e/users_spec/user_crud.cy.ts` ([link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-e67a0213157496a67503f421a72b4e510886da71661a6cd810c2fc1c094b93f0L190-L192), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-e67a0213157496a67503f421a72b4e510886da71661a6cd810c2fc1c094b93f0L210-L212), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-e67a0213157496a67503f421a72b4e510886da71661a6cd810c2fc1c094b93f0L230-L232), [link](https://github.com/coronasafe/care_fe/pull/5573/files?diff=unified&w=0#diff-e67a0213157496a67503f421a72b4e510886da71661a6cd810c2fc1c094b93f0L250-L252))
