### PR TITLE
Fix alignment of 'Preset Name'

### DIFF
--- a/src/Components/Assets/configure/CameraConfigure.tsx
+++ b/src/Components/Assets/configure/CameraConfigure.tsx
@@ -57,7 +57,7 @@ export default function CameraConfigure(props: CameraConfigureProps) {
                 id="location"
                 type="text"
                 value={newPreset}
-                className="mt-2"
+                className="mt-1"
                 onChange={(e) => setNewPreset(e.value)}
                 error=""
               />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08295b3</samp>

Reduced the margin-top of the input element in `CameraConfigure.tsx` to improve the layout of the camera preset form.

## Proposed Changes

- Fixes #5849 
![image](https://github.com/coronasafe/care_fe/assets/3626859/33bc40bc-8cd2-4b6c-9eaf-c7a0223415a2)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08295b3</samp>

* Reduce the top margin of the input element for camera name to align it better with the label and button elements ([link](https://github.com/coronasafe/care_fe/pull/5855/files?diff=unified&w=0#diff-4c1baacac3d75a05f7ec5e73a9168d3aa337f6da0a9c5e9f7050b7ba97458167L60-R60))
