### PR TITLE
Cypress Test - Create Consultation For a new patient 

### DIFF
--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -48,7 +48,6 @@ describe("Patient Creation with consultation", () => {
     );
     cy.get("[data-testid=permanent-address] input").check();
     cy.get("#pincode").type("682001");
-    cy.wait(2000);
     cy.get("[data-testid=localbody] button")
       .click()
       .then(() => {
@@ -130,7 +129,7 @@ describe("Patient Creation with consultation", () => {
     )
       .click()
       .type("1A");
-    cy.wait(2000);
+    cy.wait(1000);
     cy.get("#icd11_diagnoses_object [role='option']")
       .contains("1A03 Intestinal infections due to Escherichia coli")
       .click();
@@ -141,7 +140,6 @@ describe("Patient Creation with consultation", () => {
     cy.contains("button", "Add Prescription Medication")
       .should("be.visible")
       .click();
-    cy.wait(1000);
     cy.get("div#medicine input[placeholder='Select'][role='combobox']")
       .click()
       .type("paracet");

--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -137,6 +137,26 @@ describe("Patient Creation with consultation", () => {
     cy.get("#consultation_notes").click().type("generalnote");
     cy.get("#verified_by").click().type("generalnote");
     cy.get("#submit").click();
+    // Below code for the prescription module only present while creating a new consultation
+    cy.contains("button", "Add Prescription Medication")
+      .should("be.visible")
+      .click();
+    cy.wait(1000);
+    cy.get("div#medicine input[placeholder='Select'][role='combobox']")
+      .click()
+      .type("paracet");
+    cy.get("div#medicine [role='option']")
+      .contains("PARACETAMOL TAB IP ,500 mg.")
+      .should("be.visible")
+      .click();
+    cy.get("#dosage").click().type("3");
+    cy.get("#frequency")
+      .click()
+      .then(() => {
+        cy.get("div#frequency [role='option']").contains("Twice daily").click();
+      });
+    cy.get("button#submit").should("be.visible").click();
+    cy.get("[data-testid='return-to-patient-dashboard']").click();
   });
   afterEach(() => {
     cy.saveLocalStorage();

--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -12,7 +12,7 @@ const calculateAge = () => {
   return currentYear - parseInt(yearOfBirth);
 };
 
-describe("Patient Creation", () => {
+describe("Patient Creation with consultation", () => {
   before(() => {
     cy.loginByApi(username, password);
     cy.saveLocalStorage();
@@ -23,7 +23,7 @@ describe("Patient Creation", () => {
     cy.awaitUrl("/patients");
   });
 
-  it("Create a patient", () => {
+  it("Create a new patient with no consultation", () => {
     cy.get("button").should("contain", "Add Patient Details");
     cy.get("#add-patient-div").click();
     cy.get("input[name='facilities']")
@@ -43,34 +43,22 @@ describe("Patient Creation", () => {
       .then(() => {
         cy.get("[role='option']").contains("Male").click();
       });
-    cy.get("[data-testid=state] button")
-      .click()
-      .then(() => {
-        cy.get("[role='option']").contains("Kerala").click();
-      });
-    cy.get("[data-testid=district] button")
-      .click()
-      .then(() => {
-        cy.get("[role='option']").contains("Ernakulam").click();
-      });
+    cy.get("[data-testid=current-address] textarea").type(
+      "Test Patient Address"
+    );
+    cy.get("[data-testid=permanent-address] input").check();
+    cy.get("#pincode").type("682001");
+    cy.wait(2000);
     cy.get("[data-testid=localbody] button")
       .click()
       .then(() => {
         cy.get("[role='option']").first().click();
       });
-    cy.get("[data-testid=current-address] textarea").type(
-      "Test Patient Address"
-    );
-    cy.get("[data-testid=permanent-address] input").check();
     cy.get("[data-testid=ward-respective-lsgi] button")
       .click()
       .then(() => {
         cy.get("[role='option']").contains("1: PAZHAMTHOTTAM").click();
       });
-    cy.get("button").contains("COVID Details").click();
-    cy.get("select#test_type").select("ANTIGEN");
-    cy.get("[name='is_vaccinated']").check();
-    cy.get("[data-testid=pincode] input").type("159015");
     cy.get("[name=medical_history_check_1]").check();
     cy.get("[data-testid=blood-group] button")
       .click()
@@ -87,7 +75,7 @@ describe("Patient Creation", () => {
     });
   });
 
-  it("Dashboard", () => {
+  it("Patient Detail verification post registration", () => {
     cy.log(patient_url);
     cy.awaitUrl(patient_url);
     cy.url().should("include", "/facility/");
@@ -105,21 +93,9 @@ describe("Patient Creation", () => {
     cy.get("[data-testid=patient-dashboard]").should("contain", "O+");
   });
 
-  it("Edit", () => {
+  it("Edit the patient details", () => {
     cy.awaitUrl(patient_url + "/update");
-    cy.get("[data-testid=state] button").should("contain", "Kerala");
-    cy.get("[data-testid=district] button").should("contain", "Ernakulam");
-    cy.get("[data-testid=localbody] button").should("contain", "Aikaranad");
-    cy.get("[data-testid=current-address] textarea").should(
-      "contain",
-      "Test Patient Address"
-    );
-    cy.get("[data-testid=permanent-address] input").should("be.checked");
-    cy.get("[data-testid=ward-respective-lsgi] button").should(
-      "contain",
-      "PAZHAMTHOTTAM"
-    );
-    cy.get("[data-testid=pincode] input").should("have.value", "159015");
+    cy.get("[data-testid=name] input").clear().type("Test E2E User Editted");
     cy.get("button").get("[data-testid=submit-button]").click();
     cy.url().should("include", "/patient");
     cy.url().then((url) => {
@@ -129,6 +105,39 @@ describe("Patient Creation", () => {
     });
   });
 
+  it("Create a New consultation to existing patient", () => {
+    cy.visit(patient_url + "/consultation");
+    cy.get("#consultation_status")
+      .click()
+      .then(() => {
+        cy.get("[role='option']").contains("Out-patient (walk in)").click();
+      });
+    cy.get("#symptoms")
+      .click()
+      .then(() => {
+        cy.get("[role='option']").contains("ASYMPTOMATIC").click();
+      });
+    cy.get("#symptoms").click();
+    cy.get("#history_of_present_illness").click().type("histroy");
+    cy.get("#examination_details")
+      .click()
+      .type("Examination details and Clinical conditions");
+    cy.get("#weight").click().type("70");
+    cy.get("#height").click().type("170");
+    cy.get("#ip_no").type("192.168.1.11");
+    cy.get(
+      "#icd11_diagnoses_object input[placeholder='Select'][role='combobox']"
+    )
+      .click()
+      .type("1A");
+    cy.wait(2000);
+    cy.get("#icd11_diagnoses_object [role='option']")
+      .contains("1A03 Intestinal infections due to Escherichia coli")
+      .click();
+    cy.get("#consultation_notes").click().type("generalnote");
+    cy.get("#verified_by").click().type("generalnote");
+    cy.get("#submit").click();
+  });
   afterEach(() => {
     cy.saveLocalStorage();
   });

--- a/src/Components/Medicine/ManagePrescriptions.tsx
+++ b/src/Components/Medicine/ManagePrescriptions.tsx
@@ -33,7 +33,12 @@ export default function ManagePrescriptions({ consultationId }: Props) {
           </div>
         </div>
         <div className="flex flex-col-reverse md:flex-row gap-3 w-full md:items-center">
-          <ButtonV2 variant="secondary" border onClick={() => goBack()}>
+          <ButtonV2
+            variant="secondary"
+            border
+            onClick={() => goBack()}
+            data-testid="return-to-patient-dashboard"
+          >
             <CareIcon className="care-l-angle-left-b text-lg" />
             {t("return_to_patient_dashboard")}
           </ButtonV2>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1ed6b2</samp>

The pull request improves the end-to-end testing of the patient and consultation features by updating the test suite to reflect the latest UI changes and adding a new test case for consultation creation. It also adds a `data-testid` attribute to a button component to facilitate testing.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1ed6b2</samp>

*  Rename patient creation test suite and test case to include consultation ([link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL15-R15), [link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL26-R26))
*  Update patient creation test case to match new patient registration form fields ([link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL46-R51), [link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL61-L64), [link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL70-L73))
*  Rename dashboard test case to clarify its purpose and scope ([link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL90-R78))
*  Simplify edit test case to only change and verify patient name and URL ([link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL108-R98))
*  Add new consultation test case to create and verify a consultation for an existing patient with a prescription medication ([link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaR108-R160))
*  Add `data-testid` attribute to `ButtonV2` component for returning to patient dashboard ([link](https://github.com/coronasafe/care_fe/pull/5603/files?diff=unified&w=0#diff-942bb577e937a415d7cab5e59eb19b960601cfcf9274b9182f1a71a8ab821c66L36-R41))
