### PR TITLE
Hide discharge file tab on patient page

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -308,7 +308,7 @@ export const FileUpload = (props: FileUploadProps) => {
         if (res?.data) {
           audio_urls(res.data.results);
           setuploadedUnarchievedFiles(
-            res.data.results.filter(
+            res?.data?.results?.filter(
               (file: FileUploadModel) =>
                 file.upload_completed || file.file_category === "AUDIO"
             )
@@ -332,26 +332,28 @@ export const FileUpload = (props: FileUploadProps) => {
         }
         setIsLoading(false);
       }
-      const dischargeSummaryFileData = {
-        file_type: "DISCHARGE_SUMMARY",
-        associating_id: getAssociatedId(),
-        is_archived: false,
-        limit: limit,
-        offset: offset,
-      };
-      res = await dispatch(viewUpload(dischargeSummaryFileData));
-      if (!status.aborted) {
-        if (res?.data) {
-          setuploadedDischargeSummaryFiles(res.data.results);
-          setTotalDischargeSummaryFilesCount(res.data.count);
-          if (res?.data?.results?.length > 0) {
-            setTabs([
-              ...tabs,
-              {
-                name: "Discharge Summary",
-                value: "DISCHARGE_SUMMARY",
-              },
-            ]);
+      if (type === "CONSULTATION") {
+        const dischargeSummaryFileData = {
+          file_type: "DISCHARGE_SUMMARY",
+          associating_id: getAssociatedId(),
+          is_archived: false,
+          limit: limit,
+          offset: offset,
+        };
+        res = await dispatch(viewUpload(dischargeSummaryFileData));
+        if (!status.aborted) {
+          if (res?.data) {
+            setuploadedDischargeSummaryFiles(res.data.results);
+            setTotalDischargeSummaryFilesCount(res.data.count);
+            if (res?.data?.results?.length > 0) {
+              setTabs([
+                ...tabs,
+                {
+                  name: "Discharge Summary",
+                  value: "DISCHARGE_SUMMARY",
+                },
+              ]);
+            }
           }
         }
         setIsLoading(false);
@@ -1571,7 +1573,7 @@ export const FileUpload = (props: FileUploadProps) => {
         {sortFileState === "UNARCHIVED" ? (
           // First it would check the filtered array contains any files or not else it would state the message
           <>
-            {uploadedUnarchievedFiles.length > 0 ? (
+            {uploadedUnarchievedFiles?.length > 0 ? (
               uploadedUnarchievedFiles.map((item: FileUploadModel) =>
                 renderFileUpload(item)
               )
@@ -1596,7 +1598,7 @@ export const FileUpload = (props: FileUploadProps) => {
         ) : sortFileState === "ARCHIVED" ? (
           // First it would check the filtered array contains any files or not else it would state the message
           <>
-            {uploadedArchievedFiles.length > 0 ? (
+            {uploadedArchievedFiles?.length > 0 ? (
               uploadedArchievedFiles.map((item: FileUploadModel) =>
                 renderFileUpload(item)
               )


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5640e03</samp>

This pull request enhances the file upload component for patient files by preventing errors and unnecessary actions. It uses `?.` operators and a `file_type` check in `src/Components/Patient/FileUpload.tsx`.

## Proposed Changes

- Fixes #5986 
![image](https://github.com/coronasafe/care_fe/assets/3626859/5c6dcf3a-e7d7-4b83-8c41-0b98352779f3)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5640e03</samp>

*  Add optional chaining operators to prevent errors from undefined or null values in API responses and state variables ([link](https://github.com/coronasafe/care_fe/pull/5988/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L311-R311), [link](https://github.com/coronasafe/care_fe/pull/5988/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1574-R1576), [link](https://github.com/coronasafe/care_fe/pull/5988/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1599-R1601))
*  Add condition to dispatch `viewUpload` action only for consultation files and avoid unnecessary API calls and rendering of discharge summary tab ([link](https://github.com/coronasafe/care_fe/pull/5988/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L335-R356))
