### PR TITLE
Cypress | Shift Filter | POM Approach

### DIFF
--- a/cypress/e2e/shifting_spec/filter.cy.ts
+++ b/cypress/e2e/shifting_spec/filter.cy.ts
@@ -1,6 +1,9 @@
 import { afterEach, before, beforeEach, cy, describe, it } from "local-cypress";
+import ShiftingPage from "../../pageobject/Shift/ShiftFilters";
 
 describe("Shifting section filter", () => {
+  const shiftingPage = new ShiftingPage();
+
   before(() => {
     cy.loginByApi("devdistrictadmin", "Coronasafe@123");
     cy.saveLocalStorage();
@@ -9,204 +12,47 @@ describe("Shifting section filter", () => {
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.awaitUrl("/shifting");
-    cy.get("button").should("contain", "Filters").contains("Filters").click();
+    shiftingPage.advancedFilterButton().click();
   });
 
-  it("filter by origin facility", () => {
-    cy.intercept(/\/api\/v1\/getallfacilities/).as("facilities_filter");
-    cy.get("[name='origin_facility']")
-      .wait(100)
-      .type("Dummy")
-      .wait("@facilities_filter");
-    cy.get("[name='origin_facility']").wait(100).type("{downarrow}{enter}");
-    cy.contains("Apply").click();
+  it("filter by facility", () => {
+    shiftingPage.filterByFacility(
+      "Dummy Shifting",
+      "Dummy Shifting",
+      "District Admin"
+    );
+
+    shiftingPage.facilityAssignedBadge().should("exist");
+    shiftingPage.currentFacilityBadge().should("exist");
   });
 
-  it("filter by assigned facility", () => {
-    cy.intercept(/\/api\/v1\/getallfacilities/).as("facilities_filter");
-    cy.get("[name='assigned_facility']")
-      .wait(100)
-      .type("Dummy")
-      .wait("@facilities_filter");
-    cy.get("[name='assigned_facility']").wait(100).type("{downarrow}{enter}");
-    cy.contains("Apply").click();
-  });
-
-  it("filter by assigned to user", () => {
-    cy.intercept(/\/api\/v1\/users/).as("users_filter");
-    cy.get("[id='assigned-to']")
-      .wait(100)
-      .type("cypress")
-      .wait("@users_filter");
-    cy.get("[id='assigned-to']").wait(100).type("{downarrow}{enter}");
-    cy.contains("Apply").click();
-
-    // cy.intercept(/\/api\/v1\/users/).as("users_filter");
-    // cy.get("[name='assigned_to']").type("cypress").wait("@users_filter");
-    // cy.get("[name='assigned_to']").type("{downarrow}{enter}");
-    // cy.contains("Apply").click();
-  });
-
-  it("filter by ordering", () => {
-    [
-      "DESC Created Date",
-      "ASC Modified Date",
-      "DESC Modified Date",
+  it("filter by other category", () => {
+    shiftingPage.filterByOtherCategory(
       "ASC Created Date",
-    ].forEach((select) => {
-      cy.get("[id='ordering'] > div > button")
-        .click()
-        .wait(100)
-        .get("li")
-        .contains(select)
-        .click()
-        .wait(100);
-      cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      cy.contains("Apply").click().wait("@shifting_filter");
-      cy.contains("Filters").click();
-      // cy.get("[name='ordering']").select(select).wait(100);
-      // cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      // cy.contains("Apply").click().wait("@shifting_filter");
-      // cy.contains("Filters").click();
-    });
+      "yes",
+      "yes",
+      "POSITIVE",
+      "no",
+      "MODERATE",
+      "9999999999"
+    );
+
+    shiftingPage.diseaseStatusBadge().should("exist");
+    shiftingPage.orderingBadge().should("exist");
+    shiftingPage.breathlessnessLevelBadge().should("exist");
+    shiftingPage.phoneNumberBadge().should("exist");
   });
 
-  it("filter by emergency case", () => {
-    ["yes", "no"].forEach((select) => {
-      cy.get("[id='emergency'] > div > button")
-        .click()
-        .wait(100)
-        .get("li")
-        .contains(select)
-        .click()
-        .wait(100);
-      cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      cy.contains("Apply").click().wait("@shifting_filter");
-      cy.contains("Filters").click();
-      // cy.get("[name='emergency']").select(select).wait(100);
-      // cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      // cy.contains("Apply").click().wait("@shifting_filter");
-      // cy.contains("Filters").click();
-    });
-  });
+  it("filter by date", () => {
+    shiftingPage.filterByDate("#date-1", "#date-8", "#date-1", "#date-8");
 
-  it("filter by antenatal", () => {
-    ["yes", "no"].forEach((select) => {
-      cy.get("[id='is-antenatal'] > div > button")
-        .click()
-        .wait(100)
-        .get("li")
-        .contains(select)
-        .click()
-        .wait(100);
-      cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      cy.contains("Apply").click().wait("@shifting_filter");
-      cy.contains("Filters").click();
-      // cy.get("[name='is-antenatal']").select(select);
-      // cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      // cy.contains("Apply").click().wait("@shifting_filter");
-      // cy.contains("Filters").click();
-    });
-  });
-
-  it("filter by upshift case", () => {
-    ["yes", "no"].forEach((select) => {
-      cy.get("[id='is-up-shift'] > div > button")
-        .click()
-        .wait(100)
-        .get("li")
-        .contains(select)
-        .click()
-        .wait(100);
-      cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      cy.contains("Apply").click().wait("@shifting_filter");
-      cy.contains("Filters").click();
-      // cy.get("[name='is-up-shift']").select(select);
-      // cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      // cy.contains("Apply").click().wait("@shifting_filter");
-      // cy.contains("Filters").click();
-    });
-  });
-
-  it("filter by disease status", () => {
-    ["POSITIVE", "SUSPECTED", "NEGATIVE", "RECOVERED"].forEach((select) => {
-      cy.get("[id='disease-status'] > div > button")
-        .click()
-        .wait(100)
-        .get("li")
-        .contains(select)
-        .click()
-        .wait(100);
-      cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      cy.contains("Apply").click().wait("@shifting_filter");
-      cy.contains("Filters").click();
-      // cy.get("[name='disease_status']").select(select);
-      // cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      // cy.contains("Apply").click().wait("@shifting_filter");
-      // cy.contains("Filters").click();
-    });
-  });
-
-  it("filter by breathlessness level", () => {
-    ["NOT BREATHLESS", "MILD", "MODERATE", "SEVERE"].forEach((select) => {
-      cy.get("[id='breathlessness-level'] > div > button")
-        .click()
-        .wait(100)
-        .get("li")
-        .contains(select)
-        .click()
-        .wait(100);
-      cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      cy.contains("Apply").click().wait("@shifting_filter");
-      cy.contains("Filters").click();
-      // cy.get("[name='breathlessness_level']").select(select);
-      // cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-      // cy.contains("Apply").click().wait("@shifting_filter");
-      // cy.contains("Filters").click();
-    });
-  });
-
-  it("filter by patient phone number", () => {
-    const phoneNumber = "9999999999";
-    cy.intercept(/\/api\/v1\/shift/).as("shiftFilter");
-    cy.get("[name='patient_phone_number']").type(phoneNumber);
-    cy.contains("Apply").click();
-    cy.wait("@shiftFilter").then((interception) => {
-      expect(interception?.request?.query?.patient_phone_number).to.eq(
-        `+91${phoneNumber}`
-      );
-    });
-  });
-
-  it("filter by created date", () => {
-    cy.contains("Created Date")
-      .parent()
-      .within(() => {
-        cy.get("input[placeholder='Start date']").click();
-        cy.contains("1").click();
-        cy.get("input[placeholder='End date']").click();
-        cy.contains("21").click();
-      });
-    cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-    cy.contains("Apply").click().wait("@shifting_filter");
-  });
-
-  it("filter by modified date", () => {
-    cy.contains("Modified Date")
-      .parent()
-      .within(() => {
-        cy.get("input[placeholder='Start date']").click();
-        cy.contains("1").click();
-        cy.get("input[placeholder='End date']").click();
-        cy.contains("21").click();
-      });
-    cy.intercept(/\/api\/v1\/shift/).as("shifting_filter");
-    cy.contains("Apply").click().wait("@shifting_filter");
+    shiftingPage.createdAfterBadge().should("exist");
+    shiftingPage.createdBeforeBadge().should("exist");
+    shiftingPage.modifiedAfterBadge().should("exist");
+    shiftingPage.modifiedBeforeBadge().should("exist");
   });
 
   afterEach(() => {
-    cy.contains("Filters").click({ force: true });
-    cy.contains("Clear").click();
     cy.saveLocalStorage();
   });
 });

--- a/cypress/pageobject/Shift/ShiftFilters.ts
+++ b/cypress/pageobject/Shift/ShiftFilters.ts
@@ -1,0 +1,173 @@
+class ShiftingPage {
+  advancedFilterButton() {
+    return cy.get("#advanced-filter");
+  }
+
+  originFacilityInput() {
+    return cy.get("input[name='origin_facility']");
+  }
+
+  assignedFacilityInput() {
+    return cy.get("input[name='assigned_facility']");
+  }
+
+  assignedToInput() {
+    return cy.get("#assigned-to");
+  }
+
+  orderingInput() {
+    return cy.get("#ordering");
+  }
+
+  emergencyInput() {
+    return cy.get("#emergency");
+  }
+
+  isUpShiftInput() {
+    return cy.get("#is-up-shift");
+  }
+
+  diseaseStatusInput() {
+    return cy.get("#disease-status");
+  }
+
+  isAntenatalInput() {
+    return cy.get("#is-antenatal");
+  }
+
+  breathlessnessLevelInput() {
+    return cy.get("#breathlessness-level");
+  }
+
+  phoneNumberInput() {
+    return cy.get("#patient_phone_number");
+  }
+
+  createdDateStartInput() {
+    return cy.get("input[name='created_date_start']");
+  }
+
+  modifiedDateStartInput() {
+    return cy.get("input[name='modified_date_start']");
+  }
+
+  applyFilterButton() {
+    return cy.get("#apply-filter");
+  }
+
+  facilityAssignedBadge() {
+    return cy.get("[data-testid='Facility assigned']");
+  }
+
+  currentFacilityBadge() {
+    return cy.get("[data-testid='Current facility']");
+  }
+
+  diseaseStatusBadge() {
+    return cy.get("[data-testid='Disease status']");
+  }
+
+  orderingBadge() {
+    return cy.get("[data-testid='Ordering']");
+  }
+
+  breathlessnessLevelBadge() {
+    return cy.get("[data-testid='Breathlessness level']");
+  }
+
+  phoneNumberBadge() {
+    return cy.get("[data-testid='Phone no.']");
+  }
+
+  createdAfterBadge() {
+    return cy.get("[data-testid='Created after']");
+  }
+
+  createdBeforeBadge() {
+    return cy.get("[data-testid='Created before']");
+  }
+
+  modifiedAfterBadge() {
+    return cy.get("[data-testid='Modified after']");
+  }
+
+  modifiedBeforeBadge() {
+    return cy.get("[data-testid='Modified before']");
+  }
+
+  filterByFacility(
+    origin_facility: string,
+    assigned_facility: string,
+    assigned_to: string
+  ) {
+    this.originFacilityInput().click().type(origin_facility);
+    cy.get("[role='option']").contains(origin_facility).click();
+
+    this.assignedFacilityInput().click().type(assigned_facility);
+    cy.get("[role='option']").contains(assigned_facility).click();
+
+    this.assignedToInput().click().type(assigned_to);
+    cy.get("[role='option']").contains(assigned_to).click();
+
+    this.applyFilterButton().click();
+  }
+
+  filterByOtherCategory(
+    ordering: string,
+    emergency: string,
+    is_up_shift: string,
+    disease_status: string,
+    is_antenatal: string,
+    breathlessness_level: string,
+    patient_phone_number: string
+  ) {
+    this.orderingInput().click();
+    cy.get("[role='option']").contains(ordering).click();
+
+    this.emergencyInput().click();
+    cy.get("[role='option']").contains(emergency).click();
+
+    this.isUpShiftInput().click();
+    cy.get("[role='option']").contains(is_up_shift).click();
+
+    this.diseaseStatusInput().click();
+    cy.get("[role='option']").contains(disease_status).click();
+
+    this.isAntenatalInput().click();
+    cy.get("[role='option']").contains(is_antenatal).click();
+
+    this.breathlessnessLevelInput().click();
+    cy.get("[role='option']").contains(breathlessness_level).click();
+
+    this.phoneNumberInput().click().type(patient_phone_number);
+
+    this.applyFilterButton().click();
+  }
+
+  filterByDate(
+    created_date_start: string,
+    created_date_end: string,
+    modified_date_start: string,
+    modified_date_end: string
+  ) {
+    this.createdDateStartInput().click();
+    cy.get("[id^='headlessui-popover-panel-'] .care-l-angle-left-b")
+      .eq(0)
+      .closest("button")
+      .click();
+    cy.get(created_date_start).click();
+    cy.get(created_date_end).click();
+
+    this.modifiedDateStartInput().click();
+    cy.get("[id^='headlessui-popover-panel-'] .care-l-angle-left-b")
+      .eq(0)
+      .closest("button")
+      .click();
+    cy.get(modified_date_start).click();
+    cy.get(modified_date_end).click();
+
+    this.applyFilterButton().click();
+  }
+}
+
+export default ShiftingPage;

--- a/src/CAREUI/interactive/FiltersSlideover.tsx
+++ b/src/CAREUI/interactive/FiltersSlideover.tsx
@@ -29,11 +29,16 @@ export default function FiltersSlideover({
         <div className="flex items-center justify-between">
           <span className="font-bold text-lg">{t("advanced_filters")}</span>
           <div className="flex items-center justify-end gap-1 mr-2">
-            <ButtonV2 variant="danger" ghost onClick={onClear}>
+            <ButtonV2
+              variant="danger"
+              ghost
+              onClick={onClear}
+              id="clear-filter"
+            >
               <CareIcon className="care-l-filter-slash text-lg" />
               <span>{t("clear")}</span>
             </ButtonV2>
-            <ButtonV2 ghost onClick={onApply}>
+            <ButtonV2 ghost onClick={onApply} id="apply-filter">
               {t("apply")}
             </ButtonV2>
           </div>
@@ -54,6 +59,7 @@ export const AdvancedFilterButton = ({ onClick }: { onClick: () => void }) => {
       border
       className="bg-white w-full sm:w-auto"
       onClick={onClick}
+      id="advanced-filter"
     >
       <CareIcon className="care-l-filter" />
       <span className="py-0.5">{t("advanced_filters")}</span>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c57369</samp>

The pull request refactors the test code for the shifting section filter using a page object class `ShiftingPage`. It also adds `id` attributes to some filter components in `FiltersSlideover.tsx` to make them easier to locate by the test code. The changes aim to improve the readability, maintainability, and robustness of the test code.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c57369</samp>

*  Refactor the test code for the shifting section filter using the page object pattern ([link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-d3a579859bf06b117ab928edef6479c88a9d3468289a4a4e90d999d8bb2c4f0aL2-R6), [link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-d3a579859bf06b117ab928edef6479c88a9d3468289a4a4e90d999d8bb2c4f0aL12-R55), [link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-e6bca479d69646ee80d05d5bd70b494cc5748f0363ff11fd34ccf44f18b2959aR1-R173))
  * Import and instantiate the `ShiftingPage` class from `cypress/pageobject/Shift/ShiftFilters.ts` in the test file `cypress/e2e/shifting_spec/filter.cy.ts` ([link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-d3a579859bf06b117ab928edef6479c88a9d3468289a4a4e90d999d8bb2c4f0aL2-R6))
  * Replace the low-level commands for interacting with the filter inputs and buttons with the high-level methods from the `ShiftingPage` class ([link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-d3a579859bf06b117ab928edef6479c88a9d3468289a4a4e90d999d8bb2c4f0aL12-R55))
  * Define the `ShiftingPage` class with methods for accessing and manipulating the filter elements and buttons in `cypress/pageobject/Shift/ShiftFilters.ts` ([link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-e6bca479d69646ee80d05d5bd70b494cc5748f0363ff11fd34ccf44f18b2959aR1-R173))
* Add `id` attributes to the filter buttons in the `FiltersSlideover` component ([link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-5020fbd9bdc19f8fac9938efbe0f199406977ca3b30b40c2d9065a6bd48c7ac5L32-R41), [link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-5020fbd9bdc19f8fac9938efbe0f199406977ca3b30b40c2d9065a6bd48c7ac5R62))
  * Add an `id` attribute to the clear and apply filter buttons in `src/CAREUI/interactive/FiltersSlideover.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-5020fbd9bdc19f8fac9938efbe0f199406977ca3b30b40c2d9065a6bd48c7ac5L32-R41))
  * Add an `id` attribute to the advanced filter button in `src/CAREUI/interactive/FiltersSlideover.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5833/files?diff=unified&w=0#diff-5020fbd9bdc19f8fac9938efbe0f199406977ca3b30b40c2d9065a6bd48c7ac5R62))
