### PR TITLE
Replace screenfull package with useFullscreen hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "redux": "^4.1.0",
         "redux-thunk": "^2.3.0",
         "rescript-webapi": "^0.6.1",
-        "screenfull": "^5.1.0",
         "use-keyboard-shortcut": "^1.1.6",
         "uuid": "^8.3.2"
       },
@@ -14886,18 +14885,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/screenfull": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
-      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/sdp": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
@@ -27649,11 +27636,6 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
-    },
-    "screenfull": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
-      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
     },
     "sdp": {
       "version": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0",
     "rescript-webapi": "^0.6.1",
-    "screenfull": "^5.1.0",
     "use-keyboard-shortcut": "^1.1.6",
     "uuid": "^8.3.2"
   },

--- a/src/Common/hooks/useFullscreen.ts
+++ b/src/Common/hooks/useFullscreen.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 
-export default function useFullscreen(): [boolean, (value: boolean) => void] {
+export default function useFullscreen(): [
+  boolean,
+  (value: boolean, element?: HTMLElement) => void
+] {
   const [isFullscreen, _setIsFullscreen] = useState(
     !!document.fullscreenElement
   );
@@ -15,12 +18,11 @@ export default function useFullscreen(): [boolean, (value: boolean) => void] {
       document.removeEventListener("fullscreenchange", onFullscreenChange);
   }, []);
 
-  const setFullscreen = (value: boolean) => {
-    if (value) {
-      document.documentElement.requestFullscreen();
-    } else {
-      document.exitFullscreen();
-    }
+  const setFullscreen = (value: boolean, element?: HTMLElement) => {
+    const fullscreenElement = element ?? document.documentElement;
+
+    if (value) fullscreenElement.requestFullscreen();
+    else document.exitFullscreen();
   };
 
   return [isFullscreen, setFullscreen];

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -26,10 +26,10 @@ import FeedButton from "./FeedButton";
 import Loading from "../../Common/Loading";
 import ReactPlayer from "react-player";
 import { classNames } from "../../../Utils/utils";
-import screenfull from "screenfull";
 import { useDispatch } from "react-redux";
 import { useHLSPLayer } from "../../../Common/hooks/useHLSPlayer";
 import useKeyboardShortcut from "use-keyboard-shortcut";
+import useFullscreen from "../../../Common/hooks/useFullscreen.js";
 
 interface IFeedProps {
   facilityId: string;
@@ -54,6 +54,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
   const [bed, setBed] = useState<any>();
   const [precision, setPrecision] = useState(1);
   const [cameraState, setCameraState] = useState<PTZState | null>(null);
+  const [isFullscreen, setFullscreen] = useFullscreen();
 
   useEffect(() => {
     const fetchFacility = async () => {
@@ -299,14 +300,13 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
       });
     },
     fullScreen: () => {
-      if (!(screenfull.isEnabled && liveFeedPlayerRef.current)) return;
-      !screenfull.isFullscreen
-        ? screenfull.request(
-            videoWrapper.current
-              ? videoWrapper.current
-              : (liveFeedPlayerRef.current as HTMLElement)
-          )
-        : screenfull.exit();
+      if (!liveFeedPlayerRef.current) return;
+      setFullscreen(
+        !isFullscreen,
+        videoWrapper.current
+          ? videoWrapper.current
+          : (liveFeedPlayerRef.current as HTMLElement)
+      );
     },
     updatePreset: (option) => {
       getCameraStatus({
@@ -576,7 +576,7 @@ export const FeedCameraPTZHelpButton = (props: { cameraPTZ: CameraPTZ[] }) => {
   return (
     <button
       key="option.action"
-      className="tooltip rounded text-2xl text-white/40"
+      className="tooltip rounded text-2xl text-gray-600"
     >
       <CareIcon className="care-l-question-circle" />
 

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useRef } from "react";
 import { useDispatch } from "react-redux";
-import screenfull from "screenfull";
 import useKeyboardShortcut from "use-keyboard-shortcut";
 import {
   listAssetBeds,
@@ -23,6 +22,7 @@ import CareIcon from "../../../CAREUI/icons/CareIcon";
 import Page from "../../Common/components/Page";
 import ConfirmDialog from "../../Common/ConfirmDialog";
 import { FieldLabel } from "../../Form/FormFields/FormField";
+import useFullscreen from "../../../Common/hooks/useFullscreen";
 
 const LiveFeed = (props: any) => {
   const middlewareHostname =
@@ -47,6 +47,8 @@ const LiveFeed = (props: any) => {
   });
   const [toDelete, setToDelete] = useState<any>(null);
   const [toUpdate, setToUpdate] = useState<any>(null);
+  const [_isFullscreen, setFullscreen] = useFullscreen();
+
   const { width } = useWindowDimensions();
   const extremeSmallScreenBreakpoint = 320;
   const isExtremeSmallScreen =
@@ -227,8 +229,8 @@ const LiveFeed = (props: any) => {
       });
     },
     fullScreen: () => {
-      if (!(screenfull.isEnabled && liveFeedPlayerRef.current)) return;
-      screenfull.request(liveFeedPlayerRef.current);
+      if (!liveFeedPlayerRef.current) return;
+      setFullscreen(true, liveFeedPlayerRef.current);
     },
     updatePreset: (option) => {
       getCameraStatus({

--- a/src/Components/Hub/LiveFeedTile.tsx
+++ b/src/Components/Hub/LiveFeedTile.tsx
@@ -3,10 +3,10 @@ import React, { useEffect, useState, useRef, useCallback } from "react";
 import * as Notification from "../../Utils/Notifications.js";
 import { useDispatch } from "react-redux";
 import ReactPlayer from "react-player";
-import screenfull from "screenfull";
 import { getAsset, listAssetBeds } from "../../Redux/actions";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { useTranslation } from "react-i18next";
+import useFullscreen from "../../Common/hooks/useFullscreen.js";
 interface LiveFeedTileProps {
   assetId: string;
 }
@@ -38,6 +38,7 @@ export default function LiveFeedTile(props: LiveFeedTileProps) {
     zoom: 0,
   });
   const { t } = useTranslation();
+  const [_isFullscreen, setFullscreen] = useFullscreen();
 
   useEffect(() => {
     let loadingTimeout: any;
@@ -238,10 +239,8 @@ export default function LiveFeedTile(props: LiveFeedTileProps) {
 
   const liveFeedPlayerRef = useRef<any>(null);
   const handleClickFullscreen = () => {
-    if (screenfull.isEnabled) {
-      if (liveFeedPlayerRef.current) {
-        screenfull.request(liveFeedPlayerRef.current.wrapper);
-      }
+    if (liveFeedPlayerRef.current) {
+      setFullscreen(true, liveFeedPlayerRef.current.wrapper);
     }
   };
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b675685</samp>

This pull request replaces the `screenfull` library with a custom hook for fullscreen functionality in various components. This reduces dependencies, simplifies the code, and allows more flexibility in choosing the fullscreen element. The affected components are `Feed.tsx`, `LiveFeed.tsx`, and `LiveFeedTile.tsx`.

## Proposed Changes

- Fixes #5840

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b675685</samp>

*  Remove `screenfull` dependency from `package.json` ([link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L100))
*  Modify `useFullscreen` hook to accept an optional `element` parameter ([link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-eec8de18e882e1ee2144afca01af4d4d0832f2005940ff56dc152880d68448d2L3-R6))
*  Update `setFullscreen` function to use native fullscreen methods and `element` parameter ([link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-eec8de18e882e1ee2144afca01af4d4d0832f2005940ff56dc152880d68448d2L18-R25))
*  Replace `screenfull` library with `useFullscreen` hook in `Feed.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L29-R32), [link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R57), [link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L302-R309))
*  Change question icon color to lighter gray in `FeedCameraPTZHelpButton` component ([link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L579-R579))
*  Replace `screenfull` library with `useFullscreen` hook in `LiveFeed.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L3), [link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983R25), [link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983R50-R51), [link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L230-R233))
*  Replace `screenfull` library with `useFullscreen` hook in `LiveFeedTile.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-f1fa18372778e6aeb971f8d3800d03463dd8fbed66c90ad406eb986fc4b620f4L6-R9), [link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-f1fa18372778e6aeb971f8d3800d03463dd8fbed66c90ad406eb986fc4b620f4R41), [link](https://github.com/coronasafe/care_fe/pull/5857/files?diff=unified&w=0#diff-f1fa18372778e6aeb971f8d3800d03463dd8fbed66c90ad406eb986fc4b620f4L241-R243))
