### PR TITLE
Tailwinds Patient Home (Confirm Transfer Complete Dialog)

### DIFF
--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -1,4 +1,3 @@
-import { CircularProgress } from "@material-ui/core";
 import { navigate } from "raviger";
 import moment from "moment";
 import React, { useCallback, useEffect, useState } from "react";
@@ -23,11 +22,6 @@ import { ConsultationCard } from "../Facility/ConsultationCard";
 import { ConsultationModel } from "../Facility/models";
 import { PatientModel, SampleTestModel } from "./models";
 import { SampleTestCard } from "./SampleTestCard";
-import Dialog from "@material-ui/core/Dialog";
-import DialogActions from "@material-ui/core/DialogActions";
-import DialogTitle from "@material-ui/core/DialogTitle";
-import { LegacyErrorHelperText } from "../Common/HelperInputFields";
-import Modal from "@material-ui/core/Modal";
 import Chip from "../../CAREUI/display/Chip";
 import { classNames, formatDate } from "../../Utils/utils";
 import ButtonV2 from "../Common/components/ButtonV2";
@@ -35,9 +29,12 @@ import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import RelativeDateUserMention from "../Common/RelativeDateUserMention";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { useTranslation } from "react-i18next";
+import CircularProgress from "../Common/components/CircularProgress";
+import Page from "../Common/components/Page";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
+import { FieldErrorText } from "../Form/FormFields/FormField";
 
 const Loading = loadable(() => import("../Common/Loading"));
