### PR TITLE
Make patient category required in shifting

### DIFF
--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -330,7 +330,7 @@ export const ShiftCreate = (props: patientShiftProps) => {
         />
 
         <PatientCategorySelect
-          required={false}
+          required={true}
           {...field("patient_category")}
           value={patientCategory}
           onChange={(e) => setPatientCategory(e.value)}

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -411,7 +411,7 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
           />
 
           <PatientCategorySelect
-            required={false}
+            required={true}
             name="patient_category"
             value={state.form.patient_category}
             onChange={handleFormFieldChange}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed06ea4</samp>

This pull request makes the `patient category` field required in both the `ShiftCreate.tsx` and `ShiftDetailsUpdate.tsx` components. This is to ensure that the patient category is always provided when creating or updating a shift request, as it influences the facility allocation and the shift priority.

## Proposed Changes

- Fixes #5946 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed06ea4</samp>

*  Make patient category select field required in both shift create and shift details update forms ([link](https://github.com/coronasafe/care_fe/pull/5947/files?diff=unified&w=0#diff-7ec03dd8838e59d1d7ef0aa4f42c6ed82aa5f086d5d280b42617974f674f561fL333-R333), [link](https://github.com/coronasafe/care_fe/pull/5947/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL414-R414))
