### PR TITLE
Tailwinds `ResourceDetails.tsx`

### DIFF
--- a/src/Components/Resource/CommentSection.tsx
+++ b/src/Components/Resource/CommentSection.tsx
@@ -7,6 +7,7 @@ import Pagination from "../Common/Pagination";
 import { formatDate } from "../../Utils/utils";
 import CircularProgress from "../Common/components/CircularProgress";
 import ButtonV2 from "../Common/components/ButtonV2";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 
 interface CommentSectionProps {
   id: string;
@@ -72,17 +73,16 @@ const CommentSection = (props: CommentSectionProps) => {
 
   return (
     <div className="w-full flex flex-col">
-      <textarea
-        rows={3}
+      <TextAreaFormField
+        name="comment"
         placeholder="Type your comment"
-        className="mt-4 border border-gray-500 rounded-lg p-4 focus:border-primary-600 focus:ring-primary-600"
         value={commentBox}
-        onChange={(e) => setCommentBox(e.target.value)}
+        onChange={(e) => setCommentBox(e.value)}
       />
       <div className="flex w-full justify-end">
         <ButtonV2 onClick={onSubmitComment}>Post Your Comment</ButtonV2>
       </div>
-      <div className=" w-full">
+      <div className="w-full">
         {isLoading ? (
           <CircularProgress className="h-12 w-12" />
         ) : (

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -5,17 +5,13 @@ import { classNames } from "../../Utils/utils";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getResourceDetails, deleteResourceRecord } from "../../Redux/actions";
 import { navigate } from "raviger";
-import Button from "@material-ui/core/Button";
-import Dialog from "@material-ui/core/Dialog";
-import DialogActions from "@material-ui/core/DialogActions";
-import DialogContent from "@material-ui/core/DialogContent";
-import DialogContentText from "@material-ui/core/DialogContentText";
-import DialogTitle from "@material-ui/core/DialogTitle";
 import * as Notification from "../../Utils/Notifications.js";
 import CommentSection from "./CommentSection";
 import { formatDate } from "../../Utils/utils";
+import ButtonV2 from "../Common/components/ButtonV2";
+import Page from "../Common/components/Page";
+import ConfirmDialogV2 from "../Common/ConfirmDialogV2";
 const Loading = loadable(() => import("../Common/Loading"));
-const PageTitle = loadable(() => import("../Common/PageTitle"));
 
 export default function ResourceDetails(props: { id: string }) {
   const dispatch: any = useDispatch();
@@ -233,33 +229,26 @@ export default function ResourceDetails(props: { id: string }) {
   }
 
   return (
-    <div>
+    <Page
+      title={"Resource details"}
+      crumbsReplacements={{ [props.id]: { name: data.title } }}
+      backUrl={"/resource/board-view"}
+    >
       {isPrintMode ? (
         <div className="my-4">
-          <div className="my-4 flex justify-end ">
-            <button
-              onClick={(_) => window.print()}
-              className="btn btn-primary mr-2"
-            >
+          <div className="my-4 flex justify-end gap-2">
+            <ButtonV2 onClick={() => window.print()}>
               <i className="fas fa-print mr-2"></i> Print Approval Letter
-            </button>
-            <button
-              onClick={(_) => setIsPrintMode(false)}
-              className="btn btn-default"
-            >
+            </ButtonV2>
+            <ButtonV2 onClick={() => setIsPrintMode(false)} variant="secondary">
               <i className="fas fa-times mr-2"></i> Close
-            </button>
+            </ButtonV2>
           </div>
           {ApprovalLetter(data)}
         </div>
       ) : (
         <div className="mx-3 md:mx-8 mb-10">
           <div className="my-4 flex flex-col items-start md:flex-row md:justify-between md:items-center">
-            <PageTitle
-              title={"Resource details"}
-              crumbsReplacements={{ [props.id]: { name: data.title } }}
-              backUrl={"/resource/board-view"}
-            />
             <div>
               <button
                 onClick={(_) => setIsPrintMode(true)}
@@ -287,21 +276,12 @@ export default function ResourceDetails(props: { id: string }) {
           <div className="border rounded-lg bg-white shadow h-full text-black mt-4 p-4">
             <div className="flex flex-col sm:flex-row sm:justify-between mb-4">
               <div className="text-xl font-semibold">{data.title || "--"}</div>
-              <div>
-                <div className="mt-4 sm:mt-2">
-                  <Button
-                    fullWidth
-                    variant="contained"
-                    color="primary"
-                    size="small"
-                    onClick={() =>
-                      navigate(`/resource/${data.external_id}/update`)
-                    }
-                  >
-                    Update Status/Details
-                  </Button>
-                </div>
-              </div>
+              <ButtonV2
+                className="w-full mt-4 sm:mt-2"
+                href={`/resource/${data.external_id}/update`}
+              >
+                Update Status/Details
+              </ButtonV2>
             </div>
 
             <div className="grid gap-2 grid-cols-1 md:grid-cols-2">
@@ -370,46 +350,25 @@ export default function ResourceDetails(props: { id: string }) {
               </div>
             </div>
 
-            <div className="flex justify-end mt-4 hidden">
+            <div className="flex justify-end mt-4">
               <div>
-                <Button
-                  fullWidth
-                  variant="contained"
-                  color="secondary"
-                  size="small"
+                <ButtonV2
+                  className="w-full"
+                  variant="danger"
                   onClick={() => setOpenDeleteResourceDialog(true)}
                 >
                   Delete Record
-                </Button>
+                </ButtonV2>
 
-                <Dialog
-                  open={openDeleteResourceDialog}
+                <ConfirmDialogV2
+                  title="Authorize resource delete"
+                  description="Are you sure you want to delete this record?"
+                  action="Delete"
+                  variant="danger"
+                  show={openDeleteResourceDialog}
                   onClose={() => setOpenDeleteResourceDialog(false)}
-                >
-                  <DialogTitle id="alert-dialog-title">
-                    Authorize resource delete
-                  </DialogTitle>
-                  <DialogContent>
-                    <DialogContentText id="alert-dialog-description">
-                      Are you sure you want to delete this record?
-                    </DialogContentText>
-                  </DialogContent>
-                  <DialogActions>
-                    <Button
-                      onClick={() => setOpenDeleteResourceDialog(false)}
-                      color="primary"
-                    >
-                      No
-                    </Button>
-                    <Button
-                      color="primary"
-                      onClick={handleResourceDelete}
-                      autoFocus
-                    >
-                      Yes
-                    </Button>
-                  </DialogActions>
-                </Dialog>
+                  onConfirm={handleResourceDelete}
+                />
               </div>
             </div>
           </div>
@@ -477,6 +436,6 @@ export default function ResourceDetails(props: { id: string }) {
           </div>
         </div>
       )}
-    </div>
+    </Page>
   );
 }

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -249,14 +249,9 @@ export default function ResourceDetails(props: { id: string }) {
       ) : (
         <div className="mx-3 md:mx-8 mb-10">
           <div className="my-4 flex flex-col items-start md:flex-row md:justify-between md:items-center">
-            <div>
-              <button
-                onClick={(_) => setIsPrintMode(true)}
-                className="btn btn-primary"
-              >
-                <i className="fas fa-file-alt mr-2"></i> Approval Letter
-              </button>
-            </div>
+            <ButtonV2 onClick={(_) => setIsPrintMode(true)}>
+              <i className="fas fa-file-alt mr-2"></i> Approval Letter
+            </ButtonV2>
           </div>
           {data.assigned_to_object && (
             <div className="relative rounded-lg shadow bg-primary-200">


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3665fcb</samp>

Refactored ResourceDetails component to use new UI components. This enhances the app's appearance, functionality and user experience. Updated `src/Components/Resource/ResourceDetails.tsx` file.

## Proposed Changes

- Fixes #4993
- Fixes #5693

![image](https://github.com/coronasafe/care_fe/assets/25143503/4ad7c7ee-dd25-4f28-a512-dd6cae6956f6)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3665fcb</samp>

*  Replace old UI components with new ones for consistency and usability ([link](https://github.com/coronasafe/care_fe/pull/5668/files?diff=unified&w=0#diff-9bc75f1eec9edc5184b0e770a808d2cddf3ffbd8bf29bc29bdeb734c683ab43cL8-R14), [link](https://github.com/coronasafe/care_fe/pull/5668/files?diff=unified&w=0#diff-9bc75f1eec9edc5184b0e770a808d2cddf3ffbd8bf29bc29bdeb734c683ab43cL236-R245), [link](https://github.com/coronasafe/care_fe/pull/5668/files?diff=unified&w=0#diff-9bc75f1eec9edc5184b0e770a808d2cddf3ffbd8bf29bc29bdeb734c683ab43cL258-L262), [link](https://github.com/coronasafe/care_fe/pull/5668/files?diff=unified&w=0#diff-9bc75f1eec9edc5184b0e770a808d2cddf3ffbd8bf29bc29bdeb734c683ab43cL290-R284), [link](https://github.com/coronasafe/care_fe/pull/5668/files?diff=unified&w=0#diff-9bc75f1eec9edc5184b0e770a808d2cddf3ffbd8bf29bc29bdeb734c683ab43cL373-R371), [link](https://github.com/coronasafe/care_fe/pull/5668/files?diff=unified&w=0#diff-9bc75f1eec9edc5184b0e770a808d2cddf3ffbd8bf29bc29bdeb734c683ab43cL480-R439))
