### PR TITLE
fixed space between space between the KASP and View CNS button in facility card

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -83,7 +83,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
               <div className="px-4 py-4 w-full">
                 <div className="flow-root">
                   {facility.kasp_empanelled && (
-                    <div className="float-right mt-2 inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium leading-5 bg-yellow-100 text-yellow-800">
+                    <div className="float-right mt-2 ml-2 inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium leading-5 bg-yellow-100 text-yellow-800">
                       {kasp_string}
                     </div>
                   )}


### PR DESCRIPTION
### WHAT
Minor bug in UI of Facility Card there is no space between the KASP and View CNS button

## Proposed Changes

- Fixes #5577?
- Added `ml-2` tailwind class for left margin 0.5rem/8px to the kasp div in `FacilityCard.tsx`
![image](https://github.com/coronasafe/care_fe/assets/54521651/33e78809-b2cc-4441-91d6-9431ffa87727)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80a45d7</samp>

* Add a left margin to the KASP badge on the facility card to improve alignment and readability ([link](https://github.com/coronasafe/care_fe/pull/5578/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L86-R86))
