### PR TITLE
rename spo2 to resp

### DIFF
--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -84,7 +84,7 @@ export default function HL7PatientVitalsMonitor({
               ECG: "text-lime-300",
               ECG_CHANNEL_2: "invisible",
               Pleth: "text-yellow-300",
-              SpO2: "text-sky-300",
+              Resp: "text-sky-300",
             }}
           />
           <canvas


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b3ddd5</samp>

Added respiratory rate monitoring to patient vitals dashboard. Updated `colors` prop of `VitalsChart` component in `HL7PatientVitalsMonitor.tsx` to reflect the new waveform.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b3ddd5</samp>

* Add respiratory rate monitoring to the patient vitals dashboard ([link](https://github.com/coronasafe/care_fe/pull/5725/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L87-R87))
  - Set the color of the respiratory rate waveform on the `VitalsChart` component ([link](https://github.com/coronasafe/care_fe/pull/5725/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L87-R87))
  - Remove the SpO2 waveform from the `VitalsChart` component, since it is not displayed ([link](https://github.com/coronasafe/care_fe/pull/5725/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L87-R87))
