### PR TITLE
add option to manually specify regenerate summary request

### DIFF
--- a/src/Components/Facility/DischargeSummaryModal.tsx
+++ b/src/Components/Facility/DischargeSummaryModal.tsx
@@ -167,16 +167,13 @@ export default function DischargeSummaryModal(props: Props) {
           onChange={(e) => setEmail(e.value)}
           error={emailError}
         />
-        <div className="mt-6">
-          {!props.consultation.discharge_date && (
-            <CheckBoxFormField
-              name="regenDischargeSummary"
-              className="flex-1"
-              label={"Regenerate discharge summary"}
-              onChange={(e) => setRegenDischargeSummary(e.value)}
-            />
-          )}
-        </div>
+        {!props.consultation.discharge_date && (
+          <CheckBoxFormField
+            name="regenDischargeSummary"
+            label={"Regenerate discharge summary"}
+            onChange={(e) => setRegenDischargeSummary(e.value)}
+          />
+        )}
         <div className="flex flex-col-reverse gap-2 lg:flex-row lg:justify-end">
           <Cancel onClick={props.onClose} />
           <Submit onClick={handleDownload} disabled={downloading}>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a5b38f</samp>

This change enhances the discharge summary modal feature by adding a `regenerate` option and improving the UI and logic. This allows the user to update the discharge summary with the latest data and preview it before downloading it. The change affects the file `src/Components/Facility/DischargeSummaryModal.tsx`.

## Proposed Changes

- Fixes #5971

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a5b38f</samp>

*  Add a checkbox input to the discharge summary modal to allow the user to regenerate the discharge summary ([link](https://github.com/coronasafe/care_fe/pull/5989/files?diff=unified&w=0#diff-39335d35e610da8e2fd6d2725736effd21d866256bfb88da465ca8ebb60a4105R20), [link](https://github.com/coronasafe/care_fe/pull/5989/files?diff=unified&w=0#diff-39335d35e610da8e2fd6d2725736effd21d866256bfb88da465ca8ebb60a4105L140-R180))
*  Define new state variable and functions to handle the regeneration and preview of the discharge summary ([link](https://github.com/coronasafe/care_fe/pull/5989/files?diff=unified&w=0#diff-39335d35e610da8e2fd6d2725736effd21d866256bfb88da465ca8ebb60a4105L35-R50), [link](https://github.com/coronasafe/care_fe/pull/5989/files?diff=unified&w=0#diff-39335d35e610da8e2fd6d2725736effd21d866256bfb88da465ca8ebb60a4105L64-R116))
*  Modify the existing `handleDownload` function to check the user's choice and call the appropriate function ([link](https://github.com/coronasafe/care_fe/pull/5989/files?diff=unified&w=0#diff-39335d35e610da8e2fd6d2725736effd21d866256bfb88da465ca8ebb60a4105L45-R68), [link](https://github.com/coronasafe/care_fe/pull/5989/files?diff=unified&w=0#diff-39335d35e610da8e2fd6d2725736effd21d866256bfb88da465ca8ebb60a4105L64-R116))
*  Refactor the existing logic of generating and previewing the discharge summary into a new function `downloadDischargeSummary` ([link](https://github.com/coronasafe/care_fe/pull/5989/files?diff=unified&w=0#diff-39335d35e610da8e2fd6d2725736effd21d866256bfb88da465ca8ebb60a4105L64-R116))
