### PR TITLE
Hotfix: Skip libphonenumber's As You Type formatting

### DIFF
--- a/src/Components/Form/FormFields/PhoneNumberFormField.tsx
+++ b/src/Components/Form/FormFields/PhoneNumberFormField.tsx
@@ -39,7 +39,8 @@ export default function PhoneNumberFormField(props: Props) {
 
   const setValue = (value: string) => {
     asYouType.reset();
-    field.handleChange(asYouType.input(value));
+    asYouType.input(value);
+    field.handleChange(value);
   };
 
   return (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e16e304</samp>

Fixed a bug in the phone number field of the form component. The change simplifies the `setValue` function and avoids formatting issues when changing the country code.

## Proposed Changes

- Hotfix: Skip libphonenumber's As You Type formatting

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e16e304</samp>

* Fix phone number field bug by removing `asYouType.input` call inside `field.handleChange` and calling it separately before passing the raw value ([link](https://github.com/coronasafe/care_fe/pull/5775/files?diff=unified&w=0#diff-a3de35fe1ee44fd0ec04a82bf508c17c010278d094beb28630efc1264830d01eL42-R43))
