### PR TITLE
fixed tooltip visibility in mobile view

### DIFF
--- a/src/CAREUI/display/RecordMeta.tsx
+++ b/src/CAREUI/display/RecordMeta.tsx
@@ -26,7 +26,7 @@ const RecordMeta = ({ time, user, prefix, className }: Props) => {
   let child = (
     <div className="tooltip">
       <span className="underline">{relativeTime}</span>
-      <span className="tooltip-text flex -translate-x-1/3 gap-1 text-xs font-medium tracking-wider">
+      <span className="tooltip-text flex gap-1 text-xs font-medium tracking-wider">
         {moment(time).format("hh:mm A; DD/MM/YYYY")}
         {user && (
           <>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93ab453</samp>

Fixed tooltip text alignment in `RecordMeta.tsx`. Removed a CSS class that was causing the text to be offset from the underline element.

## Proposed Changes

- Fixes #5891 
- Tooltip now properly visible on mobile view

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
