### PR TITLE
Adds support to type date

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -13,6 +13,7 @@ import {
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { Popover } from "@headlessui/react";
 import { classNames } from "../../Utils/utils";
+import moment from "moment";
 
 type DatePickerType = "date" | "month" | "year";
 export type DatePickerPosition = "LEFT" | "RIGHT" | "CENTER";
@@ -228,7 +229,7 @@ const DateInputV2: React.FC<Props> = ({
                   disabled={disabled}
                   className={`cui-input-base cursor-pointer disabled:cursor-not-allowed ${className}`}
                   placeholder={placeholder ?? "Select date"}
-                  value={value && format(value, "yyyy-MM-dd")}
+                  value={value && moment(value).format("DD / MM / YYYY")}
                 />
                 <div className="absolute right-0 top-1/2 -translate-y-1/2 p-2">
                   <CareIcon className="care-l-calendar-alt text-lg text-gray-600" />
@@ -247,10 +248,28 @@ const DateInputV2: React.FC<Props> = ({
                   )}
                 >
                   <div className="mb-4 flex w-full flex-col items-center justify-between">
-                    <p className="text-sm font-medium text-gray-600">
-                      {placeholder}
-                    </p>
-                    <div className="flex">
+                    <input
+                      key={value && moment(value).format("DD / MM / YYYY")}
+                      className="cui-input-base bg-gray-50"
+                      defaultValue={
+                        value && moment(value).format("DD / MM / YYYY")
+                      }
+                      onChange={(e) => {
+                        const momentObj = moment(
+                          e.target.value,
+                          "DD / MM / YYYY"
+                        );
+
+                        if (momentObj.isValid()) {
+                          onChange(momentObj.toDate());
+                        }
+                      }}
+                      // label={placeholder}
+                      // labelClassName="text-sm"
+                      // errorClassName="hidden"
+                      // inputClassName="bg-gray-100"
+                    />
+                    <div className="mt-4 flex">
                       <button
                         type="button"
                         disabled={!isDateWithinConstraints()}

--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -229,7 +229,7 @@ const DateInputV2: React.FC<Props> = ({
                   disabled={disabled}
                   className={`cui-input-base cursor-pointer disabled:cursor-not-allowed ${className}`}
                   placeholder={placeholder ?? "Select date"}
-                  value={value && moment(value).format("DD / MM / YYYY")}
+                  value={value && moment(value).format("DD/MM/YYYY")}
                 />
                 <div className="absolute right-0 top-1/2 -translate-y-1/2 p-2">
                   <CareIcon className="care-l-calendar-alt text-lg text-gray-600" />
@@ -249,19 +249,20 @@ const DateInputV2: React.FC<Props> = ({
                 >
                   <div className="mb-4 flex w-full flex-col items-center justify-between">
                     <input
-                      // key={value && moment(value).format("DD / MM / YYYY")}
+                      // key={value && moment(value).format("DD/MM/YYYY")}
                       className="cui-input-base bg-gray-50"
-                      defaultValue={
-                        value && moment(value).format("DD / MM / YYYY")
-                      }
+                      defaultValue={value && moment(value).format("DD/MM/YYYY")}
+                      placeholder="DD/MM/YYYY"
                       onChange={(e) => {
                         const momentObj = moment(
                           e.target.value,
-                          "DD / MM / YYYY"
+                          "DD/MM/YYYY",
+                          true
                         );
 
                         if (momentObj.isValid()) {
                           onChange(momentObj.toDate());
+                          close();
                         }
                       }}
                     />

--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -249,7 +249,7 @@ const DateInputV2: React.FC<Props> = ({
                 >
                   <div className="mb-4 flex w-full flex-col items-center justify-between">
                     <input
-                      key={value && moment(value).format("DD / MM / YYYY")}
+                      // key={value && moment(value).format("DD / MM / YYYY")}
                       className="cui-input-base bg-gray-50"
                       defaultValue={
                         value && moment(value).format("DD / MM / YYYY")
@@ -264,10 +264,6 @@ const DateInputV2: React.FC<Props> = ({
                           onChange(momentObj.toDate());
                         }
                       }}
-                      // label={placeholder}
-                      // labelClassName="text-sm"
-                      // errorClassName="hidden"
-                      // inputClassName="bg-gray-100"
                     />
                     <div className="mt-4 flex">
                       <button

--- a/src/Components/Common/DateRangeInputV2.tsx
+++ b/src/Components/Common/DateRangeInputV2.tsx
@@ -28,7 +28,7 @@ const DateRangeInputV2 = ({ value, onChange, ...props }: Props) => {
           className={props.className}
           value={start}
           onChange={(start) => {
-            onChange({ start, end: start });
+            onChange({ start, end });
             setShowEndPicker(true);
           }}
           min={props.min}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b90f31a</samp>

Improved and restyled the date input component in `DateInputV2.tsx` using `moment` to handle date formats and validations.

## Proposed Changes

- Fixes #5909

<img width="1749" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/b015e74a-de3e-4bc3-8366-2e9e5eec4378">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b90f31a</samp>

*  Import `moment` library to handle date formatting and parsing ([link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bR16))
*  Replace input element with custom input component that allows manual date entry in DD / MM / YYYY format, validates input using `moment`, and updates `onChange` prop with parsed date object ([link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL231-R232), [link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL250-R272))
*  Move button element below input component and add margin-top ([link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL250-R272))
*  Use `moment` to format `value` prop of input component in DD / MM / YYYY format instead of yyyy-MM-dd format ([link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL231-R232))
*  Add key prop to input component that depends on `value` prop to trigger re-render when value changes ([link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL250-R272))
*  Comment out label and error props of input component as they are not used ([link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL250-R272))
*  Add custom styling props to input component to match design ([link](https://github.com/coronasafe/care_fe/pull/5953/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL250-R272))
