### PR TITLE
Reset HL7/Ventilator socket url when not available

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -139,6 +139,14 @@ export const ConsultationDetails = (props: any) => {
           `wss://${ventilatorMiddleware}/observations/${ventilatorMeta?.local_ip_address}`
         );
       }
+
+      if (
+        !(hl7Middleware && hl7Meta?.local_ip_address) &&
+        !(ventilatorMiddleware && ventilatorMeta?.local_ip_address)
+      ) {
+        setHL7SocketUrl(undefined);
+        setVentilatorSocketUrl(undefined);
+      }
     };
 
     fetchData();


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4569200</samp>

This change improves the performance and reliability of the real-time data monitoring feature by avoiding socket connections to unavailable or unconfigured data sources. It affects the `ConsultationDetails.tsx` file that handles the data streams from HL7 and ventilator devices.

## Proposed Changes

- Fixes #5806 
![image](https://github.com/coronasafe/care_fe/assets/3626859/30248290-164f-429a-94e5-b9b0903eab12)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4569200</samp>

*  Check HL7 and ventilator middleware and metadata availability before setting socket URLs ([link](https://github.com/coronasafe/care_fe/pull/5808/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR142-R149))
