### PR TITLE
Minor changes in shifting form

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -864,7 +864,6 @@ export const FacilityCreate = (props: FacilityProps) => {
                     {...field("phone_number")}
                     label={t("emergency_contact_number")}
                     required
-                    disableCountry
                   />
                   <div className="grid grid-cols-1 gap-4 py-4 sm:grid-cols-2 md:col-span-2 xl:grid-cols-4">
                     <TextFormField

--- a/src/Components/Form/FormFields/PhoneNumberFormField.tsx
+++ b/src/Components/Form/FormFields/PhoneNumberFormField.tsx
@@ -26,7 +26,6 @@ const phoneCodes: Record<string, CountryData> = phoneCodesJson;
 interface Props extends FormFieldBaseProps<string> {
   placeholder?: string;
   autoComplete?: string;
-  disableCountry?: boolean;
   disableValidation?: boolean;
 }
 
@@ -96,42 +95,40 @@ export default function PhoneNumberFormField(props: Props) {
           )}
           maxLength={field.value?.startsWith("1800") ? 11 : 15}
           placeholder={props.placeholder}
-          value={formatPhoneNumber(field.value, props.disableCountry)}
+          value={formatPhoneNumber(field.value)}
           onChange={(e) => setValue(e.target.value)}
           disabled={field.disabled}
           onBlur={() => setError(validate(field.value, "blur"))}
         />
-        {!props.disableCountry && (
-          <div className="absolute inset-y-0 right-0 flex items-center">
-            <label htmlFor={field.id + "__country"} className="sr-only">
-              Country
-            </label>
-            <select
-              disabled={field.disabled}
-              id={field.id + "__country"}
-              name="country"
-              autoComplete="country"
-              className="cui-input-base h-full border-0 bg-transparent pl-2 pr-8 text-end font-medium tracking-wider text-gray-700 focus:ring-2 focus:ring-inset"
-              value={
-                asYouType.getCountry() ??
-                (field.value?.startsWith("1800") ? "1800" : "Other")
-              }
-              onChange={(e) => {
-                if (e.target.value === "1800") return setValue("1800");
-                if (e.target.value === "Other") return setValue("");
-                setValue(conditionPhoneCode(phoneCodes[e.target.value].code));
-              }}
-            >
-              {Object.entries(phoneCodes).map(([country, { flag }]) => (
-                <option key={country} value={country}>
-                  {flag} {country}
-                </option>
-              ))}
-              <option value="Other">Other</option>
-              <option value="1800">Support</option>
-            </select>
-          </div>
-        )}
+        <div className="absolute inset-y-0 right-0 flex items-center">
+          <label htmlFor={field.id + "__country"} className="sr-only">
+            Country
+          </label>
+          <select
+            disabled={field.disabled}
+            id={field.id + "__country"}
+            name="country"
+            autoComplete="country"
+            className="cui-input-base h-full border-0 bg-transparent pl-2 pr-8 text-end font-medium tracking-wider text-gray-700 focus:ring-2 focus:ring-inset"
+            value={
+              asYouType.getCountry() ??
+              (field.value?.startsWith("1800") ? "1800" : "Other")
+            }
+            onChange={(e) => {
+              if (e.target.value === "1800") return setValue("1800");
+              if (e.target.value === "Other") return setValue("");
+              setValue(conditionPhoneCode(phoneCodes[e.target.value].code));
+            }}
+          >
+            {Object.entries(phoneCodes).map(([country, { flag }]) => (
+              <option key={country} value={country}>
+                {flag} {country}
+              </option>
+            ))}
+            <option value="Other">Other</option>
+            <option value="1800">Support</option>
+          </select>
+        </div>
       </div>
     </FormField>
   );
@@ -142,12 +139,12 @@ const conditionPhoneCode = (code: string) => {
   return code.startsWith("+") ? code : "+" + code;
 };
 
