### PR TITLE
Restrict month arrows in DatePicker

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -253,7 +253,12 @@ const DateInputV2: React.FC<Props> = ({
                     <div className="flex">
                       <button
                         type="button"
-                        disabled={!isDateWithinConstraints()}
+                        disabled={
+                          !isDateWithinConstraints(
+                            getLastDay(),
+                            datePickerHeaderDate.getMonth() - 1
+                          )
+                        }
                         className="aspect-square inline-flex cursor-pointer items-center justify-center rounded p-2 transition duration-100 ease-in-out hover:bg-gray-300"
                         onClick={decrement}
                       >

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -225,6 +225,7 @@ const DischargeModal = ({
         {preDischargeForm.discharge_reason === "REC" && (
           <div>
             <DateFormField
+              position="LEFT"
               label="Discharge Date"
               name="discharge_date"
               value={moment(preDischargeForm?.discharge_date).toDate()}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 177f7ce</samp>

This pull request enhances the `DateInputV2` component to make it more user-friendly and compatible with various devices. It fixes the popover placement and the min date validation for the date picker.

## Proposed Changes

- Fixes #5914
![image](https://github.com/coronasafe/care_fe/assets/3626859/9d1e9e59-0106-4d1b-9107-7397ed67770a)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 177f7ce</samp>

*  Adjust the date picker popover position to be responsive and aligned with the input element on medium and larger screens ([link](https://github.com/coronasafe/care_fe/pull/5965/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL195-R197))
*  Add a parameter to check the previous month button availability based on the min and max constraints ([link](https://github.com/coronasafe/care_fe/pull/5965/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL256-R261))
*  Use the `getLastDay` function to calculate the last day of the previous month for the parameter ([link](https://github.com/coronasafe/care_fe/pull/5965/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL256-R261))
