### PR TITLE
Fix incorrect type for csv export

### DIFF
--- a/src/Common/hooks/useExport.tsx
+++ b/src/Common/hooks/useExport.tsx
@@ -27,7 +27,7 @@ export default function useExport() {
     if (res.status === 200) {
       const a = document.createElement("a");
       const blob = new Blob([parse(res.data)], {
-        type: "text/css",
+        type: "text/csv",
       });
       a.href = URL.createObjectURL(blob);
       a.download = filename;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b12a8a</samp>

Fixed a bug in the `useExport` hook that caused the exported data to be formatted as CSS instead of CSV. Changed the `type` property of the `Blob` object to `text/csv` in `src/Common/hooks/useExport.tsx`.

## Proposed Changes

- Fixes csv files being downloaded as .css in special cases.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b12a8a</samp>

* Fix export data format by changing `type` property of `Blob` object from `text/css` to `text/csv` ([link](https://github.com/coronasafe/care_fe/pull/5822/files?diff=unified&w=0#diff-5a7e65e6272e26b8aba1dc849f95833fa066fc051d4aabc84d4b738ff7fee343L30-R30))
