### PR TITLE
Set Min. Respiratory Rate to 0

### DIFF
--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -150,7 +150,7 @@ function UptimeInfoPopover({
   return (
     <Popover className="relative mt-10 hidden sm:block">
       <Popover.Panel
-        className={`absolute z-50 w-64 px-4 sm:px-0 lg:w-96 ${
+        className={`absolute z-50 w-64 px-4 sm:px-0 lg:w-96${
           day > numDays - 10
             ? "-translate-x-6"
             : day < 10

--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -150,7 +150,7 @@ function UptimeInfoPopover({
   return (
     <Popover className="relative mt-10 hidden sm:block">
       <Popover.Panel
-        className={`absolute z-50 w-64 px-4 sm:px-0 lg:w-96${
+        className={`absolute z-50 w-64 px-4 sm:px-0 lg:w-96 ${
           day > numDays - 10
             ? "-translate-x-6"
             : day < 10

--- a/src/Components/CriticalCareRecording/HemodynamicParameters/CriticalCare__HemodynamicParametersEditor.res
+++ b/src/Components/CriticalCareRecording/HemodynamicParameters/CriticalCare__HemodynamicParametersEditor.res
@@ -279,14 +279,14 @@ let make = (~hemodynamicParameter, ~updateCB, ~id, ~consultationId) => {
       />
       <Slider
         title={"Respiratory Rate (bpm)"}
-        start={"10"}
+        start={"0"}
         end={"70"}
         interval={"5"}
         step={1.0}
         value={Belt.Option.mapWithDefault(state.resp, "", string_of_int)}
         setValue={s => send(SetResp(int_of_string(s)))}
         getLabel={getStatus(12.0, "Low", 16.0, "High")}
-        hasError={ValidationUtils.isInputInRangeInt(10, 70, state.resp)}
+        hasError={ValidationUtils.isInputInRangeInt(0, 70, state.resp)}
       />
       <div className="w-full">
         <div className="mx-2">

--- a/src/Components/CriticalCareRecording/HemodynamicParameters/CriticalCare__HemodynamicParametersEditor.res
+++ b/src/Components/CriticalCareRecording/HemodynamicParameters/CriticalCare__HemodynamicParametersEditor.res
@@ -279,14 +279,14 @@ let make = (~hemodynamicParameter, ~updateCB, ~id, ~consultationId) => {
       />
       <Slider
         title={"Respiratory Rate (bpm)"}
-        start={"0"}
+        start={"1"}
         end={"70"}
         interval={"5"}
         step={1.0}
         value={Belt.Option.mapWithDefault(state.resp, "", string_of_int)}
         setValue={s => send(SetResp(int_of_string(s)))}
         getLabel={getStatus(12.0, "Low", 16.0, "High")}
-        hasError={ValidationUtils.isInputInRangeInt(0, 70, state.resp)}
+        hasError={ValidationUtils.isInputInRangeInt(1, 70, state.resp)}
       />
       <div className="w-full">
         <div className="mx-2">

--- a/src/Components/CriticalCareRecording/HemodynamicParameters/CriticalCare__HemodynamicParametersEditor.res
+++ b/src/Components/CriticalCareRecording/HemodynamicParameters/CriticalCare__HemodynamicParametersEditor.res
@@ -279,14 +279,14 @@ let make = (~hemodynamicParameter, ~updateCB, ~id, ~consultationId) => {
       />
       <Slider
         title={"Respiratory Rate (bpm)"}
-        start={"1"}
+        start={"0"}
         end={"70"}
         interval={"5"}
         step={1.0}
         value={Belt.Option.mapWithDefault(state.resp, "", string_of_int)}
         setValue={s => send(SetResp(int_of_string(s)))}
         getLabel={getStatus(12.0, "Low", 16.0, "High")}
-        hasError={ValidationUtils.isInputInRangeInt(1, 70, state.resp)}
+        hasError={ValidationUtils.isInputInRangeInt(0, 70, state.resp)}
       />
       <div className="w-full">
         <div className="mx-2">

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -561,7 +561,7 @@ export const DailyRounds = (props: any) => {
                   label="Respiratory Rate"
                   unit="bpm"
                   required
-                  start={0}
+                  start={1}
                   end={50}
                   step={1}
                   thresholds={[

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -561,7 +561,7 @@ export const DailyRounds = (props: any) => {
                   label="Respiratory Rate"
                   unit="bpm"
                   required
-                  start={10}
+                  start={0}
                   end={50}
                   step={1}
                   thresholds={[

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -561,7 +561,7 @@ export const DailyRounds = (props: any) => {
                   label="Respiratory Rate"
                   unit="bpm"
                   required
-                  start={1}
+                  start={0}
                   end={50}
                   step={1}
                   thresholds={[


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d01622</samp>

This pull request updates the respiratory rate input components in `CriticalCare__HemodynamicParametersEditor.res` and `DailyRounds.tsx` to allow zero as a valid value. It also fixes a minor CSS bug in `Uptime.tsx`.

## Proposed Changes

- Fixes #5926

![image](https://github.com/coronasafe/care_fe/assets/3626859/3ed278e9-896e-4e36-8e55-79b58607fd52)
![image](https://github.com/coronasafe/care_fe/assets/3626859/41d6d93d-547e-4c38-af13-5bf0c5ed32b3)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d01622</samp>

*  Lower the minimum value of the respiratory rate slider and validation function from 10 to 0 in the hemodynamic parameters editor and the daily rounds components ([link](https://github.com/coronasafe/care_fe/pull/5931/files?diff=unified&w=0#diff-7191db1b7945f0c3f2b16284b302528a656690587da5bd62f29c27bcdeea99e7L282-R282), [link](https://github.com/coronasafe/care_fe/pull/5931/files?diff=unified&w=0#diff-7191db1b7945f0c3f2b16284b302528a656690587da5bd62f29c27bcdeea99e7L289-R289), [link](https://github.com/coronasafe/care_fe/pull/5931/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L564-R564)). This allows the user to enter zero as a valid input for the respiratory rate in cases of mechanical ventilation or apnea.
