### PR TITLE
Fixed overflow and wrapping in vitals monitor

### DIFF
--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -258,7 +258,7 @@ export default function CentralNursingStation({ facilityId }: Props) {
           No Vitals Monitor present in this location or facility.
         </div>
       ) : (
-        <div className="mt-1 grid grid-cols-1 lg:grid-cols-2 3xl:grid-cols-3 gap-1">
+        <div className="mt-1 grid grid-cols-1 xl:grid-cols-2 3xl:grid-cols-3 gap-1">
           {data.map((props) => (
             <HL7PatientVitalsMonitor
               key={props.patientAssetBed?.bed.id}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = {
     screens: {
       vs: "348px",
       ...defaultTheme.screens,
-      "3xl": "1600px",
+      "3xl": "1920px",
     },
     extend: {
       fontFamily: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68afa78</samp>

Improved the responsiveness of the patient vitals monitor UI by changing the grid layout breakpoint for extra large screens in `CentralNursingStation.tsx`.

## Proposed Changes

- Fixes #5786 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68afa78</samp>

*  Adjusted the grid layout for the patient vitals monitor component to use two columns on extra large screens instead of large screens ([link](https://github.com/coronasafe/care_fe/pull/5794/files?diff=unified&w=0#diff-95b57b1137a563f4d92c994d950f87bc81e4a3eb129066d34a3c851d58c3609dL261-R261))
