### PR TITLE
fetch assets only when bed is assigned

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -1,3 +1,4 @@
+import { AssetBedModel, AssetClass } from "../Assets/AssetTypes";
 import {
   CONSULTATION_TABS,
   DISCHARGE_REASONS,
@@ -18,7 +19,7 @@ import {
 } from "../../Redux/actions";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { useCallback, useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
+
 import { ABGPlots } from "./Consultations/ABGPlots";
 import ButtonV2 from "../Common/components/ButtonV2";
 import CareIcon from "../../CAREUI/icons/CareIcon";
@@ -26,33 +27,32 @@ import Chip from "../../CAREUI/display/Chip";
 import { DailyRoundsList } from "./Consultations/DailyRoundsList";
 import { DialysisPlots } from "./Consultations/DialysisPlots";
 import DischargeModal from "./DischargeModal";
+import DischargeSummaryModal from "./DischargeSummaryModal";
 import DoctorVideoSlideover from "./DoctorVideoSlideover";
 import { Feed } from "./Consultations/Feed";
 import { FileUpload } from "../Patient/FileUpload";
+import HL7PatientVitalsMonitor from "../VitalsMonitor/HL7PatientVitalsMonitor";
 import InvestigationTab from "./Investigations/investigationsTab";
 import { make as Link } from "../Common/components/Link.gen";
+import MedicineAdministrationsTable from "../Medicine/MedicineAdministrationsTable";
 import { NeurologicalTable } from "./Consultations/NeurologicalTables";
+import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import { NursingPlot } from "./Consultations/NursingPlot";
 import { NutritionPlots } from "./Consultations/NutritionPlots";
 import PatientInfoCard from "../Patient/PatientInfoCard";
 import { PatientModel } from "../Patient/models";
+import PrescriptionsTable from "../Medicine/PrescriptionsTable";
 import { PressureSoreDiagrams } from "./Consultations/PressureSoreDiagrams";
 import { PrimaryParametersPlot } from "./Consultations/PrimaryParametersPlot";
 import ReadMore from "../Common/components/Readmore";
+import VentilatorPatientVitalsMonitor from "../VitalsMonitor/VentilatorPatientVitalsMonitor";
 import { VentilatorPlot } from "./Consultations/VentilatorPlot";
 import { formatDate } from "../../Utils/utils";
 import loadable from "@loadable/component";
 import moment from "moment";
 import { navigate } from "raviger";
+import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
-import PrescriptionsTable from "../Medicine/PrescriptionsTable";
-import MedicineAdministrationsTable from "../Medicine/MedicineAdministrationsTable";
-import DischargeSummaryModal from "./DischargeSummaryModal";
-import VentilatorPatientVitalsMonitor from "../VitalsMonitor/VentilatorPatientVitalsMonitor";
-
-import { AssetBedModel, AssetClass } from "../Assets/AssetTypes";
-import HL7PatientVitalsMonitor from "../VitalsMonitor/HL7PatientVitalsMonitor";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -1150,12 +1150,13 @@ export const ConsultationDetails = (props: any) => {
 
 const VitalsCard = ({ consultation }: { consultation: ConsultationModel }) => {
   const dispatch = useDispatch<any>();
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [hl7SocketUrl, setHL7SocketUrl] = useState<string>();
   const [ventilatorSocketUrl, setVentilatorSocketUrl] = useState<string>();
 
   useEffect(() => {
-    if (!consultation.facility) return;
+    if (!consultation.facility || !consultation.current_bed?.bed_object.id)
+      return;
 
     const fetchData = async () => {
       setLoading(true);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5290cab</samp>

This pull request enhances the `ConsultationDetails.tsx` component by fixing bugs, removing clutter, and adding new functionalities for displaying the patient's bed, discharge, and vitals information.

## Proposed Changes

- Fixes the issue of showing vitals when bed is not assigned

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5290cab</samp>

*  Import types for AssetBedModel and AssetClass from Assets module to fetch and display bed details in consultation details page ([link](https://github.com/coronasafe/care_fe/pull/5769/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR1))
* Remove unused import of useDispatch hook from react-redux library ([link](https://github.com/coronasafe/care_fe/pull/5769/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL21-R22))
* Add imports for DischargeSummaryModal, HL7PatientVitalsMonitor, NonReadOnlyUsers, and VentilatorPatientVitalsMonitor components to render discharge summary modal, HL7 patient vitals monitor, authorization logic for non-read-only users, and ventilator patient vitals monitor respectively in consultation details page ([link](https://github.com/coronasafe/care_fe/pull/5769/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL29-R48))
* Move imports for moment, raviger, react-redux, and react-i18next libraries to the top of the file and remove duplicate imports for NonReadOnlyUsers, PrescriptionsTable, MedicineAdministrationsTable, DischargeSummaryModal, and VentilatorPatientVitalsMonitor components, following the convention of importing external libraries before internal modules and avoiding redundant imports ([link](https://github.com/coronasafe/care_fe/pull/5769/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL47-R56))
* Modify VitalsCard component to set initial loading state to false and add condition to check if consultation has a current bed object with an id before fetching bed details, preventing unnecessary loading and API calls and fixing a bug where bed details would not update when bed is changed ([link](https://github.com/coronasafe/care_fe/pull/5769/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL1153-R1159))
