### PR TITLE
Fixes `z-` index of vitals component 

### DIFF
--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -141,7 +141,7 @@ export default function CentralNursingStation({ facilityId }: Props) {
               leaveFrom="opacity-100 translate-y-0"
               leaveTo="opacity-0 translate-y-1"
             >
-              <Popover.Panel className="absolute z-10 mt-1 w-96 transform -translate-x-1/2 px-4 sm:px-0 lg:max-w-3xl">
+              <Popover.Panel className="absolute z-30 mt-1 w-96 transform -translate-x-1/2 px-4 sm:px-0 lg:max-w-3xl">
                 <div className="rounded-lg shadow-lg ring-1 ring-gray-400">
                   <div className="rounded-t-lg bg-gray-100 px-6 py-4">
                     <div className="flow-root rounded-md">

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -100,7 +100,7 @@ export default function HL7PatientVitalsMonitor({
             {...waveformCanvas.size}
           />
         </div>
-        <div className="z-50 bg-[#020617] grid grid-cols-3 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
+        <div className="z-10 bg-[#020617] grid grid-cols-3 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
           {/* Pulse Rate */}
           <div className="flex justify-between items-center p-1">
             <div className="flex flex-col h-full items-start text-sm text-primary-400 font-bold">

--- a/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
@@ -101,7 +101,7 @@ export default function VentilatorPatientVitalsMonitor({
             {...waveformCanvas.size}
           />
         </div>
-        <div className="z-50 bg-[#020617] grid grid-cols-3 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
+        <div className="z-10 bg-[#020617] grid grid-cols-3 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
           <NonWaveformData
             label="PEEP"
             attr={data.peep}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04dfed9</samp>

Adjusted the z-index values of various components in `CentralNursingStation.tsx`, `HL7PatientVitalsMonitor.tsx`, and `VentilatorPatientVitalsMonitor.tsx` to fix a popover menu bug and improve the layout of the patient vitals monitor.

## Proposed Changes

- Fixes `z-` index of vitals component 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04dfed9</samp>

*  Increase the z-index of the popover menu for the patient card to prevent it from being overlapped by other elements on the page ([link](https://github.com/coronasafe/care_fe/pull/5737/files?diff=unified&w=0#diff-95b57b1137a563f4d92c994d950f87bc81e4a3eb129066d34a3c851d58c3609dL144-R144))
*  Decrease the z-index of the divs containing the vitals data for the HL7 and ventilator patient vitals monitor components to match the z-index of the divs containing the waveforms and to avoid overlapping the popover menu ([link](https://github.com/coronasafe/care_fe/pull/5737/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L103-R103), [link](https://github.com/coronasafe/care_fe/pull/5737/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L104-R104))
