### PR TITLE
Tailwinds `ResourceCreate.tsx`

### DIFF
--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -10,7 +10,6 @@ import {
   RESOURCE_SUBCATEGORIES,
 } from "../../Common/constants";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
-import { Card, CardContent } from "@material-ui/core";
 import { phonePreg } from "../../Common/validation";
 
 import { createResource, getAnyFacility } from "../../Redux/actions";
@@ -24,8 +23,9 @@ import { SelectFormField } from "../Form/FormFields/SelectFormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import RadioFormField from "../Form/FormFields/RadioFormField";
 import { FieldLabel } from "../Form/FormFields/FormField";
+import Card from "../../CAREUI/display/Card";
+import Page from "../Common/components/Page";
 
-const PageTitle = loadable(() => import("../Common/PageTitle"));
 const Loading = loadable(() => import("../Common/Loading"));
 
 interface resourceProps {
@@ -219,121 +219,114 @@ export default function ResourceCreate(props: resourceProps) {
   }
 
   return (
-    <div className="px-2 pb-2">
-      <PageTitle
-        title={t("create_resource_request")}
-        crumbsReplacements={{
-          [facilityId]: { name: facilityName },
-          resource: { style: "pointer-events-none" },
-        }}
-        backUrl={`/facility/${facilityId}`}
-      />
-      <div className="mt-4">
-        <Card>
-          <CardContent>
-            <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
-              <TextFormField
-                required
-                label={t("contact_person")}
-                name="refering_facility_contact_name"
-                value={state.form.refering_facility_contact_name}
-                onChange={handleChange}
-                error={state.errors.refering_facility_contact_name}
-              />
-              <PhoneNumberFormField
-                label={t("contact_phone")}
-                name="refering_facility_contact_number"
-                required
-                disableCountry
-                value={state.form.refering_facility_contact_number}
-                onChange={handleFormFieldChange}
-                error={state.errors.refering_facility_contact_number}
-              />
+    <Page
+      title={t("create_resource_request")}
+      crumbsReplacements={{
+        [facilityId]: { name: facilityName },
+        resource: { style: "pointer-events-none" },
+      }}
+      backUrl={`/facility/${facilityId}`}
+    >
+      <Card className="mt-4">
+        <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
+          <TextFormField
+            required
+            label={t("contact_person")}
+            name="refering_facility_contact_name"
+            value={state.form.refering_facility_contact_name}
+            onChange={handleChange}
+            error={state.errors.refering_facility_contact_name}
+          />
+          <PhoneNumberFormField
+            label={t("contact_phone")}
+            name="refering_facility_contact_number"
+            required
+            disableCountry
+            value={state.form.refering_facility_contact_number}
+            onChange={handleFormFieldChange}
+            error={state.errors.refering_facility_contact_number}
+          />
 
-              <div className="md:col-span-2">
-                <FieldLabel required>{t("approving_facility")}</FieldLabel>
-                <FacilitySelect
-                  multiple={false}
-                  facilityType={1500}
-                  name="approving_facility"
-                  selected={state.form.approving_facility}
-                  setSelected={(value: any) =>
-                    handleValueChange(value, "approving_facility")
-                  }
-                  errors={state.errors.approving_facility}
-                />
-              </div>
+          <div className="md:col-span-2">
+            <FieldLabel required>{t("approving_facility")}</FieldLabel>
+            <FacilitySelect
+              multiple={false}
+              facilityType={1500}
+              name="approving_facility"
+              selected={state.form.approving_facility}
+              setSelected={(value: any) =>
+                handleValueChange(value, "approving_facility")
+              }
+              errors={state.errors.approving_facility}
+            />
+          </div>
 
-              <SelectFormField
-                label={t("category")}
-                name="category"
-                required
-                value={state.form.category}
-                options={RESOURCE_CATEGORY_CHOICES}
-                optionLabel={(option: string) => option}
-                optionValue={(option: string) => option}
-                onChange={({ value }) => handleValueChange(value, "category")}
-              />
-              <SelectFormField
-                label={t("sub_category")}
-                name="sub_category"
-                required
-                value={state.form.sub_category}
-                options={RESOURCE_SUBCATEGORIES}
-                optionLabel={(option: OptionsType) => option.text}
-                optionValue={(option: OptionsType) => option.id}
-                onChange={({ value }) =>
-                  handleValueChange(value, "sub_category")
-                }
-              />
+          <SelectFormField
+            label={t("category")}
+            name="category"
+            required
+            value={state.form.category}
+            options={RESOURCE_CATEGORY_CHOICES}
+            optionLabel={(option: string) => option}
+            optionValue={(option: string) => option}
+            onChange={({ value }) => handleValueChange(value, "category")}
+          />
+          <SelectFormField
+            label={t("sub_category")}
+            name="sub_category"
+            required
+            value={state.form.sub_category}
+            options={RESOURCE_SUBCATEGORIES}
+            optionLabel={(option: OptionsType) => option.text}
+            optionValue={(option: OptionsType) => option.id}
+            onChange={({ value }) => handleValueChange(value, "sub_category")}
+          />
 
-              <TextFormField
-                label={t("request_title")}
-                name="title"
-                placeholder={t("request_title_placeholder")}
-                value={state.form.title}
-                onChange={handleChange}
-                error={state.errors.title}
-              />
+          <TextFormField
+            label={t("request_title")}
+            name="title"
+            placeholder={t("request_title_placeholder")}
+            value={state.form.title}
+            onChange={handleChange}
+            error={state.errors.title}
+          />
 
-              <TextFormField
-                label={t("required_quantity")}
-                name="requested_quantity"
-                value={state.form.required_quantity}
-                onChange={handleChange}
-              />
+          <TextFormField
+            label={t("required_quantity")}
+            name="requested_quantity"
+            value={state.form.required_quantity}
+            onChange={handleChange}
+          />
 
-              <div className="md:col-span-2">
-                <TextAreaFormField
-                  label={t("request_description")}
-                  name="reason"
-                  rows={5}
-                  required
-                  placeholder={t("request_description_placeholder")}
-                  value={state.form.reason}
-                  onChange={handleChange}
-                  error={state.errors.reason}
-                />
-              </div>
+          <div className="md:col-span-2">
+            <TextAreaFormField
+              label={t("request_description")}
+              name="reason"
+              rows={5}
+              required
+              placeholder={t("request_description_placeholder")}
+              value={state.form.reason}
+              onChange={handleChange}
+              error={state.errors.reason}
+            />
+          </div>
 
-              <RadioFormField
-                label={t("is_this_an_emergency")}
-                name="emergency"
-                options={[true, false]}
-                optionDisplay={(o) => (o ? t("yes") : t("no"))}
-                optionValue={(o) => String(o)}
-                value={state.form.emergency}
-                onChange={handleChange}
-              />
+          <RadioFormField
+            label={t("is_this_an_emergency")}
+            name="emergency"
+            options={[true, false]}
+            optionDisplay={(o) => (o ? t("yes") : t("no"))}
+            optionValue={(o) => String(o)}
+            value={state.form.emergency}
+            onChange={handleChange}
+          />
 
-              <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">
-                <Cancel onClick={() => goBack()} />
-                <Submit onClick={handleSubmit} />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+          <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">
+            <Cancel onClick={() => goBack()} />
+            <Submit onClick={handleSubmit} />
+          </div>
+        </div>
+      </Card>
+    </Page>
   );
 }

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -227,104 +227,102 @@ export default function ResourceCreate(props: resourceProps) {
       }}
       backUrl={`/facility/${facilityId}`}
     >
