### PR TITLE
Fix emergency checkbox for Resource

### DIFF
--- a/src/Components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/Components/Resource/ResourceDetailsUpdate.tsx
@@ -217,12 +217,11 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
   }
 
   return (
-
-    <Page 
-    title="Update Resource Request"
-    backUrl={`/resource/${props.id}`}
-    crumbsReplacements={{ [props.id]: { name: requestTitle } }}>
-    
+    <Page
+      title="Update Resource Request"
+      backUrl={`/resource/${props.id}`}
+      crumbsReplacements={{ [props.id]: { name: requestTitle } }}
+    >
       <div className="mt-4">
         <Card className="w-full flex flex-col">
           <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
@@ -242,12 +241,12 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
                   <CircularProgress />
                 ) : (
                   <UserAutocompleteFormField
-                      label="Assigned To"
-                      value = {assignedUser===null?undefined:assignedUser}
-                      onChange={handleOnSelect}
-                      error=""
-                      name="assigned_to"
-                      />
+                    label="Assigned To"
+                    value={assignedUser === null ? undefined : assignedUser}
+                    onChange={handleOnSelect}
+                    error=""
+                    name="assigned_to"
+                  />
                 )}
               </div>
             </div>
@@ -332,10 +331,9 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
                 options={[true, false]}
                 optionDisplay={(o) => (o ? "Yes" : "No")}
                 optionValue={(o) => String(o)}
-                value={state.form.emergency}
+                value={String(state.form.emergency)}
                 error={state.errors.emergency}
               />
-
             </div>
 
             <div className="md:col-span-2 flex flex-col md:flex-row gap-2 justify-between mt-4">


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d83c4c7</samp>

Reformatted code and fixed a type mismatch in the resource update form. The file `ResourceDetailsUpdate.tsx` was modified to handle the select field correctly.

## Proposed Changes

- Fixes #5845 
![image](https://github.com/coronasafe/care_fe/assets/3626859/dc96beb8-82ca-42c6-94c3-88a68ea899c5)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d83c4c7</samp>

*  Fixed type mismatch error in `ResourceDetailsUpdate.tsx` by changing value prop of `SelectField` component from boolean to string ([link](https://github.com/coronasafe/care_fe/pull/5856/files?diff=unified&w=0#diff-c90efac597325ec542fa64782ea87ef14525f4133eb06f34eb4595e6aadd157aL335-R336))
* Simplified value prop of `UserAutocompleteFormField` component in `ResourceDetailsUpdate.tsx` by using ternary operator instead of conditional expression ([link](https://github.com/coronasafe/care_fe/pull/5856/files?diff=unified&w=0#diff-c90efac597325ec542fa64782ea87ef14525f4133eb06f34eb4595e6aadd157aL245-R249))
* Reformatted code in `ResourceDetailsUpdate.tsx` to improve readability and consistency of indentation and spacing of component props ([link](https://github.com/coronasafe/care_fe/pull/5856/files?diff=unified&w=0#diff-c90efac597325ec542fa64782ea87ef14525f4133eb06f34eb4595e6aadd157aL220-R224), [link](https://github.com/coronasafe/care_fe/pull/5856/files?diff=unified&w=0#diff-c90efac597325ec542fa64782ea87ef14525f4133eb06f34eb4595e6aadd157aL245-R249))
