### PR TITLE
UI fix on facilities page

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -164,7 +164,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                             : "bg-primary-100 button-primary-border"
                         }`}
                       >
-                        <span className="tooltip-text tooltip-bottom -translate-y-2">
+                        <span className="tooltip-text tooltip-bottom md:tooltip-right -translate-y-2">
                           Live Patients / Total beds
                         </span>{" "}
                         <CareIcon

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -164,7 +164,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                             : "bg-primary-100 button-primary-border"
                         }`}
                       >
-                        <span className="tooltip-text tooltip-right -translate-y-2">
+                        <span className="tooltip-text tooltip-bottom -translate-y-2">
                           Live Patients / Total beds
                         </span>{" "}
                         <CareIcon


### PR DESCRIPTION
## Proposed Changes

- Fixes #5604 
http://localhost:4000/facility
Placed the `occupancy` tooltip at the bottom of the button
![image](https://github.com/coronasafe/care_fe/assets/70687348/2911f371-9886-4e47-a1ee-f8b1ade21cec)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a832dc</samp>

* Change the tooltip position for the live patients / total beds indicator from right to bottom ([link](https://github.com/coronasafe/care_fe/pull/5605/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L167-R167)). This avoids overlapping with the facility name in the `FacilityCard.tsx` component and improves readability and usability.
