### PR TITLE
Make mandatory validation in ONVIF camera and HL7 monitor asset page #3585

### DIFF
--- a/src/Components/Assets/AssetType/HL7Monitor.tsx
+++ b/src/Components/Assets/AssetType/HL7Monitor.tsx
@@ -59,7 +59,7 @@ const HL7Monitor = (props: HL7MonitorProps) => {
       const data = {
         meta: {
           asset_type: assetType,
-          middleware_hostname: middlewareHostname, // TODO: remove this infavour of facility.middleware_address
+          middleware_hostname: middlewareHostname, // TODO: remove this in favor of facility.middleware_address
           local_ip_address: localipAddress,
         },
       };
@@ -94,6 +94,7 @@ const HL7Monitor = (props: HL7MonitorProps) => {
                   label="Middleware Hostname"
                   value={middlewareHostname}
                   onChange={(e) => setMiddlewareHostname(e.value)}
+                  required // Added required attribute
                 />
                 <TextFormField
                   name="localipAddress"
@@ -125,4 +126,5 @@ const HL7Monitor = (props: HL7MonitorProps) => {
     </>
   );
 };
+
 export default HL7Monitor;

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -156,6 +156,10 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
     setLoadingAddPreset(false);
   };
 
+  const handleCameraAddressBlur = () => {
+    setIpAddressError("");
+  };
+
   if (isLoading) return <Loading />;
 
   return (
@@ -176,6 +180,7 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
             autoComplete="off"
             value={cameraAddress}
             onChange={({ value }) => setCameraAddress(value)}
+            onBlur={handleCameraAddressBlur} // Add onBlur event handler
             error={ipAddressError}
             required
           />

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -167,11 +167,11 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
       <form className="bg-white rounded shadow p-8" onSubmit={handleSubmit}>
         <div className="grid gap-x-4 grid-cols-1 lg:grid-cols-2">
           <TextFormField
+            value={middlewareHostname}
+            onChange={({ value }) => setMiddlewareHostname(value)}
             name="middleware_hostname"
             label="Hospital Middleware Hostname"
             autoComplete="off"
-            value={middlewareHostname}
-            onChange={({ value }) => setMiddlewareHostname(value)}
             required
           />
           <TextFormField


### PR DESCRIPTION
### WHAT
The fields in ONVIF camera and HL7 monitor asset page are not mandatory
![image](https://github.com/coronasafe/care_fe/assets/76262941/4a9cf8f0-3031-46d8-a39b-19a2beeff538)
![image](https://github.com/coronasafe/care_fe/assets/76262941/ed533569-a9d9-4f16-842b-01c36ca41ea9)

## Proposed Changes

- Fixes #3585 
- In ONVIFCamera.tsx
  - Added the required attribute to the TextFormField components for the fields "Hospital Middleware Hostname," "Local IP Address," "Username," "Password," and "Stream UUID" to make them required fields.
  - Added a validation check in the handleSubmit function to ensure all the required fields are filled. If any required field is empty, an error notification is shown, and the form submission is prevented.
  - Added a validation check in the handleSubmit function to validate the IP address entered in the "Local IP Address" field using the checkIfValidIP function. If the IP address is not valid, an error message is displayed, and the form submission is prevented.
- In HL7 Montior.tsx
  - Added the required attribute to the TextFormField component for that field.
![image](https://github.com/coronasafe/care_fe/assets/76262941/f1a7f73d-475f-40f7-acce-c589aa25be22)
![image](https://github.com/coronasafe/care_fe/assets/76262941/b84d6fe4-e5df-43da-9a8a-80ad799a71ac)
![image](https://github.com/coronasafe/care_fe/assets/76262941/aff7342e-ef1e-4d3c-a4ba-38b3330dd4c7)
![image](https://github.com/coronasafe/care_fe/assets/76262941/9f7bd4d6-e9c8-48ad-af4b-632254f24df6)
![image](https://github.com/coronasafe/care_fe/assets/76262941/41df51fc-e740-4c14-be60-163275f73781)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b11517</samp>

*  Fix typo and add required attribute to middleware hostname text field in `HL7Monitor.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL62-R62), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacR97))
* Remove empty line in `HL7Monitor.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacR129))
* Rename and validate state variable for IP address error in `ONVIFCamera.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL34-R34), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL74-R101), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL164-R180))
* Add error handling and notification logic to `handleSubmit` function in `ONVIFCamera.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL74-R101), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL95-R117), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL134-R153))
* Add required attributes to stream UUID, camera address, username, and password text fields in `ONVIFCamera.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR171), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL164-R180), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR188), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR197), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR208))
* Remove unnecessary Promise.resolve wrapper and extra dots from error messages in `ONVIFCamera.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL116-R136), [link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL134-R153))
* Remove empty line in `ONVIFCamera.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5590/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR236))
