### PR TITLE
Fix autocomplete highlight

### DIFF
--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -196,8 +196,8 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
               )}
               {filteredOptions.map((option, index) => (
                 <Combobox.Option
-                  id={`${props.id}-option-${option.label}`}
-                  key={index}
+                  id={`${props.id}-option-${option.label}-value-${index}`}
+                  key={`${props.id}-option-${option.label}-value-${index}`}
                   className={dropdownOptionClassNames}
                   value={option}
                 >


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c0b9f5</samp>

Fix autocomplete bug with duplicate labels. Change `id` and `key` attributes of `Combobox.Option` in `Autocomplete.tsx` to include option index.

## Proposed Changes

- Fixes #5962 

![image](https://github.com/coronasafe/care_fe/assets/3626859/6d5f501a-b4c0-4b11-87ad-1ffd6caac2b5)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c0b9f5</samp>

* Fix a bug where the autocomplete component does not select the correct option when there are duplicate labels ([link](https://github.com/coronasafe/care_fe/pull/5964/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9L199-R200))