-const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export const PatientHome = (props: any) => {
   const { facilityId, id } = props;
@@ -339,7 +336,7 @@ export const PatientHome = (props: any) => {
   let consultationList, sampleList;
 
   if (isConsultationLoading) {
-    consultationList = <CircularProgress size={20} />;
+    consultationList = <CircularProgress />;
   } else if (consultationListData.length === 0) {
     consultationList = (
       <div>
@@ -360,7 +357,7 @@ export const PatientHome = (props: any) => {
   }
 
   if (isSampleLoading) {
-    sampleList = <CircularProgress size={20} />;
+    sampleList = <CircularProgress />;
   } else if (sampleListData.length === 0) {
     sampleList = (
       <div>
@@ -394,7 +391,14 @@ export const PatientHome = (props: any) => {
   };
 
   return (
-    <div className="px-2 pb-2">
+    <Page
+      title={"Patient Details"}
+      crumbsReplacements={{
+        [facilityId]: { name: patientData?.facility_object?.name },
+        [id]: { name: patientData?.name },
+      }}
+      backUrl={facilityId ? `/facility/${facilityId}/patients` : "/patients"}
+    >
       {showAlertMessage.show && (
         <AlertDialog
           title={showAlertMessage.title}
@@ -404,18 +408,7 @@ export const PatientHome = (props: any) => {
         />
       )}
 
-      <div id="revamp">
-        <PageTitle
-          title={"Patient Details"}
-          crumbsReplacements={{
-            [facilityId]: { name: patientData?.facility_object?.name },
-            [id]: { name: patientData?.name },
-          }}
-          backUrl={
-            facilityId ? `/facility/${facilityId}/patients` : "/patients"
-          }
-        />
-
+      <div>
         <div className="relative mt-2">
           <div className="max-w-screen-xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
             <div className="md:flex">
@@ -959,55 +952,19 @@ export const PatientHome = (props: any) => {
                             >
                               {t("transfer_to_receiving_facility")}
                             </ButtonV2>
-                            <Modal
-                              open={modalFor === shift.external_id}
+                            <ConfirmDialogV2
+                              title="Confirm Transfer Complete"
+                              description="Are you sure you want to mark this transfer as complete? The Origin facility will no longer have access to this patient"
+                              show={modalFor === shift.external_id}
+                              action="Confirm"
                               onClose={() =>
                                 setModalFor({
                                   externalId: undefined,
                                   loading: false,
                                 })
                               }
-                            >
-                              <div className="h-screen w-full absolute flex items-center justify-center bg-modal">
-                                <div className="bg-white rounded shadow p-8 m-4 max-w-sm max-h-full text-center">
-                                  <div className="mb-4">
-                                    <h1 className="text-2xl">
-                                      Confirm Transfer Complete!
-                                    </h1>
-                                  </div>
-                                  <div className="mb-8">
-                                    <p>
-                                      Are you sure you want to mark this
-                                      transfer as complete? The Origin facility
-                                      will no longer have access to this patient
-                                    </p>
-                                  </div>
-                                  <div className="flex gap-2 justify-center">
-                                    <ButtonV2
-                                      size="small"
-                                      className="w-full"
-                                      onClick={() => {
-                                        setModalFor({
-                                          externalId: undefined,
-                                          loading: false,
-                                        });
-                                      }}
-                                    >
-                                      Cancel
-                                    </ButtonV2>
-                                    <ButtonV2
-                                      size="small"
-                                      className="w-full"
-                                      onClick={() =>
-                                        handleTransferComplete(shift)
-                                      }
-                                    >
-                                      Confirm
-                                    </ButtonV2>
-                                  </div>
-                                </div>
-                              </div>
-                            </Modal>
+                              onConfirm={() => handleTransferComplete(shift)}
+                            />
                           </div>
                         )}
                     </div>
@@ -1479,16 +1436,11 @@ export const PatientHome = (props: any) => {
         </section>
       </div>
 
-      <Dialog
-        maxWidth={"md"}
-        open={openAssignVolunteerDialog}
+      <ConfirmDialogV2
+        title={`Assign a volunteer to ${patientData.name}`}
+        show={openAssignVolunteerDialog}
         onClose={() => setOpenAssignVolunteerDialog(false)}
-      >
-        <div className="mx-10 my-5">
-          <DialogTitle id="form-dialog-title">
-            Assign a volunteer to {patientData.name}
-          </DialogTitle>
-
+        description={
           <div>
             <OnlineUsersSelect
               userId={assignedVolunteerObject?.id || patientData.assigned_to}
@@ -1497,23 +1449,12 @@ export const PatientHome = (props: any) => {
               user_type={"Volunteer"}
               outline={false}
             />
-            <LegacyErrorHelperText error={errors.assignedVolunteer} />
+            <FieldErrorText error={errors.assignedVolunteer} />
           </div>
-
-          <DialogActions>
-            <ButtonV2
-              variant="secondary"
-              onClick={() => {
-                handleVolunteerSelect(patientData.assigned_to_object);
-                setOpenAssignVolunteerDialog(false);
-              }}
-            >
-              Cancel
-            </ButtonV2>
-            <ButtonV2 onClick={handleAssignedVolunteer}>Submit</ButtonV2>
-          </DialogActions>
-        </div>
-      </Dialog>
+        }
+        action="Assign"
+        onConfirm={handleAssignedVolunteer}
+      />
 
       <div>
         <h2 className="font-semibold text-2xl leading-tight ml-0 mt-9">
@@ -1548,6 +1489,6 @@ export const PatientHome = (props: any) => {
           </div>
         )}
       </div>
-    </div>
+    </Page>
   );
 };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0136e3</samp>

Refactor `PatientHome` component to use common UI components and clean up code.

## Proposed Changes

- Fixes #4979

![image](https://github.com/coronasafe/care_fe/assets/25143503/7a32c271-be5e-4182-96c6-e42cf0922b5e)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0136e3</samp>

*  Remove unused imports of `CircularProgress`, `Dialog`, `DialogActions`, `DialogTitle`, `LegacyErrorHelperText` and `Modal` from various components ([link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL1), [link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL26-L30))
*  Add imports of `CircularProgress`, `Page`, `ConfirmDialogV2` and `FieldErrorText` from common components to provide consistent UI elements ([link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL38-R37))
*  Replace `div` element with `Page` component to render page title, breadcrumbs and back button with common layout and styling ([link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL397-R401), [link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL407-R411))
*  Remove `size` prop from `CircularProgress` components, as it is not needed for the default size ([link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL342-R339), [link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL363-R360))
*  Replace `Modal` and `Dialog` components with `ConfirmDialogV2` component to render confirmation dialogs with common UI elements and props ([link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL962-R959), [link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL970-R967), [link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL1482-R1443), [link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL1500-R1458))
*  Replace `LegacyErrorHelperText` component with `FieldErrorText` component to render error text with consistent UI element ([link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL1500-R1458))
*  Close `Page` component tag ([link](https://github.com/coronasafe/care_fe/pull/5662/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL1551-R1492))
