### PR TITLE
Allow 10 digit number without country code

### DIFF
--- a/src/Components/Users/UserFilter.tsx
+++ b/src/Components/Users/UserFilter.tsx
@@ -14,7 +14,9 @@ import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
 
 const parsePhoneNumberForFilterParam = (phoneNumber: string) => {
   if (!phoneNumber) return "";
-  return parsePhoneNumberFromString(phoneNumber)?.format("E.164") || "";
+  if (phoneNumber.startsWith("+"))
+    return parsePhoneNumberFromString(phoneNumber)?.format("E.164") || "";
+  return phoneNumber;
 };
 
 export default function UserFilter(props: any) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a12db2</samp>

Fixed user filter by phone number bug in `UserFilter.tsx`. Modified `parsePhoneNumberForFilterParam` function to handle phone numbers without a plus sign.

## Proposed Changes

- Fixes #5846 
![image](https://github.com/coronasafe/care_fe/assets/3626859/9d07441e-a351-4f72-aa06-d01868cab5d3)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a12db2</samp>

* Fixed user filter by phone number to handle numbers without a plus sign ([link](https://github.com/coronasafe/care_fe/pull/5850/files?diff=unified&w=0#diff-f9f925077f8a2a85dc2ce98d7b1d106635fccd175f50e19fd28f403d28029807L17-R19))
