### PR TITLE
 All the buttons are not in full width during responsive view,  fixed

### DIFF
--- a/src/Components/Common/components/ButtonV2.tsx
+++ b/src/Components/Common/components/ButtonV2.tsx
@@ -105,7 +105,7 @@ const ButtonV2 = ({
 }: ButtonProps) => {
   const className = classNames(
     props.className,
-    "font-medium h-min w-full md:w-fit inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1",
+    "font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1",
     `button-size-${size}`,
     `justify-${align}`,
     `button-shape-${circle ? "circle" : "square"}`,

--- a/src/Components/Common/components/ButtonV2.tsx
+++ b/src/Components/Common/components/ButtonV2.tsx
@@ -105,7 +105,7 @@ const ButtonV2 = ({
 }: ButtonProps) => {
   const className = classNames(
     props.className,
-    "font-medium h-min inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1",
+    "font-medium h-min w-full md:w-fit inline-flex whitespace-pre items-center gap-2 transition-all duration-200 ease-in-out cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 outline-offset-1",
     `button-size-${size}`,
     `justify-${align}`,
     `button-shape-${circle ? "circle" : "square"}`,

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1571,7 +1571,7 @@ export const FileUpload = (props: FileUploadProps) => {
                 {uploadStarted ? (
                   <LinearProgressWithLabel value={uploadPercent} />
                 ) : (
-                  <div className="flex flex-col md:flex-row gap-2 items-center justify-start md:justify-end w-full">
+                  <div className="flex flex-col md:flex-row gap-2  justify-start md:justify-end w-full">
                     <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
                       {({ isAuthorized }) =>
                         isAuthorized ? (
@@ -1590,7 +1590,7 @@ export const FileUpload = (props: FileUploadProps) => {
                         )
                       }
                     </AuthorizedChild>
-                    <div className="w-min">
+                    <div>
                       <ButtonV2 onClick={() => setModalOpenForCamera(true)}>
                         <CareIcon className="care-l-camera text-lg mr-2" />
                         Open Camera

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1505,7 +1505,7 @@ export const FileUpload = (props: FileUploadProps) => {
                 InputLabelProps={{ shrink: !!audioName }}
                 value={audioName}
                 disabled={uploadStarted}
-                onChange={(e: any) => {
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   setAudioName(e.target.value);
                 }}
                 errors={audioFileError}
@@ -1514,7 +1514,7 @@ export const FileUpload = (props: FileUploadProps) => {
                 Please allow browser permission before you start speaking
               </div>
               {audiouploadStarted ? (
-                <LinearProgressWithLabel value={uploadPercent} />
+                <LinearProgress variant="determinate" value={uploadPercent} />
               ) : (
                 <div className="flex flex-col lg:flex-row justify-between w-full">
                   {audioBlobExists && (
@@ -1522,9 +1522,7 @@ export const FileUpload = (props: FileUploadProps) => {
                       <ButtonV2
                         variant="danger"
                         className="w-full"
-                        onClick={() => {
-                          deleteAudioBlob();
-                        }}
+                        onClick={deleteAudioBlob}
                       >
                         <CareIcon className="care-l-trash h-4" /> Delete
                       </ButtonV2>
@@ -1538,12 +1536,7 @@ export const FileUpload = (props: FileUploadProps) => {
                   />
                   {audioBlobExists && (
                     <div className="flex items-center w-full md:w-auto">
-                      <ButtonV2
-                        onClick={() => {
-                          handleAudioUpload();
-                        }}
-                        className="w-full"
-                      >
+                      <ButtonV2 onClick={handleAudioUpload} className="w-full">
                         <CareIcon className={"care-l-cloud-upload text-xl"} />
                         Save
                       </ButtonV2>
@@ -1578,7 +1571,7 @@ export const FileUpload = (props: FileUploadProps) => {
                 {uploadStarted ? (
                   <LinearProgressWithLabel value={uploadPercent} />
                 ) : (
-                  <div className="flex flex-col md:flex-row gap-2 items-center justify-start md:justify-end">
+                  <div className="flex flex-col md:flex-row gap-2 items-center justify-start md:justify-end w-full">
                     <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
                       {({ isAuthorized }) =>
                         isAuthorized ? (
@@ -1597,18 +1590,23 @@ export const FileUpload = (props: FileUploadProps) => {
                         )
                       }
                     </AuthorizedChild>
-                    <ButtonV2 onClick={() => setModalOpenForCamera(true)}>
-                      <CareIcon className="care-l-camera text-lg mr-2" />
-                      Open Camera
-                    </ButtonV2>
-                    <ButtonV2
-                      authorizeFor={NonReadOnlyUsers}
-                      disabled={!file || !uploadFileName || !isActive}
-                      onClick={() => handleUpload({ status })}
-                    >
-                      <CareIcon className="care-l-cloud-upload text-lg" />
-                      {t("upload")}
-                    </ButtonV2>
+                    <div className="w-min">
+                      <ButtonV2 onClick={() => setModalOpenForCamera(true)}>
+                        <CareIcon className="care-l-camera text-lg mr-2" />
+                        Open Camera
+                      </ButtonV2>
+                    </div>
+
+                    <div>
+                      <ButtonV2
+                        authorizeFor={NonReadOnlyUsers}
+                        disabled={!file || !uploadFileName || !isActive}
+                        onClick={() => handleUpload({ status })}
+                      >
+                        <CareIcon className="care-l-cloud-upload text-lg" />
+                        {t("upload")}
+                      </ButtonV2>
+                    </div>
                   </div>
                 )}
                 {file && (

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -1571,7 +1571,7 @@ export const FileUpload = (props: FileUploadProps) => {
                 {uploadStarted ? (
                   <LinearProgressWithLabel value={uploadPercent} />
                 ) : (
-                  <div className="flex flex-col md:flex-row gap-2  justify-start md:justify-end w-full">
+                  <div className="flex flex-col md:flex-row gap-2 justify-start md:justify-end w-full">
                     <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
                       {({ isAuthorized }) =>
                         isAuthorized ? (
@@ -1591,7 +1591,10 @@ export const FileUpload = (props: FileUploadProps) => {
                       }
                     </AuthorizedChild>
                     <div>
-                      <ButtonV2 onClick={() => setModalOpenForCamera(true)}>
+                      <ButtonV2
+                        className="w-full md:w-fit"
+                        onClick={() => setModalOpenForCamera(true)}
+                      >
                         <CareIcon className="care-l-camera text-lg mr-2" />
                         Open Camera
                       </ButtonV2>
@@ -1599,6 +1602,7 @@ export const FileUpload = (props: FileUploadProps) => {
 
                     <div>
                       <ButtonV2
+                        className="w-full md:w-fit"
                         authorizeFor={NonReadOnlyUsers}
                         disabled={!file || !uploadFileName || !isActive}
                         onClick={() => handleUpload({ status })}

--- a/src/Utils/VoiceRecorder.tsx
+++ b/src/Utils/VoiceRecorder.tsx
@@ -38,7 +38,7 @@ export const VoiceRecorder = (props: any) => {
 
   return (
     <div>
-      <div className="sm:w-full">
+      <div>
         {isRecording ? (
           <>
             <div className="space-x-2 flex">
@@ -67,6 +67,7 @@ export const VoiceRecorder = (props: any) => {
               <ButtonV2
                 onClick={startRecording}
                 authorizeFor={NonReadOnlyUsers}
+                className="w-full md:w-fit"
               >
                 <CareIcon className="care-l-microphone text-lg" />
                 {t("record")}

--- a/src/Utils/VoiceRecorder.tsx
+++ b/src/Utils/VoiceRecorder.tsx
@@ -38,7 +38,7 @@ export const VoiceRecorder = (props: any) => {
 
   return (
     <div>
-      <div>
+      <div className="sm:w-full">
         {isRecording ? (
           <>
             <div className="space-x-2 flex">


### PR DESCRIPTION
issue- In the file tab of patient consultation page, all the buttons are not in full width during responsive view
Required fix -in the mobile responsive view, the buttons in the file tab should be on constant full width

![image](https://github.com/coronasafe/care_fe/assets/95141585/d9eff491-fc48-4e6f-ac8e-708b86dd4965)

![image](https://github.com/coronasafe/care_fe/assets/95141585/e1f0fd97-05e6-4e55-b356-2d85b53bb43a)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA



### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93cc2b7</samp>

*  Adjust the width of the `ButtonV2` component to be responsive to screen sizes ([link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-4b12d1558958a3f190a6b752fcd0dc3412364a61308465dcc60892b2b03bf65cL108-R108))
*  Use the `React.ChangeEvent<HTMLInputElement>` type for the input `onChange` handler in the `FileUpload` component ([link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1508-R1508))
*  Replace the custom `LinearProgressWithLabel` component with the Material UI `LinearProgress` component in the `FileUpload` component ([link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1517-R1517))
*  Pass the `deleteAudioBlob` and `handleAudioUpload` functions directly to the `ButtonV2` `onClick` props in the `FileUpload` component, to avoid creating new functions on every render ([link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1525-R1525), [link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1541-R1539))
*  Add the `w-full` class to the parent div of the buttons in the `FileUpload` component, to align them with the input element ([link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1581-R1574))
*  Wrap each button in a separate div in the `FileUpload` component, to prevent them from shrinking or expanding based on the available space ([link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1600-R1609))
*  Add the `sm:w-full` class to the parent div of the recording UI in the `VoiceRecorder` component, to prevent it from overflowing or getting cut off on small screens ([link](https://github.com/coronasafe/care_fe/pull/5608/files?diff=unified&w=0#diff-8e3baf9867fa0cfaf010498614e08a80e9010c7f23c2542c705b90e0d85f85bcL41-R41))
