### PR TITLE
Fixed vitals monitor data overlapping waveforms

### DIFF
--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -103,7 +103,7 @@ export default function HL7PatientVitalsMonitor({
             />
           </div>
         </div>
-        <div className="md:absolute md:right-0 md:inset-y-0 z-10 bg-[#020617] grid gap-x-8 gap-y-4 md:gap-x-0 md:gap-y-0 grid-cols-2 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
+        <div className="md:right-0 md:inset-y-0 bg-[#020617] grid gap-x-8 gap-y-4 md:gap-x-0 md:gap-y-0 grid-cols-2 md:grid-cols-1 md:divide-y divide-blue-600 text-white tracking-wider">
           {/* Pulse Rate */}
           <NonWaveformData
             label="ECG"


### PR DESCRIPTION
## Proposed Changes

- Part of #5869 
- The vitals monitor is now displayed completely in the asset configure page
- Noticed and fixed the bed selection dropdown cutting the vitals monitor in the same page as shown below.

![image](https://github.com/coronasafe/care_fe/assets/113630200/9bad3546-f122-4a84-88d4-7bceab40a1dc)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 39e3b9c</samp>

*  Remove `md:absolute` class from non-waveform data div to prevent overlap with waveform data on smaller screens ([link](https://github.com/coronasafe/care_fe/pull/5881/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L106-R106))
