### PR TITLE
Clear location data when facility filter is removed

### DIFF
--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -45,7 +45,7 @@ function AssetFilter(props: any) {
   useEffect(() => {
     setFacilityId(facility?.id ? facility?.id : "");
     setLocationId(
-      facility.id === qParams.facility ? qParams.location ?? "" : ""
+      facility?.id === qParams.facility ? qParams.location ?? "" : ""
     );
   }, [facility, location]);
 
@@ -94,6 +94,8 @@ function AssetFilter(props: any) {
             setLocation(locationData.data);
           }
         }
+      } else {
+        setLocation(initialLocation);
       }
     },
     [filter.location]

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -70,11 +70,11 @@ const AssetsList = () => {
         page: qParams.page,
         offset: (qParams.page ? qParams.page - 1 : 0) * resultsPerPage,
         search_text: qParams.search || "",
-        facility: qParams.facility,
-        asset_type: qParams.asset_type,
-        asset_class: qParams.asset_class,
-        location: qParams.location,
-        status: qParams.status,
+        facility: qParams.facility || "",
+        asset_type: qParams.asset_type || "",
+        asset_class: qParams.asset_class || "",
+        location: qParams.facility ? qParams.location || "" : "",
+        status: qParams.status || "",
       };
       const { data } = await dispatch(listAssets(params));
       if (!status.aborted) {
@@ -149,7 +149,8 @@ const AssetsList = () => {
   );
   const fetchLocationName = useCallback(
     async (status: statusType) => {
-      if (!qParams.location) return setLocationName("");
+      if (!qParams.location || !qParams.facility)
+        return setLocationName(undefined);
       setIsLoading(true);
       const res = await dispatch(
         getFacilityAssetLocation(qParams.facility, qParams.location)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e2dc65</samp>

Fix a bug and add a feature to `AssetFilter` component. The bug could crash the app when filtering assets by facility, and the feature improves the user experience by clearing the location filter when the facility filter changes.

## Proposed Changes

- Fixes #5804 
![image](https://github.com/coronasafe/care_fe/assets/3626859/01791879-7258-43f0-a716-0be62f7610b7)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e2dc65</samp>

* Fix a typo in the `AssetFilter` component that could cause an error when checking the facility filter ([link](https://github.com/coronasafe/care_fe/pull/5814/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L48-R48))
* Add an else branch to the `useEffect` hook in `AssetFilter.tsx` to reset the location filter when the facility filter is changed ([link](https://github.com/coronasafe/care_fe/pull/5814/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96R97-R98))
