### PR TITLE
Fixes filter from being undefined in shifting filters

### DIFF
--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -207,7 +207,8 @@ export default function ListFilter(props: any) {
       emergency: emergency || "",
       is_up_shift: is_up_shift || "",
       patient_phone_number: patient_phone_number
-        ? parsePhoneNumberFromString(patient_phone_number)?.format("E.164")
+        ? parsePhoneNumberFromString(patient_phone_number)?.format("E.164") ??
+          ""
         : "",
       created_date_before:
         created_date_before && moment(created_date_before).isValid()


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9b4eac</samp>

Fix phone number filter for shifting requests. Use nullish coalescing operator to avoid sending invalid values to the API in `ListFilter.tsx`.

## Proposed Changes

- Fixes #5815

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d9b4eac</samp>

*  Prevent sending invalid phone number to API filter by adding nullish coalescing operator ([link](https://github.com/coronasafe/care_fe/pull/5819/files?diff=unified&w=0#diff-9bd3f042da788b477c58be6b5fe84715b43138511ba961eda57b3317333bfe18L210-R211))
