### PR TITLE
Minor UI fix: Justify end discharge buttons in consultation dashboard

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -419,23 +419,19 @@ export const ConsultationDetails = (props: any) => {
                   </div>
                 )}
               </div>
-              <div className="flex h-full flex-col gap-2 text-right lg:flex-row">
-                <button
-                  className="btn btn-primary"
-                  onClick={() => setOpenDischargeSummaryDialog(true)}
-                >
+              <div className="flex h-full w-full flex-col justify-end gap-2 text-right lg:flex-row">
+                <ButtonV2 onClick={() => setOpenDischargeSummaryDialog(true)}>
                   <i className="fas fa-clipboard-list"></i>
-                  &nbsp; Discharge Summary
-                </button>
+                  <span>Discharge Summary</span>
+                </ButtonV2>
 
-                <button
-                  className="btn btn-primary"
+                <ButtonV2
                   onClick={() => setOpenDischargeDialog(true)}
                   disabled={!!consultationData.discharge_date}
                 >
                   <i className="fas fa-hospital-user"></i>
-                  &nbsp; Discharge from CARE
-                </button>
+                  <span>Discharge from CARE</span>
+                </ButtonV2>
               </div>
             </div>
             <div className="flex flex-col justify-between gap-2 p-4 md:flex-row">

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -422,7 +422,7 @@ export const ConsultationDetails = (props: any) => {
               <div className="flex h-full w-full flex-col justify-end gap-2 text-right lg:flex-row">
                 <ButtonV2 onClick={() => setOpenDischargeSummaryDialog(true)}>
                   <i className="fas fa-clipboard-list"></i>
-                  <span>Discharge Summary</span>
+                  <span>{t("discharge_summary")}</span>
                 </ButtonV2>
 
                 <ButtonV2
@@ -430,7 +430,7 @@ export const ConsultationDetails = (props: any) => {
                   disabled={!!consultationData.discharge_date}
                 >
                   <i className="fas fa-hospital-user"></i>
-                  <span>Discharge from CARE</span>
+                  <span>{t("discharge_from_care")}</span>
                 </ButtonV2>
               </div>
             </div>

--- a/src/Locale/en/Consultation.json
+++ b/src/Locale/en/Consultation.json
@@ -6,6 +6,8 @@
   "no_log_update_delta": "No changes since previous log update",
   "virtual_nursing_assistant": "Virtual Nursing Assistant",
   "discharge": "Discharge",
+  "discharge_summary": "Discharge Summary",
+  "discharge_from_care": "Discharge from CARE",
   "generating_discharge_summary": "Generating discharge summary",
   "discharge_summary_not_ready": "Discharge summary is not ready yet.",
   "download_discharge_summary": "Download discharge summary",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca19f0f</samp>

Refactored the consultation details page to use a custom button component and improve the layout and accessibility.

## Proposed Changes

- Fixes #5929 

<img width="2528" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/ea3d60e5-2246-49e7-b73e-a4c7ef89708b">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca19f0f</samp>

*  Refactor buttons to use `ButtonV2` component for consistent style and behavior ([link](https://github.com/coronasafe/care_fe/pull/5930/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL422-R434))
*  Add `flex` and `w-full` classes to parent `div` for alignment and spacing ([link](https://github.com/coronasafe/care_fe/pull/5930/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL422-R434))
*  Wrap button text in `span` elements for accessibility and readability ([link](https://github.com/coronasafe/care_fe/pull/5930/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL422-R434))
