### PR TITLE
Fix initial state of Create Shift form

### DIFF
--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -57,13 +57,13 @@ export const ShiftCreate = (props: patientShiftProps) => {
     vehicle_preference: "",
     comments: "",
     refering_facility_contact_name: "",
-    refering_facility_contact_number: "",
+    refering_facility_contact_number: "+91",
     assigned_facility_type: null,
     preferred_vehicle_choice: null,
     breathlessness_level: null,
     patient_category: "",
     ambulance_driver_name: "",
-    ambulance_phone_number: "",
+    ambulance_phone_number: undefined,
     ambulance_number: "",
   };
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 94ad7e9</samp>

This pull request improves the phone number input and validation in the `ShiftCreate` component. It changes the default values for `shifting_approving_facility_contact_number` and `assigned_facility_contact_number` in `src/Components/Patient/ShiftCreate.tsx`.

## Proposed Changes

- Fixes #5744

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 94ad7e9</samp>

* Change the default value of `refering_facility_contact_number` to "+91" to indicate the country code for India ([link](https://github.com/coronasafe/care_fe/pull/5751/files?diff=unified&w=0#diff-7ec03dd8838e59d1d7ef0aa4f42c6ed82aa5f086d5d280b42617974f674f561fL60-R60))
* Fix the validation error for `ambulance_phone_number` by setting its default value to `undefined` ([link](https://github.com/coronasafe/care_fe/pull/5751/files?diff=unified&w=0#diff-7ec03dd8838e59d1d7ef0aa4f42c6ed82aa5f086d5d280b42617974f674f561fL66-R66))
