### PR TITLE
Fix is_telemedicine checkbox

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -321,6 +321,7 @@ export const ConsultationForm = (props: any) => {
             is_telemedicine: `${res.data.is_telemedicine}`,
             is_kasp: `${res.data.is_kasp}`,
             assigned_to: res.data.assigned_to || "",
+            assigned_to_object: res.data.assigned_to_object,
             ett_tt: res.data.ett_tt ? Number(res.data.ett_tt) : 3,
             special_instruction: res.data.special_instruction || "",
             weight: res.data.weight ? res.data.weight : "",
@@ -622,7 +623,9 @@ export const ConsultationForm = (props: any) => {
         action: state.form.action,
         review_interval: state.form.review_interval,
         assigned_to:
-          state.form.is_telemedicine === "true" ? state.form.assigned_to : "",
+          state.form.is_telemedicine.toString() === "true"
+            ? state.form.assigned_to
+            : "",
         special_instruction: state.form.special_instruction,
         weight: Number(state.form.weight),
         height: Number(state.form.height),
@@ -1218,8 +1221,8 @@ export const ConsultationForm = (props: any) => {
                           <CheckBoxFormField
                             className="col-span-6"
                             {...field("is_telemedicine")}
+                            value={JSON.parse(state.form.is_telemedicine)}
                             label="Is Telemedicine required for the patient?"
-                            onChange={handleFormFieldChange}
                           />
 
                           {JSON.parse(state.form.is_telemedicine) && (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab33d08</samp>

This pull request enhances the consultation form component by adding user information, fixing a logic error, and refactoring the code. It affects the file `src/Components/Facility/ConsultationForm.tsx`.

## Proposed Changes

![image](https://github.com/coronasafe/care_fe/assets/3626859/dc9f283f-e391-4531-89a0-3061f0a2daf5)

![image](https://github.com/coronasafe/care_fe/assets/3626859/d4e83b99-3b73-4306-9638-892bfa5c9460)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab33d08</samp>

*  Add `assigned_to_object` property to store assigned user details in `ConsultationForm` state ([link](https://github.com/coronasafe/care_fe/pull/5705/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR324))
*  Fix bug in `is_telemedicine` comparison by converting state value to string ([link](https://github.com/coronasafe/care_fe/pull/5705/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL625-R628))
*  Simplify `is_telemedicine` field by removing `onChange` handler and adding `value` attribute ([link](https://github.com/coronasafe/care_fe/pull/5705/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL1221-R1225))
