### PR TITLE
Restores `asset_class` disable edit logic

### DIFF
--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -585,6 +585,7 @@ const AssetCreate = (props: AssetProps) => {
                         data-testid="asset-class-input"
                       >
                         <SelectFormField
+                          disabled={!!(props.assetId && asset_class)}
                           name="asset_class"
                           label="Asset Class"
                           value={asset_class}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d14c4a1</samp>

Prevent changing asset class of existing assets in asset creation form. Disable `asset class` field in `AssetCreate.tsx` if `asset id` and `asset class` props are given.

## Proposed Changes

- Fixes #5748


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d14c4a1</samp>

* Disable the asset class field in the asset creation form if the asset id and asset class are already provided as props ([link](https://github.com/coronasafe/care_fe/pull/5750/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073R588)). This prevents changing the asset class of an existing asset in `src/Components/Facility/AssetCreate.tsx`.
