### PR TITLE
Removed extra padding on users page in mobile view

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -416,7 +416,7 @@ export default function ManageUsers() {
     <Page
       title="User Management"
       hideBack={true}
-      className="mx-5 px-2"
+      className=""
       breadcrumbs={false}
     >
       {expandSkillList && (

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -416,7 +416,6 @@ export default function ManageUsers() {
     <Page
       title="User Management"
       hideBack={true}
-      className=""
       breadcrumbs={false}
     >
       {expandSkillList && (


### PR DESCRIPTION
## Proposed Changes
- Fixes #5828 
http://localhost:4000/users
Removed extra padding from Users page in mobile view
Mobile view:
![image](https://github.com/coronasafe/care_fe/assets/70687348/e6aac052-8aaa-4046-b1f9-eac91332041c)

Desktop view:
![image](https://github.com/coronasafe/care_fe/assets/70687348/3ffb10e2-5429-4dbb-ad35-f22c33d9a2e3)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b77a4fc</samp>

* Remove extra margin and padding from page title ([link](https://github.com/coronasafe/care_fe/pull/5829/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121L419-R419))
