### PR TITLE
Added `cypress passed` label

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   cypress-run:
-    if: github.repository == 'coronasafe/care_fe'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 📥
@@ -23,40 +22,53 @@ jobs:
           repository: coronasafe/care
           path: care
 
+      - name: Docker Layer Caching 🍥
+        uses: satackey/action-docker-layer-caching@v0.0.11
+
       - name: Run docker compose up on care 🐳
-        run: cd care && touch .env && make docker_config_file=docker-compose.pre-built.yaml up && cd .. && sleep 60s
-        # Voluntarily kept 60 seconds delay to wait for migrations to complete.
+        run: cd care && touch .env && make build && make up && cd .. && sleep 30s
+        # Voluntarily kept 30 seconds delay to wait for migrations to complete.
 
       - name: Run Django collectstatic and load dummy data on care 🐍
         run: |
+          docker exec care python manage.py collectstatic
           docker exec care python manage.py load_dummy_data
 
       - name: Check care is up ♻
         run: curl -o /dev/null -s -w "%{http_code}\n" http://localhost:9000
 
       - name: Change api proxy url 📝
-        run: 'sed --in-place "s^target: .*,^target: \"http://localhost:9000\",^g" vite.config.ts'
+        run: 'sed --in-place "s^\"proxy\": .*,^\"proxy\": \"http://localhost:9000\",^g" package.json'
 
       - name: Install dependencies 📦
-        run: npm install
+        run: npm install --legacy-peer-deps
 
-      - name: Build & Compile rescript files ⚙️
-        run: "npm run build"
+      - name: Compile rescript files ⚙️
+        run: "npm run re:build"
 
       - name: Cypress run 🥬
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v4
         with:
           env: SKIP_PREFLIGHT_CHECK=true
           install: false
-          start: "npx vite preview --host"
+          start: "npm run start:react"
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
           browser: electron
-          record: true
-        env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: --max_old_space_size=4096
+
+      - name: Remove cypress passed label on failure 🏷️
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: failure()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: cypress passed
+
+      - name: Add cypress passed label on success 🏷️
+        uses: actions-ecosystem/action-add-labels@v1
+        if: success()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: cypress passed
 
       - name: Remove cypress failed label on success 🏷️
         uses: actions-ecosystem/action-remove-labels@v1
@@ -73,7 +85,7 @@ jobs:
           labels: cypress failed
 
       - name: Upload cypress screenshots on failure 📸
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: cypress-screenshots
@@ -81,7 +93,7 @@ jobs:
 
       # Test run video was always captured, so this action uses "always()" condition
       - name: Upload cypress videos 📹
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         if: always()
         with:
           name: cypress-videos


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6859047</samp>

This pull request enhances the frontend testing workflow by enabling it to run on forks and pull requests, using Docker Layer Caching and the backend source code, and updating some dependencies and configurations. It affects the `.github/workflows/cypress.yaml` file.

## Proposed Changes

- Added `cypress passed` label

cc: @nihal467 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6859047</samp>

*  Enable workflow to run on forks and pull requests from other repositories ([link](https://github.com/coronasafe/care_fe/pull/5651/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L14))
*  Use Docker Layer Caching and build care backend image from source code ([link](https://github.com/coronasafe/care_fe/pull/5651/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L26-R34))
*  Run Django collectstatic command to serve static files for frontend ([link](https://github.com/coronasafe/care_fe/pull/5651/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L26-R34))
*  Update steps to run frontend tests using Cypress ([link](https://github.com/coronasafe/care_fe/pull/5651/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L38-R72))
*  Downgrade actions/upload-artifact action from v3 to v2 for stability and reliability ([link](https://github.com/coronasafe/care_fe/pull/5651/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L76-R88), [link](https://github.com/coronasafe/care_fe/pull/5651/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L84-R96))
