### PR TITLE
Change error format for Facility config page

### DIFF
--- a/src/Components/Facility/UpdateFacilityMiddleware.tsx
+++ b/src/Components/Facility/UpdateFacilityMiddleware.tsx
@@ -23,6 +23,7 @@ const initForm = {
 };
 const initialState = {
   form: { ...initForm },
+  errors: {},
 };
 
 const FormReducer = (state = initialState, action: any) => {
@@ -85,8 +86,9 @@ export const UpdateFacilityMiddleware = (props: any) => {
     e.preventDefault();
     setIsLoading(true);
     if (!state.form.middleware_address) {
-      Notification.Error({
-        msg: "Middleware Address is required",
+      dispatch({
+        type: "set_error",
+        errors: { middleware_address: ["Middleware Address is required"] },
       });
       setIsLoading(false);
       return;
@@ -96,8 +98,11 @@ export const UpdateFacilityMiddleware = (props: any) => {
         /^(?!https?:\/\/)[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*\.[a-zA-Z]{2,}$/
       ) === null
     ) {
-      Notification.Error({
-        msg: "Invalid Middleware Address",
+      dispatch({
+        type: "set_error",
+        errors: {
+          middleware_address: ["Invalid Middleware Address"],
+        },
       });
       setIsLoading(false);
       return;
@@ -151,6 +156,7 @@ export const UpdateFacilityMiddleware = (props: any) => {
                 label="Facility Middleware Address"
                 value={state.form.middleware_address}
                 onChange={(e) => handleChange(e)}
+                error={state.errors?.middleware_address}
               />
             </div>
           </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d58a2e</samp>

The pull request improves the user experience of updating a facility's middleware address by showing validation errors inline, instead of as toast notifications. It changes the `UpdateFacilityMiddleware` component in `src/Components/Facility/UpdateFacilityMiddleware.tsx` to implement this feature.

## Proposed Changes

- Fixes #5689 
![image](https://github.com/coronasafe/care_fe/assets/3626859/0115e5b4-5f66-487e-b33b-e1187ba9b175)
![image](https://github.com/coronasafe/care_fe/assets/3626859/7e81bc21-72c1-4cb2-93ca-cd238c741a31)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d58a2e</samp>

* Add a new property `errors` to the `initialState` object to store the validation errors for the form fields ([link](https://github.com/coronasafe/care_fe/pull/5711/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeR26))
* Replace the toast notifications with dispatch calls that update the `errors` state with the message for the `middleware_address` field, for both the cases when the field is empty or invalid ([link](https://github.com/coronasafe/care_fe/pull/5711/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL88-R91), [link](https://github.com/coronasafe/care_fe/pull/5711/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL99-R105))
* Pass the `error` prop to the `TextInputField` component to render the error message below the input field ([link](https://github.com/coronasafe/care_fe/pull/5711/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeR159))
