### PR TITLE
Add discharge summary to  file uploads section

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -706,12 +706,14 @@ export const FileUpload = (props: FileUploadProps) => {
                         </span>{" "}
                         {item.name}
                       </div>
-                      <div>
-                        <span className="font-semibold leading-relaxed">
-                          Created By:
-                        </span>{" "}
-                        {item.uploaded_by ? item.uploaded_by.username : null}
-                      </div>
+                      {sortFileState != "DISCHARGE_SUMMARY" && (
+                        <div>
+                          <span className="font-semibold leading-relaxed">
+                            Created By:
+                          </span>{" "}
+                          {item.uploaded_by ? item.uploaded_by.username : null}
+                        </div>
+                      )}
                       {item.created_date && (
                         <RecordMeta
                           prefix={


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b6397d</samp>

This pull request enhances the patient file upload feature by adding support for discharge summary files. It changes the `FileUpload` component to handle the new file type and display the uploaded files in the patient details page. It also updates the `src/Components/Patient/FileUpload.tsx` file with the necessary UI and logic changes.

## Proposed Changes

- Fixes #5912
![image](https://github.com/coronasafe/care_fe/assets/3626859/444ac7d1-b648-4095-9c7b-462c93a6631a)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9b6397d</samp>

*  Add state variables and logic to handle discharge summary files for a patient ([link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R149-R150), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R198-R199), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L216-R223), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R335-R358), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L444-R475), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L480-R511), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6R1621-R1647))
*  Use optional chaining to access `data` property of `res` object safely ([link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L304-R308), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L325-R329))
*  Conditionally render `Created By` section, edit and delete buttons for file cards based on the current tab ([link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L678-R716), [link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L727-R763))
*  Avoid rendering archived files when switching to discharge summary tab ([link](https://github.com/coronasafe/care_fe/pull/5963/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1562-R1596))
