### PR TITLE
Disable editing category from consultation form if a daily round exists

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -218,6 +218,7 @@ export const ConsultationForm = (props: any) => {
   const [consultationDetailsVisible, consultationDetailsRef] = useVisibility();
   const [diagnosisVisible, diagnosisRef] = useVisibility(-300);
   const [treatmentPlanVisible, treatmentPlanRef] = useVisibility(-300);
+  const [disabledFields, setDisabledFields] = useState<string[]>([]);
 
   const sections = {
     "Consultation Details": {
@@ -327,6 +328,10 @@ export const ConsultationForm = (props: any) => {
           };
           dispatch({ type: "set_form", form: formData });
           setBed(formData.bed);
+
+          if (res.data.last_daily_round) {
+            setDisabledFields((fields) => [...fields, "category"]);
+          }
         } else {
           goBack();
         }
@@ -774,6 +779,7 @@ export const ConsultationForm = (props: any) => {
       value: (state.form as any)[name],
       error: (state.errors as any)[name],
       onChange: handleFormFieldChange,
+      disabled: disabledFields.includes(name),
     };
   };
 
@@ -963,6 +969,13 @@ export const ConsultationForm = (props: any) => {
                   {String(state.form.consultation_status) !== "1" && (
                     <div className="col-span-6" ref={fieldRef["category"]}>
                       <PatientCategorySelect
+                        labelSuffix={
+                          disabledFields.includes("category") && (
+                            <p className="text-xs font-medium text-warning-500">
+                              A daily round already exists.
+                            </p>
+                          )
+                        }
                         required
                         label="Category"
                         {...field("category")}
@@ -977,8 +990,8 @@ export const ConsultationForm = (props: any) => {
                     <SelectFormField
                       required
                       label="Decision after consultation"
-                      disabled={String(state.form.consultation_status) === "1"}
                       {...selectField("suggestion")}
+                      disabled={String(state.form.consultation_status) === "1"}
                       options={CONSULTATION_SUGGESTION.filter(
                         ({ deprecated }) => !deprecated
                       )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0b26b8</samp>

This pull request improves the user experience and data consistency of the consultation form by disabling irrelevant or redundant fields based on the consultation state and the `daily_round` data. It also provides feedback to the user about why the `category` field is disabled.

## Proposed Changes

- Fixes #5990 

<img width="369" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/4330a1be-8af9-4a89-acdb-52061258ae7e">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0b26b8</samp>

*  Introduce `disabledFields` state variable to store form fields that should be disabled ([link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR221))
*  Disable `category` field if consultation has a last daily round ([link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR331-R334), [link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR972-R978), [link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL980-R994))
*  Disable `suggestion` field if consultation status is 1 ([link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR782), [link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL980-R994))
*  Add warning message to `category` field label if disabled ([link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR972-R978))
*  Reorder props for `suggestion` field to avoid overwriting `disabled` prop ([link](https://github.com/coronasafe/care_fe/pull/5993/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL980-R994))
