### PR TITLE
fix no data issue in notice borad on hard reload

### DIFF
--- a/src/Components/Notifications/NoticeBoard.tsx
+++ b/src/Components/Notifications/NoticeBoard.tsx
@@ -16,7 +16,10 @@ export const NoticeBoard = () => {
   useEffect(() => {
     setIsLoading(true);
     dispatch(
-      getNotifications({ offset: 0, event: "MESSAGE", medium_sent: "SYSTEM" })
+      getNotifications(
+        { offset: 0, event: "MESSAGE", medium_sent: "SYSTEM" },
+        new Date().getTime().toString()
+      )
     )
       .then((res: any) => {
         if (res && res.data) {

--- a/src/Components/Notifications/NoticeBoard.tsx
+++ b/src/Components/Notifications/NoticeBoard.tsx
@@ -7,7 +7,7 @@ import { formatDate } from "../../Utils/utils";
 import { useTranslation } from "react-i18next";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 
-export const NoticeBoard: any = () => {
+export const NoticeBoard = () => {
   const dispatch: any = useDispatch();
   const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState<any[]>([]);

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -684,14 +684,8 @@ export const partialUpdateExternalResult = (id: number, params: object) => {
 };
 
 // Notifications
-export const getNotifications = (params: object) => {
-  return fireRequest(
-    "getNotifications",
-    [],
-    params,
-    {},
-    new Date().getTime().toString()
-  );
+export const getNotifications = (params: object, altKey?: string) => {
+  return fireRequest("getNotifications", [], params, {}, altKey);
 };
 
 export const getNotificationData = (pathParam: object) => {

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -685,7 +685,13 @@ export const partialUpdateExternalResult = (id: number, params: object) => {
 
 // Notifications
 export const getNotifications = (params: object) => {
-  return fireRequest("getNotifications", [], params);
+  return fireRequest(
+    "getNotifications",
+    [],
+    params,
+    {},
+    new Date().getTime().toString()
+  );
 };
 
 export const getNotificationData = (pathParam: object) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e537978</samp>

This pull request improves the `NoticeBoard` component by using a regular function instead of a type declaration, and fixes the caching issue of the `getNotifications` action by passing a timestamp as the cache key. These changes enhance the code quality and the user experience of the notifications feature.

## Proposed Changes

- Fixes #3449 
- fix no data issue in notice borad on hard reload


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e537978</samp>

*  Invalidate cache and fetch latest notifications by passing timestamp to `fireRequest` ([link](https://github.com/coronasafe/care_fe/pull/6025/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eL688-R694))
* Simplify `NoticeBoard` component by using regular function instead of type declaration ([link](https://github.com/coronasafe/care_fe/pull/6025/files?diff=unified&w=0#diff-33552eee109f3cbc88f165a1053317d2af34c789d901afe14c866b5d1977a144L10-R10))
