### PR TITLE
Moves prescriptions caution text to left (start)

### DIFF
--- a/src/Components/Medicine/PrescriptionBuilder.tsx
+++ b/src/Components/Medicine/PrescriptionBuilder.tsx
@@ -100,7 +100,7 @@ export default function PrescriptionBuilder({
             is_prn ? "add_prn_prescription" : "add_prescription_medication"
           )}
           description={
-            <div className="flex gap-2 w-full justify-end mt-2 text-warning-500">
+            <div className="flex gap-2 w-full justify-start mt-2 text-warning-500">
               <CareIcon className="care-l-exclamation-triangle text-base" />
               <span>{t("modification_caution_note")}</span>
             </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 013f2cc</samp>

Fixed the alignment of the caution note in the prescription builder component. Changed the CSS class of the note element in `PrescriptionBuilder.tsx` to align it to the left.

## Proposed Changes

Issue reported by @nihal467 

- Moves prescriptions caution text to left (start)

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/e45a1d0b-13f9-45c2-9402-ac27c0684c64">

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 013f2cc</samp>

* Align the caution note to the left for better readability and consistency ([link](https://github.com/coronasafe/care_fe/pull/5903/files?diff=unified&w=0#diff-0fc0190fc40c3632ab75e28ed25ca3e19fb88e40e6482a6238371180d4af4157L103-R103))
