### PR TITLE
wrapping of text patient note bug fixed

### DIFF
--- a/src/Components/Patient/PatientNotes.tsx
+++ b/src/Components/Patient/PatientNotes.tsx
@@ -141,8 +141,8 @@ const PatientNotes = (props: PatientNotesProps) => {
                 key={note.id}
                 className="flex p-4 bg-white rounded-lg text-gray-800 mt-4 flex-col w-full border border-gray-300"
               >
-                <span className="whitespace-pre">{note.note}</span>
-                <div className="mt-3">
+                <span className="max-w-full pl-2">{note.note}</span>
+                <div className="mt-3 pl-2">
                   <span className="text-xs text-gray-500">
                     {formatDate(note.created_date) || "-"}
                   </span>


### PR DESCRIPTION
### WHAT
Bug fixed : Text Overflow from Card in PatientNotes

##Changes

- Fixes #5633 
- White-space pre removed
- max-width : 100% added
-  Some padding added for alignment

## After Fixes
![image_Fixes](https://github.com/coronasafe/care_fe/assets/97380192/37c05791-56f7-4e09-9fc0-1fda58bbb8e7)

@rithviknishad  @kunal00000 

