### PR TITLE
Replaced Material UI components to CAREUI

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -1,10 +1,5 @@
-import {
-  CardContent,
-  RadioGroup,
-  Box,
-  FormControlLabel,
-  Radio,
-} from "@material-ui/core";
+import Card from "../../CAREUI/display/Card";
+import RadioFormField from "../Form/FormFields/RadioFormField.js";
 import { navigate } from "raviger";
 import moment from "moment";
 import loadable from "@loadable/component";
@@ -513,7 +508,7 @@ export const DailyRounds = (props: any) => {
       <div className="mt-4">
         <div className="bg-white rounded shadow">
           <form onSubmit={(e) => handleSubmit(e)}>
-            <CardContent>
+            <Card>
               <div className="flex flex-col md:flex-row gap-4">
                 <div className="w-full md:w-1/3">
                   <LegacyDateTimeFiled
@@ -565,29 +560,19 @@ export const DailyRounds = (props: any) => {
               </div>
               {!id && hasPreviousLog && (
                 <div id="clone_last-div" className="mt-4">
-                  <FieldLabel id="clone_last">
-                    Do you want to copy Values from Previous Log?
-                  </FieldLabel>
-                  <RadioGroup
-                    aria-label="clone_last"
+                  <RadioFormField
                     name="clone_last"
+                    label={"Do you want to copy Values from Previous Log?"}
+                    options={[
+                      { label: "Yes", value: "true" },
+                      { label: "No", value: "false" },
+                    ]}
                     value={state.form.clone_last}
                     onChange={handleChange}
-                    style={{ padding: "0px 5px" }}
-                  >
-                    <Box display="flex" flexDirection="row">
-                      <FormControlLabel
-                        value="true"
-                        control={<Radio />}
-                        label="Yes"
-                      />
-                      <FormControlLabel
-                        value="false"
-                        control={<Radio />}
-                        label="No"
-                      />
-                    </Box>
-                  </RadioGroup>
+                    optionDisplay={(option) => option.label}
+                    optionValue={(option) => option.value}
+                    error={state.errors.clone_last}
+                  />
                   <LegacyErrorHelperText error={state.errors.clone_last} />
                 </div>
               )}
@@ -952,7 +937,7 @@ export const DailyRounds = (props: any) => {
                 <Cancel onClick={() => goBack()} />
                 <Submit onClick={(e) => handleSubmit(e)} label={buttonText} />
               </div>
-            </CardContent>
+            </Card>
           </form>
         </div>
       </div>


### PR DESCRIPTION
### WHAT
Replaced Material UI and legacy form fields in the external result update page. Radio buttons created using RadioFormField 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b0f415</samp>

Refactor UI components in `DailyRounds.tsx` to use custom components and fix a missing closing tag. This improves the code quality and readability of the patient daily rounds feature.

## Proposed Changes

- Fixes #4976 
- Replaced MUI to CARE UI 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b0f415</samp>

*  Replace material-ui components with custom components for better UI consistency and reusability ([link](https://github.com/coronasafe/care_fe/pull/5607/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L1-R2), [link](https://github.com/coronasafe/care_fe/pull/5607/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L516-R511), [link](https://github.com/coronasafe/care_fe/pull/5607/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L568-R575), [link](https://github.com/coronasafe/care_fe/pull/5607/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L955-R940))
