### PR TITLE
Central Nursing Station: Dynamic aspect ratio for Vitals (variable timespan based on screen size 📱🖥️)

### DIFF
--- a/src/Common/hooks/useBreakpoints.ts
+++ b/src/Common/hooks/useBreakpoints.ts
@@ -33,7 +33,5 @@ export default function useBreakpoints<T>(
     return acc;
   }, "default" as Breakpoints);
 
-  console.log("breakpoint", breakpoint);
-
   return map[breakpoint] ?? map.default;
 }

--- a/src/Common/hooks/useBreakpoints.ts
+++ b/src/Common/hooks/useBreakpoints.ts
@@ -33,5 +33,7 @@ export default function useBreakpoints<T>(
     return acc;
   }, "default" as Breakpoints);
 
+  console.log("breakpoint", breakpoint);
+
   return map[breakpoint] ?? map.default;
 }

--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -23,6 +23,7 @@ import CheckBoxFormField from "../Form/FormFields/CheckBoxFormField";
 import { useTranslation } from "react-i18next";
 import { SortOption } from "../Common/SortDropdown";
 import { SelectFormField } from "../Form/FormFields/SelectFormField";
+import useVitalsAspectRatioConfig from "../VitalsMonitor/useVitalsAspectRatioConfig";
 
 const PER_PAGE_LIMIT = 6;
 
@@ -116,6 +117,17 @@ export default function CentralNursingStation({ facilityId }: Props) {
     qParams.ordering,
     qParams.bed_is_occupied,
   ]);
+
+  const { config, hash } = useVitalsAspectRatioConfig({
+    default: 6 / 11,
+    vs: 10 / 11,
+    sm: 17 / 11,
+    md: 19 / 11,
+    lg: 11 / 11,
+    xl: 13 / 11,
+    "2xl": 16 / 11,
+    "3xl": 12 / 11,
+  });
 
   return (
     <Page
@@ -257,12 +269,13 @@ export default function CentralNursingStation({ facilityId }: Props) {
           No Vitals Monitor present in this location or facility.
         </div>
       ) : (
-        <div className="mt-1 grid grid-cols-1 gap-1 xl:grid-cols-2 3xl:grid-cols-3">
+        <div className="mt-1 grid grid-cols-1 gap-1 lg:grid-cols-2 3xl:grid-cols-3">
           {data.map((props) => (
-            <div className="text-clip">
+            <div className="overflow-hidden text-clip">
               <HL7PatientVitalsMonitor
-                key={props.patientAssetBed?.bed.id}
+                key={`${props.patientAssetBed?.bed.id}-${hash}`}
                 {...props}
+                config={config}
               />
             </div>
           ))}

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -54,9 +54,8 @@ import { navigate } from "raviger";
 import { useDispatch, useSelector } from "react-redux";
 import { useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
-import useBreakpoints from "../../Common/hooks/useBreakpoints";
-import { getVitalsCanvasSizeAndDuration } from "../VitalsMonitor/utils";
 import { triggerGoal } from "../Common/Plausible";
+import useVitalsAspectRatioConfig from "../VitalsMonitor/useVitalsAspectRatioConfig";
 
 const Loading = loadable(() => import("../Common/Loading"));
 const PageTitle = loadable(() => import("../Common/PageTitle"));
@@ -221,7 +220,7 @@ export const ConsultationDetails = (props: any) => {
     });
   }, []);
 
