### PR TITLE
Tailwinds `SetInventoryForm.tsx`

### DIFF
--- a/src/Components/Facility/SetInventoryForm.tsx
+++ b/src/Components/Facility/SetInventoryForm.tsx
@@ -1,19 +1,18 @@
-import { Card, CardContent, InputLabel } from "@material-ui/core";
 import { useCallback, useReducer, useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import loadable from "@loadable/component";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getItems, setMinQuantity, getAnyFacility } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import {
-  LegacySelectField,
-  LegacyTextInputField,
-} from "../Common/HelperInputFields";
 import { InventoryItemsModel } from "./models";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import useAppHistory from "../../Common/hooks/useAppHistory";
+import Page from "../Common/components/Page";
+import Card from "../../CAREUI/display/Card";
+import { FieldChangeEvent } from "../Form/FormFields/Utils";
+import { SelectFormField } from "../Form/FormFields/SelectFormField";
+import TextFormField from "../Form/FormFields/TextFormField";
 const Loading = loadable(() => import("../Common/Loading"));
-const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 const initForm = {
   id: "",
@@ -48,7 +47,6 @@ export const SetInventoryForm = (props: any) => {
   const { facilityId } = props;
   const dispatchAction: any = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
-  // const [offset, setOffset] = useState(0);
   const [data, setData] = useState<Array<InventoryItemsModel>>([]);
   const [currentUnit, setCurrentUnit] = useState<any>();
   const [facilityName, setFacilityName] = useState("");
@@ -123,10 +121,8 @@ export const SetInventoryForm = (props: any) => {
     goBack();
   };
 
-  const handleChange = (e: any) => {
-    const form = { ...state.form };
-    form[e.target.name] = e.target.value;
-    dispatch({ type: "set_form", form });
+  const handleChange = ({ name, value }: FieldChangeEvent<unknown>) => {
+    dispatch({ type: "set_form", form: { ...state.form, [name]: value } });
   };
 
   if (isLoading) {
@@ -134,78 +130,55 @@ export const SetInventoryForm = (props: any) => {
   }
 
   return (
-    <div className="px-2 pb-2">
-      <PageTitle
-        title="Set Minimum Quantity"
-        crumbsReplacements={{
-          [facilityId]: { name: facilityName },
-          min_quantity: {
-            name: "Min Quantity",
-            uri: `/facility/${facilityId}/inventory/min_quantity/list`,
-          },
-          set: {
-            style: "pointer-events-none",
-          },
-        }}
-        backUrl={`/facility/${facilityId}/inventory/min_quantity/list`}
-      />
-      <div className="mt-4">
-        <Card>
-          <form onSubmit={(e) => handleSubmit(e)}>
-            <CardContent>
-              <div className="mt-2 grid gap-4 grid-cols-1 md:grid-cols-2">
-                <div>
-                  <InputLabel id="inventory_name_label">
-                    Inventory Name
-                  </InputLabel>
-                  <LegacySelectField
-                    name="id"
-                    variant="outlined"
-                    margin="dense"
-                    value={state.form.id}
-                    options={data.map((e) => {
-                      return { id: e.id, name: e.name };
-                    })}
-                    onChange={handleChange}
-                    optionKey="id"
-                    optionValue="name"
-                  />
-                </div>
+    <Page
+      title="Set Minimum Quantity"
+      crumbsReplacements={{
+        [facilityId]: { name: facilityName },
+        min_quantity: {
+          name: "Min Quantity",
+          uri: `/facility/${facilityId}/inventory/min_quantity/list`,
+        },
+        set: {
+          style: "pointer-events-none",
+        },
+      }}
+      backUrl={`/facility/${facilityId}/inventory/min_quantity/list`}
+    >
+      <Card>
+        <form
+          onSubmit={(e) => handleSubmit(e)}
+          className="mt-6 grid gap-4 grid-cols-1 md:grid-cols-2"
+        >
+          <SelectFormField
+            name="id"
+            label="Inventory Name"
+            value={state.form.id}
+            options={data}
+            onChange={handleChange}
+            optionValue={(item) => item.id}
+            optionLabel={(item) => item.name}
+          />
 
-                <div>
-                  <InputLabel id="inventory_name_label">Unit</InputLabel>
-                  <LegacyTextInputField
-                    name="id"
-                    variant="outlined"
-                    margin="dense"
-                    type="string"
-                    value={currentUnit}
-                    errors=""
-                  />
-                </div>
+          <TextFormField
+            name="unit"
+            label="Unit"
+            value={currentUnit}
+            onChange={handleChange}
+          />
 
-                <div className="md:col-span-2">
-                  <InputLabel id="quantity">Item Min Quantity</InputLabel>
-                  <LegacyTextInputField
-                    fullWidth
-                    name="quantity"
-                    variant="outlined"
-                    margin="dense"
-                    type="number"
-                    value={state.form.quantity}
-                    onChange={handleChange}
-                    errors=""
-                  />
-                </div>
-              </div>
-              <div className="sm:flex sm:justify-between mt-4">
-                <Cancel onClick={() => goBack()} />
-                <Submit onClick={handleSubmit} label="Set" />
-              </div>
-            </CardContent>
-          </form>
-        </Card>
-      </div>
-    </div>
+          <TextFormField
+            name="quantity"
+            type="number"
+            value={state.form.quantity}
+            onChange={handleChange}
+          />
+
+          <div className="sm:flex sm:justify-between mt-4 col-span-1 md:col-span-2">
+            <Cancel onClick={() => goBack()} />
+            <Submit onClick={handleSubmit} label="Set" />
+          </div>
+        </form>
+      </Card>
+    </Page>
   );
 };

--- a/src/Components/Facility/SetInventoryForm.tsx
+++ b/src/Components/Facility/SetInventoryForm.tsx
@@ -144,13 +144,15 @@ export const SetInventoryForm = (props: any) => {
       }}
       backUrl={`/facility/${facilityId}/inventory/min_quantity/list`}
     >
-      <Card>
+      <Card className="mt-10 max-w-3xl mx-auto">
         <form
           onSubmit={(e) => handleSubmit(e)}
           className="mt-6 grid gap-4 grid-cols-1 md:grid-cols-2"
         >
           <SelectFormField
+            className="md:col-span-2"
             name="id"
+            required
             label="Inventory Name"
             value={state.form.id}
             options={data}
@@ -160,22 +162,25 @@ export const SetInventoryForm = (props: any) => {
           />
 
           <TextFormField
-            name="unit"
-            label="Unit"
-            value={currentUnit}
-            onChange={handleChange}
-          />
-
-          <TextFormField
+            label="Minimum Quantity"
+            required
             name="quantity"
             type="number"
             value={state.form.quantity}
             onChange={handleChange}
           />
 
-          <div className="sm:flex sm:justify-between mt-4 col-span-1 md:col-span-2">
+          <TextFormField
+            name="unit"
+            label="Unit"
+            value={currentUnit}
+            onChange={handleChange}
+            disabled
+          />
+
+          <div className="flex flex-col sm:flex-row justify-end mt-4 col-span-2 gap-2">
             <Cancel onClick={() => goBack()} />
-            <Submit onClick={handleSubmit} label="Set" />
+            <Submit label="Set" />
           </div>
         </form>
       </Card>

--- a/src/Components/Facility/SetInventoryForm.tsx
+++ b/src/Components/Facility/SetInventoryForm.tsx
@@ -145,12 +145,8 @@ export const SetInventoryForm = (props: any) => {
       backUrl={`/facility/${facilityId}/inventory/min_quantity/list`}
     >
       <Card className="mt-10 max-w-3xl mx-auto">
-        <form
-          onSubmit={(e) => handleSubmit(e)}
-          className="mt-6 grid gap-4 grid-cols-1 md:grid-cols-2"
-        >
+        <form onSubmit={(e) => handleSubmit(e)} className="mt-6 flex flex-col">
           <SelectFormField
-            className="md:col-span-2"
             name="id"
             required
             label="Inventory Name"
@@ -161,24 +157,27 @@ export const SetInventoryForm = (props: any) => {
             optionLabel={(item) => item.name}
           />
 
-          <TextFormField
-            label="Minimum Quantity"
-            required
-            name="quantity"
-            type="number"
-            value={state.form.quantity}
-            onChange={handleChange}
-          />
+          <div className="flex gap-2">
+            <TextFormField
+              className="w-full"
+              label="Minimum Quantity"
+              required
+              name="quantity"
+              type="number"
+              value={state.form.quantity}
+              onChange={handleChange}
+            />
 
-          <TextFormField
-            name="unit"
-            label="Unit"
-            value={currentUnit}
-            onChange={handleChange}
-            disabled
-          />
+            <TextFormField
+              name="unit"
+              label="Unit"
+              value={currentUnit}
+              onChange={handleChange}
+              disabled
+            />
+          </div>
 
-          <div className="flex flex-col sm:flex-row justify-end mt-4 col-span-2 gap-2">
+          <div className="flex flex-col sm:flex-row justify-end mt-4 gap-2">
             <Cancel onClick={() => goBack()} />
             <Submit label="Set" />
           </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4cf4c4d</samp>

Refactored the SetInventoryForm component to improve the UI and code quality. Used consistent and reusable components, simplified the logic, and cleaned up the code.

## Proposed Changes

- Fixes #4958 
- Fixes #5691

![image](https://github.com/coronasafe/care_fe/assets/25143503/3de0d72e-0695-4989-821e-2cccf11abf37)



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4cf4c4d</samp>

*  Refactor the component to use the new form fields and the custom `Card` component ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L1), [link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L8-R15), [link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L126-R125), [link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L137-R182))
  - Remove unused imports of `Card`, `CardContent`, and `InputLabel` from `@material-ui/core` ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L1))
  - Replace imports of `LegacySelectField` and `LegacyTextInputField` from `../Common/HelperInputFields` with imports of `SelectFormField` and `TextFormField` from `../Form/FormFields` ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L8-R15))
  - Add imports of `Page` from `../Common/components/Page`, `Card` from `../../CAREUI/display/Card`, and `FieldChangeEvent` from `../Form/FormFields/Utils` ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L8-R15))
  - Simplify the `handleChange` function to use the `FieldChangeEvent` type and dispatch the form update with a single line of code ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L126-R125))
  - Wrap the JSX returned by the component with the `Page` component to handle the page title and breadcrumbs, instead of using the `PageTitle` component and a `div` with custom classes ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L137-R182))
  - Use the custom `Card` component, instead of the `@material-ui/core` component, to style the form ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L137-R182))
  - Replace the legacy form fields with the new `SelectFormField` and `TextFormField` components, and adjust the form layout to use the `grid` and `col-span` classes, instead of the `md:grid-cols-2` class ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L137-R182))
* Remove commented out code for the `offset` state, as it was not used in the component ([link](https://github.com/coronasafe/care_fe/pull/5656/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L51))
