### PR TITLE
Improve password check on reset pass page

### DIFF
--- a/src/Components/Auth/ResetPassword.tsx
+++ b/src/Components/Auth/ResetPassword.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import { useDispatch } from "react-redux";
 import * as Notification from "../../Utils/Notifications.js";
 import { postResetPassword, checkResetToken } from "../../Redux/actions";
@@ -8,7 +7,8 @@ import { useTranslation } from "react-i18next";
 import { LocalStorageKeys } from "../../Common/constants";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import TextFormField from "../Form/FormFields/TextFormField";
-import CollapseV2 from "../Common/components/CollapseV2";
+import { validateRule } from "../Users/UserAdd";
+import { validatePassword } from "../../Common/validation.js";
 
 export const ResetPassword = (props: any) => {
   const dispatch: any = useDispatch();
@@ -20,7 +20,10 @@ export const ResetPassword = (props: any) => {
   const initErr: any = {};
   const [form, setForm] = useState(initForm);
   const [errors, setErrors] = useState(initErr);
-  const [passReg, setPassReg] = useState(0);
+  const [passwordInputInFocus, setPasswordInputInFocus] = useState(false);
+  const [confirmPasswordInputInFocus, setConfirmPasswordInputInFocus] =
+    useState(false);
+
   const { t } = useTranslation();
   const handleChange = (e: any) => {
     const { value, name } = e;
@@ -31,7 +34,6 @@ export const ResetPassword = (props: any) => {
       setErrors(errorField);
     }
     fieldValue[name] = value;
-    setPassReg(0);
     setForm(fieldValue);
   };
 
@@ -40,12 +42,10 @@ export const ResetPassword = (props: any) => {
     const err = Object.assign({}, errors);
     if (form.password !== form.confirm) {
       hasError = true;
-      setPassReg(1);
       err.confirm = t("password_mismatch");
     }
 
-    const regex = /^(?=.*[a-z]+)(?=.*[A-Z]+)(?=.*[0-9]+)(?=.*[!@#$%^&*]).{8,}$/;
-    if (!regex.test(form.password)) {
+    if (!validatePassword(form.password)) {
       hasError = true;
       err.password = t("invalid_password");
     }
@@ -120,26 +120,44 @@ export const ResetPassword = (props: any) => {
                 placeholder={t("new_password")}
                 onChange={handleChange}
                 error={errors.password}
+                onFocus={() => setPasswordInputInFocus(true)}
+                onBlur={() => setPasswordInputInFocus(false)}
               />
-              <CollapseV2 opened={passReg === 0}>
-                <div className="mb-4 px-4">
-                  <ul className="text-red-500 list-disc">
-                    <li>{t("min_password_len_8")}</li>
-                    <li>{t("req_atleast_one_digit")}</li>
-                    <li>{t("req_atleast_one_uppercase")}</li>
-                    <li>{t("req_atleast_one_lowercase")}</li>
-                    <li>{t("req_atleast_one_symbol")}</li>
-                  </ul>
+              {passwordInputInFocus && (
+                <div className="pl-2 text-small text-gray-500 mb-2">
+                  {validateRule(
+                    form.password?.length >= 8,
+                    "Password should be atleast 8 characters long"
+                  )}
+                  {validateRule(
+                    form.password !== form.password.toUpperCase(),
+                    "Password should contain at least 1 lowercase letter"
+                  )}
+                  {validateRule(
+                    form.password !== form.password.toLowerCase(),
+                    "Password should contain at least 1 uppercase letter"
+                  )}
+                  {validateRule(
+                    /\d/.test(form.password),
+                    "Password should contain at least 1 number"
+                  )}
                 </div>
-              </CollapseV2>
+              )}
               <TextFormField
                 type="password"
                 name="confirm"
                 placeholder={t("confirm_password")}
                 onChange={handleChange}
                 error={errors.confirm}
+                onFocus={() => setConfirmPasswordInputInFocus(true)}
+                onBlur={() => setConfirmPasswordInputInFocus(false)}
               />
-              <LegacyErrorHelperText error={errors.token} />
+              {confirmPasswordInputInFocus &&
+                form.confirm.length > 0 &&
+                validateRule(
+                  form.confirm === form.password,
+                  "Confirm password should match the entered password"
+                )}
             </div>
             <div className="sm:flex sm:justify-between grid p-4">
               <Cancel onClick={() => navigate("/login")} />

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -131,6 +131,26 @@ const user_create_reducer = (state = initialState, action: any) => {
 const getDate = (value: any) =>
   value && moment(value).isValid() && moment(value).toDate();
 
+export const validateRule = (
+  condition: boolean,
+  content: JSX.Element | string
+) => {
+  return (
+    <div>
+      {condition ? (
+        <i className="fas fa-circle-check text-green-500" />
+      ) : (
+        <i className="fas fa-circle-xmark text-red-500" />
+      )}{" "}
+      <span
+        className={classNames(condition ? "text-primary-500" : "text-red-500")}
+      >
+        {content}
+      </span>
+    </div>
+  );
+};
+
 export const UserAdd = (props: UserProps) => {
   const { goBack } = useAppHistory();
   const dispatchAction: any = useDispatch();
@@ -529,25 +549,6 @@ export const UserAdd = (props: UserProps) => {
     }
     dispatch({ type: "set_error", errors });
     return true;
-  };
-
-  const validateRule = (condition: boolean, content: JSX.Element | string) => {
-    return (
-      <div>
-        {condition ? (
-          <i className="fas fa-circle-check text-green-500" />
-        ) : (
-          <i className="fas fa-circle-xmark text-red-500" />
-        )}{" "}
-        <span
-          className={classNames(
-            condition ? "text-primary-500" : "text-red-500"
-          )}
-        >
-          {content}
-        </span>
-      </div>
-    );
   };
 
   const handleSubmit = async (e: any) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d22cf47</samp>

The pull request enhances the password validation and UI for the reset password and user add features. It extracts the `validateRule` component from `UserAdd.tsx` and applies it to `ResetPassword.tsx`, replacing some outdated components. It also cleans up some unused code and imports.

## Proposed Changes

- Fixes #5685 

![image](https://github.com/coronasafe/care_fe/assets/3626859/3c2ff024-9110-4bf4-8329-1cf4b8e18b0b)

![image](https://github.com/coronasafe/care_fe/assets/3626859/5f72f8be-b270-4bd7-9897-d02a60622b67)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d22cf47</samp>

*  Remove unused import of `LegacyErrorHelperText` and add imports of `validateRule` and `validatePassword` in `ResetPassword.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L2), [link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L11-R11))
*  Add state variables to track focus of password and confirm password fields in `ResetPassword.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L23-R26))
*  Simplify password validation logic by using `validatePassword` function in `ResetPassword.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L43-R48))
*  Replace `CollapseV2` component with conditional rendering of `validateRule` component to show password validation rules in `ResetPassword.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L123-R145))
*  Remove `LegacyErrorHelperText` component and add conditional rendering of `validateRule` component to show confirm password match in `ResetPassword.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L141-R160))
*  Move and export `validateRule` component to the top level of `UserAdd.tsx` for reuse ([link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-61941d2843942da2640b50b54d0f8503484ec0a268e75b7962d90faf364d3827R134-R153))
*  Remove duplicate definition of `validateRule` component in `UserAdd` component in `UserAdd.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5694/files?diff=unified&w=0#diff-61941d2843942da2640b50b54d0f8503484ec0a268e75b7962d90faf364d3827L534-L552))