-  const vitalsAspectRatio = useBreakpoints({
+  const vitals = useVitalsAspectRatioConfig({
     default: undefined,
     md: 8 / 11,
     lg: 15 / 11,
@@ -229,9 +228,6 @@ export const ConsultationDetails = (props: any) => {
     "2xl": 19 / 11,
     "3xl": 23 / 11,
   });
-
-  const vitalsConfig = getVitalsCanvasSizeAndDuration(vitalsAspectRatio);
-  const vitalsConfigHash = JSON.stringify(vitalsConfig);
 
   if (isLoading) {
     return <Loading />;
@@ -579,7 +575,7 @@ export const ConsultationDetails = (props: any) => {
                             {hl7SocketUrl && (
                               <div className="min-h-[400px] flex-1">
                                 <HL7PatientVitalsMonitor
-                                  key={`hl7-${hl7SocketUrl}-${vitalsConfigHash}`}
+                                  key={`hl7-${hl7SocketUrl}-${vitals.hash}`}
                                   patientAssetBed={{
                                     asset:
                                       monitorBedData?.asset_object as AssetData,
@@ -588,14 +584,14 @@ export const ConsultationDetails = (props: any) => {
                                     meta: monitorBedData?.asset_object?.meta,
                                   }}
                                   socketUrl={hl7SocketUrl}
-                                  config={vitalsConfig}
+                                  config={vitals.config}
                                 />
                               </div>
                             )}
                             {ventilatorSocketUrl && (
                               <div className="min-h-[400px] flex-1">
                                 <VentilatorPatientVitalsMonitor
-                                  key={`ventilator-${ventilatorSocketUrl}-${vitalsConfigHash}`}
+                                  key={`ventilator-${ventilatorSocketUrl}-${vitals.hash}`}
                                   patientAssetBed={{
                                     asset:
                                       ventilatorBedData?.asset_object as AssetData,
@@ -604,7 +600,7 @@ export const ConsultationDetails = (props: any) => {
                                     meta: ventilatorBedData?.asset_object?.meta,
                                   }}
                                   socketUrl={ventilatorSocketUrl}
-                                  config={vitalsConfig}
+                                  config={vitals.config}
                                 />
                               </div>
                             )}

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -51,42 +51,36 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
               </span>
             )}
             {patient && (
-              <span className="text-sm font-bold text-gray-400">
+              <span className="text-xs font-bold text-gray-400 md:text-sm">
                 {patient.age}y;{" "}
                 {GENDER_TYPES.find((g) => g.id === patient.gender)?.icon}
               </span>
             )}
           </div>
-          <div className="flex gap-3">
+          <div className="flex items-center gap-3 text-xs md:text-sm">
             {asset && (
-              <div className="flex items-center gap-2 text-sm">
-                <Link
-                  className="flex gap-2 text-gray-500"
-                  href={`/facility/${patient?.facility_object?.id}/assets/${asset?.id}`}
-                >
-                  <span className="flex items-center gap-1">
-                    <CareIcon className="care-l-monitor-heart-rate text-base" />
-                    {asset.name}
-                  </span>
-                </Link>
-              </div>
+              <Link
+                className="flex items-center gap-1 text-gray-500"
+                href={`/facility/${patient?.facility_object?.id}/assets/${asset?.id}`}
+              >
+                <CareIcon className="care-l-monitor-heart-rate text-sm md:text-base" />
+                <span>{asset.name}</span>
+              </Link>
             )}
             {bed && (
-              <div className="flex items-center gap-2 text-sm">
-                <Link
-                  className="flex gap-2 text-gray-500"
-                  href={`/facility/${patient?.facility_object?.id}/location/${bed?.location_object?.id}/beds`}
-                >
-                  <span className="flex items-center gap-1">
-                    <CareIcon className="care-l-bed text-base" />
-                    {bed.name}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <CareIcon className="care-l-location-point text-base" />
-                    {bed.location_object?.name}
-                  </span>
-                </Link>
-              </div>
+              <Link
+                className="flex items-center gap-2 text-gray-500"
+                href={`/facility/${patient?.facility_object?.id}/location/${bed?.location_object?.id}/beds`}
+              >
+                <span className="flex items-center gap-1">
+                  <CareIcon className="care-l-bed text-sm md:text-base" />
+                  <span>{bed.name}</span>
+                </span>
+                <span className="flex items-center gap-1">
+                  <CareIcon className="care-l-location-point text-sm md:text-base" />
+                  <span>{bed.location_object?.name}</span>
+                </span>
+              </Link>
             )}
           </div>
         </div>

--- a/src/Components/VitalsMonitor/useVitalsAspectRatioConfig.ts
+++ b/src/Components/VitalsMonitor/useVitalsAspectRatioConfig.ts
@@ -1,0 +1,13 @@
+import useBreakpoints from "../../Common/hooks/useBreakpoints";
+import { getVitalsCanvasSizeAndDuration } from "./utils";
+
+export default function useVitalsAspectRatioConfig(
+  breakpointsMap: Parameters<typeof useBreakpoints<number | undefined>>[0]
+) {
+  const vitalsAspectRatio = useBreakpoints(breakpointsMap);
+
+  const config = getVitalsCanvasSizeAndDuration(vitalsAspectRatio);
+  const hash = JSON.stringify(config);
+
+  return { config, hash };
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32c56e3</samp>

This pull request enhances the responsiveness and layout of the vitals monitor components in the facility views. It introduces a new custom hook `useVitalsAspectRatioConfig` that calculates the optimal configuration based on the screen size and aspect ratio. It also refactors and updates the existing components that use the vitals monitor to leverage the new hook. It also adds a console log statement for debugging purposes.

## Proposed Changes

- Central Nursing Station: Dynamic aspect ratio for Vitals (variable timespan based on screen size)
- Fixed waveform overflow in mobile view

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32c56e3</samp>

*  Add a custom hook `useVitalsAspectRatioConfig` to calculate the optimal configuration for the vitals monitor based on the screen size and aspect ratio ([link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-256715a409e98c5fa8292122707fee36f11bd6c058e4b7c27667cab8866d7523R1-R13))
*  Use the `useVitalsAspectRatioConfig` hook in the `CentralNursingStation` component and pass the `config` and `hash` values to the `HL7PatientVitalsMonitor` component props ([link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-95b57b1137a563f4d92c994d950f87bc81e4a3eb129066d34a3c851d58c3609dR26), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-95b57b1137a563f4d92c994d950f87bc81e4a3eb129066d34a3c851d58c3609dR121-R131), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-95b57b1137a563f4d92c994d950f87bc81e4a3eb129066d34a3c851d58c3609dL260-R278))
*  Use the `useVitalsAspectRatioConfig` hook in the `ConsultationDetails` component and pass the `config` and `hash` values to the `HL7PatientVitalsMonitor` and `VentilatorPatientVitalsMonitor` component props ([link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL57-R58), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL224-R223), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL233-L235), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL582-R578), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL591-R587), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL598-R594), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL607-R603))
*  Remove the unused imports of `useBreakpoints` and `getVitalsCanvasSizeAndDuration` from the `ConsultationDetails` component ([link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL57-R58))
*  Modify the font size and layout of the patient age, gender, asset, and bed links in the `HL7PatientVitalsMonitor` component to improve responsiveness and readability ([link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L54-R54), [link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L60-R83))
*  Add a console log statement to the `useBreakpoints` hook to debug the current breakpoint value ([link](https://github.com/coronasafe/care_fe/pull/6036/files?diff=unified&w=0#diff-ec264d92a29007377252af3a689ca16dc0379a5bb5fe15c1217672c9c19f072cR36-R37))
