### PR TITLE
Tailwinds `FacilityUsers.tsx`

### DIFF
--- a/src/Components/Facility/FacilityUsers.tsx
+++ b/src/Components/Facility/FacilityUsers.tsx
@@ -14,8 +14,6 @@ import {
 import Pagination from "../Common/Pagination";
 import { USER_TYPES, RESULTS_PER_PAGE_LIMIT } from "../../Common/constants";
 import { FacilityModel } from "../Facility/models";
-
-import { IconButton } from "@material-ui/core";
 import LinkFacilityDialog from "../Users/LinkFacilityDialog";
 import UserDeleteDialog from "../Users/UserDeleteDialog";
 import * as Notification from "../../Utils/Notifications.js";
@@ -24,9 +22,10 @@ import UnlinkFacilityDialog from "../Users/UnlinkFacilityDialog";
 import { classNames } from "../../Utils/utils";
 import CountBlock from "../../CAREUI/display/Count";
 import CareIcon from "../../CAREUI/icons/CareIcon";
+import ButtonV2 from "../Common/components/ButtonV2";
+import Page from "../Common/components/Page";
 
 const Loading = loadable(() => import("../Common/Loading"));
-const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export default function FacilityUsers(props: any) {
   const { facilityId } = props;
@@ -235,9 +234,10 @@ export default function FacilityUsers(props: any) {
             >
               <div className="flex items-center  space-x-1">
                 <div className="font-semibold">{facility.name}</div>
-                <IconButton
+                <ButtonV2
                   size="small"
-                  color="secondary"
+                  circle
+                  variant="secondary"
                   disabled={isFacilityLoading}
                   onClick={() =>
                     setUnlinkFacilityData({
@@ -247,8 +247,8 @@ export default function FacilityUsers(props: any) {
                     })
                   }
                 >
-                  <CareIcon className="care-l-multiply text-xl font-bold" />
-                </IconButton>
+                  <CareIcon className="care-l-multiply" />
+                </ButtonV2>
               </div>
             </div>
           ))}
@@ -452,7 +452,12 @@ export default function FacilityUsers(props: any) {
   }
 
   return (
-    <div>
+    <Page
+      title={`Users - ${facilityData?.name}`}
+      hideBack={true}
+      className="mx-3 md:mx-8"
+      breadcrumbs={false}
+    >
       {linkFacility.show && (
         <LinkFacilityDialog
           username={linkFacility.username}
@@ -460,12 +465,6 @@ export default function FacilityUsers(props: any) {
           handleCancel={hideLinkFacilityModal}
         />
       )}
-      <PageTitle
-        title={`Users - ${facilityData?.name}`}
-        hideBack={true}
-        className="mx-3 md:mx-8"
-        breadcrumbs={false}
-      />
 
       <div className="mt-5 grid grid-cols-1 md:gap-5 sm:grid-cols-3 m-4 md:px-4">
         <CountBlock
@@ -486,6 +485,6 @@ export default function FacilityUsers(props: any) {
           handleOk={handleSubmit}
         />
       )}
-    </div>
+    </Page>
   );
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6a313a</samp>

Refactored `FacilityUsers` component to use common UI components and removed unused code.

## Proposed Changes

- Fixes #4954 

![image](https://github.com/coronasafe/care_fe/assets/25143503/b59156ce-dc98-4e17-bbd6-6ba2d39cd117)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6a313a</samp>

*  Replace `IconButton` with `ButtonV2` and adjust `CareIcon` styles in `FacilityUsers.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5614/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL17-L18), [link](https://github.com/coronasafe/care_fe/pull/5614/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL238-R240), [link](https://github.com/coronasafe/care_fe/pull/5614/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL250-R251))
*  Add `Page` component as a wrapper for `FacilityUsers.tsx` and remove `PageTitle` component ([link](https://github.com/coronasafe/care_fe/pull/5614/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL27-R28), [link](https://github.com/coronasafe/care_fe/pull/5614/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL455-R460), [link](https://github.com/coronasafe/care_fe/pull/5614/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL463-L468), [link](https://github.com/coronasafe/care_fe/pull/5614/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL489-R488))
