### PR TITLE
Align fields in update shift request form

### DIFF
--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -303,7 +303,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
           handleSubmit(true);
         }}
       />
-      <Card className="mx-auto mt-4 w-full max-w-4xl !p-6">
+      <Card className="mx-auto mt-4 w-full max-w-4xl md:p-6 lg:p-8">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <SelectFormField
             name="status"
@@ -319,7 +319,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
             optionValue={(option) => option.text}
             optionSelectedLabel={(option) => option.text}
             onChange={handleFormFieldChange}
-            className="mt-2 w-full bg-white md:col-span-1 md:leading-5"
+            className="w-full bg-white md:col-span-1 md:leading-5"
           />
 
           {wartime_shifting &&
@@ -360,7 +360,6 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
               multiple={false}
               freeText
               name="assigned_facility"
-              className="mt-4"
               selected={state.form.assigned_facility_object}
               setSelected={(obj) =>
                 setFacility(obj, "assigned_facility_object")


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02b82d5</samp>

Improved the UI of the shifting details update form in `ShiftDetailsUpdate.tsx` to make it more consistent and user-friendly.

## Proposed Changes

- Fixes #5932 

<img width="1974" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/d2b9466a-4226-42e7-844d-de72eaa49c9e">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02b82d5</samp>

*  Increase the padding of the card component for medium and large screens to improve the layout and spacing of the form fields ([link](https://github.com/coronasafe/care_fe/pull/5933/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL306-R306))
*  Remove the margin-top of the select and button components to align them with the other fields in the same row and reduce the gap between the form and the button ([link](https://github.com/coronasafe/care_fe/pull/5933/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL322-R322), [link](https://github.com/coronasafe/care_fe/pull/5933/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL363))
