### PR TITLE
Make error messages consistent

### DIFF
--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -540,10 +540,10 @@ const AssetCreate = (props: AssetProps) => {
                           setLocation((selectedId as string) || "")
                         }
                         selected={location}
-                        errors=""
                         showAll={false}
                         multiple={false}
                         facilityId={facilityId as unknown as number}
+                        errors={state.errors.location}
                       />
                     </div>
                     {/* Asset Type */}

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -22,6 +22,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
   const dispatchAction: any = useDispatch();
   const [notifyModalFor, setNotifyModalFor] = useState(undefined);
   const [notifyMessage, setNotifyMessage] = useState("");
+  const [notifyError, setNotifyError] = useState("");
 
   const handleNotifySubmit = async (id: any) => {
     const data = {
@@ -29,6 +30,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
       message: notifyMessage,
     };
     if (data.message.trim().length >= 1) {
+      setNotifyError("");
       const res = await dispatchAction(sendNotificationMessages(data));
       if (res && res.status == 204) {
         Notification.Success({
@@ -39,9 +41,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
         Notification.Error({ msg: "Something went wrong..." });
       }
     } else {
-      Notification.Error({
-        msg: "Notification should contain atleast 1 character.",
-      });
+      setNotifyError("Message cannot be empty");
     }
   };
 
@@ -204,11 +204,11 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                           <TextAreaFormField
                             id="NotifyModalMessageInput"
                             name="message"
-                            required
                             rows={5}
                             className="pt-4 pb-2"
                             onChange={(e) => setNotifyMessage(e.value)}
                             placeholder="Type your message..."
+                            error={notifyError}
                           />
                           <div className="flex flex-col-reverse md:flex-row gap-2 justify-between">
                             <Cancel

--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -19,6 +19,7 @@ type AutocompleteFormFieldProps<T, V> = FormFieldBaseProps<V> & {
   dropdownIcon?: React.ReactNode | undefined;
   isLoading?: boolean;
   allowRawInput?: boolean;
+  error?: string;
 };
 
 const AutocompleteFormField = <T, V>(
@@ -43,6 +44,7 @@ const AutocompleteFormField = <T, V>(
         onQuery={props.onQuery}
         isLoading={props.isLoading}
         allowRawInput={props.allowRawInput}
+        error={field.error}
         requiredError={field.error ? props.required : false}
       />
     </FormField>
@@ -66,6 +68,7 @@ type AutocompleteProps<T, V = T> = {
   requiredError?: boolean;
   isLoading?: boolean;
   allowRawInput?: boolean;
+  error?: string;
 } & (
   | {
       required?: false;
@@ -132,7 +135,7 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
   return (
     <div
       className={
-        props.requiredError
+        props.requiredError || props.error
           ? "border rounded border-red-500 " + props.className
           : props.className
       }

--- a/src/Components/Form/FormFields/AutocompleteMultiselect.tsx
+++ b/src/Components/Form/FormFields/AutocompleteMultiselect.tsx
@@ -8,6 +8,7 @@ import {
   dropdownOptionClassNames,
   MultiSelectOptionChip,
 } from "../MultiSelectMenuV2";
+import { classNames } from "../../../Utils/utils";
 
 type OptionCallback<T, R> = (option: T) => R;
 
@@ -50,6 +51,7 @@ type AutocompleteMutliSelectProps<T, V = T> = {
   onChange: OptionCallback<V[], void>;
   onQuery?: (query: string) => void;
   isLoading?: boolean;
+  error?: string;
 };
 
 /**
@@ -92,7 +94,10 @@ export const AutocompleteMutliSelect = <T, V>(
           <div className="flex">
             <Combobox.Input
               multiple
-              className="cui-input-base pr-16 truncate"
+              className={classNames(
+                "cui-input-base pr-16 truncate",
+                props.error && "border-danger-500"
+              )}
               placeholder={
                 value.length
                   ? `${value.length} item(s) selected`


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6927078</samp>

This pull request improves the error handling and user interface of various form components in the `care_fe` frontend. It adds custom error messages and border colors to the `Autocomplete`, `AutocompleteMultiselect`, and `AutocompleteFormField` components, and fixes the notification modal in the `FacilityCard` component.

## Proposed Changes

- Fixes #5698 

![image](https://github.com/coronasafe/care_fe/assets/3626859/3f7ca1a7-f724-4e16-9245-e6c04aec2d56)
![image](https://github.com/coronasafe/care_fe/assets/3626859/f96f677e-bfd1-43a0-a3ab-7661acc993aa)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6927078</samp>

*  Add `error` prop to `AutocompleteFormField` component to display validation error message for location field in asset creation form ([link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L543-R546))
*  Add `notifyError` state variable to `FacilityCard` component to store and display error message for notification modal input field ([link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098R25), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L207-R211))
*  Reset `notifyError` state variable to empty string when notification modal is opened to clear previous error message ([link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098R33))
*  Replace `Notification.Error` function call with setting `notifyError` state variable to custom error message for notification modal input field ([link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L42-R44))
*  Add `error` prop to `Autocomplete` and `AutocompleteMutliSelect` components to pass and display validation error message for autocomplete fields ([link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R22), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R47), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R71), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9L135-R138), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-28d507e00241cf05471a9ea9c0fc3bc4bdfd9fde43cf6924a0836062b8dd21c2R11), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-28d507e00241cf05471a9ea9c0fc3bc4bdfd9fde43cf6924a0836062b8dd21c2R54), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-28d507e00241cf05471a9ea9c0fc3bc4bdfd9fde43cf6924a0836062b8dd21c2L95-R100))
*  Modify conditional logic for applying `border-red-500` and `border-danger-500` classes to `Autocomplete` and `AutocompleteMutliSelect` components to make them more responsive to validation errors ([link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9L135-R138), [link](https://github.com/coronasafe/care_fe/pull/5715/files?diff=unified&w=0#diff-28d507e00241cf05471a9ea9c0fc3bc4bdfd9fde43cf6924a0836062b8dd21c2L95-R100))
