### PR TITLE
Fix edit consultation form

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -256,6 +256,7 @@ export const ConsultationForm = (props: any) => {
   useEffect(() => {
     async function fetchPatientName() {
       if (patientId) {
+        setIsLoading(true);
         const res = await dispatchAction(getPatient({ id: patientId }));
         if (res.data) {
           setPatientName(res.data.name);
@@ -272,6 +273,7 @@ export const ConsultationForm = (props: any) => {
         setPatientName("");
         setFacilityName("");
       }
+      if (!id) setIsLoading(false);
     }
     fetchPatientName();
   }, [dispatchAction, patientId]);
@@ -282,7 +284,7 @@ export const ConsultationForm = (props: any) => {
 
   const fetchData = useCallback(
     async (status: statusType) => {
-      setIsLoading(true);
+      if (!patientId) setIsLoading(true);
       const res = await dispatchAction(getConsultation(id));
       handleFormFieldChange({
         name: "InvestigationAdvice",
@@ -342,11 +344,13 @@ export const ConsultationForm = (props: any) => {
 
   useAbortableEffect(
     (status: statusType) => {
-      if (id) {
+      if (id && patientId && patientName) {
+        fetchData(status);
+      } else if (id && !patientId) {
         fetchData(status);
       }
     },
-    [fetchData, id]
+    [fetchData, id, patientId, patientName]
   );
 
   if (isLoading) return <Loading />;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7787077</samp>

This pull request enhances the performance and usability of the `ConsultationForm` component. It prevents redundant or invalid API calls and displays a loading spinner when fetching the patient name from `src/Components/Facility/ConsultationForm.tsx`.

## Proposed Changes

- Fixes #5746

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7787077</samp>

* Show a loading indicator while fetching the patient name from the API ([link](https://github.com/coronasafe/care_fe/pull/5755/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR259))
* Hide the loading indicator if the consultation id is not available ([link](https://github.com/coronasafe/care_fe/pull/5755/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR276))
* Prevent showing the loading indicator if the patient id is not available yet ([link](https://github.com/coronasafe/care_fe/pull/5755/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL285-R287))
