### PR TITLE
Fix page area cropping out while printing

### DIFF
--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -449,7 +449,7 @@ export default function AppRouter() {
 
   return (
     <SidebarShrinkContext.Provider value={{ shrinked, setShrinked }}>
-      <div className="absolute inset-0 h-screen flex overflow-hidden bg-gray-100">
+      <div className="absolute inset-0 h-screen flex overflow-hidden print:overflow-visible bg-gray-100">
         <>
           <div className="block md:hidden">
             <MobileSidebar open={sidebarOpen} setOpen={setSidebarOpen} />{" "}
@@ -459,7 +459,7 @@ export default function AppRouter() {
           </div>
         </>
 
-        <div className="flex flex-col w-full flex-1 overflow-hidden">
+        <div className="flex flex-col w-full flex-1 overflow-hidden print:overflow-visible">
           <div className="flex md:hidden relative z-10 shrink-0 h-16 bg-white shadow">
             <button
               onClick={() => setSidebarOpen(true)}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57876b0</samp>

This pull request improves the printability of the app by adding a new CSS class `print:overflow-visible` to the root and main content div elements in `src/Router/AppRouter.tsx`. This prevents clipping of the page content when printing, especially for the patient details page.

## Proposed Changes

- Fixes #5634

![image](https://github.com/coronasafe/care_fe/assets/3626859/bed00975-2c2d-4874-a2c4-68f73d279002)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 57876b0</samp>

*  Enable content to fit paper size when printing the app by adding `print:overflow-visible` class to root and main content div elements ([link](https://github.com/coronasafe/care_fe/pull/5637/files?diff=unified&w=0#diff-54de9c6ab4bf014bd5f50afa466003ba1a5ae1537a615261440d158cd59187f1L452-R452), [link](https://github.com/coronasafe/care_fe/pull/5637/files?diff=unified&w=0#diff-54de9c6ab4bf014bd5f50afa466003ba1a5ae1537a615261440d158cd59187f1L462-R462)) in `AppRouter.tsx`
