### PR TITLE
Tailwinds Log Lab Results page

### DIFF
--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -1,83 +1,48 @@
-import {
-  Paper,
-  TableCell,
-  TableContainer,
-  Table,
-  TableHead,
-  TableRow,
-  TableBody,
-  InputLabel,
-  Typography,
-  Box,
-} from "@material-ui/core";
-import { LegacySelectField } from "../../Common/HelperInputFields";
-import { createStyles, makeStyles, withStyles } from "@material-ui/styles";
-import React from "react";
-import { useState } from "react";
-import { LegacyTextInputField } from "../../Common/HelperInputFields";
+import { FieldChangeEvent } from "../../Form/FormFields/Utils";
+import { SelectFormField } from "../../Form/FormFields/SelectFormField";
+import TextFormField from "../../Form/FormFields/TextFormField";
 import _ from "lodash";
+import { useState } from "react";
 
-const useStyle = makeStyles(() => ({
-  tableCell: {
-    paddingTop: 0,
-    paddingBottom: 0,
-  },
-}));
-
-const StyledTableRow = withStyles(() =>
-  createStyles({
-    root: {
-      "&:nth-of-type(odd)": {
-        backgroundColor: "#f7f7f7",
-      },
-      "&:hover": {
-        backgroundColor: "#eeeeee",
-      },
-    },
-  })
-)(TableRow);
-
-const TestRow = ({ data, value, onChange }: any) => {
-  const className = useStyle();
-  const inputType = data.investigation_type === "Float" ? "number" : "text";
+const TestRow = ({ data, value, onChange, i }: any) => {
   return (
-    <StyledTableRow>
-      <TableCell className={className.tableCell}>{data.name}</TableCell>
-      <TableCell className={className.tableCell} align="right">
+    <tr className={i % 2 == 0 ? "bg-gray-50" : "bg-white"}>
+      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+        {data.name}
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 text-right">
         {data.investigation_type === "Choice" ? (
-          <LegacySelectField
-            name="preferred_vehicle_choice"
-            variant="outlined"
-            optionArray={true}
+          <SelectFormField
+            name={data.name}
             value={value}
-            options={["Unselected", ...data.choices.split(",")]}
+            options={data?.choices.split(",")}
+            optionLabel={(o: string) => o}
+            optionValue={(o: string) => o}
             onChange={onChange}
-            className="border-l border-r border-gray-400"
           />
         ) : (
-          <input
-            className="lg:w-full h-12 text-right text-sm border-l border-r focus:ring-primary-500 focus:border-primary-500 bg-[#fbfafc]"
+          <TextFormField
+            name={data.name}
             value={value}
             onChange={onChange}
-            type={inputType}
-            step="any"
+            type={data.investigation_type === "Float" ? "number" : "text"}
             placeholder="Enter value"
           />
         )}
-      </TableCell>
-      <TableCell className={className.tableCell} align="left">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.unit || "---"}
-      </TableCell>
-      <TableCell className={className.tableCell} align="right">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.min_value ?? "---"}
-      </TableCell>
-      <TableCell className={className.tableCell} align="right">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.max_value ?? "---"}
-      </TableCell>
-      <TableCell className={className.tableCell} align="right">
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {data.ideal_value || "---"}
-      </TableCell>
-    </StyledTableRow>
+      </td>
+    </tr>
   );
 };
 
