### PR TITLE
Fix asset uptime status keys

### DIFF
--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -26,12 +26,12 @@ export enum AssetClass {
   VENTILATOR = "VENTILATOR",
 }
 
-export enum AssetStatus {
-  "not_monitored" = 0,
-  "operational" = 1,
-  "down" = 2,
-  "maintenance" = 3,
-}
+export const AssetStatus = {
+  not_monitored: "Not Monitored",
+  operational: "Operational",
+  down: "Down",
+  maintenance: "Under Maintenance",
+};
 
 export const assetClassProps = {
   ONVIF: {
@@ -96,7 +96,7 @@ export interface AssetUptimeRecord {
     id: string;
     name: string;
   };
-  status: number;
+  status: string;
   timestamp: string;
   created_date: string;
   modified_date: string;

--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -262,7 +262,7 @@ export default function Uptime(props: { assetId: string }) {
             moment(record.timestamp).hour() < end
         );
         if (recordsInPeriod.length === 0) {
-          if (moment().set("hour", end).isBefore(moment())) {
+          if (moment().hour(end).minute(0).second(0).isBefore(moment())) {
             statusColors.push(
               statusColors[statusColors.length - 1] ??
                 STATUS_COLORS["not_monitored"]

--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -99,7 +99,9 @@ function StatusPopover({
                         <div className="flex justify-between" key={index}>
                           <span
                             className={`capitalize ${
-                              STATUS_COLORS_TEXT[incident.status]
+                              STATUS_COLORS_TEXT[
+                                incident.status as keyof typeof STATUS_COLORS_TEXT
+                              ]
                             }`}
                           >
                             {incident.status}
@@ -161,8 +163,8 @@ export default function Uptime(props: { assetId: string }) {
   const setUptimeRecord = (records: AssetUptimeRecord[]): void => {
     const recordsByDayBefore: { [key: number]: AssetUptimeRecord[] } = {};
     records.forEach((record) => {
-      const timestamp = moment(record.timestamp);
-      const today = moment();
+      const timestamp = moment(record.timestamp).startOf("day");
+      const today = moment().startOf("day");
       const diffDays = today.diff(timestamp, "days");
       if (diffDays < 100) {
         recordsByDayBefore[diffDays] = recordsByDayBefore[diffDays]
@@ -227,14 +229,12 @@ export default function Uptime(props: { assetId: string }) {
       const dayRecords = summary[day];
       const statusColors = [];
       for (let i = 0; i < 3; i++) {
-        const start = moment()
-          .startOf("day")
-          .add(i * 8, "hours");
-        const end = moment()
-          .startOf("day")
-          .add((i + 1) * 8, "hours");
-        const recordsInPeriod = dayRecords.filter((record) =>
-          moment(record.timestamp).isBetween(start, end)
+        const start = i * 8;
+        const end = (i + 1) * 8;
+        const recordsInPeriod = dayRecords.filter(
+          (record) =>
+            moment(record.timestamp).hour() >= start &&
+            moment(record.timestamp).hour() < end
         );
         if (
           recordsInPeriod.some(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8330f2b</samp>

The pull request refactors the code and UI for displaying asset status and uptime. It replaces the `AssetStatus` enum with a constant object and uses strings instead of enum keys. It also adds a new component `StatusPopover` that shows incident details in the uptime chart. These changes simplify the code and improve the user experience.

## Proposed Changes

- Fixes Asset uptime page by updating the status keys to match with the backend

<img width="666" alt="Screenshot 2023-07-18 at 10 41 58 PM" src="https://github.com/coronasafe/care_fe/assets/3626859/e39d271d-c86b-4df2-9853-a1d0de842810">

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8330f2b</samp>

*  Replace `AssetStatus` enum with constant object for easier UI display and comparison ([link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-b1df14c97376139c1e0b897e944b610f11afea110738c80cd6ae9c0fd448eb6dL29-R34), [link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-b1df14c97376139c1e0b897e944b610f11afea110738c80cd6ae9c0fd448eb6dL99-R99), [link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L17-R20), [link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L232-R241), [link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L238-R247), [link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L244-R253))
*  Add `StatusPopover` component to `Uptime` component to show incident details in popover ([link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841R28-R142))
*  Remove previous `StatusPopover` component from `Uptime` component ([link](https://github.com/coronasafe/care_fe/pull/5887/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L40-L145))
