### PR TITLE
Use `package-lock.json` instead of `yarn.lock` in Docker build cache of Deploy CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'Dockerfile') }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('package-lock.json', 'Dockerfile') }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'Dockerfile') }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('package-lock.json', 'Dockerfile') }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
@@ -148,7 +148,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'Dockerfile') }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('package-lock.json', 'Dockerfile') }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf1f43f</samp>

Update cache key for buildx action in GitHub workflows. This improves the consistency and efficiency of the deployment process for `care_fe`.

## Proposed Changes

- Use `package-lock.json` instead of `yarn.lock` in Docker build cache of Deploy CI

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf1f43f</samp>

*  Update cache key for buildx action to use `package-lock.json` file instead of `yarn.lock` and `.yarnrc.yml` files in `.github/workflows/deploy.yaml` ([link](https://github.com/coronasafe/care_fe/pull/5897/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L37-R37), [link](https://github.com/coronasafe/care_fe/pull/5897/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L89-R89), [link](https://github.com/coronasafe/care_fe/pull/5897/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L151-R151))
