### PR TITLE
added negative doctor count check for facility 

### DIFF
--- a/src/Components/Facility/DoctorCapacity.tsx
+++ b/src/Components/Facility/DoctorCapacity.tsx
@@ -131,6 +131,10 @@ export const DoctorCapacity = (props: DoctorCapacityProps) => {
         errors[field] = "Field is required";
         invalidForm = true;
       }
+      if (field === "count" && state.form[field] < 0) {
+        errors[field] = "Doctor count cannot be negative";
+        invalidForm = true;
+      }
     });
     if (invalidForm) {
       dispatch({ type: "set_error", errors });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de5ad67</samp>

Validate `count` field in `DoctorCapacity` form. This change prevents negative values for the number of doctors in a facility in `src/Components/Facility/DoctorCapacity.tsx`.

## Proposed Changes

- Fixes #5996 
http://localhost:4000/facility/657c32be-d584-476c-9ce2-0412f0e7692e
Show error when user tries to give a negative value for the doctor count for a facility.
![image](https://github.com/coronasafe/care_fe/assets/70687348/8e713df8-a970-4d75-be46-8a13462c0459)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de5ad67</samp>

* Add a validation check for the `count` field of the `DoctorCapacity` form to prevent negative values ([link](https://github.com/coronasafe/care_fe/pull/5997/files?diff=unified&w=0#diff-6ecf3e8854de3cbfb407d68fad0e6a0c43d2aee9ae994fef7832c3b5ac60a2f5R134-R137))
* Display an error message and mark the form as invalid if the `count` value is negative ([link](https://github.com/coronasafe/care_fe/pull/5997/files?diff=unified&w=0#diff-6ecf3e8854de3cbfb407d68fad0e6a0c43d2aee9ae994fef7832c3b5ac60a2f5R134-R137))
