### PR TITLE
Remove default values for Manage Inventory page

### DIFF
--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -23,7 +23,7 @@ const initForm = {
   id: "",
   quantity: "",
   unit: "",
-  isIncoming: false,
+  isIncoming: undefined,
 };
 
 const initError = Object.assign(
@@ -77,10 +77,6 @@ export const AddInventoryForm = (props: any) => {
       if (!status.aborted) {
         if (res && res.data) {
           setData(res.data.results);
-          dispatch({
-            type: "set_form",
-            form: { ...state.form, id: res.data.results[0]?.id },
-          });
         }
         setIsLoading(false);
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 522dc5a</samp>

Fixed a bug in inventory editing and improved form initialization. The file `AddInventoryForm.tsx` now preserves the id of the inventory items and avoids setting a default value for `isIncoming` that could cause errors.

## Proposed Changes

- Fixes #5801 
![image](https://github.com/coronasafe/care_fe/assets/3626859/85e461f7-9766-4a08-b9a9-f53e43da1b6a)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 522dc5a</samp>

* Fix a bug where the incoming/outgoing radio buttons were not showing the correct value when editing an existing inventory item by setting the initial value of `isIncoming` to `undefined` ([link](https://github.com/coronasafe/care_fe/pull/5813/files?diff=unified&w=0#diff-0cbcee446c25081b9cc3657703cc28e1aadc287f7d948423827bcff814f803b9L26-R26))
* Preserve the id of the existing inventory item when editing it by removing the dispatch action that sets the form id to the first result from the API response ([link](https://github.com/coronasafe/care_fe/pull/5813/files?diff=unified&w=0#diff-0cbcee446c25081b9cc3657703cc28e1aadc287f7d948423827bcff814f803b9L80-L83))
