### PR TITLE
Fixes phone number field initial state in user filters

### DIFF
--- a/src/Components/Users/UserFilter.tsx
+++ b/src/Components/Users/UserFilter.tsx
@@ -23,8 +23,8 @@ export default function UserFilter(props: any) {
   const [filterState, setFilterState] = useMergeState({
     first_name: filter.first_name || "",
     last_name: filter.last_name || "",
-    phone_number: filter.phone_number || "+91",
-    alt_phone_number: filter.alt_phone_number || "+91",
+    phone_number: filter.phone_number || undefined,
+    alt_phone_number: filter.alt_phone_number || undefined,
     user_type: filter.user_type || "",
     district_id: filter.district_id || "",
     district_ref: null,
@@ -33,8 +33,8 @@ export default function UserFilter(props: any) {
   const clearFilterState = {
     first_name: "",
     last_name: "",
-    phone_number: "+91",
-    alt_phone_number: "+91",
+    phone_number: undefined,
+    alt_phone_number: undefined,
     user_type: "",
     district_id: "",
     district_ref: null,
@@ -59,9 +59,8 @@ export default function UserFilter(props: any) {
     const data = {
       first_name: first_name || "",
       last_name: last_name || "",
-      phone_number: parsePhoneNumberForFilterParam(phone_number) || "+91",
-      alt_phone_number:
-        parsePhoneNumberForFilterParam(alt_phone_number) || "+91",
+      phone_number: parsePhoneNumberForFilterParam(phone_number),
+      alt_phone_number: parsePhoneNumberForFilterParam(alt_phone_number),
       user_type: user_type || "",
       district_id: district_id || "",
     };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e24f07a</samp>

Removed hardcoded country code from user filter component. This allows users to search for phone numbers without the `"+91"` prefix and reduces unnecessary API requests.

## Proposed Changes

- Fixes #5743

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e24f07a</samp>

*  Remove default and fallback values for phone number filters to avoid sending unnecessary or invalid query parameters to the backend API ([link](https://github.com/coronasafe/care_fe/pull/5754/files?diff=unified&w=0#diff-f9f925077f8a2a85dc2ce98d7b1d106635fccd175f50e19fd28f403d28029807L26-R27), [link](https://github.com/coronasafe/care_fe/pull/5754/files?diff=unified&w=0#diff-f9f925077f8a2a85dc2ce98d7b1d106635fccd175f50e19fd28f403d28029807L36-R37), [link](https://github.com/coronasafe/care_fe/pull/5754/files?diff=unified&w=0#diff-f9f925077f8a2a85dc2ce98d7b1d106635fccd175f50e19fd28f403d28029807L62-R63))
