### PR TITLE
Cypress Test: update trigger to have write perms for fork PRs

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,7 +3,7 @@ name: Cypress Tests
 on:
   schedule:
     - cron: "30 22 * * *"
-  pull_request:
+  pull_request_target:
     branches:
       - develop
       - master


### PR DESCRIPTION
### References: 

- https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks