### PR TITLE
Add 10bedicu logo to homepage

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -11,6 +11,8 @@
     "static_black_logo": "https://cdn.coronasafe.network/black-logo.svg",
     "static_dpg_white_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
     "static_coronasafe_logo": "https://3451063158-files.gitbook.io/~/files/v0/b/gitbook-legacy-files/o/assets%2F-M233b0_JITp4nk0uAFp%2F-M2Dx6gKxOSU45cjfgNX%2F-M2DxFOkMmkPNn0I6U9P%2FCoronasafe-logo.png?alt=media&token=178cc96d-76d9-4e27-9efb-88f3186368e8",
+    "static_custom_logo": "https://cdn.coronasafe.network/10bedicu_logo.png",
+    "custom_site_link": "https://10bedicu.org",
     "gmaps_api_key": "AIzaSyDsBAc3y7deI5ZO3NtK5GuzKwtUzQNJNUk",
     "gov_data_api_key": "579b464db66ec23bdd000001cdd3946e44ce4aad7209ff7b23ac571b",
     "recaptcha_site_key": "6LdvxuQUAAAAADDWVflgBqyHGfq-xmvNJaToM0pN",

--- a/src/Common/hooks/useConfig.ts
+++ b/src/Common/hooks/useConfig.ts
@@ -22,7 +22,7 @@ export interface IConfig {
    */
   static_custom_logo: string;
   static_custom_logo_alt: string;
-  static_custom_logo_white: string;
+  static_custom_logo_white: boolean;
   custom_description: string;
   custom_site_link: string;
   /**

--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -221,10 +221,10 @@ export const Login = (props: { forgot?: boolean }) => {
             <h1 className="text-4xl lg:text-5xl font-black text-white leading-tight tracking-wider">
               {t("care")}
             </h1>
-            {custom_description ? (
+            {custom_description || custom_site_link ? (
               <div className="py-6">
                 <ReactMarkdown className="max-w-xl text-gray-400">
-                  {custom_description}
+                  {custom_description || t("goal")}
                 </ReactMarkdown>
                 <div className="mx-auto mt-2">
                   <a
@@ -233,7 +233,7 @@ export const Login = (props: { forgot?: boolean }) => {
                     rel="noopener noreferrer"
                     className="text-primary-400 hover:text-primary-500"
                   >
-                    {custom_site_link}
+                    {custom_site_link.replace(/(^\w+:|^)\/\//, "")}
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8c6507</samp>

This pull request adds customization options for the logo and the site link in the Login component, based on the public/config.json file. It also updates the IConfig interface and the config file for the 10bedicu.org deployment.

## Proposed Changes

![image](https://github.com/coronasafe/care_fe/assets/3626859/d0de42bf-65fa-4150-82f2-ba295d97a114)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f8c6507</samp>

*  Add custom logo and site link fields to config file and interface ([link](https://github.com/coronasafe/care_fe/pull/5883/files?diff=unified&w=0#diff-67644ab310d9ac1e98b6694f279c0dcd973ae26b1fd9ef1658281a2b91194adeR14-R15), [link](https://github.com/coronasafe/care_fe/pull/5883/files?diff=unified&w=0#diff-85ddd82d8d8242a8120ad7bf95ed40ce93b4290afb8e17e7c2370bfb2086dd71L25-R25))
*  Display custom description or site link in login component if present, otherwise use default description and translation ([link](https://github.com/coronasafe/care_fe/pull/5883/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304L224-R227))
*  Remove protocol prefix from site link to save space and avoid redundancy ([link](https://github.com/coronasafe/care_fe/pull/5883/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304L236-R236))
