### PR TITLE
Change goal names for plausible tracking

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -214,7 +214,7 @@ export const ConsultationDetails = (props: any) => {
 
   useAbortableEffect((status: statusType) => {
     fetchData(status);
-    triggerGoal("ConsultationView", {
+    triggerGoal("Patient Consultation Viewed", {
       facilityId: facilityId,
       patientId: patientId,
       consultationId: consultationId,
@@ -334,7 +334,7 @@ export const ConsultationDetails = (props: any) => {
                 </ButtonV2>
                 <button
                   onClick={() => {
-                    triggerGoal("DoctorConnectClick", {
+                    triggerGoal("Doctor Connect Clicked", {
                       consultationId,
                       facilityId: patientData.facility,
                       patientId: patientData.id,

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -388,7 +388,7 @@ export const Feed: React.FC<IFeedProps> = ({
                       console.log(
                         "onSuccess: Set Preset to " + preset?.meta?.preset_name
                       );
-                      triggerGoal("CameraPresetClick", {
+                      triggerGoal("Camera Preset Clicked", {
                         presetName: preset?.meta?.preset_name,
                         consultationId,
                         patientId,
@@ -402,7 +402,7 @@ export const Feed: React.FC<IFeedProps> = ({
                       console.log(
                         "onError: Set Preset to " + preset?.meta?.preset_name
                       );
-                      triggerGoal("CameraPresetClick", {
+                      triggerGoal("Camera Preset Clicked", {
                         presetName: preset?.meta?.preset_name,
                         consultationId,
                         patientId,
@@ -552,7 +552,7 @@ export const Feed: React.FC<IFeedProps> = ({
                   camProp={button}
                   styleType="BUTTON"
                   clickAction={() => {
-                    triggerGoal("CameraFeedMove", {
+                    triggerGoal("Camera Feed Moved", {
                       direction: button.action,
                       consultationId,
                       patientId,

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -766,7 +766,7 @@ export const PatientManager = () => {
             {showDoctorConnect && (
               <ButtonV2
                 onClick={() => {
-                  triggerGoal("DoctorConnectClick", {
+                  triggerGoal("Doctor Connect Clicked", {
                     facilityId: qParams.facility,
                     userId: currentUser.data.id,
                     page: "FacilityPatientsList",

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -31,6 +31,7 @@ import CircularProgress from "../Common/components/CircularProgress";
 import Page from "../Common/components/Page";
 import ConfirmDialog from "../Common/ConfirmDialog";
 import UserAutocompleteFormField from "../Common/UserAutocompleteFormField";
+import { triggerGoal } from "../Common/Plausible";
 
 const Loading = loadable(() => import("../Common/Loading"));
 
@@ -222,6 +223,11 @@ export const PatientHome = (props: any) => {
   useAbortableEffect(
     (status: statusType) => {
       fetchpatient(status);
+      triggerGoal("Patient Consultation Viewed", {
+        facilityId: facilityId,
+        patientId: patientData.id,
+        userID: currentUser.data.id,
+      });
     },
     [dispatch, fetchpatient]
   );

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -223,7 +223,7 @@ export const PatientHome = (props: any) => {
   useAbortableEffect(
     (status: statusType) => {
       fetchpatient(status);
-      triggerGoal("Patient Consultation Viewed", {
+      triggerGoal("Patient Profile Viewed", {
         facilityId: facilityId,
         patientId: patientData.id,
         userID: currentUser.data.id,

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -19,7 +19,7 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
 
   useEffect(() => {
     if (isOnline) {
-      triggerGoal("DeviceView", {
+      triggerGoal("Device Viewed", {
         patientId: patient?.id,
         bedId: bed?.id,
         assetId: asset?.id,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdc8b72</samp>

This pull request updates the goal names and file locations for some analytics events related to patient consultations, patient profiles, doctor connect, and device view. These changes improve the clarity, consistency, and organization of the analytics code and data.

## Proposed Changes

- Changes the goal names to be more human readable.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fdc8b72</samp>

*  Change goal names for tracking events to make them more consistent and descriptive ([link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL217-R217), [link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL337-R337), [link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L391-R391), [link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L405-R405), [link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L555-R555), [link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L769-R769), [link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L22-R22))
*  Move `Feed` component from `src/Components/Facility/Consultations/Feed.tsx` to `src/Components/Facility/ConsultationDetails.tsx` to reflect the change in the component structure ([link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L391-R391), [link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L405-R405))
*  Import `triggerGoal` function from `src/Components/Common/Plausible.ts` to `src/Components/Patient/PatientHome.tsx` to enable tracking the patient profile view event ([link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fR34))
*  Add goal name for tracking the patient profile view event as "Patient Profile Viewed" with the relevant parameters in `src/Components/Patient/PatientHome.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6017/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fR226-R230))
