### PR TITLE
Dynamic aspect ratio for HL7 and Ventilator Vitals Monitors

### DIFF
--- a/src/Common/hooks/useBreakpoints.ts
+++ b/src/Common/hooks/useBreakpoints.ts
@@ -1,0 +1,37 @@
+import useWindowDimensions from "./useWindowDimensions";
+
+type Breakpoints = "vs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl";
+
+// Ensure that the breakpoint widths are sorted in ascending order.
+const BREAKPOINT_WIDTH: Record<Breakpoints, number> = {
+  vs: 348,
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+  "3xl": 1920,
+};
+
+/**
+ * Returns the value mapped to the current breakpoint. Mobile-first.
+ *
+ * @param map A map of breakpoints to values.
+ * @param defaultValue The default value.
+ * @returns The value mapped to the current breakpoint.
+ */
+export default function useBreakpoints<T>(
+  map: Partial<Record<Breakpoints, T>> & { default: T }
+) {
+  const { width } = useWindowDimensions();
+
+  const breakpoint = Object.entries(map).reduce((acc, [key]) => {
+    if (width >= BREAKPOINT_WIDTH[key as Breakpoints]) {
+      return key as Breakpoints;
+    }
+
+    return acc;
+  }, "default" as Breakpoints);
+
+  return map[breakpoint] ?? map.default;
+}

--- a/src/Common/hooks/useWindowDimensions.ts
+++ b/src/Common/hooks/useWindowDimensions.ts
@@ -1,13 +1,19 @@
 import { useState, useEffect } from "react";
+
 const getWindowDimensions = () => {
-  const { innerWidth: width, innerHeight: height } = window;
   return {
-    width,
-    height,
+    width: window.innerWidth,
+    height: window.innerHeight,
   };
 };
 
-const useWindowDimensions = () => {
+/**
+ * A hook that returns the current window dimensions.
+ * @example
+ * const { height, width } = useWindowDimensions();
+ * @returns The current window dimensions.
+ */
+export default function useWindowDimensions() {
   const [windowDimensions, setWindowDimensions] = useState(
     getWindowDimensions()
   );
@@ -22,18 +28,4 @@ const useWindowDimensions = () => {
   }, []);
 
   return windowDimensions;
-};
-export default useWindowDimensions;
-
-//usage of this hook
-
-/* const Component = () => {
-    const { height, width } = useWindowDimensions();
-  
-    return (
-      <div>
-        width: {width} ~ height: {height}
-      </div>
-    );
-  }
-*/
+}

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -55,6 +55,8 @@ import { navigate } from "raviger";
 import { useDispatch } from "react-redux";
 import { useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
+import useBreakpoints from "../../Common/hooks/useBreakpoints";
+import { getVitalsCanvasSizeAndDuration } from "../VitalsMonitor/utils";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -210,6 +212,18 @@ export const ConsultationDetails = (props: any) => {
   useAbortableEffect((status: statusType) => {
     fetchData(status);
   }, []);
+
+  const vitalsAspectRatio = useBreakpoints({
+    default: undefined,
+    md: 8 / 11,
+    lg: 15 / 11,
+    xl: 13 / 11,
+    "2xl": 19 / 11,
+    "3xl": 23 / 11,
+  });
+
+  const vitalsConfig = getVitalsCanvasSizeAndDuration(vitalsAspectRatio);
+  const vitalsConfigHash = JSON.stringify(vitalsConfig);
 
   if (isLoading) {
     return <Loading />;
@@ -548,6 +562,7 @@ export const ConsultationDetails = (props: any) => {
                             {hl7SocketUrl && (
                               <div className="min-h-[400px] flex-1">
                                 <HL7PatientVitalsMonitor
+                                  key={`hl7-${hl7SocketUrl}-${vitalsConfigHash}`}
                                   patientAssetBed={{
                                     asset:
                                       monitorBedData?.asset_object as AssetData,
@@ -556,13 +571,14 @@ export const ConsultationDetails = (props: any) => {
                                     meta: monitorBedData?.asset_object?.meta,
                                   }}
                                   socketUrl={hl7SocketUrl}
-                                  config={{ wide: true }}
+                                  config={vitalsConfig}
                                 />
                               </div>
                             )}
                             {ventilatorSocketUrl && (
                               <div className="min-h-[400px] flex-1">
                                 <VentilatorPatientVitalsMonitor
+                                  key={`ventilator-${ventilatorSocketUrl}-${vitalsConfigHash}`}
                                   patientAssetBed={{
                                     asset:
                                       ventilatorBedData?.asset_object as AssetData,
@@ -571,7 +587,7 @@ export const ConsultationDetails = (props: any) => {
                                     meta: ventilatorBedData?.asset_object?.meta,
                                   }}
                                   socketUrl={ventilatorSocketUrl}
-                                  config={{ wide: true }}
+                                  config={vitalsConfig}
                                 />
                               </div>
                             )}

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -556,6 +556,7 @@ export const ConsultationDetails = (props: any) => {
                                     meta: monitorBedData?.asset_object?.meta,
                                   }}
                                   socketUrl={hl7SocketUrl}
+                                  config={{ wide: true }}
                                 />
                               </div>
                             )}
@@ -570,6 +571,7 @@ export const ConsultationDetails = (props: any) => {
                                     meta: ventilatorBedData?.asset_object?.meta,
                                   }}
                                   socketUrl={ventilatorSocketUrl}
+                                  config={{ wide: true }}
                                 />
                               </div>
                             )}

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -1,34 +1,25 @@
 import { useEffect } from "react";
 import useHL7VitalsMonitor from "./useHL7VitalsMonitor";
