### PR TITLE
Added `cypress passed` label

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   cypress-run:
+    permissions: write-all
     if: github.repository == 'coronasafe/care_fe'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -58,6 +58,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max_old_space_size=4096
 
+      - name: Remove cypress passed label on failure 🏷️
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: failure()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: cypress passed
+
+      - name: Add cypress passed label on success 🏷️
+        uses: actions-ecosystem/action-add-labels@v1
+        if: success()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: cypress passed
+
       - name: Remove cypress failed label on success 🏷️
         uses: actions-ecosystem/action-remove-labels@v1
         if: success()

--- a/cypress/e2e/users_spec/user_crud.cy.ts
+++ b/cypress/e2e/users_spec/user_crud.cy.ts
@@ -11,7 +11,7 @@ const makeid = (length: number) => {
 };
 
 const makePhoneNumber = () =>
-  "99" + Math.floor(Math.random() * 99999999).toString();
+  "99" + Math.floor(Math.random() * 9000000000 + 1000000000).toString();
 
 const username = makeid(25);
 const phone_number = makePhoneNumber();
@@ -46,15 +46,13 @@ describe("User management", () => {
     cy.wait(1000);
     cy.get("[name='phone_number']").type(phone_number);
     cy.wait(1000);
-    cy.get("[name='alt_phone_number']").type(alt_phone_number, {
-      force: true,
-    });
+    cy.get("[name='alt_phone_number']").type(alt_phone_number);
     cy.intercept(/users/).as("check_availability");
     cy.get("[id='date_of_birth']").click();
     cy.get("div").contains("20").click();
     cy.get("[id='year-0']").click();
     cy.get("[id='date-1']").click();
-    cy.get("[name='username']").type(username, { force: true });
+    cy.get("[name='username']").type(username);
     cy.wait("@check_availability").its("response.statusCode").should("eq", 200);
     cy.get("[name='password']").type("#@Cypress_test123");
     cy.get("[name='c_password']").type("#@Cypress_test123");
@@ -63,9 +61,7 @@ describe("User management", () => {
     cy.get("[name='email']").type("cypress@tester.com");
     cy.get("[id='gender'] > div > button").click();
     cy.get("div").contains("Male").click();
-    cy.get("button[id='submit']").contains("Save User").click({
-      force: true,
-    });
+    cy.get("button[id='submit']").contains("Save User").click();
     cy.verifyNotification("User added successfully");
   });
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8aa29c3</samp>

The code adds steps to the cypress workflow to automatically label pull requests with `cypress passed` or remove the label if the tests fail. This helps to show the test status and readiness of the pull requests.

## Proposed Changes
- Added `cypress passed` label

cc: @nihal467 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8aa29c3</samp>

* Add and remove "cypress passed" label to pull request based on cypress test results ([link](https://github.com/coronasafe/care_fe/pull/5652/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46R61-R74))
