### PR TITLE
Fixed overlapping buttons in Camera feed

### DIFF
--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -511,7 +511,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
             clickAction={() => cameraPTZ[4].callback()}
           />
         </div>
-        <div className="absolute bottom-8 right-8 grid grid-rows-3 grid-flow-col gap-1 z-10">
+        <div className="absolute bottom-8 left-8 grid grid-rows-3 grid-flow-col gap-1 z-10">
           {[
             false,
             cameraPTZ[2],


### PR DESCRIPTION
### WHAT
Minor UI changes: Fixed overlapping control buttons in Camera feed.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f31829</samp>

Improved the layout of the video consultation UI by moving the grid div with the media buttons to the left in `Feed.tsx`. This prevents the buttons from blocking the chat window.

## Proposed Changes
- Fixes #5595 
- Moved arrow controls away from other controls.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f31829</samp>

*  Moved the grid div with audio, video, and screen sharing buttons from right to left to avoid overlapping with the chat window ([link](https://github.com/coronasafe/care_fe/pull/5596/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L514-R514)). This improves the user interface of the video consultation feature in `Feed.tsx`.