-const formatPhoneNumber = (value: string, disableCountry?: boolean) => {
+const formatPhoneNumber = (value: string) => {
   if (value === undefined || value === null) {
-    return disableCountry ? "" : "+91 ";
+    return "+91 ";
   }
 
-  if (!isValidPhoneNumber(value) || disableCountry) {
+  if (!isValidPhoneNumber(value)) {
     return value;
   }
 

--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -272,15 +272,14 @@ export const ShiftCreate = (props: patientShiftProps) => {
       <Card className="mx-auto mt-4 flex w-full max-w-3xl flex-col px-8 py-5 md:px-16 md:py-11">
         <TextFormField
           {...field("refering_facility_contact_name")}
-          label="Contact person at the current facility"
+          label="Name of Contact person at the current facility"
           required
         />
 
         <PhoneNumberFormField
           {...field("refering_facility_contact_number")}
-          label="Contact person phone"
+          label="Contact person phone number"
           required
-          disableCountry
         />
 
         {wartime_shifting && (

--- a/src/Components/Resource/ResourceCreate.tsx
+++ b/src/Components/Resource/ResourceCreate.tsx
@@ -240,7 +240,6 @@ export default function ResourceCreate(props: resourceProps) {
           label={t("contact_phone")}
           name="refering_facility_contact_number"
           required
-          disableCountry
           value={state.form.refering_facility_contact_number}
           onChange={handleFormFieldChange}
           error={state.errors.refering_facility_contact_number}

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -722,7 +722,6 @@ export const UserAdd = (props: UserProps) => {
                 placeholder="Phone Number"
                 label="Phone Number"
                 required
-                disableCountry
               />
               <Checkbox
                 checked={state.form.phone_number_is_whatsapp}
@@ -741,7 +740,6 @@ export const UserAdd = (props: UserProps) => {
               placeholder="WhatsApp Phone Number"
               label="Whatsapp Number"
               disabled={state.form.phone_number_is_whatsapp}
-              disableCountry
             />
 
             <div>


### PR DESCRIPTION
…one number field

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a385a06</samp>

This pull request enables the country selector for phone number inputs in various forms throughout the application. This improves the consistency and usability of the phone number input component, and fixes the issue #1729 of inconsistent phone number formats for different countries. The pull request modifies the `PhoneNumberFormField` component and its usage in several files, such as `ShiftCreate.tsx`, `UserAdd.tsx`, `FacilityCreate.tsx`, and `ResourceCreate.tsx`.

## Proposed Changes

- Fixes #5943 
- Changed "Contact person at the current facility" to "Name of Contact person at the current facility"
- Changed "Contact person phone" to "Contact person phone number"
- Removed `disableCountry` prop from `PhoneNumberFormField`

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a385a06</samp>

*  Remove the `disableCountry` prop from the `PhoneNumberFormField` component and enable the country selector for the phone number inputs in various forms ([link](https://github.com/coronasafe/care_fe/pull/5978/files?diff=unified&w=0#diff-c1bd2754f233548fd1a6217ebe45fe603c71864f10c26f6350596f85b39e000cL867), [link](https://github.com/coronasafe/care_fe/pull/5978/files?diff=unified&w=0#diff-a3de35fe1ee44fd0ec04a82bf508c17c010278d094beb28630efc1264830d01eL29), [link](https://github.com/coronasafe/care_fe/pull/5978/files?diff=unified&w=0#diff-a3de35fe1ee44fd0ec04a82bf508c17c010278d094beb28630efc1264830d01eL99-R131), [link](https://github.com/coronasafe/care_fe/pull/5978/files?diff=unified&w=0#diff-a3de35fe1ee44fd0ec04a82bf508c17c010278d094beb28630efc1264830d01eL145-R147), [link](https://github.com/coronasafe/care_fe/pull/5978/files?diff=unified&w=0#diff-60a064d920f5f0359fb42250988ba67773d6bcf0e5e506b011ece11471ef740aL243), [link](https://github.com/coronasafe/care_fe/pull/5978/files?diff=unified&w=0#diff-61941d2843942da2640b50b54d0f8503484ec0a268e75b7962d90faf364d3827L725), [link](https://github.com/coronasafe/care_fe/pull/5978/files?diff=unified&w=0#diff-61941d2843942da2640b50b54d0f8503484ec0a268e75b7962d90faf364d3827L744)). This change affects the `FacilityCreate`, `ShiftCreate`, `ResourceCreate`, and `UserAdd` components in the `src/Components` directory, and is intended to resolve the issue #1729.
