### PR TITLE
Left align Patient heading in mobile view

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -728,8 +728,8 @@ export const PatientManager = () => {
           setSelectedFacility({ name: "" });
         }}
       />
-      <div className="flex flex-col lg:flex-row justify-between md:items-center">
-        <div className="flex flex-col lg:flex-row lg:gap-5 md:items-center mb-2 lg:mb-0 w-full lg:w-fit">
+      <div className="flex flex-col lg:flex-row justify-between lg:items-center">
+        <div className="flex flex-col lg:flex-row lg:gap-5 lg:items-center mb-2 lg:mb-0 w-full lg:w-fit">
           <PageTitle
             title="Patients"
             hideBack={true}

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -728,14 +728,14 @@ export const PatientManager = () => {
           setSelectedFacility({ name: "" });
         }}
       />
-      <PageTitle
-        title="Patients"
-        hideBack={true}
-        breadcrumbs={false}
-        className="mt-2"
-      />
-      <div className="flex flex-col lg:flex-row justify-between items-center">
-        <div className="flex flex-col lg:flex-row lg:gap-5 items-center mb-2 lg:mb-0 w-full lg:w-fit">
+      <div className="flex flex-col lg:flex-row justify-between md:items-center">
+        <div className="flex flex-col lg:flex-row lg:gap-5 md:items-center mb-2 lg:mb-0 w-full lg:w-fit">
+          <PageTitle
+            title="Patients"
+            hideBack={true}
+            breadcrumbs={false}
+            className="mt-2"
+          />
           <ButtonV2
             onClick={() => {
               qParams.facility

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -728,14 +728,14 @@ export const PatientManager = () => {
           setSelectedFacility({ name: "" });
         }}
       />
+      <PageTitle
+        title="Patients"
+        hideBack={true}
+        breadcrumbs={false}
+        className="mt-2"
+      />
       <div className="flex flex-col lg:flex-row justify-between items-center">
         <div className="flex flex-col lg:flex-row lg:gap-5 items-center mb-2 lg:mb-0 w-full lg:w-fit">
-          <PageTitle
-            title="Patients"
-            hideBack={true}
-            breadcrumbs={false}
-            className="mt-2"
-          />
           <ButtonV2
             onClick={() => {
               qParams.facility


### PR DESCRIPTION
## Proposed Changes

Fixes #5723 
- Left Aligned `Patients` heading ion mobile view
http://localhost:4000/patients?page=1&limit=12&emergency_phone_number=
![image](https://github.com/coronasafe/care_fe/assets/70687348/6e63ce10-84ec-4471-98f7-61dfaf3a30cb)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d2a4258</samp>

* Move `PageTitle` component outside of `div` element to fix layout issue on smaller screens ([link](https://github.com/coronasafe/care_fe/pull/5724/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L731-R738))
