### PR TITLE
Fix Cypress Failure | Facility Creation |

### DIFF
--- a/cypress/e2e/facility_spec/facility.cy.ts
+++ b/cypress/e2e/facility_spec/facility.cy.ts
@@ -11,10 +11,6 @@ describe("Facility Creation", () => {
   });
 
   beforeEach(() => {
-    Cypress.automation("remote:debugger:protocol", {
-      command: "Network.setCacheDisabled",
-      params: { cacheDisabled: true },
-    });
     cy.restoreLocalStorage();
     cy.awaitUrl("/facility");
   });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17537b2</samp>

Removed code that disabled browser cache in `cypress/e2e/facility_spec/facility.cy.ts` to improve test reliability and performance.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 17537b2</samp>

* Remove code to disable browser cache using Chrome DevTools Protocol ([link](https://github.com/coronasafe/care_fe/pull/5825/files?diff=unified&w=0#diff-8f83566c5ff03dc3e5b39f6886960f41f769619afd2ad4818387c4335fb88453L14-L17)) as it was causing flaky tests and was not necessary for the functionality of the test suite
