### PR TITLE
Production Release: SmartICU Hotfixes

### DIFF
--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -132,12 +132,12 @@ export const Login = (props: { forgot?: boolean }) => {
     if (typeof form.username === "string") {
       if (!form.username.match(/\w/)) {
         hasError = true;
-        err.username = t("field_request");
+        err.username = t("field_required");
       }
     }
     if (!form.username) {
       hasError = true;
-      err.username = t("field_request");
+      err.username = t("field_required");
     }
 
     if (hasError) {
@@ -402,7 +402,6 @@ export const Login = (props: { forgot?: boolean }) => {
                   onChange={handleChange}
                   error={errors.username}
                   outerClassName="my-4"
-                  required
                   size="large"
                   className="font-extrabold"
                 />

--- a/src/Components/Auth/ResetPassword.tsx
+++ b/src/Components/Auth/ResetPassword.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { LegacyErrorHelperText } from "../Common/HelperInputFields";
 import { useDispatch } from "react-redux";
 import * as Notification from "../../Utils/Notifications.js";
 import { postResetPassword, checkResetToken } from "../../Redux/actions";
@@ -8,7 +7,8 @@ import { useTranslation } from "react-i18next";
 import { LocalStorageKeys } from "../../Common/constants";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import TextFormField from "../Form/FormFields/TextFormField";
-import CollapseV2 from "../Common/components/CollapseV2";
+import { validateRule } from "../Users/UserAdd";
+import { validatePassword } from "../../Common/validation.js";
 
 export const ResetPassword = (props: any) => {
   const dispatch: any = useDispatch();
@@ -20,7 +20,10 @@ export const ResetPassword = (props: any) => {
   const initErr: any = {};
   const [form, setForm] = useState(initForm);
   const [errors, setErrors] = useState(initErr);
-  const [passReg, setPassReg] = useState(0);
+  const [passwordInputInFocus, setPasswordInputInFocus] = useState(false);
+  const [confirmPasswordInputInFocus, setConfirmPasswordInputInFocus] =
+    useState(false);
+
   const { t } = useTranslation();
   const handleChange = (e: any) => {
     const { value, name } = e;
@@ -31,7 +34,6 @@ export const ResetPassword = (props: any) => {
       setErrors(errorField);
     }
     fieldValue[name] = value;
-    setPassReg(0);
     setForm(fieldValue);
   };
 
@@ -40,12 +42,10 @@ export const ResetPassword = (props: any) => {
     const err = Object.assign({}, errors);
     if (form.password !== form.confirm) {
       hasError = true;
-      setPassReg(1);
       err.confirm = t("password_mismatch");
     }
 
-    const regex = /^(?=.*[a-z]+)(?=.*[A-Z]+)(?=.*[0-9]+)(?=.*[!@#$%^&*]).{8,}$/;
-    if (!regex.test(form.password)) {
+    if (!validatePassword(form.password)) {
       hasError = true;
       err.password = t("invalid_password");
     }
@@ -120,26 +120,44 @@ export const ResetPassword = (props: any) => {
                 placeholder={t("new_password")}
                 onChange={handleChange}
                 error={errors.password}
+                onFocus={() => setPasswordInputInFocus(true)}
+                onBlur={() => setPasswordInputInFocus(false)}
               />
-              <CollapseV2 opened={passReg === 0}>
-                <div className="mb-4 px-4">
-                  <ul className="text-red-500 list-disc">
-                    <li>{t("min_password_len_8")}</li>
-                    <li>{t("req_atleast_one_digit")}</li>
-                    <li>{t("req_atleast_one_uppercase")}</li>
-                    <li>{t("req_atleast_one_lowercase")}</li>
-                    <li>{t("req_atleast_one_symbol")}</li>
-                  </ul>
+              {passwordInputInFocus && (
+                <div className="pl-2 text-small text-gray-500 mb-2">
+                  {validateRule(
+                    form.password?.length >= 8,
+                    "Password should be atleast 8 characters long"
+                  )}
+                  {validateRule(
+                    form.password !== form.password.toUpperCase(),
+                    "Password should contain at least 1 lowercase letter"
+                  )}
+                  {validateRule(
+                    form.password !== form.password.toLowerCase(),
+                    "Password should contain at least 1 uppercase letter"
+                  )}
+                  {validateRule(
+                    /\d/.test(form.password),
+                    "Password should contain at least 1 number"
+                  )}
                 </div>
-              </CollapseV2>
+              )}
               <TextFormField
                 type="password"
                 name="confirm"
                 placeholder={t("confirm_password")}
                 onChange={handleChange}
                 error={errors.confirm}
+                onFocus={() => setConfirmPasswordInputInFocus(true)}
+                onBlur={() => setConfirmPasswordInputInFocus(false)}
               />
-              <LegacyErrorHelperText error={errors.token} />
+              {confirmPasswordInputInFocus &&
+                form.confirm.length > 0 &&
+                validateRule(
+                  form.confirm === form.password,
+                  "Confirm password should match the entered password"
+                )}
             </div>
             <div className="sm:flex sm:justify-between grid p-4">
               <Cancel onClick={() => navigate("/login")} />

--- a/src/Components/Facility/UpdateFacilityMiddleware.tsx
+++ b/src/Components/Facility/UpdateFacilityMiddleware.tsx
@@ -23,6 +23,7 @@ const initForm = {
 };
 const initialState = {
   form: { ...initForm },
+  errors: {},
 };
 
 const FormReducer = (state = initialState, action: any) => {
@@ -85,8 +86,9 @@ export const UpdateFacilityMiddleware = (props: any) => {
     e.preventDefault();
     setIsLoading(true);
     if (!state.form.middleware_address) {
-      Notification.Error({
-        msg: "Middleware Address is required",
+      dispatch({
+        type: "set_error",
+        errors: { middleware_address: ["Middleware Address is required"] },
       });
       setIsLoading(false);
       return;
@@ -96,8 +98,11 @@ export const UpdateFacilityMiddleware = (props: any) => {
         /^(?!https?:\/\/)[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*\.[a-zA-Z]{2,}$/
       ) === null
     ) {
-      Notification.Error({
-        msg: "Invalid Middleware Address",
+      dispatch({
+        type: "set_error",
+        errors: {
+          middleware_address: ["Invalid Middleware Address"],
+        },
       });
       setIsLoading(false);
       return;
@@ -151,6 +156,7 @@ export const UpdateFacilityMiddleware = (props: any) => {
                 label="Facility Middleware Address"
                 value={state.form.middleware_address}
                 onChange={(e) => handleChange(e)}
+                error={state.errors?.middleware_address}
               />
             </div>
           </div>

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -131,6 +131,26 @@ const user_create_reducer = (state = initialState, action: any) => {
 const getDate = (value: any) =>
   value && moment(value).isValid() && moment(value).toDate();
 
+export const validateRule = (
+  condition: boolean,
+  content: JSX.Element | string
+) => {
+  return (
+    <div>
+      {condition ? (
+        <i className="fas fa-circle-check text-green-500" />
+      ) : (
+        <i className="fas fa-circle-xmark text-red-500" />
+      )}{" "}
+      <span
+        className={classNames(condition ? "text-primary-500" : "text-red-500")}
+      >
+        {content}
+      </span>
+    </div>
+  );
+};
+
 export const UserAdd = (props: UserProps) => {
   const { goBack } = useAppHistory();
   const dispatchAction: any = useDispatch();
@@ -529,25 +549,6 @@ export const UserAdd = (props: UserProps) => {
     }
     dispatch({ type: "set_error", errors });
     return true;
-  };
-
-  const validateRule = (condition: boolean, content: JSX.Element | string) => {
-    return (
-      <div>
-        {condition ? (
-          <i className="fas fa-circle-check text-green-500" />
-        ) : (
-          <i className="fas fa-circle-xmark text-red-500" />
-        )}{" "}
-        <span
-          className={classNames(
-            condition ? "text-primary-500" : "text-red-500"
-          )}
-        >
-          {content}
-        </span>
-      </div>
-    );
   };
 
   const handleSubmit = async (e: any) => {

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -84,7 +84,7 @@ export default function HL7PatientVitalsMonitor({
               ECG: "text-lime-300",
               ECG_CHANNEL_2: "invisible",
               Pleth: "text-yellow-300",
-              SpO2: "text-sky-300",
+              Resp: "text-sky-300",
             }}
           />
           <canvas


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66a14c0</samp>

This pull request fixes some UI and validation issues in the auth, facility, and vitals monitor components. It also refactors some common components to separate files for better code organization and reusability. The files affected are `Login.tsx`, `ResetPassword.tsx`, `UpdateFacilityMiddleware.tsx`, `UserAdd.tsx`, and `HL7PatientVitalsMonitor.tsx`.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 66a14c0</samp>

*  Correct the error message for the username field in the login component to use the translation key `field_required` ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304L135-R140))
*  Remove the redundant `required` attribute from the password field in the login component ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304L405))
*  Remove the unused import of `LegacyErrorHelperText` from the reset password component ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L2))
*  Add the imports of `validateRule` and `validatePassword` to the reset password component to implement the new password validation logic and UI ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L11-R11))
*  Replace the state variables `passReg` and `setPassReg` with `passwordInputInFocus` and `confirmPasswordInputInFocus` to track the focus state of the password and confirm password fields in the reset password component ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L23-R26))
*  Replace the regex for validating the password with a call to `validatePassword` in the reset password component ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L43-R48))
*  Replace the `CollapseV2` component with a conditional rendering of the `validateRule` component to show the password requirements in the reset password component, and add the `onFocus` and `onBlur` handlers to the password field to update the focus state ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L123-R145))
*  Remove the `LegacyErrorHelperText` component and add a conditional rendering of the `validateRule` component to show the error for the confirm password field in the reset password component, and add the `onFocus` and `onBlur` handlers to the confirm password field to update the focus state ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-b316ca1b2f0fb1f051295772c9e69bec5d1ffbfe20e1cea840a5a7f21b6af892L141-R160))
*  Add the `errors` property to the initial state of the update facility middleware component to store and display the validation errors for the middleware address field ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeR26))
*  Replace the `Notification.Error` calls with dispatch actions that set the error in the state for the empty or invalid middleware address field in the update facility middleware component ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL88-R91), [link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL99-R105))
*  Add the `error` prop to the input field component for the middleware address in the update facility middleware component, which takes the error from the state and displays it as a helper text ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeR159))
*  Move the `validateRule` component from the user add component to a separate file, as it is reused in the reset password component and could be a common component for other validation scenarios ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-61941d2843942da2640b50b54d0f8503484ec0a268e75b7962d90faf364d3827R134-R153), [link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-61941d2843942da2640b50b54d0f8503484ec0a268e75b7962d90faf364d3827L534-L552))
*  Fix the typo in the color prop for the `Resp` channel in the HL7 patient vitals monitor component, and make it consistent with the `SpO2` channel ([link](https://github.com/coronasafe/care_fe/pull/5727/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L87-R87))
