### PR TITLE
Asset Detail: Fix Updtime popover clipping out of window and fix missing Icons

### DIFF
--- a/src/Components/Assets/AssetWarrantyCard.tsx
+++ b/src/Components/Assets/AssetWarrantyCard.tsx
@@ -1,6 +1,7 @@
 import moment from "moment";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { AssetData } from "./AssetTypes";
+import { classNames } from "../../Utils/utils";
 
 export default function AssetWarrantyCard(props: { asset: AssetData }) {
   const { asset } = props;
@@ -53,7 +54,9 @@ export default function AssetWarrantyCard(props: { asset: AssetData }) {
                       }
                       className="border-b border-primary-300 text-primary-300 hover:text-primary-400"
                     >
-                      <CareIcon className={"care-l- mr-1 h-5" + item[2]} />
+                      <CareIcon
+                        className={classNames(`care-l-${item[2]}`, "mr-1")}
+                      />
                       {item[1]}
                     </a>
                   </>

--- a/src/Components/Common/Uptime.tsx
+++ b/src/Components/Common/Uptime.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from "react-redux";
 import * as Notification from "../../Utils/Notifications.js";
 import { AssetStatus, AssetUptimeRecord } from "../Assets/AssetTypes";
 import { reverse } from "lodash";
+import { classNames } from "../../Utils/utils";
 
 const STATUS_COLORS = {
   Operational: "bg-green-500",
@@ -150,13 +151,14 @@ function UptimeInfoPopover({
   return (
     <Popover className="relative mt-10 hidden sm:block">
       <Popover.Panel
-        className={`absolute z-50 w-64 px-4 sm:px-0 lg:w-96${
+        className={classNames(
+          "absolute z-50 w-64 px-4 sm:px-0 lg:w-96",
           day > numDays - 10
             ? "-translate-x-6"
             : day < 10
             ? "-translate-x-full"
             : "-translate-x-1/2"
-        }`}
+        )}
         static
       >
         <UptimeInfo records={records} date={date} />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc3255d</samp>

Refactored and improved the usage of `classNames` utility function in `CareIcon` and `Uptime` components. Fixed a syntax error in `Uptime.tsx`.

## Proposed Changes

- Fixes #5938 

<img width="2176" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/26ceac84-bc4d-4115-b0c4-8ec7ad54d543">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bc3255d</samp>

* Import and use `classNames` utility function to conditionally join class names for React components in `AssetWarrantyCard.tsx` and `Uptime.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5942/files?diff=unified&w=0#diff-f8fdc58adc1307861c927edf919aca643ed7c7ee01b84e43bac0092e2af83db4R4), [link](https://github.com/coronasafe/care_fe/pull/5942/files?diff=unified&w=0#diff-f8fdc58adc1307861c927edf919aca643ed7c7ee01b84e43bac0092e2af83db4L56-R59), [link](https://github.com/coronasafe/care_fe/pull/5942/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841R9), [link](https://github.com/coronasafe/care_fe/pull/5942/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L153-R155), [link](https://github.com/coronasafe/care_fe/pull/5942/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L159-R161))
* Fix syntax error in `Popover.Panel` component's className prop in `Uptime.tsx` by replacing closing curly brace with closing parenthesis ([link](https://github.com/coronasafe/care_fe/pull/5942/files?diff=unified&w=0#diff-977c2c274ab7de444d743a9de51baee3ee6e97a077a36211c063af81c42ca841L159-R161))
