### PR TITLE
Fix Triage table width when no data is available

### DIFF
--- a/src/Components/Common/components/Table.tsx
+++ b/src/Components/Common/components/Table.tsx
@@ -4,20 +4,16 @@ export default function Table(props: {
 }) {
   return (
     <div
-      className="gap-3"
+      className="grid min-w-[1000px] gap-3 overflow-x-auto"
       style={{
-        display: "grid",
         gridTemplateRows: `repeat(${props.rows.length + 1}, minmax(0, 1fr))`,
-        overflowX: "auto",
-        minWidth: "1000px",
       }}
     >
       <div
+        className="grid h-fit rounded-sm border border-[#D2D6DC]"
         style={{
-          display: "grid",
           gridTemplateColumns: `repeat(${props.headings.length}, minmax(0, 1fr))`,
         }}
-        className="h-fit rounded-sm border border-[#D2D6DC]"
       >
         {props.headings.map((heading, i) => {
           if (i === 0) {
@@ -28,7 +24,10 @@ export default function Table(props: {
             );
           }
           return (
-            <div className="flex min-w-[24px] items-center justify-center py-[14px] text-center text-sm font-medium text-[#808080]">
+            <div
+              className="flex min-w-[24px] items-center justify-center py-[14px] text-center text-sm font-medium text-[#808080]"
+              key={heading}
+            >
               {heading}
             </div>
           );
@@ -38,13 +37,10 @@ export default function Table(props: {
       {props.rows.map((row) => {
         return (
           <div
+            className="grid min-w-[1000px] overflow-x-auto rounded-sm border border-[#D2D6DC]"
             style={{
-              display: "grid",
               gridTemplateColumns: `repeat(${props.headings.length}, minmax(0, 1fr))`,
-              overflowX: "auto",
-              minWidth: "1000px",
             }}
-            className="rounded-sm border border-[#D2D6DC]"
           >
             {row.map((item, i) => {
               if (i === 0) {

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -728,12 +728,12 @@ export const FacilityHome = (props: any) => {
               ]}
             />
             {stats.length === 0 && (
-              <div>
+              <>
                 <hr />
-                <div className="mt-3 flex items-center justify-center rounded-sm border border-[#D2D6DC] p-4 text-xl font-bold text-gray-600">
+                <div className="mt-3 flex min-w-[1000px] items-center justify-center rounded-sm border border-[#D2D6DC] p-4 text-xl font-bold text-gray-600">
                   No Data Found
                 </div>
-              </div>
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a842eed</samp>

Improved the table component and its usage in the facility home page. Refactored the code to use Tailwind CSS and React best practices, and fixed the layout of the "No Data Found" message.

## Proposed Changes

- Fixes #6040
![image](https://github.com/coronasafe/care_fe/assets/3626859/629bed56-903a-446b-863a-f80444caa78a)
![image](https://github.com/coronasafe/care_fe/assets/3626859/74ed7466-fce5-4e1a-a733-4875ced21844)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a842eed</samp>

*  Simplify `style` props of `div` elements in `Table` component using Tailwind CSS classes ([link](https://github.com/coronasafe/care_fe/pull/6042/files?diff=unified&w=0#diff-cdfebcda0aebfa93a1d0bb9cfb2cc0ed10d842aa98df2d7df0d574afd80f136cL7-R16), [link](https://github.com/coronasafe/care_fe/pull/6042/files?diff=unified&w=0#diff-cdfebcda0aebfa93a1d0bb9cfb2cc0ed10d842aa98df2d7df0d574afd80f136cL31-R30), [link](https://github.com/coronasafe/care_fe/pull/6042/files?diff=unified&w=0#diff-cdfebcda0aebfa93a1d0bb9cfb2cc0ed10d842aa98df2d7df0d574afd80f136cL41-R43))
*  Add `key` prop to `div` element that renders each heading in `Table` component ([link](https://github.com/coronasafe/care_fe/pull/6042/files?diff=unified&w=0#diff-cdfebcda0aebfa93a1d0bb9cfb2cc0ed10d842aa98df2d7df0d574afd80f136cL31-R30))
*  Adjust `min-width` of "No Data Found" message in `Table` component to match table width ([link](https://github.com/coronasafe/care_fe/pull/6042/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cL731-R736))
