### PR TITLE
Tailwinds `SampleFilters.tsx`

### DIFF
--- a/cypress/e2e/sample_test_spec/filter.cy.ts
+++ b/cypress/e2e/sample_test_spec/filter.cy.ts
@@ -13,15 +13,24 @@ describe("Sample Filter", () => {
   });
 
   it("Filter by Status", () => {
-    cy.get("[name='status']").select("APPROVED");
+    cy.get("#status").click();
+    cy.get("li[role='option']")
+      .contains(/^APPROVED$/)
+      .click();
   });
 
   it("Filter by Asset Type", () => {
-    cy.get("[name='result']").select("POSITIVE");
+    cy.get("#result").click();
+    cy.get("li[role='option']")
+      .contains(/^POSITIVE$/)
+      .click();
   });
 
   it("Filter by sample type", () => {
-    cy.get("[name='sample_type']").select("Biopsy");
+    cy.get("#sample_type").click();
+    cy.get("li[role='option']")
+      .contains(/^Biopsy$/)
+      .click();
   });
 
   afterEach(() => {

--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -465,16 +465,16 @@ export const BLOOD_GROUPS = [
 ];
 
 export const SAMPLE_TYPE_CHOICES = [
-  { id: 0, text: "UNKNOWN" },
-  { id: 1, text: "BA/ETA" },
-  { id: 2, text: "TS/NPS/NS" },
-  { id: 3, text: "Blood in EDTA" },
-  { id: 4, text: "Acute Sera" },
-  { id: 5, text: "Covalescent sera" },
-  { id: 6, text: "Biopsy" },
-  { id: 7, text: "AMR" },
-  { id: 8, text: "Communicable Diseases" },
-  { id: 9, text: "OTHER TYPE" },
+  { id: "0", text: "UNKNOWN" },
+  { id: "1", text: "BA/ETA" },
+  { id: "2", text: "TS/NPS/NS" },
+  { id: "3", text: "Blood in EDTA" },
+  { id: "4", text: "Acute Sera" },
+  { id: "5", text: "Covalescent sera" },
+  { id: "6", text: "Biopsy" },
+  { id: "7", text: "AMR" },
+  { id: "8", text: "Communicable Diseases" },
+  { id: "9", text: "OTHER TYPE" },
 ];
 
 export const ICMR_CATEGORY = [

--- a/src/Components/Patient/SampleFilters.tsx
+++ b/src/Components/Patient/SampleFilters.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { LegacySelectField } from "../Common/HelperInputFields";
 import {
   SAMPLE_TEST_STATUS,
   SAMPLE_TEST_RESULT,
@@ -10,9 +9,12 @@ import { FacilitySelect } from "../Common/FacilitySelect";
 import { FacilityModel } from "../Facility/models";
 import { getAnyFacility } from "../../Redux/actions";
 import { useDispatch } from "react-redux";
-import { CircularProgress } from "@material-ui/core";
 import useMergeState from "../../Common/hooks/useMergeState";
 import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
+import CircularProgress from "../Common/components/CircularProgress";
+import { FieldLabel } from "../Form/FormFields/FormField";
+import { SelectFormField } from "../Form/FormFields/SelectFormField";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
 
 const clearFilterState = {
   status: "",
@@ -36,13 +38,8 @@ export default function UserFilter(props: any) {
   const [isFacilityLoading, setFacilityLoading] = useState(false);
   const dispatch: any = useDispatch();
 
-  const handleChange = (event: any) => {
-    const { name, value } = event.target;
-
-    const filterData: any = { ...filterState };
-    filterData[name] = value;
-
-    setFilterState(filterData);
+  const handleChange = ({ name, value }: FieldChangeEvent<unknown>) => {
+    setFilterState({ ...filterState, [name]: value });
   };
 
   const applyFilter = () => {
@@ -70,6 +67,8 @@ export default function UserFilter(props: any) {
     fetchData();
   }, [dispatch]);
 
+  console.log(filterState.sample_type);
+
   return (
     <FiltersSlideover
       advancedFilter={props}
@@ -80,55 +79,49 @@ export default function UserFilter(props: any) {
         closeFilter();
       }}
     >
-      <div className="w-full flex-none">
-        <div className="text-sm font-semibold">Status</div>
-        <LegacySelectField
-          name="status"
-          variant="outlined"
-          margin="dense"
-          value={filterState.status || 0}
-          options={[
-            { id: "", text: "SELECT" },
-            ...SAMPLE_TEST_STATUS.map(({ id, text }) => {
-              return { id, text: text.replaceAll("_", " ") };
-            }),
-          ]}
-          onChange={handleChange}
-          errors=""
-        />
-      </div>
+      <SelectFormField
+        name="status"
+        label="Status"
+        value={filterState.status}
+        onChange={handleChange}
+        options={SAMPLE_TEST_STATUS.map(({ id, text }) => {
+          return { id, text: text.replaceAll("_", " ") };
+        })}
+        optionValue={(option) => option.id}
+        optionLabel={(option) => option.text}
+        labelClassName="text-sm"
+        errorClassName="hidden"
+      />
+
+      <SelectFormField
+        name="result"
+        label="Result"
+        value={filterState.result}
+        onChange={handleChange}
+        options={SAMPLE_TEST_RESULT}
+        optionValue={(option) => option.id}
+        optionLabel={(option) => option.text}
+        labelClassName="text-sm"
+        errorClassName="hidden"
+      />
+
+      <SelectFormField
+        name="sample_type"
+        label="Sample Test Type"
+        value={filterState.sample_type}
+        onChange={handleChange}
+        options={SAMPLE_TYPE_CHOICES}
+        optionValue={(option) => option.id}
+        optionLabel={(option) => option.text}
+        labelClassName="text-sm"
+        errorClassName="hidden"
+      />
 
       <div className="w-full flex-none">
-        <div className="text-sm font-semibold">Result</div>
-        <LegacySelectField
-          name="result"
-          variant="outlined"
-          margin="dense"
-          value={filterState.result || 0}
-          options={[{ id: "", text: "SELECT" }, ...SAMPLE_TEST_RESULT]}
-          onChange={handleChange}
-          errors=""
-        />
-      </div>
-
-      <div className="w-full flex-none">
-        <div className="text-sm font-semibold">Sample Test Type</div>
-        <LegacySelectField
-          name="sample_type"
-          variant="outlined"
-          margin="dense"
-          value={filterState.sample_type}
-          options={[{ id: "", text: "SELECT" }, ...SAMPLE_TYPE_CHOICES]}
-          onChange={handleChange}
-          errors=""
-        />
-      </div>
-
-      <div className="w-full flex-none">
-        <span className="text-sm font-semibold">Facility</span>
-        <div className="">
+        <FieldLabel className="text-sm">Facility</FieldLabel>
+        <div>
           {isFacilityLoading ? (
-            <CircularProgress size={20} />
+            <CircularProgress />
           ) : (
             <FacilitySelect
               multiple={false}
@@ -141,7 +134,6 @@ export default function UserFilter(props: any) {
                   facility_ref: obj,
                 })
               }
-              className="shifting-page-filter-dropdown"
               errors={""}
             />
           )}

--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -401,7 +401,7 @@ export default function SampleViewAdmin() {
               "Sample Test Type",
               "sample_type",
               SAMPLE_TYPE_CHOICES.find(
-                (type) => type.id.toString() === qParams.sample_type
+                (type) => type.id === qParams.sample_type
               )?.text || ""
             ),
             value("Facility", "facility", facilityName),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce8b1e7</samp>

The pull request improves the filter UI for patient samples and fixes a type mismatch issue with the `sample_type` query parameter. It uses custom form field components, simplifies the state management, and changes the `id` property of the `SAMPLE_TYPE_CHOICES` array from a number to a string in `src/Common/constants.tsx` and `src/Components/Patient/SampleViewAdmin.tsx`.

## Proposed Changes

- Fixes #4982

![image](https://github.com/coronasafe/care_fe/assets/25143503/afdae0e7-6953-4a5c-a653-4bba6fab522a)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce8b1e7</samp>

*  Change the `id` property of the `SAMPLE_TYPE_CHOICES` array from a number to a string to match the `sample_type` query parameter ([link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-37705b30476b14631124ce42dd5c3500d43fbede16f0e91f9ae2905e4adc6376L468-R477))
*  Replace the `LegacySelectField` components with the `SelectFormField` components in the sample filter UI to use custom form fields with consistent styles and props ([link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-2bc9188bc35ddbb97cd1d99ed8b3d95f660f4a9c1a77319d2181014aa83fe9a1L2), [link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-2bc9188bc35ddbb97cd1d99ed8b3d95f660f4a9c1a77319d2181014aa83fe9a1L83-R124))
*  Simplify the `handleChange` function in `SampleFilters.tsx` to use the `FieldChangeEvent` type and the `useMergeState` hook ([link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-2bc9188bc35ddbb97cd1d99ed8b3d95f660f4a9c1a77319d2181014aa83fe9a1L13-R17), [link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-2bc9188bc35ddbb97cd1d99ed8b3d95f660f4a9c1a77319d2181014aa83fe9a1L39-R42))
*  Import the `CircularProgress`, `FieldLabel`, `SelectFormField` components and the `FieldChangeEvent` type from custom files instead of external libraries in `SampleFilters.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-2bc9188bc35ddbb97cd1d99ed8b3d95f660f4a9c1a77319d2181014aa83fe9a1L13-R17))
*  Add a console log statement to debug the `sample_type` filter value in `SampleFilters.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-2bc9188bc35ddbb97cd1d99ed8b3d95f660f4a9c1a77319d2181014aa83fe9a1R70-R71))
*  Remove the `className` prop from the `FacilitySelect` component in `SampleFilters.tsx` as it was not needed ([link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-2bc9188bc35ddbb97cd1d99ed8b3d95f660f4a9c1a77319d2181014aa83fe9a1L144))
*  Compare the `id` property of the `SAMPLE_TYPE_CHOICES` array with the `sample_type` query parameter as a string in `SampleViewAdmin.tsx` to match the change in [link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-37705b30476b14631124ce42dd5c3500d43fbede16f0e91f9ae2905e4adc6376L468-R477) ([link](https://github.com/coronasafe/care_fe/pull/5630/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL404-R404))
