### PR TITLE
Refactoring command.ts file

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,6 +1,6 @@
-import "cypress-localstorage-commands";
+// commands.ts
 
-import { Cypress, cy } from "local-cypress";
+import "cypress-localstorage-commands";
 
 Cypress.Commands.add("login", (username: string, password: string) => {
   cy.log(`Logging in the user: ${username}:${password}`);
@@ -22,11 +22,11 @@ Cypress.Commands.add("refreshApiLogin", (username, password) => {
     failOnStatusCode: false,
   }).then((response) => {
     if (response.status === 200) {
-      cy.writeFile("cypress/fixtures/token.json", {
+      cy.wrap({
         username: username,
         access: response.body.access,
         refresh: response.body.refresh,
-      });
+      }).as("authToken"); // Store the tokens as an alias for later use
       cy.setLocalStorage("care_access_token", response.body.access);
       cy.setLocalStorage("care_refresh_token", response.body.refresh);
     } else {
@@ -37,33 +37,55 @@ Cypress.Commands.add("refreshApiLogin", (username, password) => {
 
 Cypress.Commands.add("loginByApi", (username, password) => {
   cy.log(`Logging in the user: ${username}:${password}`);
-  cy.task("readFileMaybe", "cypress/fixtures/token.json").then(
-    (tkn: string) => {
-      const token = JSON.parse(tkn);
-      if (tkn && token.access && token.username === username) {
+
+  const loginAndSetTokens = () => {
+    // Log in the user and get the access and refresh tokens
+    cy.refreshApiLogin(username, password).then(() => {
+      cy.getLocalStorage("care_access_token").then((access) => {
+        cy.setLocalStorage("care_access_token", access);
+        cy.getLocalStorage("care_refresh_token").as("refreshToken"); // Store the refresh token as an alias for later use
+      });
+    });
+  };
+
+  // Check if the tokens exist in local storage and if they are valid
+  cy.getLocalStorage("care_access_token")
+    .then((access) => {
+      if (access) {
+        // If the access token exists, verify it with the server
         cy.request({
           method: "POST",
           url: "/api/v1/auth/token/verify/",
           body: {
-            token: token.access,
+            token: access,
           },
           headers: {
             "Content-Type": "application/json",
           },
           failOnStatusCode: false,
         }).then((response) => {
-          if (response.status === 200) {
-            cy.setLocalStorage("care_access_token", token.access);
-            cy.setLocalStorage("care_refresh_token", token.refresh);
-          } else {
-            cy.refreshApiLogin(username, password);
+          if (response.status === 403) {
+            // If the access token is invalid or expired, log in the user again
+            loginAndSetTokens();
+          } else if (response.status === 200) {
+            // If the access token is valid, set the tokens in local storage
+            cy.setLocalStorage("care_access_token", access);
+            cy.getLocalStorage("care_refresh_token").as("refreshToken"); // Store the refresh token as an alias for later use
           }
         });
       } else {
-        cy.refreshApiLogin(username, password);
+        // If the access token does not exist, log in the user
+        loginAndSetTokens();
       }
-    }
-  );
+    })
+    .then(() => {
+      // Set the refresh token from the alias to local storage
+      cy.get("@refreshToken").then((refresh) => {
+        if (refresh) {
+          cy.setLocalStorage("care_refresh_token", refresh);
+        }
+      });
+    });
 });
 
 Cypress.Commands.add(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2c79b0</samp>

Improves login commands in `commands.ts` for Cypress tests. Uses aliases and local storage to manage tokens and adds error handling for token expiration.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2c79b0</samp>

* Remove unnecessary import of Cypress and add comment with file name ([link](https://github.com/coronasafe/care_fe/pull/5979/files?diff=unified&w=0#diff-6c107e2390c5ad84e123f3be09d7b91ba35de8f8cc550d1f358c75806df47645L1-R4))
* Store tokens as alias instead of writing to file and use `cy.wrap` and `cy.as` to access them later ([link](https://github.com/coronasafe/care_fe/pull/5979/files?diff=unified&w=0#diff-6c107e2390c5ad84e123f3be09d7b91ba35de8f8cc550d1f358c75806df47645L25-R29))
* Refactor `loginByApi` command to use helper function `loginAndSetTokens` that performs login and sets tokens in local storage ([link](https://github.com/coronasafe/care_fe/pull/5979/files?diff=unified&w=0#diff-6c107e2390c5ad84e123f3be09d7b91ba35de8f8cc550d1f358c75806df47645L40-R60))
* Handle 403 status code in `loginByApi` command by refreshing tokens with `loginAndSetTokens` and sync refresh token from alias to local storage ([link](https://github.com/coronasafe/care_fe/pull/5979/files?diff=unified&w=0#diff-6c107e2390c5ad84e123f3be09d7b91ba35de8f8cc550d1f358c75806df47645L55-R88))
