### PR TITLE
Fix Cypress test not using its own care backend

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -35,7 +35,7 @@ jobs:
         run: curl -o /dev/null -s -w "%{http_code}\n" http://localhost:9000
 
       - name: Change api proxy url 📝
-        run: 'sed --in-place "s^\"target\": .*,^\"target\": \"http://localhost:9000\",^g" vite.config.ts'
+        run: 'sed --in-place "s^target: .*,^target: \"http://localhost:9000\",^g" vite.config.ts'
 
       - name: Install dependencies 📦
         run: npm install


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69bce85</samp>

Fixed the `sed` command in `.github/workflows/cypress.yaml` to remove double quotes from the `target` key in `vite.config.ts`. This prevents potential errors in the frontend configuration and testing.

## Proposed Changes

Fixes https://github.com/coronasafe/care_fe/pull/5638#issuecomment-1584441737

In `vite.config.ts` , We have the proxy in the following format:
```
target: "https://careapi.ohc.network"
```
To replace it with `sed` while configuring the Cypress test, the following pattern has to be used `s^target: .*` instead of the current `"s^\"target\": .*`. This is because we do not have the `target` wrapped around in quotes.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 69bce85</samp>

* Remove double quotes from `target` key in `vite.config.ts` file to avoid errors in JavaScript object syntax ([link](https://github.com/coronasafe/care_fe/pull/5639/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L38-R38))
