### PR TITLE
show abha details in patient register page while updating

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -371,6 +371,7 @@ export default function PatientInfoCard(props: {
               <>
                 <ButtonV2
                   className="hover:text-white flex gap-3 justify-start font-semibold"
+                  align="start"
                   onClick={() => setShowABHAProfile(true)}
                 >
                   <CareIcon className="care-l-user-square" />
@@ -378,6 +379,7 @@ export default function PatientInfoCard(props: {
                 </ButtonV2>
                 <ButtonV2
                   className="hover:text-white flex gap-3 justify-start font-semibold mt-0"
+                  align="start"
                   onClick={() => setShowLinkCareContext(true)}
                 >
                   <CareIcon className="care-l-link" />
@@ -400,6 +402,7 @@ export default function PatientInfoCard(props: {
               <>
                 <ButtonV2
                   className="hover:text-white flex gap-3 justify-start font-semibold"
+                  align="start"
                   onClick={() => setShowLinkABHANumber(true)}
                 >
                   <CareIcon className="care-l-link" />

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -357,8 +357,11 @@ export const PatientRegister = (props: PatientRegisterProps) => {
         if (res && res.data) {
           setFacilityName(res.data.facility_object.name);
           setPatientName(res.data.name);
+          console.log(res.data);
           const formData = {
             ...res.data,
+            health_id_number: res.data.abha_number_object?.abha_number || "",
+            health_id: res.data.abha_number_object?.health_id || "",
             nationality: res.data.nationality ? res.data.nationality : "India",
             gender: res.data.gender ? res.data.gender : "",
             cluster_name: res.data.cluster_name ? res.data.cluster_name : "",
@@ -1111,14 +1114,12 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                           </h1>
                           {showLinkAbhaNumberModal && (
                             <LinkABHANumberModal
-                              facilityId={facilityId}
                               show={showLinkAbhaNumberModal}
                               onClose={() => setShowLinkAbhaNumberModal(false)}
                               onSuccess={(data: any) => {
-                                if (data.facility) {
-                                  // if patient object
+                                if (id) {
                                   navigate(
-                                    `/facility/${data.facility}/patient/${data.id}/consultation`
+                                    `/facility/${facilityId}/patient/${id}`
                                   );
                                   return;
                                 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a916e8</samp>

This pull request enhances the patient registration process by showing the health ID and number of the patient, and by improving the user interface of the `LinkABHANumberModal` component. These changes enable the CARE platform to interact with the ABHA system.

## Proposed Changes

- show abha details in patient register page while updating when abha id is already linked else show link abha number button


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a916e8</samp>

*  Add `health_id_number` and `health_id` fields to `formData` object to display and store patient's ABHA information ([link](https://github.com/coronasafe/care_fe/pull/5899/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L360-R364))
*  Simplify `onSuccess` callback of `LinkABHANumberModal` component to avoid unnecessary check and use existing variables for navigation ([link](https://github.com/coronasafe/care_fe/pull/5899/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L1114-R1122))
