### PR TITLE
Tailwinds `SampleTestCard.tsx`

### DIFF
--- a/src/Components/Patient/SampleTestCard.tsx
+++ b/src/Components/Patient/SampleTestCard.tsx
@@ -1,4 +1,3 @@
-import { CardContent } from "@material-ui/core";
 import { navigate } from "raviger";
 import React, { useState } from "react";
 import { SampleTestModel } from "./models";
@@ -83,123 +82,121 @@ export const SampleTestCard = (props: SampleDetailsProps) => {
           : "bg-white hover:border-primary-500"
       } block border rounded-lg bg-white shadow cursor-pointer text-black mt-4`}
     >
-      <CardContent>
-        <div
-          onClick={(_e) =>
-            navigate(
-              `/facility/${facilityId}/patient/${patientId}/sample/${itemData.id}`
-            )
-          }
-          className="grid gap-4 grid-cols-1 md:grid-cols-4 ml-2 mt-2"
-        >
-          <div>
-            <div className="sm:col-span-1">
-              <div className="text-sm leading-5 font-semibold text-zinc-400">
-                Status{" "}
-              </div>
-              <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
-                {_.startCase(_.camelCase(itemData.status))}
-              </div>
+      <div
+        onClick={(_e) =>
+          navigate(
+            `/facility/${facilityId}/patient/${patientId}/sample/${itemData.id}`
+          )
+        }
+        className="grid gap-4 grid-cols-1 md:grid-cols-4 ml-2 mt-2"
+      >
+        <div>
+          <div className="sm:col-span-1">
+            <div className="text-sm leading-5 font-semibold text-zinc-400">
+              Status{" "}
             </div>
-          </div>
-          <div>
-            <div className="sm:col-span-1">
-              <div className="text-sm leading-5 font-semibold text-zinc-400">
-                Sample Type{" "}
-              </div>
-              <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
-                {itemData.sample_type !== "OTHER TYPE"
-                  ? itemData.sample_type
-                  : itemData.sample_type_other}
-              </div>
-            </div>
-          </div>
-          {itemData.fast_track && (
-            <div>
-              <div className="sm:col-span-1">
-                <div className="text-sm leading-5 font-semibold text-zinc-400">
-                  Fast-Track{" "}
-                </div>
-                <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
-                  {itemData.fast_track}
-                </div>
-              </div>
-            </div>
-          )}
-          <div>
-            <div className="sm:col-span-1">
-              <div className="text-sm leading-5 font-semibold text-zinc-400">
-                Result{" "}
-              </div>
-              <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
-                {_.startCase(_.camelCase(itemData.result))}
-              </div>
+            <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
+              {_.startCase(_.camelCase(itemData.status))}
             </div>
           </div>
         </div>
-        <div className="mt-4 flex flex-col md:flex-row justify-between gap-4 m-2">
-          <div className="flex flex-col md:flex-row justify-between gap-4">
-            <div>
-              <div className="text-gray-700 text-sm mb-2">
-                <span className="text-black font-medium">Date of Sample:</span>{" "}
-                {itemData.date_of_sample
-                  ? formatDate(itemData.date_of_sample)
-                  : "Not Available"}
+        <div>
+          <div className="sm:col-span-1">
+            <div className="text-sm leading-5 font-semibold text-zinc-400">
+              Sample Type{" "}
+            </div>
+            <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
+              {itemData.sample_type !== "OTHER TYPE"
+                ? itemData.sample_type
+                : itemData.sample_type_other}
+            </div>
+          </div>
+        </div>
+        {itemData.fast_track && (
+          <div>
+            <div className="sm:col-span-1">
+              <div className="text-sm leading-5 font-semibold text-zinc-400">
+                Fast-Track{" "}
               </div>
-              <div className="text-gray-700 text-sm">
-                <span className="text-black font-medium">Date of Result:</span>{" "}
-                {itemData.date_of_result
-                  ? formatDate(itemData.date_of_result)
-                  : "Not Available"}
+              <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
+                {itemData.fast_track}
               </div>
             </div>
           </div>
-          <div className="flex flex-col gap-2">
-            {
-              <div className="text-sm text-gray-700 items-center flex flex-col md:flex-row">
-                Created:{" "}
-                <RelativeDateUserMention
-                  actionDate={itemData.created_date}
-                  user={itemData.created_by}
-                />
-              </div>
-            }
+        )}
+        <div>
+          <div className="sm:col-span-1">
+            <div className="text-sm leading-5 font-semibold text-zinc-400">
+              Result{" "}
+            </div>
+            <div className="mt-1 text-sm leading-5 font-medium whitespace-normal break-words overflow-x-scroll">
+              {_.startCase(_.camelCase(itemData.result))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-4 flex flex-col md:flex-row justify-between gap-4 m-2">
+        <div className="flex flex-col md:flex-row justify-between gap-4">
+          <div>
+            <div className="text-gray-700 text-sm mb-2">
+              <span className="text-black font-medium">Date of Sample:</span>{" "}
+              {itemData.date_of_sample
+                ? formatDate(itemData.date_of_sample)
+                : "Not Available"}
+            </div>
+            <div className="text-gray-700 text-sm">
+              <span className="text-black font-medium">Date of Result:</span>{" "}
+              {itemData.date_of_result
+                ? formatDate(itemData.date_of_result)
+                : "Not Available"}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          {
             <div className="text-sm text-gray-700 items-center flex flex-col md:flex-row">
-              Last Modified:{" "}
+              Created:{" "}
               <RelativeDateUserMention
-                actionDate={itemData.modified_date}
-                user={itemData.last_edited_by}
+                actionDate={itemData.created_date}
+                user={itemData.created_by}
               />
             </div>
+          }
+          <div className="text-sm text-gray-700 items-center flex flex-col md:flex-row">
+            Last Modified:{" "}
+            <RelativeDateUserMention
+              actionDate={itemData.modified_date}
+              user={itemData.last_edited_by}
+            />
           </div>
         </div>
-        <div className="mt-4 flex flex-col gap-2 md:flex-row justify-between mx-2">
-          {itemData.status === "APPROVED" && (
-            <ButtonV2
-              onClick={(e) => {
-                e.stopPropagation();
-                handleApproval(4, itemData);
-              }}
-              className="bg-white hover:bg-gray-300 border border-gray-500 text-black"
-            >
-              Send to Collection Centre
-            </ButtonV2>
-          )}
+      </div>
+      <div className="mt-4 flex flex-col gap-2 md:flex-row justify-between mx-2">
+        {itemData.status === "APPROVED" && (
           <ButtonV2
-            onClick={() => showUpdateStatus(itemData)}
-            className="bg-white hover:bg-gray-300 border border-gray-500 text-black"
-            authorizeFor={NonReadOnlyUsers}
-          >
-            Update Sample Test Status
-          </ButtonV2>
-          <ButtonV2
-            onClick={(_e) => navigate(`/sample/${itemData.id}`)}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleApproval(4, itemData);
+            }}
             className="bg-white hover:bg-gray-300 border border-gray-500 text-black"
           >
-            Sample Report
+            Send to Collection Centre
           </ButtonV2>
-        </div>
-      </CardContent>
+        )}
+        <ButtonV2
+          onClick={() => showUpdateStatus(itemData)}
+          className="bg-white hover:bg-gray-300 border border-gray-500 text-black"
+          authorizeFor={NonReadOnlyUsers}
+        >
+          Update Sample Test Status
+        </ButtonV2>
+        <ButtonV2
+          onClick={(_e) => navigate(`/sample/${itemData.id}`)}
+          className="bg-white hover:bg-gray-300 border border-gray-500 text-black"
+        >
+          Sample Report
+        </ButtonV2>
+      </div>
       {statusDialog.show && (
         <UpdateStatusDialog
           sample={statusDialog.sample}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a61ccfc</samp>

Refactored `SampleTestCard` component to allow navigation to sample details. Removed unnecessary `CardContent` wrapper and adjusted card layout.

## Proposed Changes

- Fixes #4985

![image](https://github.com/coronasafe/care_fe/assets/25143503/86b2ffa4-404a-4dce-b3ce-89e6b32548e3)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a61ccfc</samp>

* Remove `CardContent` wrapper from sample test card to fix click navigation bug ([link](https://github.com/coronasafe/care_fe/pull/5658/files?diff=unified&w=0#diff-15b7c35aac8026980901950dd4689f22e8fbb3e744340fccd55045f11528d84fL1), [link](https://github.com/coronasafe/care_fe/pull/5658/files?diff=unified&w=0#diff-15b7c35aac8026980901950dd4689f22e8fbb3e744340fccd55045f11528d84fL86-R199))
* Adjust inner elements of sample test card to maintain layout and spacing ([link](https://github.com/coronasafe/care_fe/pull/5658/files?diff=unified&w=0#diff-15b7c35aac8026980901950dd4689f22e8fbb3e744340fccd55045f11528d84fL86-R199))
