### PR TITLE
Fix missing badges on Shifting filter

### DIFF
--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -22,7 +22,9 @@ export default function BadgesList(props: any) {
   useEffect(() => {
     async function fetchData() {
       if (!qParams.assigned_to) return setAssignedUsername("");
-      const res = await dispatch(getUserList({ id: qParams.assigned_to }));
+      const res = await dispatch(
+        getUserList({ id: qParams.assigned_to }, "assigned_user_name")
+      );
       const { first_name, last_name } = res?.data?.results[0];
       setAssignedUsername(`${first_name} ${last_name}`);
     }
@@ -77,19 +79,12 @@ export default function BadgesList(props: any) {
 
   return (
     <FilterBadges
-      badges={({
-        badge,
-        boolean,
-        phoneNumber,
-        dateRange,
-        kasp,
-        value,
-      }: any) => [
+      badges={({ badge, phoneNumber, dateRange, kasp, value }: any) => [
         badge(t("status"), "status"),
-        boolean(t("emergency"), "emergency", booleanFilterOptions),
+        badge(t("emergency"), "emergency", booleanFilterOptions),
         kasp(),
-        boolean(t("up_shift"), "is_up_shift", booleanFilterOptions),
-        boolean(t("antenatal"), "is_antenatal", booleanFilterOptions),
+        badge(t("up_shift"), "is_up_shift", booleanFilterOptions),
+        badge(t("antenatal"), "is_antenatal", booleanFilterOptions),
         phoneNumber(t("phone_no"), "patient_phone_number"),
         badge(t("patient_name"), "patient_name"),
         ...dateRange(t("created"), "created_date"),

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -65,8 +65,8 @@ export const deleteFacility = (id: string) => {
 export const deleteFacilityCoverImage = (id: string) => {
   return fireRequest("deleteFacilityCoverImage", [], {}, { id });
 };
-export const getUserList = (params: object) => {
-  return fireRequest("userList", [], params);
+export const getUserList = (params: object, key?: string) => {
+  return fireRequest("userList", [], params, null, key);
 };
 
 export const getUserListSkills = (pathParam: object) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8771017</samp>

Improved the performance and usability of the shifting badges list by caching user data and simplifying the filter logic. Modified the `getUserList` action to support caching with a custom key.

## Proposed Changes

- Fixes #5854 

![image](https://github.com/coronasafe/care_fe/assets/3626859/35e60681-ef03-4646-91d1-c6ca87a9f9e9)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8771017</samp>

*  Enable caching user data in redux store by passing optional key argument to `getUserList` action and `fireRequest` function ([link](https://github.com/coronasafe/care_fe/pull/5860/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eL68-R69), [link](https://github.com/coronasafe/care_fe/pull/5860/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfL25-R27))
*  Simplify rendering boolean filters in `FilterBadges` component by using `badge` function for all cases ([link](https://github.com/coronasafe/care_fe/pull/5860/files?diff=unified&w=0#diff-ad01be0595a11ef4726b15e4f322ea148b5f8f925723fe01e6b974d29bc628cfL80-R87))
