### PR TITLE
Fix cypress patient test

### DIFF
--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -192,8 +192,7 @@ describe("Patient Creation with consultation", () => {
       .click();
     cy.get("div#medicine_object input[placeholder='Select'][role='combobox']")
       .click()
-      .type("dolo");
-    cy.get("#medicine_object-option-DOLO").click();
+      .type("dolo{enter}");
     cy.get("#dosage").type("3", { force: true });
     cy.get("#frequency")
       .click()


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1966601</samp>

Simplify medicine selection in `patient_crud.cy.ts` test by using enter key. This improves the test reliability and code quality.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1966601</samp>

*  Simplify the code for selecting a medicine name in the patient prescription form by using the enter key instead of clicking on the option element ([link](https://github.com/coronasafe/care_fe/pull/5975/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL195-R195))
