### PR TITLE
External Results List: Apply `mobile_number` filter only if valid

### DIFF
--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -39,6 +39,26 @@ export default function ResultList() {
   const [resultId, setResultId] = useState(-1);
   const [dataList, setDataList] = useState({ lsgList: [], wardList: [] });
 
+  const [phone_number, setPhoneNumber] = useState("");
+  const [phoneNumberError, setPhoneNumberError] = useState("");
+
+  const setPhoneNum = (mobile_number: string) => {
+    setPhoneNumber(mobile_number);
+    if (mobile_number.length >= 13) {
+      setPhoneNumberError("");
+      updateQuery({ mobile_number });
+      return;
+    }
+
+    if (mobile_number === "+91" || mobile_number === "") {
+      setPhoneNumberError("");
+      updateQuery({ mobile_number: "" });
+      return;
+    }
+
+    setPhoneNumberError("Enter a valid number");
+  };
+
   let manageResults: any = null;
   useEffect(() => {
     setIsLoading(true);
@@ -279,8 +299,9 @@ export default function ResultList() {
               <PhoneNumberFormField
                 name="mobile_number"
                 labelClassName="hidden"
-                value={qParams.mobile_number || "+91"}
-                onChange={(event) => updateQuery({ [event.name]: event.value })}
+                value={phone_number}
+                onChange={(e) => setPhoneNum(e.value)}
+                error={phoneNumberError}
                 placeholder="Search by Phone Number"
               />
             </div>

--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -93,6 +93,10 @@ export default function ResultList() {
       .catch(() => {
         setIsLoading(false);
       });
+
+    if (!params.mobile_number) {
+      setPhoneNum("+91");
+    }
   }, [
     dispatch,
     qParams.name,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47525d8</samp>

This change adds a new feature to the external result list component, allowing users to filter results by phone number. It modifies `ResultList.tsx` to include a phone number search field and related logic.

## Proposed Changes

- Fixes #5873

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 47525d8</samp>

* Add a state variable and a function to handle phone number input and validation ([link](https://github.com/coronasafe/care_fe/pull/5889/files?diff=unified&w=0#diff-3ff48bac32004c8412fdd842f678d61ab738bbada999fa8d9fa1da73f760ea11R42-R61))
* Use the state variable and function in the phone number search field component and pass the error message as a prop ([link](https://github.com/coronasafe/care_fe/pull/5889/files?diff=unified&w=0#diff-3ff48bac32004c8412fdd842f678d61ab738bbada999fa8d9fa1da73f760ea11L282-R304))
