### PR TITLE
add scrollbar to investigation table

### DIFF
--- a/src/Components/Facility/Investigations/InvestigationTable.tsx
+++ b/src/Components/Facility/Investigations/InvestigationTable.tsx
@@ -126,7 +126,7 @@ export const InvestigationTable = ({
       />
       <br />
       <div id="section-to-print">
-        <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+        <div className="shadow overflow-x-scroll border-b border-gray-200 sm:rounded-lg">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>

--- a/src/Components/Facility/Investigations/Reports/ReportTable.tsx
+++ b/src/Components/Facility/Investigations/Reports/ReportTable.tsx
@@ -102,7 +102,7 @@ const ReportTable: React.FC<ReportTableProps> = ({
           </span>
         </div>
         <br />
-        <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+        <div className="shadow overflow-x-scroll border-b border-gray-200 sm:rounded-lg">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca73a55</samp>

Improved the responsiveness of the investigation and report tables by enabling horizontal scrolling on smaller screens. Modified the `overflow` classes in `InvestigationTable.tsx` and `ReportTable.tsx`.

## Proposed Changes

![image](https://github.com/coronasafe/care_fe/assets/3626859/f04cd5e4-6917-4e26-9755-a938e3937321)
![image](https://github.com/coronasafe/care_fe/assets/3626859/ab7fbecf-e99f-4a36-bd4c-cbf9690ebeca)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca73a55</samp>

*  Enable horizontal scrolling of investigation and report tables on small screens ([link](https://github.com/coronasafe/care_fe/pull/5816/files?diff=unified&w=0#diff-2ae93478d8f7125dcfe12e7bb404ef8476538ea7a08c85fdbb0aa3f42453bcd9L129-R129), [link](https://github.com/coronasafe/care_fe/pull/5816/files?diff=unified&w=0#diff-9ce9396be65f9fd9008cafc76d8321d00574725c27d6a8ca3b0fc6324d8da141L105-R105))
