### PR TITLE
Tailwinds `UnlinkSkillDialog.tsx`

### DIFF
--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -94,8 +94,8 @@ export default ({ show, setShow, username }: IProps) => {
         <UnlinkSkillDialog
           skillName={deleteSkill.skill_object.name || ""}
           userName={username}
-          handleCancel={() => setDeleteSkill(null)}
-          handleOk={() => removeSkill(username, deleteSkill.id)}
+          onCancel={() => setDeleteSkill(null)}
+          onSubmit={() => removeSkill(username, deleteSkill.id)}
         />
       )}
       <SlideOverCustom

--- a/src/Components/Users/UnlinkSkillDialog.tsx
+++ b/src/Components/Users/UnlinkSkillDialog.tsx
@@ -1,58 +1,38 @@
-import React, { useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  Button,
-} from "@material-ui/core";
+import { useState } from "react";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 
-interface ConfirmDialogProps {
+interface Props {
   skillName: string;
   userName: string;
-  handleCancel: () => void;
-  handleOk: () => void;
+  onCancel: () => void;
+  onSubmit: () => void;
 }
 
-const UnlinkSkillDialog = (props: ConfirmDialogProps) => {
-  const { skillName, userName, handleCancel, handleOk } = props;
-
-  const [disable, setDisable] = useState(false);
+export default function UnlinkSkillDialog(props: Props) {
+  const [disabled, setDisabled] = useState(false);
 
   const handleSubmit = () => {
-    handleOk();
-    setDisable(true);
+    props.onSubmit();
+    setDisabled(true);
   };
-  return (
-    <Dialog open={true} onClose={handleCancel}>
-      <DialogContent>
-        <div className="md:min-w-[400px] max-w-[650px]">
-          <DialogContentText
-            id="alert-dialog-description"
-            className="flex text-gray-800 leading-relaxed sm:min-w-[400px]"
-          >
-            <div>
-              Are you sure you want to unlink the skill{" "}
-              <strong>{skillName}</strong> from user <strong>{userName}</strong>
-              ? the user will not have the skill associated anymore.
-            </div>
-          </DialogContentText>
-        </div>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleCancel} color="primary">
-          Cancel
-        </Button>
-        <button
-          onClick={handleSubmit}
-          className="font-medium btn btn-danger"
-          disabled={disable}
-        >
-          Delete
-        </button>
-      </DialogActions>
-    </Dialog>
-  );
-};
 
-export default UnlinkSkillDialog;
+  return (
+    <ConfirmDialogV2
+      action="Unlink"
+      title="Unlink Skill"
+      variant="warning"
+      onClose={props.onCancel}
+      onConfirm={handleSubmit}
+      disabled={disabled}
+      show
+      description={
+        <span>
+          Are you sure you want to unlink the skill{" "}
+          <strong>{props.skillName}</strong> from user{" "}
+          <strong>{props.userName}</strong>? the user will not have the skill
+          associated anymore.
+        </span>
+      }
+    ></ConfirmDialogV2>
+  );
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32ccb2f</samp>

This pull request simplifies and standardizes the code for the `UnlinkSkillDialog` component that allows users to remove skills from their profiles. It renames some props, moves the component to the same file as its parent, and replaces the `Dialog` component with the `ConfirmDialogV2` component.

## Proposed Changes

- Fixes #5003

![image](https://github.com/coronasafe/care_fe/assets/25143503/35493ee9-5b29-4339-bedd-914874b5f21d)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32ccb2f</samp>

*  Rename props of `UnlinkSkillDialog` component to match convention and avoid confusion ([link](https://github.com/coronasafe/care_fe/pull/5628/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L97-R98))
*  Move `UnlinkSkillDialog` component to `SkillsSlideOver.tsx` file and refactor it to use `ConfirmDialogV2` component ([link](https://github.com/coronasafe/care_fe/pull/5628/files?diff=unified&w=0#diff-cd8d41a0e17f0d0e54080513b6f1ce3ee8f4fbefebb4644b256da0110a2b321eL1-R38))
