### PR TITLE
Fixes date time initial value formatting for Log update measured at, Discharge (death date time) and Bed start date time

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1013,7 +1013,7 @@ export const ConsultationForm = (props: any) => {
                         <TextFormField
                           {...field("death_datetime")}
                           type="datetime-local"
-                          max={new Date().toISOString().slice(0, 16)}
+                          max={moment().format("YYYY-MM-DDTHH:mm")}
                           required={state.form.suggestion === "DD"}
                           label="Date & Time of Death"
                           value={state.form.death_datetime}

--- a/src/Components/Facility/Consultations/Beds.tsx
+++ b/src/Components/Facility/Consultations/Beds.tsx
@@ -19,17 +19,6 @@ import { formatDate } from "../../../Utils/utils";
 import moment from "moment";
 import { useDispatch } from "react-redux";
 
-const formatDateTime: () => string = () => {
-  const current = new Date();
-  const yyyy = String(current.getFullYear()).padStart(4, "0");
-  const mm = String(current.getMonth() + 1).padStart(2, "0");
-  const dd = String(current.getDate()).padStart(2, "0");
-  const hh = String(current.getHours()).padStart(2, "0");
-  const min = String(current.getMinutes()).padStart(2, "0");
-
-  return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
-};
-
 interface BedsProps {
   facilityId: string;
   patientId: string;
@@ -45,7 +34,9 @@ const Beds = (props: BedsProps) => {
   const dispatch = useDispatch<any>();
   const { facilityId, consultationId, discharged } = props;
   const [bed, setBed] = React.useState<BedModel>({});
-  const [startDate, setStartDate] = React.useState<string>(formatDateTime());
+  const [startDate, setStartDate] = React.useState<string>(
+    moment().format("YYYY-MM-DDTHH:mm")
+  );
   const [consultationBeds, setConsultationBeds] = React.useState<CurrentBed[]>(
     []
   );

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -28,9 +28,9 @@ import CircularProgress from "../Common/components/CircularProgress";
 interface PreDischargeFormInterface {
   discharge_reason: string;
   discharge_notes: string;
-  discharge_date: string | null;
-  death_datetime: string | null;
-  death_confirmed_doctor: string | null;
+  discharge_date?: string;
+  death_datetime?: string;
+  death_confirmed_doctor?: string;
 }
 
 interface IProps {
@@ -40,8 +40,8 @@ interface IProps {
   afterSubmit?: () => void;
   discharge_reason?: string;
   discharge_notes?: string;
-  discharge_date?: string | null;
-  death_datetime?: string | null;
+  discharge_date?: string;
+  death_datetime?: string;
 }
 
 const DischargeModal = ({
@@ -54,8 +54,8 @@ const DischargeModal = ({
   },
   discharge_reason = "",
   discharge_notes = "",
-  discharge_date = new Date().toISOString(),
-  death_datetime = null,
+  discharge_date = moment().format("YYYY-MM-DDTHH:mm"),
+  death_datetime = moment().format("YYYY-MM-DDTHH:mm"),
 }: IProps) => {
   const { enable_hcx } = useConfig();
   const dispatch: any = useDispatch();
@@ -65,7 +65,7 @@ const DischargeModal = ({
       discharge_notes,
       discharge_date,
       death_datetime,
-      death_confirmed_doctor: null,
+      death_confirmed_doctor: undefined,
     });
   const [latestClaim, setLatestClaim] = useState<HCXClaimModel>();
   const [isCreateClaimLoading, setIsCreateClaimLoading] = useState(false);
@@ -256,26 +256,25 @@ const DischargeModal = ({
         )}
         {preDischargeForm.discharge_reason === "EXP" && (
           <div>
-            <div>
-              Death Date and Time
-              <span className="text-danger-500">{" *"}</span>
-              <input
-                type="datetime-local"
-                className="block w-[calc(100%-5px)] rounded border border-gray-400 bg-gray-100 px-4 py-2 text-sm hover:bg-gray-200 focus:border-primary-500 focus:bg-white focus:outline-none focus:ring-primary-500"
-                value={preDischargeForm.death_datetime ?? ""}
-                required
-                min={consultationData?.admission_date?.substring(0, 16)}
-                max={moment(new Date()).format("YYYY-MM-DDThh:mm")}
-                onChange={(e) => {
-                  setPreDischargeForm((form) => {
-                    return {
-                      ...form,
-                      death_datetime: e.target.value,
-                    };
-                  });
-                }}
-              />
-            </div>
+            <TextFormField
+              name="death_datetime"
+              label="Death Date and Time"
+              type="datetime-local"
+              value={preDischargeForm.death_datetime}
+              onChange={(e) => {
+                setPreDischargeForm((form) => {
+                  return {
+                    ...form,
+                    death_datetime: e.value,
+                  };
+                });
+              }}
+              required
+              min={moment(consultationData?.admission_date).format(
+                "YYYY-MM-DDTHH:mm"
+              )}
+              max={moment().format("YYYY-MM-DDTHH:mm")}
+            />
             <TextFormField
               name="death_confirmed_by"
               label="Confirmed By"

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -417,10 +417,10 @@ export const DailyRounds = (props: any) => {
               className="w-full"
               label="Measured at"
               type="datetime-local"
-              value={
-                state.form.taken_at ?? new Date().toISOString().slice(0, 16)
-              }
-              max={new Date().toISOString().slice(0, 16)}
+              value={moment(state.form.taken_at || undefined).format(
+                "YYYY-MM-DDTHH:mm"
+              )}
+              max={moment().format("YYYY-MM-DDTHH:mm")}
             />
           </div>
           <div className="w-full md:w-1/3">


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b6492f</samp>

The pull request updates several components in the `src/Components/Facility` and `src/Components/Patient` directories to use `moment` library for date and time formatting. This improves the code readability, consistency, and compatibility. It also fixes some UI and data issues in the `DischargeModal` and `ConsultationForm` components.

## Proposed Changes

- Fixes #5922

<img width="1401" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/d9bfd6d5-d1a0-46bd-920f-a477bb09c35a">

<img width="1401" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/52c1521a-0f70-4700-856a-eaa8c3c45f7e">

<img width="1401" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/832eb81e-6253-45de-a052-e0f0eab1bab0">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b6492f</samp>

*  Use `moment` library to format date and time values consistently and compatibly across different browsers and time zones ([link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL1016-R1016), [link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbL48-R39), [link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L57-R58), [link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L259-R278), [link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L420-R423))
*  Remove unused `formatDateTime` function from `Beds` component ([link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbL22-L32))
*  Make `discharge_date`, `death_datetime`, and `death_confirmed_doctor` fields optional instead of nullable in `PreDischargeFormInterface` and `IProps` interfaces in `DischargeModal.tsx` to avoid sending null values to the backend API ([link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L31-R33), [link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L43-R44))
*  Use `undefined` instead of `null` as the initial value of `death_confirmed_doctor` field in `preDischargeForm` state in `DischargeModal.tsx` for the same reason as above ([link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L68-R68))
*  Use `TextFormField` component to render the input for `death_datetime` field in `DischargeModal.tsx` to ensure consistency and reusability of the UI components and to leverage the props and validations provided by the component ([link](https://github.com/coronasafe/care_fe/pull/5927/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L259-R278))
