### PR TITLE
fix: doctor capacity dropdown in the facility creation page malfunctioning

### DIFF
--- a/src/Components/Facility/DoctorCapacity.tsx
+++ b/src/Components/Facility/DoctorCapacity.tsx
@@ -4,12 +4,12 @@ import { DOCTOR_SPECIALIZATION } from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { createDoctor, getDoctor, listDoctor } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import { DoctorModal, OptionsType } from "./models";
 import ButtonV2, { Cancel } from "../Common/components/ButtonV2";
-import SelectMenuV2 from "../Form/SelectMenuV2";
-import TextFormField from "../Form/FormFields/TextFormField";
 import { FieldErrorText, FieldLabel } from "../Form/FormFields/FormField";
+import TextFormField from "../Form/FormFields/TextFormField";
 import { FieldChangeEventHandler } from "../Form/FormFields/Utils";
+import SelectMenuV2 from "../Form/SelectMenuV2";
+import { DoctorModal, OptionsType } from "./models";
 
 interface DoctorCapacityProps extends DoctorModal {
   facilityId: string;
@@ -217,14 +217,15 @@ export const DoctorCapacity = (props: DoctorCapacityProps) => {
             </FieldLabel>
             <SelectMenuV2
               id="area-of-specialization"
-              value={doctorTypes.find((type) => type.id == state.form.area)}
+              value={doctorTypes.find((type) => type.id == state.form.area)?.id}
               options={doctorTypes.filter((type) => !type.disabled)}
               optionLabel={(option) => option.text}
+              optionValue={(option) => option.id}
               requiredError={state.errors.area.length !== 0}
               onChange={(e) =>
                 handleFormFieldChange({
                   name: "area",
-                  value: (e && e.id) || "",
+                  value: e || "",
                 })
               }
               disabled={!!id}


### PR DESCRIPTION
# Bug Fix

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c56b3c</samp>

Fixed a UI bug in the doctor capacity form and cleaned up imports. The bug prevented selecting the correct doctor specialization in `SelectMenuV2` in `DoctorCapacity.tsx`.

## Proposed Changes

- Fixes #5958
- Updates value prop of `SelectMenuV2` in `Area of Specialization` field

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

## Screenshot
![image](https://github.com/coronasafe/care_fe/assets/77210185/ad694757-a45c-42cf-916b-0f79f4cf592e)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c56b3c</samp>

* Fix a bug that prevented selecting the doctor specialization by using the `id` property of the `doctorTypes` options instead of the whole object in the `SelectMenuV2` component ([link](https://github.com/coronasafe/care_fe/pull/5959/files?diff=unified&w=0#diff-6ecf3e8854de3cbfb407d68fad0e6a0c43d2aee9ae994fef7832c3b5ac60a2f5L220-R228))
* Reorder the import statements alphabetically for better readability and consistency in `DoctorCapacity.tsx` ([link](https://github.com/coronasafe/care_fe/pull/5959/files?diff=unified&w=0#diff-6ecf3e8854de3cbfb407d68fad0e6a0c43d2aee9ae994fef7832c3b5ac60a2f5L7-R12))
