### PR TITLE
Add plausible goals to track user actions

### DIFF
--- a/src/Components/Common/Plausible.tsx
+++ b/src/Components/Common/Plausible.tsx
@@ -13,7 +13,7 @@ export default function Plausible() {
     <Script
       defer
       data-domain={site_url}
-      src={`${analytics_server_url}/js/script.manual.js`}
+      src={`${analytics_server_url}/js/script.tagged-events.js`}
     />
   );
 }
@@ -44,4 +44,9 @@ const triggerPageView = () => {
 
   // Send the pageview event to Plausible
   plausible("pageview", { u: redactedUrl });
+};
+
+export const triggerGoal = (name: string, props: any) => {
+  const plausible = (window as any).plausible;
+  plausible(name, { props });
 };

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -52,11 +52,12 @@ import { formatDate } from "../../Utils/utils";
 import loadable from "@loadable/component";
 import moment from "moment";
 import { navigate } from "raviger";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
 import useBreakpoints from "../../Common/hooks/useBreakpoints";
 import { getVitalsCanvasSizeAndDuration } from "../VitalsMonitor/utils";
+import { triggerGoal } from "../Common/Plausible";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -100,6 +101,8 @@ export const ConsultationDetails = (props: any) => {
   const [ventilatorSocketUrl, setVentilatorSocketUrl] = useState<string>();
   const [monitorBedData, setMonitorBedData] = useState<AssetBedModel>();
   const [ventilatorBedData, setVentilatorBedData] = useState<AssetBedModel>();
+  const state: any = useSelector((state) => state);
+  const { currentUser } = state;
 
   useEffect(() => {
     if (
@@ -211,6 +214,12 @@ export const ConsultationDetails = (props: any) => {
 
   useAbortableEffect((status: statusType) => {
     fetchData(status);
+    triggerGoal("ConsultationView", {
+      facilityId: facilityId,
+      patientId: patientId,
+      consultationId: consultationId,
+      userID: currentUser.data.id,
+    });
   }, []);
 
   const vitalsAspectRatio = useBreakpoints({
@@ -324,7 +333,16 @@ export const ConsultationDetails = (props: any) => {
                   Shift Patient
                 </ButtonV2>
                 <button
-                  onClick={() => setShowDoctors(true)}
+                  onClick={() => {
+                    triggerGoal("DoctorConnectClick", {
+                      consultationId,
+                      facilityId: patientData.facility,
+                      patientId: patientData.id,
+                      userId: currentUser.data.id,
+                      page: "ConsultationDetails",
+                    });
+                    setShowDoctors(true);
+                  }}
                   className="btn btn-primary m-1 w-full hover:text-white"
                 >
                   Doctor Connect

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -26,10 +26,11 @@ import FeedButton from "./FeedButton";
 import Loading from "../../Common/Loading";
 import ReactPlayer from "react-player";
 import { classNames } from "../../../Utils/utils";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useHLSPLayer } from "../../../Common/hooks/useHLSPlayer";
 import useKeyboardShortcut from "use-keyboard-shortcut";
 import useFullscreen from "../../../Common/hooks/useFullscreen.js";
+import { triggerGoal } from "../../Common/Plausible.js";
 
 interface IFeedProps {
   facilityId: string;
@@ -38,7 +39,11 @@ interface IFeedProps {
 }
 const PATIENT_DEFAULT_PRESET = "Patient View".trim().toLowerCase();
 
-export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
+export const Feed: React.FC<IFeedProps> = ({
+  patientId,
+  consultationId,
+  facilityId,
+}) => {
   const dispatch: any = useDispatch();
 
   const videoWrapper = useRef<HTMLDivElement>(null);
@@ -55,6 +60,8 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
   const [precision, setPrecision] = useState(1);
   const [cameraState, setCameraState] = useState<PTZState | null>(null);
   const [isFullscreen, setFullscreen] = useFullscreen();
+  const state: any = useSelector((state) => state);
+  const { currentUser } = state;
 
   useEffect(() => {
     const fetchFacility = async () => {
@@ -381,6 +388,13 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
                       console.log(
                         "onSuccess: Set Preset to " + preset?.meta?.preset_name
                       );
+                      triggerGoal("CameraPresetClick", {
+                        presetName: preset?.meta?.preset_name,
+                        consultationId,
+                        patientId,
+                        userId: currentUser?.id,
+                        result: "success",
+                      });
                     },
                     onError: () => {
                       setLoading(CAMERA_STATES.IDLE);
@@ -388,6 +402,13 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
                       console.log(
                         "onError: Set Preset to " + preset?.meta?.preset_name
                       );
+                      triggerGoal("CameraPresetClick", {
+                        presetName: preset?.meta?.preset_name,
+                        consultationId,
+                        patientId,
+                        userId: currentUser?.id,
+                        result: "error",
+                      });
                     },
                   });
                   getCameraStatus({});
@@ -531,6 +552,13 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
                   camProp={button}
                   styleType="BUTTON"
                   clickAction={() => {
+                    triggerGoal("CameraFeedMove", {
+                      direction: button.action,
+                      consultationId,
+                      patientId,
+                      userId: currentUser?.id,
+                    });
+
                     button.callback();
                     if (cameraState) {
                       let x = cameraState.x;

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -41,10 +41,11 @@ import loadable from "@loadable/component";
 import moment from "moment";
 import { parseOptionId } from "../../Common/utils";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import useFilters from "../../Common/hooks/useFilters";
 import { useTranslation } from "react-i18next";
 import Page from "../Common/components/Page.js";
+import { triggerGoal } from "../Common/Plausible.js";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -97,6 +98,8 @@ export const PatientManager = () => {
   const [selectedFacility, setSelectedFacility] = useState<FacilityModel>({
     name: "",
   });
+  const state: any = useSelector((state) => state);
+  const { currentUser } = state;
   const [showDialog, setShowDialog] = useState(false);
   const [showDoctors, setShowDoctors] = useState(false);
   const [showDoctorConnect, setShowDoctorConnect] = useState(false);
@@ -763,6 +766,11 @@ export const PatientManager = () => {
             {showDoctorConnect && (
               <ButtonV2
                 onClick={() => {
+                  triggerGoal("DoctorConnectClick", {
+                    facilityId: qParams.facility,
+                    userId: currentUser.data.id,
+                    page: "FacilityPatientsList",
+                  });
                   setShowDoctors(true);
                 }}
               >

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -6,12 +6,27 @@ import CareIcon from "../../CAREUI/icons/CareIcon";
 import WaveformLabels from "./WaveformLabels";
 import { classNames } from "../../Utils/utils";
 import { IVitalsComponentProps, VitalsValueBase } from "./types";
+import { triggerGoal } from "../Common/Plausible";
+import { useSelector } from "react-redux";
 
 export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
   const { connect, waveformCanvas, data, isOnline } = useHL7VitalsMonitor(
     props.config
   );
   const { patient, bed, asset } = props.patientAssetBed ?? {};
+  const state: any = useSelector((state) => state);
+  const { currentUser } = state;
+
+  useEffect(() => {
+    if (isOnline) {
+      triggerGoal("DeviceView", {
+        patientId: patient?.id,
+        bedId: bed?.id,
+        assetId: asset?.id,
+        userId: currentUser?.id,
+      });
+    }
+  }, [isOnline]);
 
   useEffect(() => {
     connect(props.socketUrl);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 304ceb8</samp>

This pull request adds Plausible analytics to several components in the frontend application. It uses a custom script and a `triggerGoal` function to send events and user data to the analytics server. It also refactors some components to use react-redux hooks to access the user data from the store. The components affected are `Plausible`, `ConsultationDetails`, `Feed`, `PatientManager`, and `HL7PatientVitalsMonitor`.

## Proposed Changes

- Add goal tracking for Plausible Analytics

goalID|props|props|props|props|props
-- | -- | -- | -- | -- | --
CameraPresetClick | presetName | patientId | consultationId | result={success/error} | userId
CameraFeedMove |   | patientId | consultationId | direction={left/right/up/down} | userId
DoctorConnectClick | facilityId | patientId | consultationId (if page == ConsultationDetails) | page = {ConsultationDetails/FacilityPatientsList} | userId
ConsultationView | facilityId | patientId | consultationId |   | userId
DeviceView | bedId | patientId | assetId |   | userId


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 304ceb8</samp>

*  Change the script source for the Plausible analytics service to use a custom script that supports tagged events ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29L16-R16))
* Add a new function `triggerGoal` to the Plausible component that wraps the window.plausible function and sends custom events to the analytics server ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29R48-R52))
  - Viewing consultation details ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR217-R222))
  - Clicking on the button to connect with a doctor from the consultation details or the patient list ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL327-R345), [link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R769-R773))
  - Selecting or failing to select a camera preset in the feed component ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R391-R397), [link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R405-R411))
  - Moving the camera feed using the arrow buttons ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R555-R561))
  - Viewing the device and the vitals monitor when the device is online ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L15-R31))
  - `ConsultationDetails.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL55-R60), [link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR104-R105))
  - `Feed.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L29-R33), [link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L41-R46), [link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R63-R64))
  - `ManagePatients.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L44-R48), [link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R101-R102))
  - `HL7PatientVitalsMonitor.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6013/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8R9-R10))
