### PR TITLE
Fix asset uptime carryover

### DIFF
--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -315,6 +315,7 @@ export default function Uptime(props: { assetId: string }) {
                 previousLatestRecord?.status as keyof typeof STATUS_COLORS
               ] ?? STATUS_COLORS["Not Monitored"]
             );
+            recordsInPeriodCache[i] = [previousLatestRecord];
           } else {
             statusColors.push(STATUS_COLORS["Not Monitored"]);
           }

--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -215,10 +215,27 @@ export default function Uptime(props: { assetId: string }) {
             timestamp: moment()
               .subtract(i, "days")
               .startOf("day")
-              .toISOString(),
+              .format("YYYY-MM-DDTHH:mm:ss.SSSSSSZ"),
           });
         }
       } else {
+        if (
+          recordsByDayBefore[i].filter(
+            (r) => moment(r.timestamp).get("hour") < 8
+          ).length === 0
+        ) {
+          recordsByDayBefore[i].unshift({
+            id: "",
+            asset: { id: "", name: "" },
+            created_date: "",
+            modified_date: "",
+            status: statusToCarryOver,
+            timestamp: moment()
+              .subtract(i, "days")
+              .startOf("day")
+              .format("YYYY-MM-DDTHH:mm:ss.SSSSSSZ"),
+          });
+        }
         statusToCarryOver =
           recordsByDayBefore[i][recordsByDayBefore[i].length - 1].status;
       }
@@ -299,7 +316,9 @@ export default function Uptime(props: { assetId: string }) {
         recordsInPeriodCache[i] = recordsInPeriod;
         if (recordsInPeriod.length === 0) {
           const previousLatestRecord =
-            recordsInPeriodCache[i - 1]?.[dayRecords.length - 1];
+            recordsInPeriodCache[i - 1]?.[
+              recordsInPeriodCache[i - 1]?.length - 1
+            ];
           if (
             moment(previousLatestRecord?.timestamp)
               .hour(end)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2330cde</samp>

This pull request fixes a bug in the uptime chart component by ensuring that all records in the selected time period are included in the data fetch. It modifies the `recordsInPeriodCache` array in `src/Components/Common/Uptime.tsx` to append the previous latest record at each index.

## Proposed Changes

- Fixes a minor issue where the status from first 8 hours would not carry over to third phase of the day if there are no records in the second phase of the day

<img width="451" alt="image" src="https://github.com/coronasafe/care_fe/assets/3626859/5737bd3c-d2a5-40dc-9952-422d0c3f7754">

<img width="449" alt="image" src="https://github.com/coronasafe/care_fe/assets/3626859/92656b99-1f0b-4895-b03d-4f27f57aca57">

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2330cde</samp>

* Fix a bug where the uptime chart would sometimes show incorrect or incomplete data by adding the previous latest record to the records in period cache array at index i ([link](https://github.com/coronasafe/care_fe/pull/5896/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841R318)) in `src/Components/Common/Uptime.tsx`
