### PR TITLE
Fix month list in DateInput

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -364,7 +364,7 @@ const DateInputV2: React.FC<Props> = ({
                               new Date(
                                 datePickerHeaderDate.getFullYear(),
                                 i,
-                                datePickerHeaderDate.getDate()
+                                1
                               ),
                               "MMM"
                             )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15636cc</samp>

Fixed a month picker bug in `DateInputV2` component. The bug caused the wrong month name to appear when the current date was not in the selected month.

## Proposed Changes

- Fixes #5968 
![image](https://github.com/coronasafe/care_fe/assets/3626859/1072db29-4657-4fd8-9ea4-fdc2f3578728)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 15636cc</samp>

* Fix month name bug in date input component ([link](https://github.com/coronasafe/care_fe/pull/5972/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL367-R367))
