### PR TITLE
Tailwind `LiveFeed.tsx`

### DIFF
--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -1,9 +1,7 @@
-/* eslint-disable eqeqeq */
 import { useEffect, useState, useRef } from "react";
 import { useDispatch } from "react-redux";
 import screenfull from "screenfull";
 import useKeyboardShortcut from "use-keyboard-shortcut";
-import loadable from "@loadable/component";
 import {
   listAssetBeds,
   partialUpdateAssetBed,
@@ -15,23 +13,16 @@ import {
   useMSEMediaPlayer,
 } from "../../../Common/hooks/useMSEplayer";
 import { useFeedPTZ } from "../../../Common/hooks/useFeedPTZ";
-const PageTitle = loadable(() => import("../../Common/PageTitle"));
 import * as Notification from "../../../Utils/Notifications.js";
-import {
-  Card,
-  CardContent,
-  InputLabel,
-  Modal,
-  Tooltip,
-} from "@material-ui/core";
 import { FeedCameraPTZHelpButton } from "./Feed";
 import { AxiosError } from "axios";
-import { isNull } from "lodash";
 import { BedSelect } from "../../Common/BedSelect";
 import { BedModel } from "../models";
-import { LegacyTextInputField } from "../../Common/HelperInputFields";
 import useWindowDimensions from "../../../Common/hooks/useWindowDimensions";
 import CareIcon from "../../../CAREUI/icons/CareIcon";
+import Page from "../../Common/components/Page";
+import ConfirmDialogV2 from "../../Common/ConfirmDialogV2";
+import { FieldLabel } from "../../Form/FormFields/FormField";
 
 const LiveFeed = (props: any) => {
   const middlewareHostname =
@@ -294,85 +285,46 @@ const LiveFeed = (props: any) => {
   }
 
   return (
-    <div className="mt-4 px-6 mb-2">
-      <PageTitle title="Live Feed" hideBack={true} />
-
+    <Page title="Live Feed" hideBack>
       {toDelete && (
-        <Modal
-          className="flex h-fit justify-center items-center top-1/2"
-          open={!isNull(toDelete)}
-        >
-          <Card>
-            <CardContent>
-              <h5>
-                Confirm delete preset: {toDelete.meta.preset_name} (in bed:{" "}
-                {toDelete.bed_object.name})?
-              </h5>
-              <hr />
-              <div className="flex gap-3 justify-end mt-2">
-                <button
-                  className="bg-red-500 px-3 text-sm py-1 rounded-md text-white"
-                  onClick={() => deletePreset(toDelete.id)}
-                >
-                  Confirm
-                </button>
-                <button className="text-sm" onClick={() => setToDelete(null)}>
-                  Cancel
-                </button>
-              </div>
-            </CardContent>
-          </Card>
-        </Modal>
+        <ConfirmDialogV2
+          show
+          title="Are you sure you want to delete this preset?"
+          description={
+            <span>
+              Preset: {toDelete.meta.preset_name} (in bed:{" "}
+              {toDelete.bed_object.name})
+            </span>
+          }
+          action="Delete"
+          variant="danger"
+          onClose={() => setToDelete(null)}
+          onConfirm={() => deletePreset(toDelete.id)}
+        />
       )}
       {toUpdate && (
-        <Modal
-          className="flex h-fit justify-center items-center top-1/2"
-          open={!isNull(toUpdate)}
+        <ConfirmDialogV2
+          show
+          title="Update Preset"
+          description={"Preset: " + toUpdate.meta.preset_name}
+          action="Update"
+          variant="primary"
+          onClose={() => setToUpdate(null)}
+          onConfirm={() => updatePreset(toUpdate)}
         >
-          <Card>
-            <CardContent>
-              <h5>Update Preset</h5>
-              <hr />
-              <div>
-                <InputLabel id="asset-type">Bed</InputLabel>
-                <BedSelect
-                  name="bed"
-                  setSelected={(selected) => setBed(selected as BedModel)}
-                  selected={bed}
-                  error=""
-                  multiple={false}
-                  location={cameraAsset.location_id}
-                  facility={cameraAsset.facility_id}
-                />
-              </div>
-              <div>
-                <InputLabel id="location">Preset Name</InputLabel>
-                <LegacyTextInputField
-                  name="name"
-                  id="location"
-                  variant="outlined"
-                  margin="dense"
-                  type="text"
-                  value={preset}
-                  onChange={(e) => setNewPreset(e.target.value)}
-                  errors=""
-                />
-              </div>
-
-              <div className="flex gap-3 justify-end mt-2">
-                <button
-                  onClick={() => updatePreset(toUpdate)}
-                  className="bg-red-500 px-3 text-sm py-1 rounded-md text-white"
-                >
-                  Confirm
-                </button>
-                <button className="text-sm" onClick={() => setToUpdate(null)}>
-                  Cancel
-                </button>
-              </div>
-            </CardContent>
-          </Card>
-        </Modal>
+          <div className="flex flex-col mt-4">
+            <FieldLabel required>Bed</FieldLabel>
+            <BedSelect
+              name="bed"
+              setSelected={(selected) => setBed(selected as BedModel)}
+              selected={bed}
+              error=""
+              multiple={false}
+              location={cameraAsset.location_id}
+              facility={cameraAsset.facility_id}
+            />
+          </div>
+        </ConfirmDialogV2>
       )}
       <div className="mt-4 flex flex-col">
         <div className="flex flex-col lg:flex-row gap-4 mt-4 relative">
@@ -451,30 +403,20 @@ const LiveFeed = (props: any) => {
                     .replace("ArrowRight", "→");
 
                 return (
-                  <Tooltip
-                    placement="top"
-                    arrow={true}
-                    title={
-                      <span className="text-sm font-semibold">
-                        {`${option.label}  (${shortcutKeyDescription})`}
-                      </span>
-                    }
-                    key={option.action}
+                  <button
+                    className="bg-green-100 hover:bg-green-200 border border-green-100 p-2 flex-1 tooltip"
+                    onClick={option.callback}
                   >
-                    <button
-                      className="bg-green-100 hover:bg-green-200 border border-green-100 p-2 flex-1"
-                      onClick={option.callback}
-                    >
-                      <span className="sr-only">{option.label}</span>
-                      {option.icon ? (
-                        <i className={`fas fa-${option.icon} md:p-2`}></i>
-                      ) : (
-                        <span className="px-2 font-bold h-full w-8 flex items-center justify-center">
-                          {option.value}x
-                        </span>
-                      )}
-                    </button>
-                  </Tooltip>
+                    <span className="sr-only">{option.label}</span>
+                    {option.icon ? (
+                      <i className={`fas fa-${option.icon} md:p-2`}></i>
+                    ) : (
+                      <span className="px-2 font-bold h-full w-8 flex items-center justify-center">
+                        {option.value}x
+                      </span>
+                    )}
+                    <span className="tooltip-text tooltip-top -translate-x-1/2 text-sm font-semibold">{`${option.label}  (${shortcutKeyDescription})`}</span>
+                  </button>
                 );
               })}
               <div className="pl-3 hideonmobilescreen">
@@ -644,7 +586,7 @@ const LiveFeed = (props: any) => {
           </div>
         </div>
       </div>
-    </div>
+    </Page>
   );
 };
 

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -292,8 +292,12 @@ const LiveFeed = (props: any) => {
           title="Are you sure you want to delete this preset?"
           description={
             <span>
-              Preset: {toDelete.meta.preset_name} (in bed:{" "}
-              {toDelete.bed_object.name})
+              <p>
+                Preset: <strong>{toDelete.meta.preset_name}</strong>
+              </p>
+              <p>
+                Bed: <strong>{toDelete.bed_object.name}</strong>
+              </p>
             </span>
           }
           action="Delete"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0e2a3b</samp>

Refactored the live feed page of consultations to use common and custom components. Improved the UI design and user experience by removing clutter and adding confirmation dialogs. Modified the `LiveFeed.tsx` file and its dependencies.

## Proposed Changes

- Fixes #4966

![image](https://github.com/coronasafe/care_fe/assets/25143503/a752c637-227b-407a-9bf5-e0bab983af1b)
![image](https://github.com/coronasafe/care_fe/assets/25143503/5bfc461e-0693-42af-aedd-d45106e95978)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0e2a3b</samp>

* Replace `Modal` and `Card` components with `ConfirmDialogV2` component for confirmation dialogs in live feed page ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L297-R331))
* Replace `BedSelect` and `LegacyTextInputField` components with `FieldLabel` component for form field labels in live feed page ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L297-R331))
* Adjust layout and styling of dialog content to match design guidelines ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L297-R331))
* Replace `Tooltip` component with custom tooltip element using tailwind classes and CSS variables in live feed page ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L454-R423))
* Move tooltip text to a `span` element inside the button instead of passing as a prop ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L454-R423))
* Replace `div` element with `Page` component for common layout and header in live feed page ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L647-R593))
* Pass `hideBack` prop to `Page` component to hide back button in header ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L647-R593))
* Remove unused `loadable` import from `LiveFeed.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L1-R4))
* Remove unused imports and add new imports for custom components and native functions in `LiveFeed.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5718/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L18-R25))
