### PR TITLE
Add op_no and ip_OR_op filter for patients

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -152,7 +152,7 @@ export const PatientManager = () => {
     page: qParams.page || 1,
     limit: resultsPerPage,
     name: qParams.name || undefined,
-    ip_no: qParams.ip_no || undefined,
+    ip_or_op_no: qParams.ip_or_op_no || undefined,
     is_active:
       !qParams.last_consultation_discharge_reason &&
       (qParams.is_active || "True"),
@@ -354,7 +354,7 @@ export const PatientManager = () => {
     qParams.is_active,
     qParams.disease_status,
     qParams.name,
-    qParams.ip_no,
+    qParams.ip_or_op_no,
     qParams.page,
     qParams.phone_number,
     qParams.emergency_phone_number,
@@ -862,10 +862,10 @@ export const PatientManager = () => {
                 {...queryField("name")}
               />
               <SearchInput
-                label="Search by IP Number"
-                placeholder="Enter IP Number"
+                label="Search by IP/OP Number"
+                placeholder="Enter IP/OP Number"
                 secondary
-                {...queryField("ip_no")}
+                {...queryField("ip_or_op_no")}
               />
             </div>
             <div className="md:flex md:gap-4">
@@ -901,7 +901,7 @@ export const PatientManager = () => {
             phoneNumber("Primary number", "phone_number"),
             phoneNumber("Emergency number", "emergency_phone_number"),
             badge("Patient name", "name"),
-            badge("IP number", "ip_no"),
+            badge("IP/OP number", "ip_or_op_no"),
             ...dateRange("Modified", "modified_date"),
             ...dateRange("Created", "created_date"),
             ...dateRange("Admitted", "last_consultation_admission_date"),


### PR DESCRIPTION
Backend PR: https://github.com/coronasafe/care/pull/1484

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b613ed</samp>

Refactored the patient search feature to allow filtering by both IP and OP numbers. Modified the `ip_no` query parameter and the `ManagePatients` component accordingly.

## Proposed Changes

- Fixes #5918 

![image](https://github.com/coronasafe/care_fe/assets/3626859/24f11cdf-e9d5-4acb-8308-2ed1b8e2d3ea)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b613ed</samp>

*  Rename `ip_no` query parameter to `ip_or_op_no` to support both inpatient and outpatient numbers ([link](https://github.com/coronasafe/care_fe/pull/5960/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L155-R155))
*  Update `ip_no` dependency to `ip_or_or_no` in `useEffect` hook for patient list fetch ([link](https://github.com/coronasafe/care_fe/pull/5960/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L357-R357))
*  Modify `SearchInput` component in `src/Components/Patient/ManagePatients.tsx` to accept and display both IP and OP numbers and change label and placeholder accordingly ([link](https://github.com/coronasafe/care_fe/pull/5960/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L865-R868))
*  Modify `badge` component in `src/Components/Patient/ManagePatients.tsx` to show both IP and OP numbers and change label accordingly ([link](https://github.com/coronasafe/care_fe/pull/5960/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L904-R904))
