### PR TITLE
Fix vitals non-waveform content overflow

### DIFF
--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -114,7 +114,7 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
             />
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-x-8 gap-y-4 divide-blue-600 bg-[#020617] tracking-wider text-white md:inset-y-0 md:right-0 md:grid-cols-1 md:gap-0 md:divide-y">
+        <VitalsNonWaveformContent>
           {/* Pulse Rate */}
           <NonWaveformData
             label="ECG"
@@ -196,11 +196,21 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
               </div>
             </div>
           </div>
-        </div>
+        </VitalsNonWaveformContent>
       </div>
     </div>
   );
 }
+
+export const VitalsNonWaveformContent = ({
+  children,
+}: {
+  children: JSX.Element | JSX.Element[];
+}) => (
+  <div className="grid grid-cols-2 gap-x-8 gap-y-4 divide-blue-600 bg-[#020617] tracking-wider text-white md:absolute md:inset-y-0 md:right-0 md:grid-cols-1 md:gap-0 md:divide-y">
+    {children}
+  </div>
+);
 
 interface NonWaveformDataProps {
   label: string;

--- a/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/VentilatorPatientVitalsMonitor.tsx
@@ -6,6 +6,7 @@ import useVentilatorVitalsMonitor from "./useVentilatorVitalsMonitor";
 import { IVitalsComponentProps, VitalsValueBase } from "./types";
 import { classNames } from "../../Utils/utils";
 import WaveformLabels from "./WaveformLabels";
+import { VitalsNonWaveformContent } from "./HL7PatientVitalsMonitor";
 
 export default function VentilatorPatientVitalsMonitor(
   props: IVitalsComponentProps
@@ -114,7 +115,7 @@ export default function VentilatorPatientVitalsMonitor(
             />
           </div>
         </div>
-        <div className="grid grid-cols-3 divide-blue-600 bg-[#020617] tracking-wider text-white md:inset-y-0 md:right-0 md:grid-cols-1 md:divide-y">
+        <VitalsNonWaveformContent>
           <NonWaveformData
             label="PEEP"
             attr={data.peep}
@@ -135,7 +136,7 @@ export default function VentilatorPatientVitalsMonitor(
             attr={data.fio2}
             className="text-yellow-300"
           />
-        </div>
+        </VitalsNonWaveformContent>
       </div>
     </div>
   );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 164545f</samp>

The pull request adds a new component `VitalsNonWaveformContent` to display non-waveform vitals data for HL7 and ventilator patients. It also refactors the `VentilatorPatientVitalsMonitor` component to use the new component and improve code reusability.

## Proposed Changes

- Fix vitals non-waveform content overflow

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/5fb5b1b0-f964-4f6a-a144-a22ae07c93eb">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 164545f</samp>

*  Extract a custom component `VitalsNonWaveformContent` from the `div` element that contains the non-waveform vitals data in the HL7 patient vitals monitor component ([link](https://github.com/coronasafe/care_fe/pull/6002/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L117-R117), [link](https://github.com/coronasafe/care_fe/pull/6002/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L199-R199), [link](https://github.com/coronasafe/care_fe/pull/6002/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8R205-R214))
* Import and use the `VitalsNonWaveformContent` component in the ventilator patient vitals monitor component to avoid code duplication and improve readability ([link](https://github.com/coronasafe/care_fe/pull/6002/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441R9), [link](https://github.com/coronasafe/care_fe/pull/6002/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L117-R118), [link](https://github.com/coronasafe/care_fe/pull/6002/files?diff=unified&w=0#diff-bb12f370b6b547e3f616f017db12154d62c12ee2d7e84c31776068752c1f5441L138-R139))
