### PR TITLE
Tailwind src/Components/Facility/Investigations/Table

### DIFF
--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -1,83 +1,48 @@
-import {
-  Paper,
-  TableCell,
-  TableContainer,
-  Table,
-  TableHead,
-  TableRow,
-  TableBody,
-  InputLabel,
-  Typography,
-  Box,
-} from "@material-ui/core";
-import { LegacySelectField } from "../../Common/HelperInputFields";
-import { createStyles, makeStyles, withStyles } from "@material-ui/styles";
-import React from "react";
-import { useState } from "react";
-import { LegacyTextInputField } from "../../Common/HelperInputFields";
+import { FieldChangeEvent } from "../../Form/FormFields/Utils";
+import { SelectFormField } from "../../Form/FormFields/SelectFormField";
+import TextFormField from "../../Form/FormFields/TextFormField";
 import _ from "lodash";
+import { useState } from "react";
 
-const useStyle = makeStyles(() => ({
-  tableCell: {
-    paddingTop: 0,
-    paddingBottom: 0,
-  },
-}));
-
-const StyledTableRow = withStyles(() =>
-  createStyles({
-    root: {
-      "&:nth-of-type(odd)": {
-        backgroundColor: "#f7f7f7",
-      },
-      "&:hover": {
-        backgroundColor: "#eeeeee",
-      },
-    },
-  })
-)(TableRow);
-
-const TestRow = ({ data, value, onChange }: any) => {
-  const className = useStyle();
-  const inputType = data.investigation_type === "Float" ? "number" : "text";
+const TestRow = ({ data, value, onChange, i }: any) => {
   return (
-    <StyledTableRow>
-      <TableCell className={className.tableCell}>{data.name}</TableCell>
-      <TableCell className={className.tableCell} align="right">
+    <tr className={i % 2 == 0 ? "bg-gray-50" : "bg-white"}>
+      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+        {data.name}
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 text-right">
         {data.investigation_type === "Choice" ? (
-          <LegacySelectField
-            name="preferred_vehicle_choice"
-            variant="outlined"
-            optionArray={true}
+          <SelectFormField
+            name={data.name}
             value={value}
-            options={["Unselected", ...data.choices.split(",")]}
+            options={data?.choices.split(",")}
+            optionLabel={(o: string) => o}
+            optionValue={(o: string) => o}
             onChange={onChange}
-            className="border-l border-r border-gray-400"
           />
         ) : (
-          <input
-            className="lg:w-full h-12 text-right text-sm border-l border-r focus:ring-primary-500 focus:border-primary-500 bg-[#fbfafc]"
+          <TextFormField
+            name={data.name}
             value={value}
             onChange={onChange}
-            type={inputType}
-            step="any"
+            type={data.investigation_type === "Float" ? "number" : "text"}
             placeholder="Enter value"
           />
         )}
-      </TableCell>
-      <TableCell className={className.tableCell} align="left">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.unit || "---"}
-      </TableCell>
-      <TableCell className={className.tableCell} align="right">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.min_value ?? "---"}
-      </TableCell>
-      <TableCell className={className.tableCell} align="right">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.max_value ?? "---"}
-      </TableCell>
-      <TableCell className={className.tableCell} align="right">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.ideal_value || "---"}
-      </TableCell>
-    </StyledTableRow>
+      </td>
+    </tr>
   );
 };
 
@@ -98,46 +63,48 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
   };
 
   return (
-    <Box padding="1rem" margin="1rem 0">
-      {title && (
-        <Typography component="h1" variant="h4">
-          {title}
-        </Typography>
-      )}
+    <div className="p-4 m-4">
+      {title && <h1 className="text-3xl font-bold">{title}</h1>}
       <br />
-      <InputLabel>Search Test</InputLabel>
-      <LegacyTextInputField
-        value={searchFilter}
+      <TextFormField
+        name="test_search"
+        label="Search Test"
+        className="mt-2"
         placeholder="Search test"
-        errors=""
-        variant="outlined"
-        margin="dense"
-        onChange={(e) => setSearchFilter(e.target.value)}
+        value={searchFilter}
+        onChange={(e) => setSearchFilter(e.value)}
       />
       <br />
-      <TableContainer component={Paper}>
-        <Table aria-label="simple table" size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell align="right">value</TableCell>
-              <TableCell align="left">Unit</TableCell>
-              <TableCell align="right">Min</TableCell>
-              <TableCell align="right">Max</TableCell>
-              <TableCell align="right">Ideal</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+      <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {["Name", "Value", "Unit", "Min", "Max", "Ideal"].map(
+                (heading) => (
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-semibold text-gray-800 uppercase tracking-wider"
+                  >
+                    {heading}
+                  </th>
+                )
+              )}
+            </tr>
+          </thead>
+          <tbody x-max="2">
             {filterTests.length > 0 ? (
-              filterTests.map((t: any) => {
+              filterTests.map((t: any, i: number) => {
                 return (
                   <TestRow
                     data={t}
+                    i={i}
                     key={t.external_id}
                     value={state[t.external_id] && state[t.external_id].value}
-                    onChange={(e: { target: { value: any } }) =>
+                    onChange={(e: FieldChangeEvent<string>) =>
                       handleValueChange(
-                        e.target.value,
+                        t.investigation_type === "Float"
+                          ? Number(e.value)
+                          : e.value,
                         `${t.external_id}.${
                           t.investigation_type === "Float" ? "value" : "notes"
                         }`
@@ -147,17 +114,13 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
                 );
               })
             ) : (
-              <TableRow>
-                <TableCell component="th" scope="row">
-                  No test
-                </TableCell>
-              </TableRow>
+              <tr className="text-center text-gray-500">No tests taken</tr>
             )}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Box>
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 };
 
-export default Table;
+export default TestTable;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95e150e</samp>

Refactored the `TestTable` component and its subcomponents to use the new form fields and tailwind classes. This improves the user experience and code quality of the investigations table in `src/Components/Facility/Investigations/Table.tsx`.

## Proposed Changes

- Fixes #4970 
- Converted all material UI components to tailwind alternatives


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95e150e</samp>

*  Refactor and redesign the `TestTable` component to use the new form fields and tailwind classes ([link](https://github.com/coronasafe/care_fe/pull/5678/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L1-R45), [link](https://github.com/coronasafe/care_fe/pull/5678/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L101-R107), [link](https://github.com/coronasafe/care_fe/pull/5678/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L150-R126))
  * Rename the `Table` component to `TestTable` and replace the material-ui components with native HTML elements and tailwind classes in `src/Components/Facility/Investigations/Table.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5678/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L150-R126))
  * Update the `TestRow` component to use the new form fields and tailwind classes in `src/Components/Facility/Investigations/Table.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5678/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L1-R45))
  * Change the table layout and styles to match the new design in `src/Components/Facility/Investigations/Table.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5678/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L101-R107))
  * Improve the no test message to be more user-friendly in `src/Components/Facility/Investigations/Table.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5678/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L150-R126))
