### PR TITLE
Removed Force:true from Cypress Asset Test

### DIFF
--- a/cypress/e2e/assets_spec/assets.cy.ts
+++ b/cypress/e2e/assets_spec/assets.cy.ts
@@ -3,7 +3,7 @@
 import { cy, describe, before, beforeEach, it } from "local-cypress";
 import { v4 as uuidv4 } from "uuid";
 
-const phone_number = "9" + parseInt((Math.random() * 10 ** 9).toString());
+const phone_number = "9999999999";
 const serial_no = parseInt((Math.random() * 10 ** 10).toString());
 
 describe("Asset", () => {
@@ -28,18 +28,20 @@ describe("Asset", () => {
     cy.get("button").should("contain", "Select");
     cy.get("button").get("#submit").click();
     cy.get("[data-testid=asset-name-input] input").type("New Test Asset");
-    cy.get("[data-testid=asset-location-input] input").type(
-      "Camera Location{enter}"
-    );
+    cy.get("[data-testid=asset-location-input] input")
+      .type("Camera Locat")
+      .then(() => {
+        cy.get("[role='option']").contains("Camera Locations").click();
+      });
     cy.get("[data-testid=asset-type-input] button")
       .click()
       .then(() => {
-        cy.get("li").contains("Internal").click();
+        cy.get("[role='option']").contains("Internal").click();
       });
     cy.get("[data-testid=asset-class-input] button")
       .click()
       .then(() => {
-        cy.get("li").contains("ONVIF Camera").click();
+        cy.get("[role='option']").contains("ONVIF Camera").click();
       });
     cy.get("[data-testid=asset-description-input] textarea").type(
       "Test Description"
@@ -90,13 +92,9 @@ describe("Asset", () => {
 
   it("Next/Previous Page", () => {
     // only works for desktop mode
-    cy.get("button")
-      .should("contain", "Next")
-      .contains("Next")
-      .click({ force: true });
-    cy.get("button")
-      .should("contain", "Previous")
-      .contains("Previous")
-      .click({ force: true });
+    cy.get("button#next-pages").click();
+    cy.url().should("include", "page=2");
+    cy.get("button#prev-pages").click();
+    cy.url().should("include", "page=1");
   });
 });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13e26df</samp>

Improve e2e tests for assets by using better selectors and url assertions. Refactor `assets.cy.ts` file accordingly.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13e26df</samp>

* Change the phone_number variable to a fixed value to avoid flaky tests ([link](https://github.com/coronasafe/care_fe/pull/5676/files?diff=unified&w=0#diff-5979985dda75f49bd8934fbd4aff8bdb17579a17a3fb07a02119011a57c335e2L6-R6))
* Use the role attribute instead of the text content to select the asset location, type, and class options for better accessibility and reliability ([link](https://github.com/coronasafe/care_fe/pull/5676/files?diff=unified&w=0#diff-5979985dda75f49bd8934fbd4aff8bdb17579a17a3fb07a02119011a57c335e2L31-R44))
* Use the id attribute instead of the text content to click the next and previous page buttons and add url assertions to verify the pagination ([link](https://github.com/coronasafe/care_fe/pull/5676/files?diff=unified&w=0#diff-5979985dda75f49bd8934fbd4aff8bdb17579a17a3fb07a02119011a57c335e2L93-R98))