-import { PatientAssetBed } from "../Assets/AssetTypes";
 import { Link } from "raviger";
 import { GENDER_TYPES } from "../../Common/constants";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import WaveformLabels from "./WaveformLabels";
 import { classNames } from "../../Utils/utils";
-import { VitalsValueBase } from "./types";
+import { IVitalsComponentProps, VitalsValueBase } from "./types";
 
-interface Props {
-  patientAssetBed?: PatientAssetBed;
-  socketUrl: string;
-  size?: { width: number; height: number };
-}
-
-export default function HL7PatientVitalsMonitor({
-  patientAssetBed,
-  socketUrl,
-  size,
-}: Props) {
-  const { connect, waveformCanvas, data, isOnline } = useHL7VitalsMonitor();
-  const { patient, bed, asset } = patientAssetBed ?? {};
+export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
+  const { connect, waveformCanvas, data, isOnline } = useHL7VitalsMonitor(
+    props.config
+  );
+  const { patient, bed, asset } = props.patientAssetBed ?? {};
 
   useEffect(() => {
-    connect(socketUrl);
-  }, [socketUrl]);
+    connect(props.socketUrl);
+  }, [props.socketUrl]);
 
   return (
     <div className="flex flex-col gap-1 rounded bg-[#020617] p-2">
-      {patientAssetBed && (
+      {props.patientAssetBed && (
         <div className="flex items-center justify-between px-2 tracking-wide">
           <div className="flex items-center gap-2">
             {patient ? (
@@ -92,14 +83,14 @@ export default function HL7PatientVitalsMonitor({
               "flex flex-col items-center justify-center gap-1 p-1 text-center font-mono font-medium text-warning-500",
               isOnline && "hidden"
             )}
-            style={{ ...(size ?? waveformCanvas.size) }}
+            style={waveformCanvas.size}
           >
             <CareIcon className="care-l-cloud-times mb-2 animate-pulse text-4xl" />
             <span className="font-bold">No incoming data from HL7 Monitor</span>
           </div>
           <div
             className={classNames("relative", !isOnline && "hidden")}
-            style={{ ...(size ?? waveformCanvas.size) }}
+            style={waveformCanvas.size}
           >
             <WaveformLabels
               labels={{
@@ -112,13 +103,13 @@ export default function HL7PatientVitalsMonitor({
             <canvas
               className="absolute left-0 top-0"
               ref={waveformCanvas.background.canvasRef}
-              style={{ ...(size ?? waveformCanvas.size) }}
+              style={waveformCanvas.size}
               {...waveformCanvas.size}
             />
             <canvas
               className="absolute left-0 top-0"
               ref={waveformCanvas.foreground.canvasRef}
-              style={{ ...(size ?? waveformCanvas.size) }}
+              style={waveformCanvas.size}
               {...waveformCanvas.size}
             />
           </div>

--- a/src/Components/VitalsMonitor/HL7VitalsRenderer.ts
+++ b/src/Components/VitalsMonitor/HL7VitalsRenderer.ts
@@ -17,11 +17,6 @@ interface Position {
   y: number;
 }
 
-/**
- * Duration of each row on the canvas in seconds.
- */
-const DURATION = 7;
-
 interface Options {
   /**
    * The size of the canvas rendering context.
@@ -53,6 +48,10 @@ interface Options {
    * Options for SPO2 channel.
    */
   spo2: ChannelOptions;
+  /**
+   * Duration of each row on the canvas in seconds.
+   */
+  duration: number;
 }
 
 /**
@@ -69,6 +68,7 @@ class HL7VitalsRenderer {
       pleth,
       spo2,
       size: { height: h, width: w },
+      duration,
     } = options;
 
     this.options = options;
@@ -77,7 +77,7 @@ class HL7VitalsRenderer {
         color: "#0ffc03",
         buffer: [],
         cursor: { x: 0, y: 0 },
-        deltaX: w / (DURATION * ecg.samplingRate),
+        deltaX: w / (duration * ecg.samplingRate),
         transform: lerp(ecg.lowLimit, ecg.highLimit, h * 0.25, 0),
         chunkSize: ecg.samplingRate * options.animationInterval * 1e-3,
         options: ecg,
@@ -88,7 +88,7 @@ class HL7VitalsRenderer {
         color: "#ffff24",
         buffer: [],
         cursor: { x: 0, y: 0 },
-        deltaX: w / (DURATION * pleth.samplingRate),
+        deltaX: w / (duration * pleth.samplingRate),
         transform: lerp(pleth.lowLimit, pleth.highLimit, h * 0.75, h * 0.5),
         chunkSize: pleth.samplingRate * options.animationInterval * 1e-3,
         options: pleth,
@@ -99,7 +99,7 @@ class HL7VitalsRenderer {
         color: "#03a9f4",
         buffer: [],
         cursor: { x: 0, y: 0 },
-        deltaX: w / (DURATION * spo2.samplingRate),
+        deltaX: w / (duration * spo2.samplingRate),
         transform: lerp(spo2.lowLimit, spo2.highLimit, h, h * 0.75),
         chunkSize: spo2.samplingRate * options.animationInterval * 1e-3,
         options: spo2,

--- a/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
@@ -1,35 +1,26 @@
 import { useEffect } from "react";
-import { PatientAssetBed } from "../Assets/AssetTypes";
 import { Link } from "raviger";
 import { GENDER_TYPES } from "../../Common/constants";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import useVentilatorVitalsMonitor from "./useVentilatorVitalsMonitor";
-import { VitalsValueBase } from "./types";
+import { IVitalsComponentProps, VitalsValueBase } from "./types";
 import { classNames } from "../../Utils/utils";
 import WaveformLabels from "./WaveformLabels";
 
-interface Props {
-  patientAssetBed?: PatientAssetBed;
-  socketUrl: string;
-  size?: { width: number; height: number };
-}
-
-export default function VentilatorPatientVitalsMonitor({
-  patientAssetBed,
-  socketUrl,
-  size,
-}: Props) {
+export default function VentilatorPatientVitalsMonitor(
+  props: IVitalsComponentProps
+) {
   const { connect, waveformCanvas, data, isOnline } =
-    useVentilatorVitalsMonitor();
-  const { patient, bed, asset } = patientAssetBed ?? {};
+    useVentilatorVitalsMonitor(props.config);
+  const { patient, bed, asset } = props.patientAssetBed ?? {};
 
   useEffect(() => {
-    connect(socketUrl);
-  }, [socketUrl]);
+    connect(props.socketUrl);
+  }, [props.socketUrl]);
 
   return (
     <div className="flex flex-col gap-1 rounded bg-[#020617] p-2">
-      {patientAssetBed && (
+      {props.patientAssetBed && (
         <div className="flex items-center justify-between px-2 tracking-wide">
           <div className="flex items-center gap-2">
             {patient ? (
@@ -93,14 +84,14 @@ export default function VentilatorPatientVitalsMonitor({
               "flex flex-col items-center justify-center gap-1 p-1 text-center font-mono font-medium text-warning-500",
               isOnline && "hidden"
             )}
-            style={{ ...(size ?? waveformCanvas.size) }}
+            style={waveformCanvas.size}
           >
             <CareIcon className="care-l-cloud-times mb-2 animate-pulse text-4xl" />
             <span className="font-bold">No incoming data from Ventilator</span>
           </div>
           <div
             className={classNames("relative", !isOnline && "hidden")}
-            style={{ ...(size ?? waveformCanvas.size) }}
+            style={waveformCanvas.size}
           >
             <WaveformLabels
               labels={{
@@ -112,13 +103,13 @@ export default function VentilatorPatientVitalsMonitor({
             <canvas
               className="absolute left-0 top-0"
               ref={waveformCanvas.background.canvasRef}
-              style={{ ...(size ?? waveformCanvas.size) }}
+              style={waveformCanvas.size}
               {...waveformCanvas.size}
             />
             <canvas
               className="absolute left-0 top-0"
               ref={waveformCanvas.foreground.canvasRef}
-              style={{ ...(size ?? waveformCanvas.size) }}
+              style={waveformCanvas.size}
               {...waveformCanvas.size}
             />
           </div>

--- a/src/Components/VitalsMonitor/VentilatorWaveformsRenderer.ts
+++ b/src/Components/VitalsMonitor/VentilatorWaveformsRenderer.ts
@@ -17,11 +17,6 @@ interface Position {
   y: number;
 }
 
-/**
- * Duration of each row on the canvas in seconds.
- */
-const DURATION = 7;
-
 interface Options {
   /**
    * The size of the canvas rendering context.
@@ -53,6 +48,10 @@ interface Options {
    * Options for Volume channel.
    */
   volume: ChannelOptions;
+  /**
+   * Duration of each row on the canvas in seconds.
+   */
+  duration: number;
 }
 
 /**
@@ -69,6 +68,7 @@ class VentilatorVitalsRenderer {
       flow,
       volume,
       size: { height: h, width: w },
+      duration,
     } = options;
 
     this.options = options;
@@ -77,7 +77,7 @@ class VentilatorVitalsRenderer {
         color: "#0ffc03",
         buffer: [],
         cursor: { x: 0, y: 0 },
-        deltaX: w / (DURATION * pressure.samplingRate),
+        deltaX: w / (duration * pressure.samplingRate),
         transform: lerp(pressure.lowLimit, pressure.highLimit, h * 0.33, 0),
         chunkSize: pressure.samplingRate * options.animationInterval * 1e-3,
         options: pressure,
@@ -88,7 +88,7 @@ class VentilatorVitalsRenderer {
         color: "#ffff24",
         buffer: [],
         cursor: { x: 0, y: 0 },
-        deltaX: w / (DURATION * flow.samplingRate),
+        deltaX: w / (duration * flow.samplingRate),
         transform: lerp(flow.lowLimit, flow.highLimit, h * 0.67, h * 0.33),
         chunkSize: flow.samplingRate * options.animationInterval * 1e-3,
         options: flow,
@@ -99,7 +99,7 @@ class VentilatorVitalsRenderer {
         color: "#03a9f4",
         buffer: [],
         cursor: { x: 0, y: 0 },
-        deltaX: w / (DURATION * volume.samplingRate),
+        deltaX: w / (duration * volume.samplingRate),
         transform: lerp(volume.lowLimit, volume.highLimit, h, h * 0.67),
         chunkSize: volume.samplingRate * options.animationInterval * 1e-3,
         options: volume,

--- a/src/Components/VitalsMonitor/types.ts
+++ b/src/Components/VitalsMonitor/types.ts
@@ -1,3 +1,5 @@
+import { PatientAssetBed } from "../Assets/AssetTypes";
+
 export interface VitalsDataBase {
   device_id: string;
   "date-time": string;
@@ -40,4 +42,14 @@ export interface ChannelOptions {
    * No. of data points expected to be received per second.
    */
   samplingRate: number;
+}
+
+export interface IUseVitalsMonitorConfig {
+  wide?: boolean;
+}
+
+export interface IVitalsComponentProps {
+  patientAssetBed?: PatientAssetBed;
+  socketUrl: string;
+  config?: IUseVitalsMonitorConfig;
 }

--- a/src/Components/VitalsMonitor/types.ts
+++ b/src/Components/VitalsMonitor/types.ts
@@ -1,4 +1,5 @@
 import { PatientAssetBed } from "../Assets/AssetTypes";
+import { getVitalsCanvasSizeAndDuration } from "./utils";
 
 export interface VitalsDataBase {
   device_id: string;
@@ -44,12 +45,8 @@ export interface ChannelOptions {
   samplingRate: number;
 }
 
-export interface IUseVitalsMonitorConfig {
-  wide?: boolean;
-}
-
 export interface IVitalsComponentProps {
   patientAssetBed?: PatientAssetBed;
   socketUrl: string;
-  config?: IUseVitalsMonitorConfig;
+  config?: ReturnType<typeof getVitalsCanvasSizeAndDuration>;
 }

--- a/src/Components/VitalsMonitor/useHL7VitalsMonitor.ts
+++ b/src/Components/VitalsMonitor/useHL7VitalsMonitor.ts
@@ -7,7 +7,7 @@ import HL7VitalsRenderer from "./HL7VitalsRenderer";
 import useCanvas from "../../Common/hooks/useCanvas";
 import {
   ChannelOptions,
-  IUseVitalsMonitorConfig,
+  IVitalsComponentProps,
   VitalsValueBase as VitalsValue,
 } from "./types";
 import { getChannel, getVitalsCanvasSizeAndDuration } from "./utils";
@@ -18,12 +18,12 @@ interface VitalsBPValue {
   map: VitalsValue;
 }
 
-export default function useHL7VitalsMonitor(config?: IUseVitalsMonitorConfig) {
+export default function useHL7VitalsMonitor(
+  config?: IVitalsComponentProps["config"]
+) {
   const waveformForegroundCanvas = useCanvas();
   const waveformBackgroundCanvas = useCanvas();
-  const rendererConfig = getVitalsCanvasSizeAndDuration(
-    config?.wide ? 19 / 11 : undefined
-  );
+  const rendererConfig = config ?? getVitalsCanvasSizeAndDuration();
 
   // Non waveform data states.
   const [isOnline, setIsOnline] = useState<boolean>(false);

--- a/src/Components/VitalsMonitor/useHL7VitalsMonitor.ts
+++ b/src/Components/VitalsMonitor/useHL7VitalsMonitor.ts
@@ -5,22 +5,12 @@ import HL7DeviceClient, {
 } from "./HL7DeviceClient";
 import HL7VitalsRenderer from "./HL7VitalsRenderer";
 import useCanvas from "../../Common/hooks/useCanvas";
-import { ChannelOptions, VitalsValueBase as VitalsValue } from "./types";
-import { getChannel } from "./utils";
-
-export const MONITOR_RATIO = {
-  w: 13,
-  h: 11,
-};
-const MONITOR_SCALE = 38;
-const MONITOR_WAVEFORMS_CANVAS_SIZE = {
-  width: MONITOR_RATIO.h * MONITOR_SCALE,
-  height: MONITOR_RATIO.h * MONITOR_SCALE,
-};
-// const MONITOR_SIZE = {
-//   width: MONITOR_RATIO.w * MONITOR_SCALE,
-//   height: MONITOR_RATIO.h * MONITOR_SCALE,
-// };
+import {
+  ChannelOptions,
+  IUseVitalsMonitorConfig,
+  VitalsValueBase as VitalsValue,
+} from "./types";
+import { getChannel, getVitalsCanvasSizeAndDuration } from "./utils";
 
 interface VitalsBPValue {
   systolic: VitalsValue;
@@ -28,9 +18,12 @@ interface VitalsBPValue {
   map: VitalsValue;
 }
 
-export default function useHL7VitalsMonitor() {
+export default function useHL7VitalsMonitor(config?: IUseVitalsMonitorConfig) {
   const waveformForegroundCanvas = useCanvas();
   const waveformBackgroundCanvas = useCanvas();
+  const rendererConfig = getVitalsCanvasSizeAndDuration(
+    config?.wide ? 19 / 11 : undefined
+  );
 
   // Non waveform data states.
   const [isOnline, setIsOnline] = useState<boolean>(false);
@@ -73,11 +66,11 @@ export default function useHL7VitalsMonitor() {
         renderer.current = new HL7VitalsRenderer({
           foregroundRenderContext: waveformForegroundCanvas.contextRef.current,
           backgroundRenderContext: waveformBackgroundCanvas.contextRef.current,
-          size: MONITOR_WAVEFORMS_CANVAS_SIZE,
           animationInterval: 50,
           ecg: ecgOptionsRef.current,
           pleth: plethOptionsRef.current,
           spo2: spo2OptionsRef.current,
+          ...rendererConfig,
         });
 
         const _renderer = renderer.current;
@@ -125,7 +118,7 @@ export default function useHL7VitalsMonitor() {
     waveformCanvas: {
       foreground: waveformForegroundCanvas,
       background: waveformBackgroundCanvas,
-      size: MONITOR_WAVEFORMS_CANVAS_SIZE,
+      size: rendererConfig.size,
     },
     data: {
       pulseRate,

--- a/src/Components/VitalsMonitor/useVentilatorVitalsMonitor.ts
+++ b/src/Components/VitalsMonitor/useVentilatorVitalsMonitor.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import useCanvas from "../../Common/hooks/useCanvas";
 import {
   ChannelOptions,
-  IUseVitalsMonitorConfig,
+  IVitalsComponentProps,
   VitalsValueBase as VitalsValue,
 } from "./types";
 import VentilatorDeviceClient, {
@@ -13,13 +13,11 @@ import VentilatorVitalsRenderer from "./VentilatorWaveformsRenderer";
 import { getChannel, getVitalsCanvasSizeAndDuration } from "./utils";
 
 export default function useVentilatorVitalsMonitor(
-  config?: IUseVitalsMonitorConfig
+  config?: IVitalsComponentProps["config"]
 ) {
   const waveformForegroundCanvas = useCanvas();
   const waveformBackgroundCanvas = useCanvas();
-  const rendererConfig = getVitalsCanvasSizeAndDuration(
-    config?.wide ? 19 / 11 : undefined
-  );
+  const rendererConfig = config ?? getVitalsCanvasSizeAndDuration();
 
   // Non waveform data states.
   const [isOnline, setIsOnline] = useState<boolean>(false);

--- a/src/Components/VitalsMonitor/useVentilatorVitalsMonitor.ts
+++ b/src/Components/VitalsMonitor/useVentilatorVitalsMonitor.ts
@@ -1,30 +1,25 @@
 import { useCallback, useRef, useState } from "react";
 import useCanvas from "../../Common/hooks/useCanvas";
-import { ChannelOptions, VitalsValueBase as VitalsValue } from "./types";
+import {
+  ChannelOptions,
+  IUseVitalsMonitorConfig,
+  VitalsValueBase as VitalsValue,
+} from "./types";
 import VentilatorDeviceClient, {
   VentilatorData,
   VentilatorVitalsWaveformData,
 } from "./VentilatorDeviceClient";
 import VentilatorVitalsRenderer from "./VentilatorWaveformsRenderer";
-import { getChannel } from "./utils";
+import { getChannel, getVitalsCanvasSizeAndDuration } from "./utils";
 
-export const MONITOR_RATIO = {
-  w: 13,
-  h: 11,
-};
-const MONITOR_SCALE = 38;
-const MONITOR_WAVEFORMS_CANVAS_SIZE = {
-  width: MONITOR_RATIO.h * MONITOR_SCALE,
-  height: MONITOR_RATIO.h * MONITOR_SCALE,
-};
-// const MONITOR_SIZE = {
-//   width: MONITOR_RATIO.w * MONITOR_SCALE,
-//   height: MONITOR_RATIO.h * MONITOR_SCALE,
-// };
-
-export default function useVentilatorVitalsMonitor() {
+export default function useVentilatorVitalsMonitor(
+  config?: IUseVitalsMonitorConfig
+) {
   const waveformForegroundCanvas = useCanvas();
   const waveformBackgroundCanvas = useCanvas();
+  const rendererConfig = getVitalsCanvasSizeAndDuration(
+    config?.wide ? 19 / 11 : undefined
+  );
 
   // Non waveform data states.
   const [isOnline, setIsOnline] = useState<boolean>(false);
@@ -64,11 +59,11 @@ export default function useVentilatorVitalsMonitor() {
         renderer.current = new VentilatorVitalsRenderer({
           foregroundRenderContext: waveformForegroundCanvas.contextRef.current,
           backgroundRenderContext: waveformBackgroundCanvas.contextRef.current,
-          size: MONITOR_WAVEFORMS_CANVAS_SIZE,
           animationInterval: 50,
           pressure: pressureOptionsRef.current,
           flow: flowOptionsRef.current,
           volume: volumeOptionsRef.current,
+          ...rendererConfig,
         });
 
         const _renderer = renderer.current;
@@ -116,7 +111,7 @@ export default function useVentilatorVitalsMonitor() {
     waveformCanvas: {
       foreground: waveformForegroundCanvas,
       background: waveformBackgroundCanvas,
-      size: MONITOR_WAVEFORMS_CANVAS_SIZE,
+      size: rendererConfig.size,
     },
     data: {
       peep,

--- a/src/Components/VitalsMonitor/utils.ts
+++ b/src/Components/VitalsMonitor/utils.ts
@@ -52,12 +52,13 @@ export const getChannel = (observation: VitalsWaveformBase): ChannelOptions => {
 };
 
 const DEFAULT_RATIO = 13 / 11;
+const DEFAULT_DURATION = 7;
 const DEFAULT_SCALE = 38 * 11;
 
 /**
  * Returns the size of the canvas for the vitals monitor.
- * @param aspectRatio The aspect ratio of the canvas.
- * @param scale The scale of the canvas.
+ * @param aspectRatio The aspect ratio of the canvas. Defaults to 13:11.
+ * @param scale The scale of the canvas. Defaults to 38 * 11.
  * @returns The computed size of the canvas.
  */
 export const getVitalsCanvasSizeAndDuration = (
@@ -69,6 +70,6 @@ export const getVitalsCanvasSizeAndDuration = (
       width: scale * ratio,
       height: scale,
     },
-    duration: (7 * ratio) / DEFAULT_RATIO,
+    duration: DEFAULT_DURATION * (ratio / DEFAULT_RATIO),
   };
 };

--- a/src/Components/VitalsMonitor/utils.ts
+++ b/src/Components/VitalsMonitor/utils.ts
@@ -50,3 +50,25 @@ export const getChannel = (observation: VitalsWaveformBase): ChannelOptions => {
     highLimit: observation["data-high-limit"] ?? 0,
   };
 };
+
+const DEFAULT_RATIO = 13 / 11;
+const DEFAULT_SCALE = 38 * 11;
+
+/**
+ * Returns the size of the canvas for the vitals monitor.
+ * @param aspectRatio The aspect ratio of the canvas.
+ * @param scale The scale of the canvas.
+ * @returns The computed size of the canvas.
+ */
+export const getVitalsCanvasSizeAndDuration = (
+  ratio = DEFAULT_RATIO,
+  scale = DEFAULT_SCALE
+) => {
+  return {
+    size: {
+      width: scale * ratio,
+      height: scale,
+    },
+    duration: (7 * ratio) / DEFAULT_RATIO,
+  };
+};


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd23ceb</samp>

This pull request improves the responsiveness and adaptability of the vitals monitor components, which display real-time vital signs of patients in the facility. It refactors the code to use a common interface and a configuration prop for the vitals monitor components, and to use a variable duration for the waveform rendering. It also simplifies the code structure and removes redundant comments. It affects the following files: `src/Components/Facility/ConsultationDetails.tsx`, `src/Components/VitalsMonitor/*`, `src/Common/hooks/useBreakpoints.ts`, and `src/Common/hooks/useWindowDimensions.ts`.

## Proposed Changes

### ✅ Adds a utility hook: `useBreakpoints` to obtain value based on the current break-point.

Usage:

```jsx
const vitalsAspectRatio = useBreakpoints({
  default: 4/11,
  md: 8 / 11,
  lg: 15 / 11,
  xl: 13 / 11,
  "2xl": 19 / 11,
  "3xl": 23 / 11,
});

// vitalsAspectRatio holds the value of the current breakpoint based on the current window width.
```

### ✅ Made `duration` to be configurable for the Vitals Renderers.

### ✅ Added utility method to get canvas render's size and duration based (configurable)

https://github.com/coronasafe/care_fe/assets/25143503/188e8c5e-f53c-48db-9a86-e284f222c392

Closes #5726 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd23ceb</samp>

*  Add `useBreakpoints` hook to get the value mapped to the current breakpoint for the vitals monitor component ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-ec264d92a29007377252af3a689ca16dc0379a5bb5fe15c1217672c9c19f072cR1-R37), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR58-R59))
*  Move `useWindowDimensions` hook to `useBreakpoints` module and remove usage example ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-b69ab45bb977e385ff53e9cd25bf730aacb671d9cd5f43013e42039e255065e4L2-R16), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-b69ab45bb977e385ff53e9cd25bf730aacb671d9cd5f43013e42039e255065e4L25-R31))
*  Pass `config` prop to `HL7PatientVitalsMonitor` and `VentilatorPatientVitalsMonitor` components to configure the vitals monitor renderer and canvas ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR216-R227), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR565), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR574), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR581), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR590), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L9-R22), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L2-R23))
*  Remove `PatientAssetBed` import from `HL7PatientVitalsMonitor` and `VentilatorPatientVitalsMonitor` modules as it is imported from `types` module ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L3), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L2-R23))
*  Remove spread operator from `style` prop of `div` and `canvas` elements in `HL7PatientVitalsMonitor` and `VentilatorPatientVitalsMonitor` modules and use `waveformCanvas.size` object directly ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L95-R86), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L102-R93), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L115-R106), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L121-R112), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L96-R87), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L103-R94), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L115-R106), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L121-R112))
*  Add `duration` property to `Options` interface and `HL7VitalsRenderer` and `VentilatorVitalsRenderer` class constructors to pass the duration of each row on the canvas ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-563a63a4ebf010e7df62f37836ede2d175cc9f861ccd42a943df2f0225cb4538R51-R54), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-563a63a4ebf010e7df62f37836ede2d175cc9f861ccd42a943df2f0225cb4538R71), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-99e9ab948a27f127f10002d4e19b0f2733193adaec572e2b3cdb8b0f5456ca37R51-R54), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-99e9ab948a27f127f10002d4e19b0f2733193adaec572e2b3cdb8b0f5456ca37R71))
*  Replace `DURATION` constant with `duration` property in the calculation of `deltaX` property of each channel in `HL7VitalsRenderer` and `VentilatorVitalsRenderer` classes ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-563a63a4ebf010e7df62f37836ede2d175cc9f861ccd42a943df2f0225cb4538L80-R80), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-563a63a4ebf010e7df62f37836ede2d175cc9f861ccd42a943df2f0225cb4538L91-R91), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-563a63a4ebf010e7df62f37836ede2d175cc9f861ccd42a943df2f0225cb4538L102-R102), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-99e9ab948a27f127f10002d4e19b0f2733193adaec572e2b3cdb8b0f5456ca37L80-R80), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-99e9ab948a27f127f10002d4e19b0f2733193adaec572e2b3cdb8b0f5456ca37L91-R91), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-99e9ab948a27f127f10002d4e19b0f2733193adaec572e2b3cdb8b0f5456ca37L102-R102))
*  Remove `DURATION` constant from `HL7VitalsRenderer` and `VentilatorVitalsRenderer` modules as it is no longer needed ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-563a63a4ebf010e7df62f37836ede2d175cc9f861ccd42a943df2f0225cb4538L20-L24), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-99e9ab948a27f127f10002d4e19b0f2733193adaec572e2b3cdb8b0f5456ca37L20-L24))
*  Add `config` parameter to `useHL7VitalsMonitor` and `useVentilatorVitalsMonitor` hooks to pass the size and duration of the vitals monitor canvas ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-01ca34fd32f0d2eae4cc9bd85e5897fe2794c872b6901d8321cd337b56845a13L31-R26), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-01ca34fd32f0d2eae4cc9bd85e5897fe2794c872b6901d8321cd337b56845a13L76-R73), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-01ca34fd32f0d2eae4cc9bd85e5897fe2794c872b6901d8321cd337b56845a13L128-R121), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-8e70c8b8f56214c7702385e1da8b62ecc1188852bf6ce7e0d7c722405a568869L9-R20), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-8e70c8b8f56214c7702385e1da8b62ecc1188852bf6ce7e0d7c722405a568869L67-R64), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-8e70c8b8f56214c7702385e1da8b62ecc1188852bf6ce7e0d7c722405a568869L119-R112))
*  Replace `MONITOR_WAVEFORMS_CANVAS_SIZE` constant with `size` property of `config` parameter in the return value of `useHL7VitalsMonitor` and `useVentilatorVitalsMonitor` hooks ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-01ca34fd32f0d2eae4cc9bd85e5897fe2794c872b6901d8321cd337b56845a13L128-R121), [link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-8e70c8b8f56214c7702385e1da8b62ecc1188852bf6ce7e0d7c722405a568869L119-R112))
*  Add `IVitalsComponentProps` interface to `types` module to define the common props for the vitals monitor components ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-feda63a5a3cad0832ad09097bb20ec4786cf119d37354f99be40a385ab506f61R47-R52))
*  Import `PatientAssetBed` type and `getVitalsCanvasSizeAndDuration` function from `AssetTypes` and `utils` modules respectively in `types` module ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-feda63a5a3cad0832ad09097bb20ec4786cf119d37354f99be40a385ab506f61R1-R3))
*  Add `getVitalsCanvasSizeAndDuration` function to `utils` module to return the size and duration of the vitals monitor canvas based on the given aspect ratio and scale or the default values based on the window dimensions and breakpoints ([link](https://github.com/coronasafe/care_fe/pull/5976/files?diff=unified&w=0#diff-b7ec0fe0d0d57288cd732e381fb87cd1ba60eedd9bdfdea37fcda0e91d0d033bR53-R75))
