### PR TITLE
Fix filter badges for Shifting and Resource

### DIFF
--- a/src/Components/Resource/BadgesList.tsx
+++ b/src/Components/Resource/BadgesList.tsx
@@ -14,7 +14,7 @@ export default function BadgesList(props: any) {
     async function fetchData() {
       if (!appliedFilters.origin_facility) return setOrginFacilityName("");
       const res = await dispatch(
-        getAnyFacility(appliedFilters.origin_facility, "origin_facility")
+        getAnyFacility(appliedFilters.origin_facility, "origin_facility_name")
       );
       setOrginFacilityName(res?.data?.name);
     }
@@ -26,7 +26,10 @@ export default function BadgesList(props: any) {
       if (!appliedFilters.approving_facility)
         return setApprovingFacilityName("");
       const res = await dispatch(
-        getAnyFacility(appliedFilters.approving_facility, "approving_facility")
+        getAnyFacility(
+          appliedFilters.approving_facility,
+          "approving_facility_name"
+        )
       );
       setApprovingFacilityName(res?.data?.name);
     }
@@ -37,7 +40,10 @@ export default function BadgesList(props: any) {
     async function fetchData() {
       if (!appliedFilters.assigned_facility) return setAssignedFacilityName("");
       const res = await dispatch(
-        getAnyFacility(appliedFilters.assigned_facility, "assigned_facility")
+        getAnyFacility(
+          appliedFilters.assigned_facility,
+          "assigned_facility_name"
+        )
       );
       setAssignedFacilityName(res?.data?.name);
     }

--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -33,7 +33,7 @@ export default function BadgesList(props: any) {
     async function fetchData() {
       if (!qParams.origin_facility) return setOriginFacilityName("");
       const res = await dispatch(
-        getAnyFacility(qParams.origin_facility, "origin_facility")
+        getAnyFacility(qParams.origin_facility, "origin_facility_name")
       );
       setOriginFacilityName(res?.data?.name);
     }
@@ -47,7 +47,7 @@ export default function BadgesList(props: any) {
       const res = await dispatch(
         getAnyFacility(
           qParams.shifting_approving_facility,
-          "shifting_approving_facility"
+          "shifting_approving_facility_name"
         )
       );
       setApprovingFacilityName(res?.data?.name);
@@ -59,7 +59,7 @@ export default function BadgesList(props: any) {
     async function fetchData() {
       if (!qParams.assigned_facility) return setAssignedFacilityName("");
       const res = await dispatch(
-        getAnyFacility(qParams.assigned_facility, "assigned_facility")
+        getAnyFacility(qParams.assigned_facility, "assigned_facility_name")
       );
       setAssignedFacilityName(res?.data?.name);
     }

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -207,7 +207,8 @@ export default function ListFilter(props: any) {
       emergency: emergency || "",
       is_up_shift: is_up_shift || "",
       patient_phone_number: patient_phone_number
-        ? parsePhoneNumberFromString(patient_phone_number)?.format("E.164")
+        ? parsePhoneNumberFromString(patient_phone_number)?.format("E.164") ??
+          ""
         : "",
       created_date_before:
         created_date_before && moment(created_date_before).isValid()


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ec0732</samp>

This pull request updates the code for fetching and displaying facility names for resource and shifting badges to use the correct API response fields. It also adds nullish coalescing to handle undefined phone numbers in the resource list filter. These changes are part of creating a new resource management module.

## Proposed Changes

- Fixes #5802
![image](https://github.com/coronasafe/care_fe/assets/3626859/2a552d36-28c8-42c8-ab01-34ae9a1f881f)
![image](https://github.com/coronasafe/care_fe/assets/3626859/f857a7e3-d0c4-4768-9869-a2f53d19745a)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ec0732</samp>

*  Changed the second argument of the `getAnyFacility` action to match the API response fields for the origin, approving, and assigned facility names ([link](https://github.com/coronasafe/care_fe/pull/5826/files?diff=unified&w=0#diff-e39ede2a5c09938bbd4d5e3d09dbad6f332fc3c70a7059544d94227d6abac960L17-R17), [link](https://github.com/coronasafe/care_fe/pull/5826/files?diff=unified&w=0#diff-e39ede2a5c09938bbd4d5e3d09dbad6f332fc3c70a7059544d94227d6abac960L29-R32), [link](https://github.com/coronasafe/care_fe/pull/5826/files?diff=unified&w=0#diff-e39ede2a5c09938bbd4d5e3d09dbad6f332fc3c70a7059544d94227d6abac960L40-R46), [link](https://github.com/coronasafe/care_fe/pull/5826/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfL36-R36), [link](https://github.com/coronasafe/care_fe/pull/5826/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfL50-R50), [link](https://github.com/coronasafe/care_fe/pull/5826/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfL62-R62)) in the `BadgesList.tsx` files for the resource and shifting modules.
