### PR TITLE
Fix external results - Cypress Failure

### DIFF
--- a/cypress/e2e/external_results_spec/external_result.cy.ts
+++ b/cypress/e2e/external_results_spec/external_result.cy.ts
@@ -51,7 +51,7 @@ describe("Edit Profile Testing", () => {
   });
 
   it("export", () => {
-    cy.intercept("/api/v1/external_result/?csv=true&").as("export");
+    cy.intercept("/api/v1/external_result/?page=1&limit=14&csv=true&").as("export");
     cy.contains("Import/Export").click().wait(100);
     cy.contains("Export Results").click();
     cy.wait("@export").then((interception) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70de05a</samp>

Fixed a cypress test for exporting external results as CSV by updating the intercept URL.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70de05a</samp>

*  Update the intercept URL for the export request to match the query parameters ([link](https://github.com/coronasafe/care_fe/pull/5911/files?diff=unified&w=0#diff-f3dfd199c9868a59bc03620f5ea72856c58d45669b415a1ba9f093ba540d39cbL54-R54))
