### PR TITLE
Add discharge_reason to patient filters

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -15,7 +15,7 @@ export const LocalStorageKeys = {
   refreshToken: "care_refresh_token",
 };
 export interface OptionsType {
-  id: number;
+  id: number | string;
   text: string;
   label?: string;
   desc?: string;

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -2,6 +2,7 @@ import * as Notification from "../../Utils/Notifications.js";
 
 import {
   ADMITTED_TO,
+  DISCHARGE_REASONS,
   GENDER_TYPES,
   PATIENT_CATEGORIES,
   PATIENT_SORT_OPTIONS,
@@ -142,14 +143,19 @@ export const PatientManager = () => {
     setEmergencyPhoneNumberError("Enter a valid number");
   };
 
-  const tabValue = qParams.is_active === "False" ? 1 : 0;
+  const tabValue =
+    qParams.last_consultation_discharge_reason || qParams.is_active === "False"
+      ? 1
+      : 0;
 
   const params = {
     page: qParams.page || 1,
     limit: resultsPerPage,
     name: qParams.name || undefined,
     ip_no: qParams.ip_no || undefined,
-    is_active: qParams.is_active || "True",
+    is_active:
+      !qParams.last_consultation_discharge_reason &&
+      (qParams.is_active || "True"),
     disease_status: qParams.disease_status || undefined,
     phone_number: qParams.phone_number
       ? parsePhoneNumberFromString(qParams.phone_number)?.format("E.164")
@@ -189,6 +195,8 @@ export const PatientManager = () => {
       qParams.last_consultation_discharge_date_after || undefined,
     last_consultation_admitted_bed_type_list:
       qParams.last_consultation_admitted_bed_type_list || undefined,
+    last_consultation_discharge_reason:
+      qParams.last_consultation_discharge_reason || undefined,
     srf_id: qParams.srf_id || undefined,
     number_of_doses: qParams.number_of_doses || undefined,
     covin_id: qParams.covin_id || undefined,
@@ -332,6 +340,7 @@ export const PatientManager = () => {
     qParams.age_max,
     qParams.age_min,
     qParams.last_consultation_admitted_bed_type_list,
+    qParams.last_consultation_discharge_reason,
     qParams.facility,
     qParams.facility_type,
     qParams.district,
@@ -932,6 +941,14 @@ export const PatientManager = () => {
               name: "Telemedicine",
               paramKey: "last_consultation_is_telemedicine",
             },
+            value(
+              "Discharge Reason",
+              "last_consultation_discharge_reason",
+              parseOptionId(
+                DISCHARGE_REASONS,
+                qParams.last_consultation_discharge_reason
+              ) || ""
+            ),
           ]}
           children={
             qParams.last_consultation_admitted_bed_type_list &&

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -7,6 +7,7 @@ import {
   DISEASE_STATUS,
   PATIENT_FILTER_CATEGORIES,
   ADMITTED_TO,
+  DISCHARGE_REASONS,
 } from "../../Common/constants";
 import moment from "moment";
 import {
@@ -75,6 +76,8 @@ export default function PatientFilter(props: any) {
       filter.last_consultation_admitted_bed_type_list
         ? filter.last_consultation_admitted_bed_type_list.split(",")
         : [],
+    last_consultation_discharge_reason:
+      filter.last_consultation_discharge_reason || null,
     srf_id: filter.srf_id || null,
     number_of_doses: filter.number_of_doses || null,
     covin_id: filter.covin_id || null,
@@ -230,6 +233,7 @@ export default function PatientFilter(props: any) {
       last_consultation_discharge_date_before,
       last_consultation_discharge_date_after,
       last_consultation_admitted_bed_type_list,
+      last_consultation_discharge_reason,
       number_of_doses,
       covin_id,
       srf_id,
@@ -314,6 +318,8 @@ export default function PatientFilter(props: any) {
       age_max: age_max || "",
       last_consultation_admitted_bed_type_list:
         last_consultation_admitted_bed_type_list || [],
+      last_consultation_discharge_reason:
+        last_consultation_discharge_reason || "",
       srf_id: srf_id || "",
       number_of_doses: number_of_doses || "",
       covin_id: covin_id || "",
@@ -448,6 +454,23 @@ export default function PatientFilter(props: any) {
                 setFilterState({
                   ...filterState,
                   last_consultation_admitted_bed_type_list: o,
+                })
+              }
+            />
+          </div>
+          <div className="w-full flex-none" id="discharge-reason-select">
+            <FieldLabel className="text-sm">Discharge Reason</FieldLabel>
+            <SelectMenuV2
+              id="last_consultation_discharge_reason"
+              placeholder="Select discharge reason"
+              options={DISCHARGE_REASONS}
+              value={filterState.last_consultation_discharge_reason}
+              optionValue={(o) => o.id}
+              optionLabel={(o) => o.text}
+              onChange={(o) =>
+                setFilterState({
+                  ...filterState,
+                  last_consultation_discharge_reason: o,
                 })
               }
             />


### PR DESCRIPTION
Backend PR: https://github.com/coronasafe/care/pull/1440

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5e02ea</samp>

Added a new feature to filter patients by their discharge reason in the patient list. This required changes to `ManagePatients.tsx`, `PatientFilter.tsx`, and `constants.tsx` to handle the new filter option and pass it to the backend API and the URL.

## Proposed Changes

- Fixes #5474
![image](https://github.com/coronasafe/care_fe/assets/3626859/afbbfaac-7581-4b89-8375-acb9b1696ea4)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5e02ea</samp>

*  Modify `OptionsType` interface to allow `id` to be number or string ([link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-37705b30476b14631124ce42dd5c3500d43fbede16f0e91f9ae2905e4adc6376L18-R18))
*  Import `DISCHARGE_REASONS` constant from `src/Common/constants.tsx` in `ManagePatients.tsx` and `PatientFilter.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R5), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aR10))
*  Add `last_consultation_discharge_reason` parameter to filter patients by discharge reason in `ManagePatients.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L145-R149), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L152-R158), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R198-R199), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R343), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R944-R951))
*  Add `SelectMenuV2` component to render dropdown menu for selecting discharge reason in `PatientFilter.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aR79-R80), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aR236), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aR321-R322), [link](https://github.com/coronasafe/care_fe/pull/5843/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aR461-R477))
