### PR TITLE
Tailwinds `SampleViewAdmin.tsx`

### DIFF
--- a/src/Components/Patient/SampleViewAdmin.tsx
+++ b/src/Components/Patient/SampleViewAdmin.tsx
@@ -26,8 +26,8 @@ import { ExportButton } from "../Common/Export";
 import CountBlock from "../../CAREUI/display/Count";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { AdvancedFilterButton } from "../../CAREUI/interactive/FiltersSlideover";
+import Page from "../Common/components/Page";
 const Loading = loadable(() => import("../Common/Loading"));
-const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export default function SampleViewAdmin() {
   const {
@@ -329,7 +329,18 @@ export default function SampleViewAdmin() {
   }
 
   return (
-    <div className="px-6">
+    <Page
+      title="Sample Management System"
+      hideBack={true}
+      breadcrumbs={false}
+      componentRight={
+        <ExportButton
+          action={() => downloadSampleTests({ ...qParams })}
+          parse={parseExportData}
+          filenamePrefix="samples"
+        />
+      }
+    >
       {statusDialog.show && (
         <UpdateStatusDialog
           sample={statusDialog.sample}
@@ -338,18 +349,6 @@ export default function SampleViewAdmin() {
           userType={userType}
         />
       )}
-      <PageTitle
-        title="Sample Management System"
-        hideBack={true}
-        breadcrumbs={false}
-        componentRight={
-          <ExportButton
-            action={() => downloadSampleTests({ ...qParams })}
-            parse={parseExportData}
-            filenamePrefix="samples"
-          />
-        }
-      />
       <div className="mt-5 lg:grid lg:grid-cols-1 gap-5">
         <div className="flex flex-col lg:flex-row gap-6 justify-between">
           <div className="w-full">
@@ -411,6 +410,6 @@ export default function SampleViewAdmin() {
       <div className="md:px-2">
         <div className="flex flex-wrap md:-mx-2 lg:-mx-6">{manageSamples}</div>
       </div>
-    </div>
+    </Page>
   );
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa68d90</samp>

Refactored the sample view admin page to use the `Page` component for better layout and code quality.

## Proposed Changes

- Fixes #4986

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa68d90</samp>

*  Replace `PageTitle` component with `Page` component, which includes title, breadcrumbs, and optional right component, to reduce code duplication and improve consistency ([link](https://github.com/coronasafe/care_fe/pull/5660/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL29-R30), [link](https://github.com/coronasafe/care_fe/pull/5660/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL332-R343), [link](https://github.com/coronasafe/care_fe/pull/5660/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL341-L352), [link](https://github.com/coronasafe/care_fe/pull/5660/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL414-R413))
* Move export button to the right of the title using `componentRight` prop of `Page` component ([link](https://github.com/coronasafe/care_fe/pull/5660/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL332-R343))
* Update `SampleViewAdmin` component to use `Page` component as root element and pass relevant props ([link](https://github.com/coronasafe/care_fe/pull/5660/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL332-R343), [link](https://github.com/coronasafe/care_fe/pull/5660/files?diff=unified&w=0#diff-7d585559109e3d0525e8e78077dc34cd2d30558110e5f8fb9204dae6e8c3338aL414-R413))