-      <Card className="mt-4">
-        <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
-          <TextFormField
+      <Card className="mt-4 grid gap-4 grid-cols-1 md:grid-cols-2">
+        <TextFormField
+          required
+          label={t("contact_person")}
+          name="refering_facility_contact_name"
+          value={state.form.refering_facility_contact_name}
+          onChange={handleChange}
+          error={state.errors.refering_facility_contact_name}
+        />
+        <PhoneNumberFormField
+          label={t("contact_phone")}
+          name="refering_facility_contact_number"
+          required
+          disableCountry
+          value={state.form.refering_facility_contact_number}
+          onChange={handleFormFieldChange}
+          error={state.errors.refering_facility_contact_number}
+        />
+
+        <div>
+          <FieldLabel required>{t("approving_facility")}</FieldLabel>
+          <FacilitySelect
+            multiple={false}
+            facilityType={1500}
+            name="approving_facility"
+            selected={state.form.approving_facility}
+            setSelected={(value: any) =>
+              handleValueChange(value, "approving_facility")
+            }
+            errors={state.errors.approving_facility}
+          />
+        </div>
+
+        <RadioFormField
+          label={t("is_this_an_emergency")}
+          name="emergency"
+          options={[true, false]}
+          optionDisplay={(o) => (o ? t("yes") : t("no"))}
+          optionValue={(o) => String(o)}
+          value={state.form.emergency}
+          onChange={handleChange}
+        />
+
+        <SelectFormField
+          label={t("category")}
+          name="category"
+          required
+          value={state.form.category}
+          options={RESOURCE_CATEGORY_CHOICES}
+          optionLabel={(option: string) => option}
+          optionValue={(option: string) => option}
+          onChange={({ value }) => handleValueChange(value, "category")}
+        />
+        <SelectFormField
+          label={t("sub_category")}
+          name="sub_category"
+          required
+          value={state.form.sub_category}
+          options={RESOURCE_SUBCATEGORIES}
+          optionLabel={(option: OptionsType) => option.text}
+          optionValue={(option: OptionsType) => option.id}
+          onChange={({ value }) => handleValueChange(value, "sub_category")}
+        />
+
+        <TextFormField
+          label={t("request_title")}
+          name="title"
+          placeholder={t("request_title_placeholder")}
+          value={state.form.title}
+          onChange={handleChange}
+          error={state.errors.title}
+        />
+
+        <TextFormField
+          label={t("required_quantity")}
+          name="requested_quantity"
+          value={state.form.required_quantity}
+          onChange={handleChange}
+        />
+
+        <div className="md:col-span-2">
+          <TextAreaFormField
+            label={t("request_description")}
+            name="reason"
+            rows={5}
             required
