### PR TITLE
Shows delete user button only for state admins or superuser

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -171,22 +171,14 @@ export default function ManageUsers() {
   };
 
   const showDelete = (user: any) => {
-    const STATE_ADMIN_LEVEL = USER_TYPES.indexOf("StateAdmin");
-    const STATE_READ_ONLY_ADMIN_LEVEL =
-      USER_TYPES.indexOf("StateReadOnlyAdmin");
-    const DISTRICT_ADMIN_LEVEL = USER_TYPES.indexOf("DistrictAdmin");
-    const level = USER_TYPES.indexOf(user.user_type);
-    const currentUserLevel = USER_TYPES.indexOf(currentUser.data.user_type);
     if (user.is_superuser) return true;
 
-    if (currentUserLevel >= STATE_ADMIN_LEVEL)
-      return user.state_object?.id === currentUser?.data?.state;
     if (
-      currentUserLevel < STATE_READ_ONLY_ADMIN_LEVEL &&
-      currentUserLevel >= DISTRICT_ADMIN_LEVEL &&
-      currentUserLevel > level
+      USER_TYPES.indexOf(currentUser.data.user_type) >=
+      USER_TYPES.indexOf("StateAdmin")
     )
-      return user?.district_object?.id === currentUser?.data?.district;
+      return user.state_object?.id === currentUser?.data?.state;
+
     return false;
   };
 
@@ -253,13 +245,14 @@ export default function ManageUsers() {
                     ></i>
                   ) : null}
                   {showDelete(user) && (
-                    <button
-                      type="button"
-                      className="m-3 px-3 py-2 self-end w-20 border border-red-500 text-center text-sm leading-4 font-medium rounded-md text-red-700 bg-white hover:text-white hover:bg-red-500 focus:outline-none focus:border-red-300 focus:ring-blue active:text-red-800 active:bg-gray-50 transition ease-in-out duration-150 hover:shadow"
+                    <ButtonV2
+                      variant="danger"
+                      ghost
+                      border
                       onClick={() => handleDelete(user)}
                     >
                       Delete
-                    </button>
+                    </ButtonV2>
                   )}
                 </div>
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4efde7d</samp>

This pull request fixes a user deletion bug and refactors the `ManageUsers` component to use a custom button component for better UI consistency and code quality.

## Proposed Changes

- Shows delete user button only for state admins or superuser

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4efde7d</samp>

*  Simplify the logic for showing the delete button for users by only checking the user role and state ([link](https://github.com/coronasafe/care_fe/pull/5670/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121L174-R181))
* Replace the native button element with the custom `ButtonV2` component for better UI consistency and maintainability ([link](https://github.com/coronasafe/care_fe/pull/5670/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121L256-R255))
