### PR TITLE
Tailwind externalResult ListFilter

### DIFF
--- a/src/Components/Common/WardAutocompleteFormField.tsx
+++ b/src/Components/Common/WardAutocompleteFormField.tsx
@@ -1,0 +1,52 @@
+import { useDispatch } from "react-redux";
+import { FormFieldBaseProps } from "../Form/FormFields/Utils";
+import AutocompleteFormField from "../Form/FormFields/Autocomplete";
+import { statusType, useAbortableEffect } from "../../Common/utils";
+import { useCallback, useState } from "react";
+import { getWardByLocalBody } from "../../Redux/actions";
+import { ILocalBody } from "./LocalBodyAutocompleteFormField";
+
+export type IWard = {
+  id: number;
+  name: string;
+};
+
+type Props = FormFieldBaseProps<IWard["id"]> & {
+  placeholder?: string;
+  local_body?: ILocalBody["id"];
+};
+
+export default function WardAutocompleteFormField(props: Props) {
+  const dispatch = useDispatch<any>();
+  const [Ward, setWard] = useState<IWard[]>();
+
+  const fetchWard = useCallback(
+    async (status: any) => {
+      setWard(undefined);
+      if (!props.local_body) {
+        return;
+      }
+      const res = await dispatch(getWardByLocalBody({ id: props.local_body }));
+      if (!status.aborted && res.data) {
+        setWard(res.data);
+      }
+    },
+    [dispatch, props.local_body]
+  );
+
+  useAbortableEffect(
+    (status: statusType) => fetchWard(status),
+    [props.local_body]
+  );
+
+  return (
+    <AutocompleteFormField
+      {...props}
+      options={Ward ?? []}
+      optionLabel={(option) => option.name}
+      optionValue={(option) => option.id}
+      isLoading={!!(props.local_body && Ward === undefined)}
+      disabled={!props.local_body}
+    />
+  );
+}

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -65,7 +65,7 @@ export default function ListFilter(props: any) {
     label: t(name),
     value: filterState[name],
     onChange: handleChange,
-    errorClassName="hidden",
+    errorClassName: "hidden",
   });
 
   const formatDateTime = (dateTime: any) => {

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -163,7 +163,6 @@ export default function ListFilter(props: any) {
             })
           : [];
       setSelectedLsgs(selectedLsgs);
-      setLoading(false);
     }
     getWardList();
   }, []);
