### PR TITLE
Fix asset uptime for phases of day

### DIFF
--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -8,10 +8,10 @@ import { AssetStatus, AssetUptimeRecord } from "../Assets/AssetTypes";
 import { reverse } from "lodash";
 
 const STATUS_COLORS = {
-  operational: "bg-green-500",
-  not_monitored: "bg-gray-400",
-  down: "bg-red-500",
-  maintenance: "bg-blue-500",
+  Operational: "bg-green-500",
+  "Not Monitored": "bg-gray-400",
+  Down: "bg-red-500",
+  "Under Maintenance": "bg-blue-500",
 };
 
 const STATUS_COLORS_TEXT = {
@@ -219,7 +219,8 @@ export default function Uptime(props: { assetId: string }) {
           });
         }
       } else {
-        statusToCarryOver = recordsByDayBefore[i][0].status;
+        statusToCarryOver =
+          recordsByDayBefore[i][recordsByDayBefore[i].length - 1].status;
       }
     }
 
@@ -286,6 +287,7 @@ export default function Uptime(props: { assetId: string }) {
       const statusColors: (typeof STATUS_COLORS)[keyof typeof STATUS_COLORS][] =
         [];
       let dayUptimeScore = 0;
+      const recordsInPeriodCache: { [key: number]: AssetUptimeRecord[] } = {};
       for (let i = 0; i < 3; i++) {
         const start = i * 8;
         const end = (i + 1) * 8;
@@ -294,48 +296,49 @@ export default function Uptime(props: { assetId: string }) {
             moment(record.timestamp).hour() >= start &&
             moment(record.timestamp).hour() < end
         );
+        recordsInPeriodCache[i] = recordsInPeriod;
         if (recordsInPeriod.length === 0) {
+          const previousLatestRecord =
+            recordsInPeriodCache[i - 1]?.[dayRecords.length - 1];
           if (
-            moment(dayRecords[0].timestamp)
+            moment(previousLatestRecord?.timestamp)
               .hour(end)
               .minute(0)
               .second(0)
               .isBefore(moment())
           ) {
-            if (
-              statusColors[statusColors.length - 1] ===
-              STATUS_COLORS["operational"]
-            ) {
+            if (previousLatestRecord?.status === AssetStatus["operational"]) {
               dayUptimeScore += 1;
             }
             statusColors.push(
-              statusColors[statusColors.length - 1] ??
-                STATUS_COLORS["not_monitored"]
+              STATUS_COLORS[
+                previousLatestRecord?.status as keyof typeof STATUS_COLORS
+              ] ?? STATUS_COLORS["Not Monitored"]
             );
           } else {
-            statusColors.push(STATUS_COLORS["not_monitored"]);
+            statusColors.push(STATUS_COLORS["Not Monitored"]);
           }
         } else if (
           recordsInPeriod.some(
             (record) => record.status === AssetStatus["down"]
           )
         ) {
-          statusColors.push(STATUS_COLORS["down"]);
+          statusColors.push(STATUS_COLORS["Down"]);
         } else if (
           recordsInPeriod.some(
             (record) => record.status === AssetStatus["maintenance"]
           )
         ) {
-          statusColors.push(STATUS_COLORS["maintenance"]);
+          statusColors.push(STATUS_COLORS["Under Maintenance"]);
         } else if (
           recordsInPeriod.some(
             (record) => record.status === AssetStatus["operational"]
           )
         ) {
-          statusColors.push(STATUS_COLORS["operational"]);
+          statusColors.push(STATUS_COLORS["Operational"]);
           dayUptimeScore += 1;
         } else {
-          statusColors.push(STATUS_COLORS["not_monitored"]);
+          statusColors.push(STATUS_COLORS["Not Monitored"]);
         }
       }
       uptimeScore[day] = dayUptimeScore;
@@ -343,9 +346,9 @@ export default function Uptime(props: { assetId: string }) {
     } else {
       uptimeScore[day] = 0;
       return [
-        STATUS_COLORS["not_monitored"],
-        STATUS_COLORS["not_monitored"],
-        STATUS_COLORS["not_monitored"],
+        STATUS_COLORS["Not Monitored"],
+        STATUS_COLORS["Not Monitored"],
+        STATUS_COLORS["Not Monitored"],
       ];
     }
   };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23bbbe2</samp>

Improved the UI and functionality of the `Uptime` component for assets. Fixed bugs, refactored code, and optimized data filtering and caching.

## Proposed Changes

- Fixes #5893

![image](https://github.com/coronasafe/care_fe/assets/3626859/817a9e75-f28d-4923-80dc-87a0c7056c28)
<img width="451" alt="image" src="https://github.com/coronasafe/care_fe/assets/3626859/08c6e87c-e920-4535-8f10-34a49b1aa0c2">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23bbbe2</samp>

*  Modify the `STATUS_COLORS` object to use more descriptive and consistent keys for the asset status values ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L11-R14))
*  Fix the `statusToCarryOver` variable to use the last record of the previous day instead of the first record ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L222-R223))
*  Add the `recordsInPeriodCache` object to store the filtered records for each hour of the day and improve performance ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841R290))
*  Assign the `recordsInPeriod` variable from the `recordsInPeriodCache` object if it exists, or from the original filtering logic otherwise ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L297-R304))
*  Introduce the `previousLatestRecord` variable to store the last record of the previous hour and use it for checking the status transition at the end of the hour ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L297-R304))
*  Update the logic for pushing the status color at the end of the hour to use the `previousLatestRecord` variable and the `status` property of the record, and change the default value to "Not Monitored" ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L305-R319))
*  Change the status color for the "down" status to "Down" ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L323-R326))
*  Change the status color for the "maintenance" status to "Under Maintenance" ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L329-R332))
*  Change the status color for the "operational" status to "Operational" ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L335-R341))
*  Change the status colors for the default case to "Not Monitored" ([link](https://github.com/coronasafe/care_fe/pull/5894/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L346-R351))
