### PR TITLE
feat: Temperature preference stored in local storage

### DIFF
--- a/src/Components/Common/TemperatureSelector.tsx
+++ b/src/Components/Common/TemperatureSelector.tsx
@@ -21,8 +21,12 @@ export const TemperatureSelector = (props: any) => {
       );
     }
   }
-  window.addEventListener("storage", handleLocalTemperatureChange);
-  window.removeEventListener("storage", handleLocalTemperatureChange);
+  useEffect(() => {
+    window.addEventListener("storage", handleLocalTemperatureChange);
+    return () => {
+      window.removeEventListener("storage", handleLocalTemperatureChange);
+    };
+  }, []);
 
   useEffect(() => {
     handleTemperature(temperature);

--- a/src/Components/Common/TemperatureSelector.tsx
+++ b/src/Components/Common/TemperatureSelector.tsx
@@ -1,40 +1,44 @@
 import { useEffect, useState } from "react";
 import { classNames } from "../../Utils/utils";
 import { SelectFormField } from "../Form/FormFields/SelectFormField";
+import { getTemperaturePreference } from "../Common/utils/DevicePreference";
 
 export const TemperatureSelector = (props: any) => {
-  const getTemperaturePreferance = () => {
-    if (window && window.localStorage) {
-      return localStorage.getItem("temperature");
-    }
-  };
   const [temperature, setTemperature] = useState<string>(
-    getTemperaturePreferance() === "Fahrenheit (°F)"
-      ? "Fahrenheit (°F)"
-      : "Celsius (°C)"
+    getTemperaturePreference() === "F" ? "Fahrenheit (°F)" : "Celsius (°C)"
   );
   const handleTemperature = (value: string) => {
     setTemperature(value);
     if (window && window.localStorage) {
-      localStorage.setItem("temperature", value);
+      localStorage.setItem("temperature", value?.charAt(0));
     }
   };
+
+  function handleLocalTemperatureChange(e: any) {
+    if (e.key === "temperature") {
+      setTemperature(
+        getTemperaturePreference() === "F" ? "Fahrenheit (°F)" : "Celsius (°C)"
+      );
+    }
+  }
+  window.addEventListener("storage", handleLocalTemperatureChange);
+  window.removeEventListener("storage", handleLocalTemperatureChange);
 
   useEffect(() => {
     handleTemperature(temperature);
   }, [temperature]);
 
   return (
-    <div className="flex justify-end items-center relative w-full">
-      <SelectFormField
-        className={classNames(props.className)}
-        id="temperature-selector"
-        name="temperature"
-        value={temperature}
-        onChange={({ value }) => handleTemperature(value)}
-        options={["Celsius (°C)", "Fahrenheit (°F)"]}
-        optionLabel={(o) => o}
-      />
-    </div>
+    <SelectFormField
+      className={classNames(props.className)}
+      id="temperature-selector"
+      name="temperature"
+      value={temperature}
+      errorClassName="hidden"
+      onChange={({ value }) => handleTemperature(value)}
+      options={["Celsius (°C)", "Fahrenheit (°F)"]}
+      optionLabel={(o) => o}
+      optionValue={(o) => o}
+    />
   );
 };

--- a/src/Components/Common/TemperatureSelector.tsx
+++ b/src/Components/Common/TemperatureSelector.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { classNames } from "../../Utils/utils";
+import { SelectFormField } from "../Form/FormFields/SelectFormField";
+
+export const TemperatureSelector = (props: any) => {
+  const getTemperaturePreferance = () => {
+    if (window && window.localStorage) {
+      return localStorage.getItem("temperature");
+    }
+  };
+  const [temperature, setTemperature] = useState<string>(
+    getTemperaturePreferance() === "Fahrenheit (°F)"
+      ? "Fahrenheit (°F)"
+      : "Celsius (°C)"
+  );
+  const handleTemperature = (value: string) => {
+    setTemperature(value);
+    if (window && window.localStorage) {
+      localStorage.setItem("temperature", value);
+    }
+  };
+
+  useEffect(() => {
+    handleTemperature(temperature);
+  }, [temperature]);
+
+  return (
+    <div className="flex justify-end items-center relative w-full">
+      <SelectFormField
+        className={classNames(props.className)}
+        id="temperature-selector"
+        name="temperature"
+        value={temperature}
+        onChange={({ value }) => handleTemperature(value)}
+        options={["Celsius (°C)", "Fahrenheit (°F)"]}
+        optionLabel={(o) => o}
+      />
+    </div>
+  );
+};

--- a/src/Components/Common/utils/DevicePreference.tsx
+++ b/src/Components/Common/utils/DevicePreference.tsx
@@ -1,0 +1,7 @@
+export function getTemperaturePreference(): "C" | "F" {
+  if (window && window.localStorage) {
+    const temp = localStorage.getItem("temperature");
+    if (temp === "F" || temp === "C") return temp;
+  }
+  return "C";
+}

--- a/src/Components/Facility/Consultations/DailyRounds/VirtualNursingAssistantLogUpdateCard.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/VirtualNursingAssistantLogUpdateCard.tsx
@@ -37,6 +37,7 @@ const extractVirtualNursingAssistantFields = (round?: DailyRoundsModel) => {
   if (!round) return;
   const {
     temperature,
+    tempratureUnit,
     temperature_measured_at,
     bp,
     resp,
@@ -47,6 +48,7 @@ const extractVirtualNursingAssistantFields = (round?: DailyRoundsModel) => {
 
   return {
     temperature,
+    tempratureUnit,
     temperature_measured_at,
     bp,
     resp,

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -9,6 +9,8 @@ import VirtualNursingAssistantLogUpdateCard from "./DailyRounds/VirtualNursingAs
 import DefaultLogUpdateCard from "./DailyRounds/DefaultLogUpdateCard";
 import { useTranslation } from "react-i18next";
 import LoadingLogUpdateCard from "./DailyRounds/LoadingCard";
+import { getTemperaturePreference } from "../../Common/utils/DevicePreference";
+import { fahrenheitToCelsius } from "../../../Utils/utils";
 
 export const DailyRoundsList = (props: any) => {
   const { t } = useTranslation();
@@ -44,7 +46,16 @@ export const DailyRoundsList = (props: any) => {
       );
       if (!status.aborted) {
         if (res && res.data) {
+          res.data.results.forEach((round: DailyRoundsModel) => {
+            round.temperatureUnit = getTemperaturePreference();
+            round.temperature =
+              round.temperatureUnit === "F"
+                ? round.temperature
+                : fahrenheitToCelsius(round.temperature);
+            return round;
+          });
           setDailyRoundsListData(res.data.results);
+          console.log(res.data.results);
           setTotalCount(res.data.count);
         }
         setIsDailyRoundLoading(false);
@@ -95,6 +106,7 @@ export const DailyRoundsList = (props: any) => {
 
       return (
         <DefaultLogUpdateCard
+          key={itemData.id}
           round={itemData}
           consultationData={consultationData}
           onViewDetails={() => {

--- a/src/Components/Patient/DailyRoundListDetails.tsx
+++ b/src/Components/Patient/DailyRoundListDetails.tsx
@@ -21,9 +21,6 @@ export const DailyRoundListDetails = (props: any) => {
   const [dailyRoundListDetailsData, setDailyRoundListDetails] =
     useState<DailyRoundsModel>({});
   const [isLoading, setIsLoading] = useState(false);
-  const [temperatureUnit, setTemperatureUnit] = useState(
-    getTemperaturePreference()
-  );
 
   const fetchpatient = useCallback(
     async (status: statusType) => {
@@ -40,10 +37,11 @@ export const DailyRoundListDetails = (props: any) => {
           const data: DailyRoundsModel = {
             ...res.data,
             temperature: Number(res.data.temperature)
-              ? temperatureUnit === "C"
-                ? fahrenheitToCelsius(Number(res.data.temperature))
-                : res.data.temperature
+              ? getTemperaturePreference() === "F"
+                ? res.data.temperature
+                : fahrenheitToCelsius(Number(res.data.temperature))
               : "",
+            temperatureUnit: getTemperaturePreference(),
             additional_symptoms_text: "",
             medication_given:
               Object.keys(res.data.medication_given).length === 0
@@ -80,23 +78,30 @@ export const DailyRoundListDetails = (props: any) => {
   );
 
   const toggleTemperatureOnLocalChange = () => {
-    const isCelcius = temperatureUnit === "C" ? true : false;
+    const isCelcius =
+      dailyRoundListDetailsData.temperatureUnit === "C" ? true : false;
     const temp = dailyRoundListDetailsData.temperature;
 
     const data = { ...dailyRoundListDetailsData };
     data.temperature = isCelcius
-      ? celsiusToFahrenheit(Number(temp))
-      : fahrenheitToCelsius(Number(temp));
-    setTemperatureUnit(temperatureUnit === "C" ? "F" : "C");
+      ? celsiusToFahrenheit(temp)
+      : fahrenheitToCelsius(temp);
+    data.temperatureUnit = isCelcius ? "F" : "C";
     setDailyRoundListDetails(data);
   };
 
   const handleLocalTemperatureChange = (e: any) => {
     if (e.key === "temperature") {
-      if (temperatureUnit === "C" && e.newValue === "F") {
+      if (
+        dailyRoundListDetailsData.temperatureUnit === "C" &&
+        e.newValue === "F"
+      ) {
         toggleTemperatureOnLocalChange();
       }
-      if (temperatureUnit === "F" && e.newValue === "C") {
+      if (
+        dailyRoundListDetailsData.temperatureUnit === "F" &&
+        e.newValue === "C"
+      ) {
         toggleTemperatureOnLocalChange();
       }
     }
@@ -152,7 +157,7 @@ export const DailyRoundListDetails = (props: any) => {
         <div className="mt-4 grid gap-4 grid-cols-1 md:grid-cols-2">
           <div>
             <span className="font-semibold leading-relaxed">Temperature: </span>
-            {`${dailyRoundListDetailsData.temperature} °${temperatureUnit}` ||
+            {`${dailyRoundListDetailsData.temperature} °${dailyRoundListDetailsData.temperatureUnit}` ||
               "-"}
           </div>
           <div>

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -158,7 +158,7 @@ export const DailyRounds = (props: any) => {
             tempInCelsius: getTemperaturePreference() === "C" ? true : false,
             temperature:
               getTemperaturePreference() === "C"
-                ? fahrenheitToCelsius(Number(res.data.temperature))
+                ? fahrenheitToCelsius(res.data.temperature)
                 : res.data.temperature,
             admitted_to: res.data.admitted_to ? res.data.admitted_to : "Select",
           };
@@ -297,7 +297,7 @@ export const DailyRounds = (props: any) => {
             pulse: state.form.pulse,
             resp: Number(state.form.resp),
             temperature: state.form.tempInCelsius
-              ? celsiusToFahrenheit(Number(state.form.temperature))
+              ? celsiusToFahrenheit(state.form.temperature)
               : state.form.temperature,
             rhythm: Number(state.form.rhythm) || 0,
             rhythm_detail: state.form.rhythm_detail,
@@ -483,8 +483,8 @@ export const DailyRounds = (props: any) => {
 
     const form = { ...state.form };
     form.temperature = isCelsius
-      ? celsiusToFahrenheit(Number(temp))
-      : fahrenheitToCelsius(Number(temp));
+      ? celsiusToFahrenheit(temp)
+      : fahrenheitToCelsius(temp);
     form.tempInCelsius = !isCelsius;
     dispatch({ type: "set_form", form });
   };

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -40,7 +40,7 @@ import { FieldLabel } from "../Form/FormFields/FormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
-import { celciusToFahrenheit, fahrenheitToCelcius } from "../../Utils/utils";
+import { celsiusToFahrenheit, fahrenheitToCelsius } from "../../Utils/utils";
 import { getTemperaturePreference } from "../Common/utils/DevicePreference";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -64,7 +64,7 @@ const initForm: any = {
   diastolic: null,
   pulse: null,
   resp: null,
-  tempInCelcius: false,
+  tempInCelsius: false,
   temperature: null,
   rhythm: "0",
   rhythm_detail: "",
@@ -155,10 +155,10 @@ export const DailyRounds = (props: any) => {
                   (i) => i.text === res.data.patient_category
                 )?.id || "Comfort"
               : "Comfort",
-            tempInCelcius: getTemperaturePreference() === "C" ? true : false,
+            tempInCelsius: getTemperaturePreference() === "C" ? true : false,
             temperature:
               getTemperaturePreference() === "C"
-                ? fahrenheitToCelcius(res.data.temperature)
+                ? fahrenheitToCelsius(Number(res.data.temperature))
                 : res.data.temperature,
             admitted_to: res.data.admitted_to ? res.data.admitted_to : "Select",
           };
@@ -296,8 +296,8 @@ export const DailyRounds = (props: any) => {
                 : undefined,
             pulse: state.form.pulse,
             resp: Number(state.form.resp),
-            temperature: state.form.tempInCelcius
-              ? celciusToFahrenheit(state.form.temperature)
+            temperature: state.form.tempInCelsius
+              ? celsiusToFahrenheit(Number(state.form.temperature))
               : state.form.temperature,
             rhythm: Number(state.form.rhythm) || 0,
             rhythm_detail: state.form.rhythm_detail,
@@ -478,27 +478,32 @@ export const DailyRounds = (props: any) => {
   };
 
   const toggleTemperature = () => {
-    const isCelcius = state.form.tempInCelcius;
+    const isCelsius = state.form.tempInCelsius;
     const temp = state.form.temperature;
 
     const form = { ...state.form };
-    form.temperature = isCelcius
-      ? celciusToFahrenheit(temp)
-      : fahrenheitToCelcius(temp);
-    form.tempInCelcius = !isCelcius;
+    form.temperature = isCelsius
+      ? celsiusToFahrenheit(Number(temp))
+      : fahrenheitToCelsius(Number(temp));
+    form.tempInCelsius = !isCelsius;
     dispatch({ type: "set_form", form });
   };
 
   function handleLocalTemperatureChange(e: any) {
     if (e.key === "temperature") {
-      if (e.oldValue === "C" && e.newValue === "F") {
+      if (e.newValue === "F" && state.form.tempInCelsius) {
         toggleTemperature();
-      } else if (e.oldValue === "F" && e.newValue === "C") {
+      } else if (e.newValue === "C" && !state.form.tempInCelsius) {
         toggleTemperature();
       }
     }
   }
-  window.addEventListener("storage", handleLocalTemperatureChange);
+  useEffect(() => {
+    window.addEventListener("storage", handleLocalTemperatureChange);
+    return () => {
+      window.removeEventListener("storage", handleLocalTemperatureChange);
+    };
+  }, [state.form.temperature]);
 
   if (isLoading) {
     return <Loading />;
@@ -806,7 +811,7 @@ export const DailyRounds = (props: any) => {
                         <div>
                           <FieldLabel className="flex flex-row justify-between">
                             Temperature{" "}
-                            {state.form.tempInCelcius
+                            {state.form.tempInCelsius
                               ? getStatus(
                                   36.4,
                                   "Low",
@@ -830,7 +835,7 @@ export const DailyRounds = (props: any) => {
                                 variant="standard"
                                 value={state.form.temperature}
                                 options={
-                                  state.form.tempInCelcius
+                                  state.form.tempInCelsius
                                     ? generateOptions(35, 41, 0.1, 1)
                                     : generateOptions(95, 106, 0.1, 1)
                                 }
@@ -858,7 +863,7 @@ export const DailyRounds = (props: any) => {
                             >
                               <span className="text-blue-700">
                                 {" "}
-                                {state.form.tempInCelcius ? "C" : "F"}{" "}
+                                {state.form.tempInCelsius ? "C" : "F"}{" "}
                               </span>
                             </div>
                           </div>

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -40,6 +40,8 @@ import { FieldLabel } from "../Form/FormFields/FormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
+import { celciusToFahrenheit, fahrenheitToCelcius } from "../../Utils/utils";
+import { getTemperaturePreference } from "../Common/utils/DevicePreference";
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
 
@@ -153,6 +155,11 @@ export const DailyRounds = (props: any) => {
                   (i) => i.text === res.data.patient_category
                 )?.id || "Comfort"
               : "Comfort",
+            tempInCelcius: getTemperaturePreference() === "C" ? true : false,
+            temperature:
+              getTemperaturePreference() === "C"
+                ? fahrenheitToCelcius(res.data.temperature)
+                : res.data.temperature,
             admitted_to: res.data.admitted_to ? res.data.admitted_to : "Select",
           };
           dispatch({ type: "set_form", form: data });
@@ -227,16 +234,6 @@ export const DailyRounds = (props: any) => {
     });
     dispatch({ type: "set_error", errors });
     return !invalidForm;
-  };
-
-  const fahrenheitToCelcius = (x: any) => {
-    const t = (Number(x) - 32.0) * (5.0 / 9.0);
-    return String(t.toFixed(1));
-  };
-
-  const celciusToFahrenheit = (x: any) => {
-    const t = (Number(x) * 9.0) / 5.0 + 32.0;
-    return String(t.toFixed(1));
   };
 
   const calculateMAP = (systolic: any, diastolic: any) => {
@@ -491,6 +488,17 @@ export const DailyRounds = (props: any) => {
     form.tempInCelcius = !isCelcius;
     dispatch({ type: "set_form", form });
   };
+
+  function handleLocalTemperatureChange(e: any) {
+    if (e.key === "temperature") {
+      if (e.oldValue === "C" && e.newValue === "F") {
+        toggleTemperature();
+      } else if (e.oldValue === "F" && e.newValue === "C") {
+        toggleTemperature();
+      }
+    }
+  }
+  window.addEventListener("storage", handleLocalTemperatureChange);
 
   if (isLoading) {
     return <Loading />;

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -260,6 +260,7 @@ export interface DailyRoundsModel {
   pulse?: number;
   resp?: number;
   temperature?: string;
+  temperatureUnit?: "C" | "F";
   temperature_measured_at?: string;
   physical_examination_info?: string;
   other_details?: string;

--- a/src/Components/Users/UserProfile.tsx
+++ b/src/Components/Users/UserProfile.tsx
@@ -23,6 +23,7 @@ import { SelectFormField } from "../Form/FormFields/SelectFormField";
 import moment from "moment";
 import { SkillModel, SkillObjectModel } from "../Users/models";
 import UpdatableApp, { checkForUpdate } from "../Common/UpdatableApp";
+import { TemperatureSelector } from "../Common/TemperatureSelector";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -705,6 +706,21 @@ export default function UserProfile() {
           </div>
           <div className="mt-5 md:mt-0 md:col-span-2">
             <LanguageSelector className="bg-white w-full" />
+          </div>
+        </div>
+        <div className="md:grid md:grid-cols-3 md:gap-6 mt-6 mb-8">
+          <div className="md:col-span-1">
+            <div className="px-4 sm:px-0">
+              <h3 className="text-lg font-medium leading-6 text-gray-900">
+                Temperature Unit
+              </h3>
+              <p className="mt-1 text-sm leading-5 text-gray-600">
+                Set your temperature unit preference
+              </p>
+            </div>
+          </div>
+          <div className="mt-5 md:mt-0 md:col-span-2">
+            <TemperatureSelector className="bg-white w-full" />
           </div>
         </div>
         <div className="md:grid md:grid-cols-3 md:gap-6 mt-6 mb-8">

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -225,12 +225,14 @@ export const formatCurrency = (price: number) =>
     currency: "INR",
   });
 
-export const fahrenheitToCelsius = (x: number) => {
-  const t = (x - 32.0) * (5.0 / 9.0);
+export const fahrenheitToCelsius = (x: any) => {
+  if (x === null || x === undefined) return x;
+  const t = (Number(x) - 32.0) * (5.0 / 9.0);
   return String(t.toFixed(1));
 };
 
-export const celsiusToFahrenheit = (x: number) => {
-  const t = (x * 9.0) / 5.0 + 32.0;
+export const celsiusToFahrenheit = (x: any) => {
+  if (x === null || x === undefined) return x;
+  const t = (Number(x) * 9.0) / 5.0 + 32.0;
   return String(t.toFixed(1));
 };

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -224,3 +224,13 @@ export const formatCurrency = (price: number) =>
     style: "currency",
     currency: "INR",
   });
+
+export const fahrenheitToCelcius = (x: any) => {
+  const t = (Number(x) - 32.0) * (5.0 / 9.0);
+  return String(t.toFixed(1));
+};
+
+export const celciusToFahrenheit = (x: any) => {
+  const t = (Number(x) * 9.0) / 5.0 + 32.0;
+  return String(t.toFixed(1));
+};

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -225,12 +225,12 @@ export const formatCurrency = (price: number) =>
     currency: "INR",
   });
 
-export const fahrenheitToCelcius = (x: any) => {
-  const t = (Number(x) - 32.0) * (5.0 / 9.0);
+export const fahrenheitToCelsius = (x: number) => {
+  const t = (x - 32.0) * (5.0 / 9.0);
   return String(t.toFixed(1));
 };
 
-export const celciusToFahrenheit = (x: any) => {
-  const t = (Number(x) * 9.0) / 5.0 + 32.0;
+export const celsiusToFahrenheit = (x: number) => {
+  const t = (x * 9.0) / 5.0 + 32.0;
   return String(t.toFixed(1));
 };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4b8d2a</samp>

The pull request adds a temperature unit preference feature to the user profile. It introduces a new `TemperatureSelector` component that handles the user's choice and uses it in the `UserProfile` component.

## Proposed Changes

- Fixes #5463 
- Change 1 - Added option for user's temperature preference
- Change 2 - Storing preference in local storage
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4b8d2a</samp>

*  Add a new component `TemperatureSelector` to let the user choose between Celsius and Fahrenheit units for temperature ([link](https://github.com/coronasafe/care_fe/pull/5589/files?diff=unified&w=0#diff-609eb01d79da66e741dfb703cbeb1f1148344610b5edf3702a94a5398ea6c83bR1-R40))
*  Import and use the `TemperatureSelector` component in the `UserProfile` component, which shows and edits the user's profile information ([link](https://github.com/coronasafe/care_fe/pull/5589/files?diff=unified&w=0#diff-212e167063b7d0bd79ef5e31edcc0aa76904bfa277b7d6fa0966055cecc5064dR26), [link](https://github.com/coronasafe/care_fe/pull/5589/files?diff=unified&w=0#diff-212e167063b7d0bd79ef5e31edcc0aa76904bfa277b7d6fa0966055cecc5064dR715-R729))
*  Style the `TemperatureSelector` component to match the form layout and background color in the `UserProfile` component ([link](https://github.com/coronasafe/care_fe/pull/5589/files?diff=unified&w=0#diff-212e167063b7d0bd79ef5e31edcc0aa76904bfa277b7d6fa0966055cecc5064dR715-R729))
