### PR TITLE
Removes the blue vertical divider present at the start of the vitals canvas

### DIFF
--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -65,40 +65,42 @@ export default function HL7PatientVitalsMonitor({
         </div>
       )}
       <div className="flex flex-col md:flex-row md:justify-between divide-y divide-x-0 md:divide-y-0 md:divide-x divide-blue-600 gap-2">
-        <div
-          className={classNames(
-            "flex flex-col gap-1 justify-center items-center text-center p-1 text-warning-500 font-medium font-mono",
-            isOnline && "hidden"
-          )}
-          style={{ ...(size ?? waveformCanvas.size) }}
-        >
-          <CareIcon className="care-l-cloud-times text-4xl animate-pulse mb-2" />
-          <span className="font-bold">No incoming data from HL7 Monitor</span>
-        </div>
-        <div
-          className={classNames("relative", !isOnline && "hidden")}
-          style={{ ...(size ?? waveformCanvas.size) }}
-        >
-          <WaveformLabels
-            labels={{
-              ECG: "text-lime-300",
-              ECG_CHANNEL_2: "invisible",
-              Pleth: "text-yellow-300",
-              Resp: "text-sky-300",
-            }}
-          />
-          <canvas
-            className="absolute top-0 left-0"
-            ref={waveformCanvas.background.canvasRef}
+        <div>
+          <div
+            className={classNames(
+              "flex flex-col gap-1 justify-center items-center text-center p-1 text-warning-500 font-medium font-mono",
+              isOnline && "hidden"
+            )}
             style={{ ...(size ?? waveformCanvas.size) }}
-            {...waveformCanvas.size}
-          />
-          <canvas
-            className="absolute top-0 left-0"
-            ref={waveformCanvas.foreground.canvasRef}
+          >
+            <CareIcon className="care-l-cloud-times text-4xl animate-pulse mb-2" />
+            <span className="font-bold">No incoming data from HL7 Monitor</span>
+          </div>
+          <div
+            className={classNames("relative", !isOnline && "hidden")}
             style={{ ...(size ?? waveformCanvas.size) }}
-            {...waveformCanvas.size}
-          />
+          >
+            <WaveformLabels
+              labels={{
+                ECG: "text-lime-300",
+                ECG_CHANNEL_2: "invisible",
+                Pleth: "text-yellow-300",
+                Resp: "text-sky-300",
+              }}
+            />
+            <canvas
+              className="absolute top-0 left-0"
+              ref={waveformCanvas.background.canvasRef}
+              style={{ ...(size ?? waveformCanvas.size) }}
+              {...waveformCanvas.size}
+            />
+            <canvas
+              className="absolute top-0 left-0"
+              ref={waveformCanvas.foreground.canvasRef}
+              style={{ ...(size ?? waveformCanvas.size) }}
+              {...waveformCanvas.size}
+            />
+          </div>
         </div>
         <div className="z-50 bg-[#020617] grid grid-cols-3 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
           {/* Pulse Rate */}

--- a/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
@@ -67,39 +67,41 @@ export default function VentilatorPatientVitalsMonitor({
         </div>
       )}
       <div className="flex flex-col md:flex-row md:justify-between divide-y divide-x-0 md:divide-y-0 md:divide-x divide-blue-600 gap-2">
-        <div
-          className={classNames(
-            "flex flex-col gap-1 justify-center items-center text-center p-1 text-warning-500 font-medium font-mono",
-            isOnline && "hidden"
-          )}
-          style={{ ...(size ?? waveformCanvas.size) }}
-        >
-          <CareIcon className="care-l-cloud-times text-4xl animate-pulse mb-2" />
-          <span className="font-bold">No incoming data from Ventilator</span>
-        </div>
-        <div
-          className={classNames("relative", !isOnline && "hidden")}
-          style={{ ...(size ?? waveformCanvas.size) }}
-        >
-          <WaveformLabels
-            labels={{
-              Pressure: "text-lime-300",
-              Flow: "text-yellow-300",
-              Volume: "text-sky-300",
-            }}
-          />
-          <canvas
-            className="absolute top-0 left-0"
-            ref={waveformCanvas.background.canvasRef}
+        <div>
+          <div
+            className={classNames(
+              "flex flex-col gap-1 justify-center items-center text-center p-1 text-warning-500 font-medium font-mono",
+              isOnline && "hidden"
+            )}
             style={{ ...(size ?? waveformCanvas.size) }}
-            {...waveformCanvas.size}
-          />
-          <canvas
-            className="absolute top-0 left-0"
-            ref={waveformCanvas.foreground.canvasRef}
+          >
+            <CareIcon className="care-l-cloud-times text-4xl animate-pulse mb-2" />
+            <span className="font-bold">No incoming data from Ventilator</span>
+          </div>
+          <div
+            className={classNames("relative", !isOnline && "hidden")}
             style={{ ...(size ?? waveformCanvas.size) }}
-            {...waveformCanvas.size}
-          />
+          >
+            <WaveformLabels
+              labels={{
+                Pressure: "text-lime-300",
+                Flow: "text-yellow-300",
+                Volume: "text-sky-300",
+              }}
+            />
+            <canvas
+              className="absolute top-0 left-0"
+              ref={waveformCanvas.background.canvasRef}
+              style={{ ...(size ?? waveformCanvas.size) }}
+              {...waveformCanvas.size}
+            />
+            <canvas
+              className="absolute top-0 left-0"
+              ref={waveformCanvas.foreground.canvasRef}
+              style={{ ...(size ?? waveformCanvas.size) }}
+              {...waveformCanvas.size}
+            />
+          </div>
         </div>
         <div className="z-50 bg-[#020617] grid grid-cols-3 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
           <NonWaveformData


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bb9351</samp>

This pull request improves the responsiveness and consistency of the vitals monitor components. It adds a parent div to the `HL7PatientVitalsMonitor` and `VentilatorPatientVitalsMonitor` components, and applies the same style and layout to both. This makes them adapt to different screen sizes and look similar.

## Proposed Changes

- Fixes #5739

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bb9351</samp>

*  Align waveform canvas and offline message horizontally or vertically depending on screen size ([link](https://github.com/coronasafe/care_fe/pull/5740/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L68-R103), [link](https://github.com/coronasafe/care_fe/pull/5740/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L70-R104))
