### PR TITLE
Fix camera controls overlap with notifications

### DIFF
--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -504,7 +504,7 @@ export const Feed: React.FC<IFeedProps> = ({
             </div>
           )}
         </div>
-        <div className="absolute right-8 top-8 z-20 flex flex-col gap-4">
+        <div className="absolute right-8 top-8 z-10 flex flex-col gap-4">
           {["fullScreen", "reset", "updatePreset", "zoomIn", "zoomOut"].map(
             (button, index) => {
               const option = cameraPTZ.find(
@@ -524,7 +524,7 @@ export const Feed: React.FC<IFeedProps> = ({
             <FeedCameraPTZHelpButton cameraPTZ={cameraPTZ} />
           </div>
         </div>
-        <div className="absolute bottom-8 right-8 z-20">
+        <div className="absolute bottom-8 right-8 z-10">
           <FeedButton
             camProp={cameraPTZ[4]}
             styleType="CHHOTUBUTTON"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7cdb95</samp>

Fixed a UI bug in the `Feed` component that caused some buttons to obscure modal dialog and other elements. Adjusted the z-index of the buttons in `src/Components/Facility/Consultations/Feed.tsx`.

## Proposed Changes

- Fixes #6055
![image](https://github.com/coronasafe/care_fe/assets/3626859/36002c08-fd37-4509-9253-aa2aaa7eba9c)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7cdb95</samp>

*  Lower the z-index of the divs containing the camera control buttons to prevent overlap with the modal dialog ([link](https://github.com/coronasafe/care_fe/pull/6057/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L507-R507), [link](https://github.com/coronasafe/care_fe/pull/6057/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L527-R527)) in `Feed.tsx`