@@ -98,46 +63,48 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
   };
 
   return (
-    <Box padding="1rem" margin="1rem 0">
-      {title && (
-        <Typography component="h1" variant="h4">
-          {title}
-        </Typography>
-      )}
+    <div className="p-4 m-4">
+      {title && <h1 className="text-3xl font-bold">{title}</h1>}
       <br />
-      <InputLabel>Search Test</InputLabel>
-      <LegacyTextInputField
-        value={searchFilter}
+      <TextFormField
+        name="test_search"
+        label="Search Test"
+        className="mt-2"
         placeholder="Search test"
-        errors=""
-        variant="outlined"
-        margin="dense"
-        onChange={(e) => setSearchFilter(e.target.value)}
+        value={searchFilter}
+        onChange={(e) => setSearchFilter(e.value)}
       />
       <br />
-      <TableContainer component={Paper}>
-        <Table aria-label="simple table" size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell align="right">value</TableCell>
-              <TableCell align="left">Unit</TableCell>
-              <TableCell align="right">Min</TableCell>
-              <TableCell align="right">Max</TableCell>
-              <TableCell align="right">Ideal</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+      <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {["Name", "Value", "Unit", "Min", "Max", "Ideal"].map(
+                (heading) => (
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-semibold text-gray-800 uppercase tracking-wider"
+                  >
+                    {heading}
+                  </th>
+                )
+              )}
+            </tr>
+          </thead>
+          <tbody x-max="2">
             {filterTests.length > 0 ? (
-              filterTests.map((t: any) => {
+              filterTests.map((t: any, i: number) => {
                 return (
                   <TestRow
                     data={t}
+                    i={i}
                     key={t.external_id}
                     value={state[t.external_id] && state[t.external_id].value}
-                    onChange={(e: { target: { value: any } }) =>
+                    onChange={(e: FieldChangeEvent<string>) =>
                       handleValueChange(
-                        e.target.value,
+                        t.investigation_type === "Float"
+                          ? Number(e.value)
+                          : e.value,
                         `${t.external_id}.${
                           t.investigation_type === "Float" ? "value" : "notes"
                         }`
@@ -147,17 +114,13 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
                 );
               })
             ) : (
-              <TableRow>
-                <TableCell component="th" scope="row">
-                  No test
-                </TableCell>
-              </TableRow>
+              <tr className="text-center text-gray-500">No tests taken</tr>
             )}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Box>
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 };
 
-export default Table;
+export default TestTable;

--- a/src/Components/Facility/Investigations/index.tsx
+++ b/src/Components/Facility/Investigations/index.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useReducer, useState } from "react";
 import { TestTable } from "./Table";
 import { useDispatch } from "react-redux";
-import Autocomplete from "@material-ui/lab/Autocomplete";
-import { Checkbox, TextField } from "@material-ui/core";
 import {
   createInvestigation,
   listInvestigationGroups,
@@ -13,9 +11,12 @@ import * as Notification from "../../../Utils/Notifications.js";
 import { navigate, useQueryParams } from "raviger";
 import loadable from "@loadable/component";
 import { useTranslation } from "react-i18next";
+import Page from "../../Common/components/Page";
+import AutocompleteMultiSelectFormField from "../../Form/FormFields/AutocompleteMultiselect";
+import { Submit } from "../../Common/components/ButtonV2";
+import Card from "../../../CAREUI/display/Card";
 
 const Loading = loadable(() => import("../../Common/Loading"));
-const PageTitle = loadable(() => import("../../Common/PageTitle"));
 
 const initialState = {
   form: {},
@@ -109,7 +110,6 @@ const Investigation = (props: {
   const [selectedInvestigations, setSelectedInvestigations] = useState<
     InvestigationType[]
   >([]);
-  const [searchInputValue, setSearchInputValue] = useState<string>("");
   const [isLoading, setIsLoading] = useState({
     investigationLoading: false,
     investigationGroupLoading: false,
@@ -282,68 +282,31 @@ const Investigation = (props: {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4">
-      <PageTitle
-        title={t("log_lab_results")}
-        crumbsReplacements={{
-          [facilityId]: { name: facilityName },
-          [patientId]: { name: patientName },
-        }}
-      />
-      <div className="mt-5">
-        <label className="text-sm" id="investigation-group-label">
-          Search Investigations & Groups
-        </label>
-        <Autocomplete
-          multiple
-          id="search-by-test"
-          fullWidth={true}
+    <Page
+      title={t("log_lab_results")}
+      crumbsReplacements={{
+        [facilityId]: { name: facilityName },
+        [patientId]: { name: patientName },
+      }}
+    >
+      <div className="flex flex-col gap-2">
+        <AutocompleteMultiSelectFormField
+          className="mt-5"
+          name="investigations"
+          placeholder="Search Investigations & Groups"
           options={searchOptions}
           value={selectedItems}
-          disableCloseOnSelect
-          inputValue={searchInputValue}
-          getOptionLabel={(option) => option.name}
-          onInputChange={(_, value, reason) => {
-            if (reason === "input" || reason === "clear") {
-              setSearchInputValue(value);
-            }
-          }}
-          renderOption={(option, { selected }) => (
-            <React.Fragment>
-              <Checkbox
-                style={{ marginRight: 8 }}
-                checked={selected}
-                color="primary"
-              />
-              {option.name} |{" "}
-              {isInvestigation(option) &&
-                option.groups.map((e) => {
-                  return (
-                    <div className="px-2 py-1 text-xs font-bold bg-gray-300 rounded-full">
-                      {e.name}
-                    </div>
-                  );
-                })}
-            </React.Fragment>
-          )}
-          renderInput={(params) => (
-            <>
-              <TextField
-                margin="dense"
-                {...params}
-                placeholder="Select Investigation"
-              />
-            </>
-          )}
-          onChange={(_: any, options: SearchItem[]) => {
-            selectItems(options);
-            setSelectedInvestigations(options.filter(isInvestigation));
+          optionLabel={(option) => option.name}
+          optionValue={(option) => option}
+          onChange={({ value }) => {
+            selectItems(value);
+            setSelectedInvestigations(value.filter(isInvestigation));
             setSelectedGroup(
               [
-                ...options
+                ...value
                   .filter((e) => !isInvestigation(e))
                   .map((e) => e.external_id),
-                ...options.reduce<string[]>(
+                ...value.reduce<string[]>(
                   (acc, option) =>
                     acc.concat(
                       isInvestigation(option)
@@ -356,34 +319,38 @@ const Investigation = (props: {
             );
           }}
         />
-      </div>
 
-      {selectedGroup.map((group_id) => {
-        const currentGroupsInvestigations = selectedInvestigations.filter((e) =>
-          e.groups.map((e) => e.external_id).includes(group_id)
-        );
-        const filteredInvestigations = currentGroupsInvestigations.length
-          ? currentGroupsInvestigations
-          : listOfInvestigations(group_id, investigations);
-        const group = findGroup(group_id, investigationGroups);
-        return (
-          <TestTable
-            data={filteredInvestigations}
-            title={group?.name}
-            key={group_id}
-            state={state.form}
-            dispatch={setState}
+        {selectedGroup.map((group_id) => {
+          const currentGroupsInvestigations = selectedInvestigations.filter(
+            (e) => e.groups.map((e) => e.external_id).includes(group_id)
+          );
+          const filteredInvestigations = currentGroupsInvestigations.length
+            ? currentGroupsInvestigations
+            : listOfInvestigations(group_id, investigations);
+          const group = findGroup(group_id, investigationGroups);
+          return (
+            <Card>
+              <TestTable
+                data={filteredInvestigations}
+                title={group?.name}
+                key={group_id}
+                state={state.form}
+                dispatch={setState}
+              />
+            </Card>
+          );
+        })}
+
+        <div className="mt-4 flex justify-end">
+          <Submit
+            className="w-full md:w-auto"
+            onClick={handleSubmit}
+            disabled={saving || !selectedGroup.length}
+            label="Save Investigation"
           />
-        );
-      })}
-      <button
-        className="btn btn-primary mt-4 ml-4"
-        onClick={handleSubmit}
-        disabled={saving || !selectedGroup.length}
-      >
-        Save Investigation
-      </button>
-    </div>
+        </div>
+      </div>
+    </Page>
   );
 };
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1606e0a</samp>

Refactored and redesigned the `Investigations` component and table to use custom form components and `tailwindcss` for better UI and UX.

## Proposed Changes

- Fixes #4968

![image](https://github.com/coronasafe/care_fe/assets/25143503/f4db53a2-89d0-4fc5-a241-aca5c2500487)

@nihal467 the issues present inside the green table are handled in a different PR (#5678) as it does not belong to this file even though it's being used here.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1606e0a</samp>

*  Replace `Autocomplete` and `TextField` components with `AutocompleteMultiSelectFormField` component in `Investigation` component ([link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4L4-L5), [link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4L112), [link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4L285-R309))
*  Add `Page`, `AutocompleteMultiSelectFormField`, `Submit`, and `Card` components to `Investigation` component and remove `PageTitle` component ([link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4L16-R19), [link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-4edb1415d33c2cec02447b0244f3b90e9a0d21a9cf79b5a2d0b854677c8aace4L359-R353))
*  Refactor `TestTable` component to use `tailwindcss` classes and custom form fields and components ([link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L1-R45), [link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L101-R107), [link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L150-R126))
*  Rename `TestTable` component to avoid confusion with `Table` component from `@material-ui` ([link](https://github.com/coronasafe/care_fe/pull/5717/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L150-R126))
