### PR TITLE
Shifting Form (create + update): default to consultation category only for Patient Category

### DIFF
--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -114,11 +114,10 @@ export const ShiftCreate = (props: patientShiftProps) => {
       if (patientId) {
         const res = await dispatchAction(getPatient({ id: patientId }));
         if (res.data) {
-          const patient_category =
-            res.data.last_consultation?.last_daily_round?.patient_category ??
-            res.data.last_consultation?.category;
           setPatientCategory(
-            PATIENT_CATEGORIES.find((c) => c.text === patient_category)?.id
+            PATIENT_CATEGORIES.find(
+              (c) => c.text === res.data.last_consultation?.category
+            )?.id
           );
           setPatientName(res.data.name);
           setFacilityName(res.data.facility_object.name);

--- a/src/Components/Shifting/ShiftDetailsUpdate.tsx
+++ b/src/Components/Shifting/ShiftDetailsUpdate.tsx
@@ -264,11 +264,8 @@ export const ShiftDetailsUpdate = (props: patientShiftProps) => {
             };
           d["initial_status"] = res.data.status;
           d["status"] = qParams.status || res.data.status;
-          const patient_category =
-            d.patient.last_consultation?.last_daily_round?.patient_category ??
-            d.patient.last_consultation?.category;
           d["patient_category"] = PATIENT_CATEGORIES.find(
-            (c) => c.text === patient_category
+            (c) => c.text === d.patient.last_consultation?.category
           )?.id;
           dispatch({ type: "set_form", form: d });
         }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d58ae89</samp>

Simplify the logic for setting the patient category in `ShiftCreate` and `ShiftDetailsUpdate` components. Use only the last consultation category to avoid inconsistencies and bugs.

## Proposed Changes

- Fixes #5951

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d58ae89</samp>

*  Simplify the logic for setting the patient category in shift request components by only using the last consultation category ([link](https://github.com/coronasafe/care_fe/pull/5952/files?diff=unified&w=0#diff-7ec03dd8838e59d1d7ef0aa4f42c6ed82aa5f086d5d280b42617974f674f561fL117-R120), [link](https://github.com/coronasafe/care_fe/pull/5952/files?diff=unified&w=0#diff-5d9f2efbfb558b3bdc89362fef4a25f68c166440805631dfb6d12b8701f9236fL267-R268))
