### PR TITLE
Center align tooltip of `RecordMeta` relative time

### DIFF
--- a/src/CAREUI/display/RecordMeta.tsx
+++ b/src/CAREUI/display/RecordMeta.tsx
@@ -22,7 +22,7 @@ const RecordMeta = ({ time, user, prefix, className }: Props) => {
   let child = (
     <div className="tooltip">
       <span className="underline">{relativeTime(time)}</span>
-      <span className="tooltip-text flex gap-1 text-xs font-medium tracking-wider">
+      <span className="tooltip-text tooltip-bottom flex -translate-x-1/2 gap-1 text-xs font-medium tracking-wider">
         {formatDateTime(time)}
         {user && (
           <>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2eb7d6d</samp>

Improved the tooltip display for record metadata in `RecordMeta.tsx`. Added CSS classes to adjust the tooltip placement and avoid overlap with the text.

## Proposed Changes

- Fixes #6062 

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/db819987-42a9-4d5b-84ea-2f509d52daa9">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2eb7d6d</samp>

*  Adjust the tooltip position and alignment for the record date and time ([link](https://github.com/coronasafe/care_fe/pull/6063/files?diff=unified&w=0#diff-f0d2ab732677f4577c5beaba451e232beca423da2365428db6644c199008447cL25-R25))
