### PR TITLE
Fix alignment issue in Pain selector

### DIFF
--- a/src/Components/CriticalCareRecording/Pain/CriticalCare__PainInputModal.res
+++ b/src/Components/CriticalCareRecording/Pain/CriticalCare__PainInputModal.res
@@ -89,8 +89,8 @@ let getStatus = (min, minText, max, maxText, val) => {
                   {str(Pain.regionToString(state.region))}
                 </span>
               </div>
-              <div className="flex flex-col sm:flex-row gap-2 mt-2">
-                <div>
+              <div className="flex flex-col sm:flex-row justify-center mt-2">
+                <div className="w-full">
                   <Slider
                     title={""}
                     className="px-0 py-5 m-0"

--- a/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
+++ b/src/Components/CriticalCareRecording/PressureSore/CriticalCare__PressureSoreInputModal.res
@@ -98,8 +98,8 @@ let make = (
                   {str(PressureSore.regionToString(state.region))}
                 </span>
               </div>
-              <div className="flex flex-col sm:flex-row gap-2 mt-2">
-                <div>
+              <div className="flex flex-col sm:flex-row justify-center mt-2">
+                <div className="w-full">
                   <label className="block font-medium text-black text-left"> {str("Width")} </label>
                   <input
                     type_="number"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1598f0</samp>

Added `justify-center` and `w-full` classes to `div` elements in `CriticalCare__PainInputModal.res` and `CriticalCare__PressureSoreInputModal.res`. This improves the alignment and width of the slider and input components in the critical care recording modals.

## Proposed Changes

- Fixes #5703 
![image](https://github.com/coronasafe/care_fe/assets/3626859/944cd008-3661-4f68-b2d5-f0b5d07d1190)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1598f0</samp>

*  Align sliders and inputs horizontally to the center of the modals and make them take up the full width of the modals for better layout and appearance ([link](https://github.com/coronasafe/care_fe/pull/5712/files?diff=unified&w=0#diff-bbae45def66441f7ec9a4fce87d2116c1789682a70d0abd98ffb399113bab632L92-R93), [link](https://github.com/coronasafe/care_fe/pull/5712/files?diff=unified&w=0#diff-14fe2d653f5739e0d30be602e5827a0d236168caf416e392f794b503776723f5L101-R102))
