### PR TITLE
Fix rescript dropdown not visible

### DIFF
--- a/src/Components/CriticalCareRecording/IOBalance/IOBalance__UnitPicker.res
+++ b/src/Components/CriticalCareRecording/IOBalance/IOBalance__UnitPicker.res
@@ -76,7 +76,7 @@ let make = (~id, ~value, ~updateCB, ~placeholder, ~selectables) => {
       id
       value
       autoComplete="off"
-      onClick={_ => setShowDropdown(_ => !showDropdown)}
+      onClick={e => {ReactEvent.Mouse.stopPropagation(e);setShowDropdown(_ => !showDropdown)}}
       onChange={e => updateCB(ReactEvent.Form.target(e)["value"])}
       className="appearance-none h-10 mt-1 block w-full border border-gray-400 rounded py-2 px-4 text-sm bg-gray-100 hover:bg-gray-200 focus:outline-none focus:bg-white focus:ring-primary-500"
       placeholder

--- a/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
+++ b/src/Components/CriticalCareRecording/components/CriticalCare__Dropdown.res
@@ -77,7 +77,7 @@ let make = (~id, ~value, ~updateCB, ~placeholder, ~selectables, ~label="", ~disa
       id
       value
       autoComplete="off"
-      onClick={_ => setShowDropdown(_ => !showDropdown)}
+      onClick={e => {ReactEvent.Mouse.stopPropagation(e); setShowDropdown(_ => !showDropdown)}}
       onChange={e => updateCB(ReactEvent.Form.target(e)["value"])}
       className="cui-input-base appearance-none h-10 mt-1 block py-2 px-4"
       disabled


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b40fe4c</samp>

The pull request improves the functionality and usability of dropdown menus in the critical care recording feature. It adds `ReactEvent.Mouse.stopPropagation` calls to the `onClick` handlers of input elements in `CriticalCare__Dropdown.res`, `IOBalance__UnitPicker.res`, and other similar components, to prevent the menus from closing when the user clicks on the inputs.

## Proposed Changes

- Fixes #5704 

![image](https://github.com/coronasafe/care_fe/assets/3626859/b82b07d7-39d6-43d2-a8e9-aceaa958c303)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b40fe4c</samp>

*  Prevent dropdown menus from closing when clicking on input elements ([link](https://github.com/coronasafe/care_fe/pull/5709/files?diff=unified&w=0#diff-e7794f2e03164be7e361ac3a8c6c44766254b2b9f58eb5e0a4273a7bc721c33aL80-R80), [link](https://github.com/coronasafe/care_fe/pull/5709/files?diff=unified&w=0#diff-2a098cfe13016562656cc939bbd8f6440a8a668fc0a68f41bdf6d94b94f6723aL79-R79))
