### PR TITLE
Make investigation table responsive / scrollable

### DIFF
--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -10,7 +10,7 @@ const TestRow = ({ data, value, onChange, i }: any) => {
       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
         {data.name}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 text-right">
+      <td className="px-6 py-4 min-w-[200px] whitespace-nowrap text-sm text-gray-700 text-right">
         {data.investigation_type === "Choice" ? (
           <SelectFormField
             name={data.name}
@@ -99,7 +99,11 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
                     data={t}
                     i={i}
                     key={t.external_id}
-                    value={state[t.external_id] && state[t.external_id].value}
+                    value={
+                      state[t.external_id] && t.investigation_type === "Float"
+                        ? state[t.external_id].value
+                        : state[t.external_id].notes
+                    }
                     onChange={(e: FieldChangeEvent<string>) =>
                       handleValueChange(
                         t.investigation_type === "Float"

--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -19,6 +19,7 @@ const TestRow = ({ data, value, onChange, i }: any) => {
             optionLabel={(o: string) => o}
             optionValue={(o: string) => o}
             onChange={onChange}
+            errorClassName="hidden"
           />
         ) : (
           <TextFormField

--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -76,7 +76,7 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
         onChange={(e) => setSearchFilter(e.value)}
       />
       <br />
-      <div className="shadow border-b border-gray-200 sm:rounded-lg overflow-x-scroll">
+      <div className="shadow border-b border-gray-200 sm:rounded-lg overflow-x-scroll sm:overflow-x-visible">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>

--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -101,9 +101,8 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
                     i={i}
                     key={t.external_id}
                     value={
-                      state[t.external_id] && t.investigation_type === "Float"
-                        ? state[t.external_id].value
-                        : state[t.external_id].notes
+                      state[t.external_id] &&
+                      (state[t.external_id].value ?? state[t.external_id].notes)
                     }
                     onChange={(e: FieldChangeEvent<string>) =>
                       handleValueChange(

--- a/src/Components/Facility/Investigations/Table.tsx
+++ b/src/Components/Facility/Investigations/Table.tsx
@@ -63,7 +63,7 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
   };
 
   return (
-    <div className="p-4 m-4">
+    <div className="md:p-4 md:m-4">
       {title && <h1 className="text-3xl font-bold">{title}</h1>}
       <br />
       <TextFormField
@@ -75,7 +75,7 @@ export const TestTable = ({ title, data, state, dispatch }: any) => {
         onChange={(e) => setSearchFilter(e.value)}
       />
       <br />
-      <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+      <div className="shadow border-b border-gray-200 sm:rounded-lg overflow-x-scroll">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 229ce6f</samp>

Improved the UI of the `TestTable` component in the facility investigations page. Made the table more adaptable to different screen sizes and easier to scroll and interact with.

## Proposed Changes

- Fixes #5809 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 229ce6f</samp>

*  Make the `TestTable` component more responsive by applying padding and margin only on medium and larger screens ([link](https://github.com/coronasafe/care_fe/pull/5812/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L66-R66))
*  Enable horizontal scrolling for the `table` element inside the `TestTable` component to avoid cutting off content on smaller screens ([link](https://github.com/coronasafe/care_fe/pull/5812/files?diff=unified&w=0#diff-0bae6f7fb2fdb18df8a369d1cdd7342f00b5716bc1268577f11830c7a3fc2541L78-R78))