-            label={t("contact_person")}
-            name="refering_facility_contact_name"
-            value={state.form.refering_facility_contact_name}
+            placeholder={t("request_description_placeholder")}
+            value={state.form.reason}
             onChange={handleChange}
-            error={state.errors.refering_facility_contact_name}
+            error={state.errors.reason}
           />
-          <PhoneNumberFormField
-            label={t("contact_phone")}
-            name="refering_facility_contact_number"
-            required
-            disableCountry
-            value={state.form.refering_facility_contact_number}
-            onChange={handleFormFieldChange}
-            error={state.errors.refering_facility_contact_number}
-          />
+        </div>
 
-          <div className="md:col-span-2">
-            <FieldLabel required>{t("approving_facility")}</FieldLabel>
-            <FacilitySelect
-              multiple={false}
-              facilityType={1500}
-              name="approving_facility"
-              selected={state.form.approving_facility}
-              setSelected={(value: any) =>
-                handleValueChange(value, "approving_facility")
-              }
-              errors={state.errors.approving_facility}
-            />
-          </div>
-
-          <SelectFormField
-            label={t("category")}
-            name="category"
-            required
-            value={state.form.category}
-            options={RESOURCE_CATEGORY_CHOICES}
-            optionLabel={(option: string) => option}
-            optionValue={(option: string) => option}
-            onChange={({ value }) => handleValueChange(value, "category")}
-          />
-          <SelectFormField
-            label={t("sub_category")}
-            name="sub_category"
-            required
-            value={state.form.sub_category}
-            options={RESOURCE_SUBCATEGORIES}
-            optionLabel={(option: OptionsType) => option.text}
-            optionValue={(option: OptionsType) => option.id}
-            onChange={({ value }) => handleValueChange(value, "sub_category")}
-          />
-
-          <TextFormField
-            label={t("request_title")}
-            name="title"
-            placeholder={t("request_title_placeholder")}
-            value={state.form.title}
-            onChange={handleChange}
-            error={state.errors.title}
-          />
-
-          <TextFormField
-            label={t("required_quantity")}
-            name="requested_quantity"
-            value={state.form.required_quantity}
-            onChange={handleChange}
-          />
-
-          <div className="md:col-span-2">
-            <TextAreaFormField
-              label={t("request_description")}
-              name="reason"
-              rows={5}
-              required
-              placeholder={t("request_description_placeholder")}
-              value={state.form.reason}
-              onChange={handleChange}
-              error={state.errors.reason}
-            />
-          </div>
-
-          <RadioFormField
-            label={t("is_this_an_emergency")}
-            name="emergency"
-            options={[true, false]}
-            optionDisplay={(o) => (o ? t("yes") : t("no"))}
-            optionValue={(o) => String(o)}
-            value={state.form.emergency}
-            onChange={handleChange}
-          />
-
-          <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">
-            <Cancel onClick={() => goBack()} />
-            <Submit onClick={handleSubmit} />
-          </div>
+        <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-end mt-4">
+          <Cancel onClick={() => goBack()} />
+          <Submit onClick={handleSubmit} />
         </div>
       </Card>
     </Page>

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -298,6 +298,7 @@ export default function ResourceCreate(props: resourceProps) {
           value={state.form.title}
           onChange={handleChange}
           error={state.errors.title}
+          required
         />
 
         <TextFormField


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c664cab</samp>

The pull request refactors the `ResourceCreate` component to use custom UI components instead of `@material-ui/core` components. This improves the code readability and the UI design of the resource creation page. The file `src/Components/Resource/ResourceCreate.tsx` was modified to implement these changes.

## Proposed Changes

- Fixes #4992
- Fixes #5692

![image](https://github.com/coronasafe/care_fe/assets/25143503/a9b634b6-e919-441d-baef-aef521acd4bb)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c664cab</samp>

*  Replace `@material-ui/core` components with custom `Card` and `Page` components for better UI design and code consistency ([link](https://github.com/coronasafe/care_fe/pull/5667/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL13), [link](https://github.com/coronasafe/care_fe/pull/5667/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL27-R28), [link](https://github.com/coronasafe/care_fe/pull/5667/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL222-R330))
*  Remove unused imports of `Card` and `CardContent` from `@material-ui/core` ([link](https://github.com/coronasafe/care_fe/pull/5667/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL13))
*  Move `Card` import to the UI section and reorder imports alphabetically ([link](https://github.com/coronasafe/care_fe/pull/5667/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL27-R28))
*  Refactor return statement of `ResourceCreate` component to use `Page` and `Card` props and adjust indentation and spacing ([link](https://github.com/coronasafe/care_fe/pull/5667/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL222-R330))
