### PR TITLE
`AutocompleteFormField`: Fixes overlap of clear button and `optionIcon`

### DIFF
--- a/src/CAREUI/icons/CareIcon.tsx
+++ b/src/CAREUI/icons/CareIcon.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 export interface CareIconProps {
   className?: string | undefined;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLSpanElement> | undefined;
 }
 
 /**

--- a/src/Components/Common/BloodPressureFormField.tsx
+++ b/src/Components/Common/BloodPressureFormField.tsx
@@ -52,9 +52,21 @@ export default function BloodPressureFormField(props: Props) {
           labelClassName="hidden"
           errorClassName="hidden"
           thresholds={[
-            { value: 0, label: "Low", className: "text-danger-500" },
-            { value: 100, label: "Normal", className: "text-primary-500" },
-            { value: 140, label: "High", className: "text-warning-500" },
+            {
+              value: 0,
+              label: "Low",
+              className: "hidden md:block text-danger-500",
+            },
+            {
+              value: 100,
+              label: "Normal",
+              className: "hidden md:block text-primary-500",
+            },
+            {
+              value: 140,
+              label: "High",
+              className: "hidden md:block text-warning-500",
+            },
           ]}
         />
         <span className="text-lg font-medium text-gray-400 px-2">/</span>
@@ -69,9 +81,21 @@ export default function BloodPressureFormField(props: Props) {
           labelClassName="hidden"
           errorClassName="hidden"
           thresholds={[
-            { value: 0, label: "Low", className: "text-danger-500" },
-            { value: 50, label: "Normal", className: "text-primary-500" },
-            { value: 90, label: "High", className: "text-warning-500" },
+            {
+              value: 0,
+              label: "Low",
+              className: "hidden md:block text-danger-500",
+            },
+            {
+              value: 50,
+              label: "Normal",
+              className: "hidden md:block text-primary-500",
+            },
+            {
+              value: 90,
+              label: "High",
+              className: "hidden md:block text-warning-500",
+            },
           ]}
         />
       </div>

--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -6,6 +6,7 @@ import { dropdownOptionClassNames } from "../MultiSelectMenuV2";
 import { FormFieldBaseProps, useFormFieldPropsResolver } from "./Utils";
 import FormField from "./FormField";
 import { classNames } from "../../../Utils/utils";
+import { useTranslation } from "react-i18next";
 
 type OptionCallback<T, R> = (option: T) => R;
 
@@ -89,6 +90,7 @@ type AutocompleteProps<T, V = T> = {
  * customizability.
  */
 export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
+  const { t } = useTranslation();
   const [query, setQuery] = useState(""); // Ensure lower case
   useEffect(() => {
     props.onQuery?.(query);
@@ -160,25 +162,28 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
               <div className="absolute right-0 top-1 mr-2 flex h-full items-center gap-1 pb-2 text-lg text-gray-900">
                 <span>{value?.icon}</span>
+
+                {value && !props.isLoading && !props.required && (
+                  <div className="tooltip">
+                    <CareIcon
+                      className="care-l-times-circle h-4 w-4 text-gray-800 hover:text-gray-500 transition-colors duration-200 ease-in-out"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        props.onChange(undefined);
+                      }}
+                    />
+                    <span className="tooltip-text tooltip-bottom -translate-x-1/2 text-xs">
+                      {t("clear_selection")}
+                    </span>
+                  </div>
+                )}
+
                 {props.isLoading ? (
                   <CareIcon className="care-l-spinner animate-spin" />
                 ) : (
                   <CareIcon className="care-l-angle-down" />
                 )}
               </div>
-              {value && (
-                <div
-                  className="absolute right-0 top-1 mr-7 flex h-full items-center gap-1 pb-2 text-lg text-gray-900 hover:text-gray-500"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    if (!props.required) props.onChange(undefined);
-                  }}
-                >
-                  {!props.isLoading && (
-                    <CareIcon className="care-l-times-circle h-4 w-4" />
-                  )}
-                </div>
-              )}
             </Combobox.Button>
           </div>
 

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -151,5 +151,6 @@
   "not_specified": "Not Specified",
   "all_changes_have_been_saved": "All changes have been saved",
   "no_data_found": "No data found",
-  "edit": "Edit"
+  "edit": "Edit",
+  "clear_selection": "Clear selection"
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8092e93</samp>

This pull request improves the UI and accessibility of the `BloodPressureFormField` and `Autocomplete` components by adding responsive classes, localization, and tooltip features. It also modifies the `onClick` prop of the `CareIcon` component to accept mouse events and updates the English translation file.

## Proposed Changes

- Fixes #5900
- Hide option icon for BP in mobile view
- Added tooltip to clear button

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/f39eca1b-498a-41cf-9cc6-a9c00ffd72c6">


<img width="342" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/d08ee6e8-f1f8-464e-b0e8-472568dc7737">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8092e93</samp>

*  Add a tooltip feature to the `Autocomplete` component that allows the user to clear their selection with a single click and a visual cue ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R9), [link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R93), [link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R165-R180), [link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9L169-L181), [link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-38a71477ce052dd5f81bf55434622f86d274a8dc6a8af1a03fb444588aec4296R154))
  * Import the `useTranslation` hook from the `react-i18next` library and declare the `t` function in the `Autocomplete.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R9), [link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R93))
  * Add a new `div` element with the `tooltip` class that contains a `CareIcon` component with a `times-circle` icon and a `span` element with a `tooltip-text` class in the `Autocomplete.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R165-R180))
  * Set the `onClick` prop of the `CareIcon` component to call the `onChange` prop of the `Autocomplete` component with an undefined value, clearing the current selection ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R165-R180))
  * Set the `span` element to display a localized string `t("clear_selection")` that explains the functionality of the icon ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R165-R180))
  * Remove the existing `div` element that was used to clear the selection from the `Autocomplete` component in the `Autocomplete.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9L169-L181))
  * Add a new key-value pair `"clear_selection": "Clear selection"` to the `Common.json` file under the `en` locale, providing the translation for the new tooltip text ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-38a71477ce052dd5f81bf55434622f86d274a8dc6a8af1a03fb444588aec4296R154))
* Make the threshold labels of the `BloodPressureFormField` component responsive and only visible on medium and larger screen sizes, improving the UI layout and readability ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-fb1dc0ae192376a9ced89da3bac5370d356e5d6bba0caea628e862ba1519a4feL55-R69), [link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-fb1dc0ae192376a9ced89da3bac5370d356e5d6bba0caea628e862ba1519a4feL72-R98))
  * Modify the `thresholds` prop of the `BloodPressureFormField` component to add a `hidden md:block` class to each threshold label in the `BloodPressureFormField.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-fb1dc0ae192376a9ced89da3bac5370d356e5d6bba0caea628e862ba1519a4feL55-R69), [link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-fb1dc0ae192376a9ced89da3bac5370d356e5d6bba0caea628e862ba1519a4feL72-R98))
* Change the `onClick` prop of the `CareIconProps` interface to accept a React mouse event handler instead of a generic function, allowing the `CareIcon` component to receive and handle mouse events from its parent components ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-9bbaedced0a7c77495fc04cdb72e39bea9ef315234027f4eab7402ba8a90af53L6-R6))
  * Update the type of the `onClick` prop of the `CareIconProps` interface to `React.MouseEventHandler<HTMLSpanElement>` in the `CareIcon.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/5901/files?diff=unified&w=0#diff-9bbaedced0a7c77495fc04cdb72e39bea9ef315234027f4eab7402ba8a90af53L6-R6))
