### PR TITLE
replaced deprecated Material UI function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom";
 import reducer from "../src/Redux/Reducer";
-import { createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
+import { createTheme, ThemeProvider } from "@material-ui/core/styles";
 import App from "./App";
 import "./i18n";
 import { applyMiddleware, createStore } from "redux";
@@ -8,10 +8,10 @@ import thunk from "redux-thunk";
 import { Provider } from "react-redux";
 import * as Sentry from "@sentry/browser";
 import "./style/index.css";
-import { registerSW } from "virtual:pwa-register"
+import { registerSW } from "virtual:pwa-register";
 
 if (import.meta.env.PROD) {
-  registerSW({ immediate: false })
+  registerSW({ immediate: false });
 }
 
 const store = createStore(reducer, applyMiddleware(thunk));
@@ -22,7 +22,7 @@ if (import.meta.env.PROD) {
   });
 }
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: "#0e9f6e",


### PR DESCRIPTION
### WHAT
Replaced `createMuiTheme` to `createTheme`.

## Proposed Changes

- Fixes #5581 
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a17fbb</samp>

*  Rename `createMuiTheme` to `createTheme` to migrate to Material-UI v5 ([link](https://github.com/coronasafe/care_fe/pull/5582/files?diff=unified&w=0#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L3-R3), [link](https://github.com/coronasafe/care_fe/pull/5582/files?diff=unified&w=0#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L25-R25))
*  Add missing semicolons for code style and error prevention ([link](https://github.com/coronasafe/care_fe/pull/5582/files?diff=unified&w=0#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L11-R14))