@@ -202,6 +201,8 @@ export default function ListFilter(props: any) {
       onClear={() => {
         navigate("/external_results");
         setFilterState(clearFilterState);
+        setSelectedLsgs([]);
+        setWards([]);
         closeFilter();
       }}
     >

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -65,6 +65,7 @@ export default function ListFilter(props: any) {
     label: t(name),
     value: filterState[name],
     onChange: handleChange,
+    errorClassName="hidden",
   });
 
   const formatDateTime = (dateTime: any) => {

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -1,9 +1,4 @@
 import { useEffect, useState } from "react";
-import {
-  LegacyAutoCompleteAsyncField,
-  LegacyTextInputField,
-} from "../Common/HelperInputFields";
-import { DateRangePicker, getDate } from "../Common/DateRangePicker";
 import { getAllLocalBodyByDistrict } from "../../Redux/actions";
 import { useDispatch, useSelector } from "react-redux";
 import moment from "moment";
@@ -11,7 +6,9 @@ import useMergeState from "../../Common/hooks/useMergeState";
 import { navigate } from "raviger";
 import { useTranslation } from "react-i18next";
 import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
-import { FieldLabel } from "../Form/FormFields/FormField";
+import TextFormField from "../Form/FormFields/TextFormField";
+import { MultiSelectFormField } from "../Form/FormFields/SelectFormField";
+import DateRangeFormField from "../Form/FormFields/DateRangeFormField";
 
 const clearFilterState = {
   created_date_before: "",
@@ -27,7 +24,6 @@ export default function ListFilter(props: any) {
   const { filter, onChange, closeFilter, dataList } = props;
   const [wardList, setWardList] = useState<any[]>([]);
   const [lsgList, setLsgList] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
 
   const [wards, setWards] = useState<any[]>([]);
   const [selectedLsgs, setSelectedLsgs] = useState<any[]>([]);
@@ -48,11 +44,11 @@ export default function ListFilter(props: any) {
   const handleDateRangeChange = (
     startDateId: string,
     endDateId: string,
-    { startDate, endDate }: any
+    e: any
   ) => {
     const filterData: any = { ...filterState };
-    filterData[startDateId] = startDate?.toString();
-    filterData[endDateId] = endDate?.toString();
+    filterData[startDateId] = e.value.start?.toString();
+    filterData[endDateId] = e.value.end?.toString();
 
     setFilterState(filterData);
   };
@@ -63,6 +59,13 @@ export default function ListFilter(props: any) {
   const handleLsgChange = (value: any) => {
     setSelectedLsgs(value);
   };
+
+  const field = (name: string) => ({
+    name,
+    label: t(name),
+    value: filterState[name],
+    onChange: handleChange,
+  });
 
   const formatDateTime = (dateTime: any) => {
     return dateTime && moment(dateTime).isValid()
@@ -90,6 +93,8 @@ export default function ListFilter(props: any) {
     } = filterState;
 
     const data = {
+      state: currentUser.data.state,
+      district: currentUser.data.district,
       wards: selectedWardIds.length ? selectedWardIds : "",
       local_bodies: selectedLsgIds.length ? selectedLsgIds : "",
       created_date_before: formatDateTime(created_date_before),
@@ -187,6 +192,9 @@ export default function ListFilter(props: any) {
     setFilterState(filterData);
   };
 
+  const getDate = (value: any) =>
+    value && moment(value).isValid() && moment(value).toDate();
+
   return (
     <FiltersSlideover
       advancedFilter={props}
@@ -198,76 +206,65 @@ export default function ListFilter(props: any) {
       }}
     >
       <div>
-        <FieldLabel>{t("lsg")}</FieldLabel>
-        <LegacyAutoCompleteAsyncField
-          className="-my-3"
-          multiple
+        <MultiSelectFormField
           name="local_bodies"
           options={lsgList}
           label={t("Local Body")}
-          variant="outlined"
           placeholder={t("select_local_body")}
-          loading={loading}
-          freeSolo={false}
           value={selectedLsgs}
-          renderOption={(option: any) => <div>{option.name}</div>}
-          getOptionSelected={(option: any, value: any) =>
-            option.id === value.id
-          }
-          getOptionLabel={(option: any) => option.name}
-          onChange={(e: object, value: any) => handleLsgChange(value)}
+          optionLabel={(option: any) => option.name}
+          onChange={(e: any) => handleLsgChange(e.value)}
         />
       </div>
 
       <div>
-        <FieldLabel>{t("Ward")}</FieldLabel>
-        <LegacyAutoCompleteAsyncField
-          className="-my-3"
-          multiple={true}
+        <MultiSelectFormField
           name="wards"
           options={filterWards()}
           label={t("Ward")}
-          variant="outlined"
           placeholder={t("select_wards")}
-          loading={loading}
-          freeSolo={false}
           value={wards}
-          renderOption={(option: any) => <div>{option.name}</div>}
-          getOptionSelected={(option: any, value: any) =>
-            option.id === value.id
-          }
-          getOptionLabel={(option: any) => option.name}
-          onChange={(e: object, value: any) => handleWardChange(value)}
+          optionLabel={(option: any) => option.name}
+          onChange={(e: any) => handleWardChange(e.value)}
         />
       </div>
-
-      <DateRangePicker
-        startDate={getDate(filterState.created_date_after)}
-        endDate={getDate(filterState.created_date_before)}
+      <DateRangeFormField
+        name="created_date"
+        id="created_date"
+        min={filterState.created_date_after}
+        max={filterState.created_date_before}
+        value={{
+          start: getDate(filterState.created_date_after),
+          end: getDate(filterState.created_date_before),
+        }}
         onChange={(e) =>
           handleDateRangeChange("created_date_after", "created_date_before", e)
         }
-        endDateId={"created_date_before"}
-        startDateId={"created_date_after"}
         label={t("created_date")}
-        size="small"
       />
-
-      <DateRangePicker
-        startDate={getDate(filterState.result_date_after)}
-        endDate={getDate(filterState.result_date_before)}
+      <DateRangeFormField
+        name="result_date"
+        id="result_date"
+        min={filterState.result_date_after}
+        max={filterState.result_date_before}
+        value={{
+          start: getDate(filterState.result_date_after),
+          end: getDate(filterState.result_date_before),
+        }}
         onChange={(e) =>
           handleDateRangeChange("result_date_after", "result_date_before", e)
         }
-        endDateId={"result_date_before"}
-        startDateId={"result_date_after"}
         label={t("result_date")}
-        size="small"
       />
-
-      <DateRangePicker
-        startDate={getDate(filterState.sample_collection_date_after)}
-        endDate={getDate(filterState.sample_collection_date_before)}
+      <DateRangeFormField
+        name="sample_collection_date"
+        id="sample_collection_date"
+        min={filterState.sample_collection_date_after}
+        max={filterState.sample_collection_date_before}
+        value={{
+          start: getDate(filterState.sample_collection_date_after),
+          end: getDate(filterState.sample_collection_date_before),
+        }}
         onChange={(e) =>
           handleDateRangeChange(
             "sample_collection_date_after",
@@ -275,25 +272,11 @@ export default function ListFilter(props: any) {
             e
           )
         }
-        endDateId={"sample_collection_date_before"}
-        startDateId={"sample_collection_date_after"}
         label={t("sample_collection_date")}
-        size="small"
       />
 
       <div className="w-full flex-none">
-        <FieldLabel>{t("srf_id")}</FieldLabel>
-        <LegacyTextInputField
-          id="srf_id"
-          name="srf_id"
-          variant="outlined"
-          margin="dense"
-          errors=""
-          value={filterState.srf_id}
-          onChange={handleChange}
-          label={t("srf_id")}
-          className="bg-white h-10 shadow-sm md:text-sm md:leading-5 md:h-9 mr-1"
-        />
+        <TextFormField {...field("srf_id")} />
       </div>
     </FiltersSlideover>
   );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0444d4</samp>

This pull request updates the `ListFilter` component for external results and adds a new `WardAutocompleteFormField` component for ward selection. The changes aim to improve the code quality and user experience of the frontend application.

## Proposed Changes

![image](https://github.com/coronasafe/care_fe/assets/3626859/8b5604db-6c7c-41d8-818b-06f409754c75)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0444d4</samp>

*  Add a new component `WardAutocompleteFormField` for ward selection based on local body ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-375c7d9be36f6059ba44941b0b596cdeca8814d2677558cd729e243dc3a38474R1-R52))
*  Remove unused imports from the `ListFilter` component ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL2-L6))
*  Update imports in the `ListFilter` component to use the new form field components ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL14-R11))
*  Remove the `loading` state variable from the `ListFilter` component, as it is handled internally by the new form field components ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL30))
*  Add a helper function `field` to reduce the boilerplate code for the text form fields in the `ListFilter` component ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fR63-R69))
*  Add the `state` and `district` properties to the `filterState` object to filter the external results by the user's location ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fR96-R97))
*  Add a helper function `getDate` to simplify the conversion and validation of date values for the date range form fields in the `ListFilter` component ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fR195-R197))
*  Replace the legacy `LegacyAutoCompleteAsyncField` and `DateRangePicker` components with the new `MultiSelectFormField` and `DateRangeFormField` components for the local body, ward, and date range filters in the `ListFilter` component ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL201-R267))
*  Replace the legacy `LegacyTextInputField` component with the new `TextFormField` component for the srf_id filter in the `ListFilter` component ([link](https://github.com/coronasafe/care_fe/pull/5757/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL278-R279))
