### PR TITLE
Consultation Suggestions: Add field "Domiciliary Care Start Date" and deprecate "home isolation"

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -323,11 +323,11 @@ export const SAMPLE_TEST_RESULT = [
 ];
 
 export const CONSULTATION_SUGGESTION = [
-  { id: "HI", text: "Home Isolation" },
+  { id: "HI", text: "Home Isolation", deprecated: true }, // # Deprecated. Preserving option for backward compatibility (use only for readonly operations)
   { id: "A", text: "Admission" },
   { id: "R", text: "Refer to another Hospital" },
-  { id: "OP", text: "OP Consultation" },
-  { id: "DC", text: "Domiciliary Care" },
+  { id: "OP", text: "OP Consultation", desc: "Out Patient Consultation" },
+  { id: "DC", text: "Domiciliary Care", desc: "Home Care" },
   { id: "DD", text: "Declare Death" },
 ];
 

--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -326,8 +326,8 @@ export const CONSULTATION_SUGGESTION = [
   { id: "HI", text: "Home Isolation", deprecated: true }, // # Deprecated. Preserving option for backward compatibility (use only for readonly operations)
   { id: "A", text: "Admission" },
   { id: "R", text: "Refer to another Hospital" },
-  { id: "OP", text: "OP Consultation", desc: "Out Patient Consultation" },
-  { id: "DC", text: "Domiciliary Care", desc: "Home Care" },
+  { id: "OP", text: "OP Consultation" },
+  { id: "DC", text: "Domiciliary Care" },
   { id: "DD", text: "Declare Death" },
 ];
 

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -508,9 +508,9 @@ export const ConsultationDetails = (props: any) => {
             {!consultationData.discharge_date &&
               hl7SocketUrl &&
               ventilatorSocketUrl && (
-                <section className="bg-white shadow-sm rounded-md flex items-stretch w-full flex-col lg:flex-row overflow-auto">
-                  <div className="w-full lg:w-auto lg:min-w-[1280px] flex flex-col lg:flex-row bg-[#020617] gap-1 justify-between rounded mx-auto">
-                    <div className="flex-1 min-h-[400px]">
+                <section className="flex w-full flex-col items-stretch overflow-auto rounded-md bg-white shadow-sm lg:flex-row">
+                  <div className="mx-auto flex w-full flex-col justify-between gap-1 rounded bg-[#020617] lg:w-auto lg:min-w-[1280px] lg:flex-row">
+                    <div className="min-h-[400px] flex-1">
                       <HL7PatientVitalsMonitor
                         patientAssetBed={{
                           asset: monitorBedData?.asset_object as AssetData,
@@ -544,7 +544,7 @@ export const ConsultationDetails = (props: any) => {
                       (!hl7SocketUrl && ventilatorSocketUrl)) && (
                       <section className="flex w-full flex-col items-stretch overflow-hidden rounded-md bg-white shadow-sm lg:col-span-2 lg:flex-row">
                         {(hl7SocketUrl || ventilatorSocketUrl) && (
-                          <div className="w-full lg:w-auto lg:min-w-[640px] flex flex-col lg:flex-row bg-[#020617] gap-1 justify-between rounded mx-auto">
+                          <div className="mx-auto flex w-full flex-col justify-between gap-1 rounded bg-[#020617] lg:w-auto lg:min-w-[640px] lg:flex-row">
                             {hl7SocketUrl && (
                               <div className="min-h-[400px] flex-1">
                                 <HL7PatientVitalsMonitor

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -982,7 +982,6 @@ export const ConsultationForm = (props: any) => {
                       options={CONSULTATION_SUGGESTION.filter(
                         ({ deprecated }) => !deprecated
                       )}
-                      optionDescription={(option) => option.desc}
                     />
                   </div>
 

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -398,8 +398,11 @@ export const ConsultationForm = (props: any) => {
           }
           return;
         case "admission_date":
-          if (state.form.suggestion === "A" && !state.form[field]) {
-            errors[field] = "Field is required as person is admitted";
+          if (
+            ["A", "DC"].includes(state.form.suggestion) &&
+            !state.form[field]
+          ) {
+            errors[field] = "Field is required";
             invalidForm = true;
           }
           return;
@@ -587,8 +590,9 @@ export const ConsultationForm = (props: any) => {
         suggestion: state.form.suggestion,
         consultation_status: Number(state.form.consultation_status),
         admitted: state.form.suggestion === "A",
-        admission_date:
-          state.form.suggestion === "A" ? state.form.admission_date : undefined,
+        admission_date: ["A", "DC"].includes(state.form.suggestion)
+          ? state.form.admission_date
+          : undefined,
         category: state.form.category,
         is_kasp: state.form.is_kasp,
         kasp_enabled_date: JSON.parse(state.form.is_kasp) ? new Date() : null,
@@ -975,7 +979,10 @@ export const ConsultationForm = (props: any) => {
                       label="Decision after consultation"
                       disabled={String(state.form.consultation_status) === "1"}
                       {...selectField("suggestion")}
-                      options={CONSULTATION_SUGGESTION}
+                      options={CONSULTATION_SUGGESTION.filter(
+                        ({ deprecated }) => !deprecated
+                      )}
+                      optionDescription={(option) => option.desc}
                     />
                   </div>
 
@@ -1040,7 +1047,7 @@ export const ConsultationForm = (props: any) => {
                     </>
                   )}
 
-                  {state.form.suggestion === "A" && (
+                  {["A", "DC"].includes(state.form.suggestion) && (
                     <>
                       <div
                         className="col-span-6"
@@ -1050,7 +1057,11 @@ export const ConsultationForm = (props: any) => {
                           {...field("admission_date")}
                           required
                           disableFuture
-                          label="Admission date"
+                          label={
+                            state.form.suggestion === "A"
+                              ? "Date of Admission"
+                              : "Domiciliary Care Start Date"
+                          }
                           position="LEFT"
                         />
                       </div>

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -514,8 +514,7 @@ export const PatientManager = () => {
           </div>
           <div className="flex flex-col items-start gap-4 md:flex-row">
             <div className="h-20 w-full min-w-[5rem] rounded-lg border border-gray-300 bg-gray-50 md:w-20">
-              {patient?.last_consultation &&
-              patient?.last_consultation?.current_bed &&
+              {patient?.last_consultation?.current_bed &&
               patient?.last_consultation?.discharge_date === null ? (
                 <div className="flex h-full flex-col items-center justify-center">
                   <span className="tooltip w-full truncate px-1 text-center text-sm text-gray-900">
@@ -540,6 +539,15 @@ export const PatientManager = () => {
                     </span>
                   </span>
                 </div>
+              ) : patient.last_consultation?.suggestion === "DC" ? (
+                <div className="flex h-full flex-col items-center justify-center">
+                  <div className="tooltip">
+                    <CareIcon className="care-l-estate text-3xl text-gray-500" />
+                    <span className="tooltip-text tooltip-bottom -translate-x-1/2 text-sm font-medium">
+                      Domiciliary Care
+                    </span>
+                  </div>
+                </div>
               ) : (
                 <div className="flex min-h-[5rem] items-center justify-center">
                   <i className="fas fa-user-injured text-3xl text-gray-500"></i>
@@ -548,21 +556,20 @@ export const PatientManager = () => {
             </div>
             <div className="flex w-full flex-col gap-2 pl-2 md:block md:flex-row">
               <div className="flex w-full justify-between gap-2">
-                <div className="text-xl font-semibold capitalize">
-                  <span>{patient.name}</span>
-                  <span className="text-gray-800">{" - " + patient.age}</span>
-                  {patient.action && patient.action != 10 && (
-                    <span className="ml-2 font-semibold text-gray-700">
-                      -{" "}
-                      {
-                        TELEMEDICINE_ACTIONS.find(
-                          (i) => i.id === patient.action
-                        )?.desc
-                      }
-                    </span>
-                  )}
+                <div className="font-semibold">
+                  <span className="text-xl capitalize">{patient.name}</span>
+                  <span className="ml-4 text-gray-800">{`${patient.age} yrs.`}</span>
                 </div>
               </div>
+
+              {patient.action && patient.action != 10 && (
+                <span className="text-sm font-semibold text-gray-700">
+                  {
+                    TELEMEDICINE_ACTIONS.find((i) => i.id === patient.action)
+                      ?.desc
+                  }
+                </span>
+              )}
 
               {patient.facility_object && (
                 <div className="mb-2">

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -222,7 +222,7 @@ export default function PatientInfoCard(props: {
                       )?.text
                     }{" "}
                     on{" "}
-                    {consultation?.suggestion === "A"
+                    {["A", "DC"].includes(consultation?.suggestion ?? "")
                       ? moment(consultation?.admission_date).format(
                           "DD/MM/YYYY"
                         )

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -175,6 +175,15 @@ export default function PatientInfoCard(props: {
               <span>{patient.age} years</span>
               <span className="mx-2">•</span>
               <span>{patient.gender}</span>
+              {consultation?.suggestion === "DC" && (
+                <>
+                  <span className="mx-2">•</span>
+                  <span className="space-x-2">
+                    Domiciliary Care{" "}
+                    <CareIcon className="care-l-estate text-base text-gray-700" />
+                  </span>
+                </>
+              )}
             </p>
             <div className="flex flex-col items-center gap-2 text-sm sm:flex-row lg:mt-4">
               {[


### PR DESCRIPTION
> Backend changes are not required for this FE PR to function. Backend changes just ensure proper validations and would reject any home isolation option in future requests.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7f0814</samp>

No summary available (Limit exceeded: required to process 67191 tokens, but only 50000 are allowed per call)

## Proposed Changes

- Fixes #5940
- Deprecated `Home Isolation`
- Added descriptions to options
- Required field: Domiciliary Care Start Date (re-uses `admission_date` field)

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/7f07909f-74bf-4063-ba71-259c51a20d46">

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/9d440542-8a59-441d-81a5-60402deb7295">

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/aa3e669a-e325-4e1b-8c7d-baca7bce2d02">




@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7f0814</samp>

No walkthrough available (Limit exceeded: required to process 67191 tokens, but only 50000 are allowed per call)
