### PR TITLE
Make buttons full width in mobile view

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1582,7 +1582,7 @@ export const FileUpload = (props: FileUploadProps) => {
                     <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
                       {({ isAuthorized }) =>
                         isAuthorized ? (
-                          <label className="font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1 button-size-default justify-center button-shape-square button-primary-default">
+                          <label className="w-full md:w-auto font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1 button-size-default justify-center button-shape-square button-primary-default">
                             <CareIcon className="care-l-file-upload-alt text-lg" />
                             {t("choose_file")}
                             <input
@@ -1597,7 +1597,10 @@ export const FileUpload = (props: FileUploadProps) => {
                         )
                       }
                     </AuthorizedChild>
-                    <ButtonV2 onClick={() => setModalOpenForCamera(true)}>
+                    <ButtonV2
+                      onClick={() => setModalOpenForCamera(true)}
+                      className="w-full md:w-auto"
+                    >
                       <CareIcon className="care-l-camera text-lg mr-2" />
                       Open Camera
                     </ButtonV2>
@@ -1605,6 +1608,7 @@ export const FileUpload = (props: FileUploadProps) => {
                       authorizeFor={NonReadOnlyUsers}
                       disabled={!file || !uploadFileName || !isActive}
                       onClick={() => handleUpload({ status })}
+                      className="w-full md:w-auto"
                     >
                       <CareIcon className="care-l-cloud-upload text-lg" />
                       {t("upload")}


### PR DESCRIPTION
## Proposed Changes

- Fixes #5575 
http://localhost:4000/sample/fea2e04e-31a9-4d53-bbba-164cff6e2538
Made the `Choose File`, `Open Camera`, and `Upload` buttons full width in mobile view on the samples page.
![image](https://github.com/coronasafe/care_fe/assets/70687348/cd90dcae-253f-4eb7-815b-942ea0783d09)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 528a136</samp>

*  Make file upload and camera buttons responsive and consistent by adding `w-full md:w-auto` class to their `label` and `ButtonV2` elements ([link](https://github.com/coronasafe/care_fe/pull/5576/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1585-R1585), [link](https://github.com/coronasafe/care_fe/pull/5576/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1600-R1603), [link](https://github.com/coronasafe/care_fe/pull/5576/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R1611)) in `FileUpload.tsx`
