### PR TITLE
Adds utility CSS class `cui-form-button-group`; Fix button responsiveness in Doctor and Bed capacity forms

### DIFF
--- a/src/Components/Facility/BedCapacity.tsx
+++ b/src/Components/Facility/BedCapacity.tsx
@@ -281,26 +281,21 @@ export const BedCapacity = (props: BedCapacityProps) => {
               max={state.form.totalCapacity}
             />
           </div>
-          <div>
-            <div className="mt-4 flex flex-col items-end justify-between gap-4 md:flex-row">
-              <div className="w-full md:w-auto">
-                <Cancel onClick={handleClose} />
-              </div>
-              <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row">
-                {!isLastOptionType && headerText === "Add Bed Capacity" && (
-                  <Submit
-                    id="bed-capacity-save-and-exit"
-                    onClick={(e) => handleSubmit(e, "Save and Exit")}
-                    label="Save Bed Capacity"
-                  />
-                )}
-                <Submit
-                  id="bed-capacity-save"
-                  onClick={(e) => handleSubmit(e)}
-                  label={buttonText}
-                />
-              </div>
-            </div>
+
+          <div className="cui-form-button-group mt-4">
+            <Cancel onClick={handleClose} />
+            {!isLastOptionType && headerText === "Add Bed Capacity" && (
+              <Submit
+                id="bed-capacity-save-and-exit"
+                onClick={(e) => handleSubmit(e, "Save and Exit")}
+                label="Save Bed Capacity"
+              />
+            )}
+            <Submit
+              id="bed-capacity-save"
+              onClick={(e) => handleSubmit(e)}
+              label={buttonText}
+            />
           </div>
         </div>
       )}

--- a/src/Components/Facility/DoctorCapacity.tsx
+++ b/src/Components/Facility/DoctorCapacity.tsx
@@ -81,7 +81,7 @@ export const DoctorCapacity = (props: DoctorCapacityProps) => {
             const updatedDoctorTypes = initDoctorTypes.map(
               (type: OptionsType) => {
                 const isExisting = existingData.find(
-                  (i: DoctorModal) => i.area === type.idnpm
+                  (i: DoctorModal) => i.area === type.id
                 );
                 return {
                   ...type,

--- a/src/Components/Facility/DoctorCapacity.tsx
+++ b/src/Components/Facility/DoctorCapacity.tsx
@@ -81,7 +81,7 @@ export const DoctorCapacity = (props: DoctorCapacityProps) => {
             const updatedDoctorTypes = initDoctorTypes.map(
               (type: OptionsType) => {
                 const isExisting = existingData.find(
-                  (i: DoctorModal) => i.area === type.id
+                  (i: DoctorModal) => i.area === type.idnpm
                 );
                 return {
                   ...type,
@@ -249,30 +249,16 @@ export const DoctorCapacity = (props: DoctorCapacityProps) => {
               min={0}
             />
           </div>
-          <div>
-            <div className="mt-4 flex flex-col justify-between md:flex-row">
-              <div className="mt-2 flex w-full flex-row gap-4 sm:w-auto">
-                <Cancel onClick={() => handleClose()} />
-              </div>
-              <div className="mt-2 flex w-full flex-row flex-wrap gap-2 sm:w-auto">
-                {!isLastOptionType && headerText === "Add Doctor Capacity" && (
-                  <ButtonV2
-                    id="save-and-exit"
-                    onClick={handleSubmit}
-                    className="w-full"
-                  >
-                    Save Doctor Capacity
-                  </ButtonV2>
-                )}
-                <ButtonV2
-                  id="doctor-save"
-                  onClick={handleSubmit}
-                  className="w-full"
-                >
-                  {buttonText}
-                </ButtonV2>
-              </div>
-            </div>
+          <div className="cui-form-button-group mt-4">
+            <Cancel onClick={() => handleClose()} />
+            {!isLastOptionType && headerText === "Add Doctor Capacity" && (
+              <ButtonV2 id="save-and-exit" onClick={handleSubmit}>
+                Save Doctor Capacity
+              </ButtonV2>
+            )}
+            <ButtonV2 id="doctor-save" onClick={handleSubmit}>
+              {buttonText}
+            </ButtonV2>
           </div>
         </div>
       )}

--- a/src/style/CAREUI.css
+++ b/src/style/CAREUI.css
@@ -164,3 +164,7 @@ button.button-warning-ghost { @apply enabled:hover:bg-warning-100 }
 
 button.button-alert-default { @apply enabled:hover:bg-alert-500 }
 button.button-alert-ghost { @apply enabled:hover:bg-alert-100 }
+
+.cui-form-button-group {
+    @apply flex flex-col-reverse md:flex-row md:justify-end gap-2 w-full md:w-auto
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c153b8b</samp>

This pull request fixes a bug in the doctor capacity form, refactors the button styles for the bed and doctor capacity forms, and adds a custom CSS class for the button layout. These changes improve the data accuracy, the user interface, and the code quality of the facility management feature.

## Proposed Changes

- Fixes #6038
- Adds utility CSS class `cui-form-button-group`
- Fix button responsiveness in **Doctor and Bed capacity** forms

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c153b8b</samp>

*  Fix typo in finding doctor capacity data by area ([link](https://github.com/coronasafe/care_fe/pull/6046/files?diff=unified&w=0#diff-6ecf3e8854de3cbfb407d68fad0e6a0c43d2aee9ae994fef7832c3b5ac60a2f5L84-R84))
*  Refactor button rendering in bed and doctor capacity forms to use custom CSS class `cui-form-button-group` ([link](https://github.com/coronasafe/care_fe/pull/6046/files?diff=unified&w=0#diff-ca49d2c12115053a336cf12a96437c052fbf2467d342662e0ae8417ba1c7b13aL284-R298), [link](https://github.com/coronasafe/care_fe/pull/6046/files?diff=unified&w=0#diff-6ecf3e8854de3cbfb407d68fad0e6a0c43d2aee9ae994fef7832c3b5ac60a2f5L252-R261))
*  Add `cui-form-button-group` class definition to `src/style/CAREUI.css` file ([link](https://github.com/coronasafe/care_fe/pull/6046/files?diff=unified&w=0#diff-745b128294a716ac5806ad2ce4bc1537c4205eb3a906d1d28f1b56d30db09eb5L167-R169))
