### PR TITLE
Fix icons in Live feed controller

### DIFF
--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -413,7 +413,7 @@ const LiveFeed = (props: any) => {
                   >
                     <span className="sr-only">{option.label}</span>
                     {option.icon ? (
-                      <i className={`fas fa-${option.icon} md:p-2`}></i>
+                      <CareIcon className={`care-${option.icon}`} />
                     ) : (
                       <span className="px-2 font-bold h-full w-8 flex items-center justify-center">
                         {option.value}x


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbd6f8f</samp>

Replaced font-awesome icons with custom `CareIcon` component in `LiveFeed.tsx`. This improves the appearance and consistency of the live feed options.

## Proposed Changes

![image](https://github.com/coronasafe/care_fe/assets/3626859/8d4a1b9e-33bc-43d2-8e33-c74fee997976)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fbd6f8f</samp>

*  Replace font-awesome icons with custom `CareIcon` component for live feed options ([link](https://github.com/coronasafe/care_fe/pull/5777/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L416-R416))
*  Pass the option name as a prop to the `CareIcon` component in the `renderOption` function in `src/Components/Facility/Consultations/LiveFeed.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5777/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L416-R416))
