### PR TITLE
Increase default limit for doctor connect list

### DIFF
--- a/src/Components/Facility/DoctorVideoSlideover.tsx
+++ b/src/Components/Facility/DoctorVideoSlideover.tsx
@@ -19,7 +19,9 @@ export default function DoctorVideoSlideover(props: {
   useEffect(() => {
     const fetchUsers = async () => {
       if (facilityId) {
-        const res = await dispatchAction(getFacilityUsers(facilityId));
+        const res = await dispatchAction(
+          getFacilityUsers(facilityId, { limit: 50 })
+        );
         if (res && res.data) {
           setDoctors(
             res.data.results
@@ -72,7 +74,7 @@ export default function DoctorVideoSlideover(props: {
           </div>
 
           <ul
-            className="max-h-96 scroll-py-3 list-none overflow-y-auto"
+            className="max-h-96 scroll-py-3 list-none overflow-y-auto py-3"
             id="options"
             role="listbox"
           >


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a409e52</samp>

Enhanced the video call feature for doctors by fetching more users and improving the user selection UI in `DoctorVideoSlideover.tsx`.

## Proposed Changes

- Fixes #6056
![image](https://github.com/coronasafe/care_fe/assets/3626859/650cd98b-5546-42a0-9a13-94bd16cfefdc)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a409e52</samp>

*  Modify `getFacilityUsers` action to accept pagination options and increase the limit to 50 ([link](https://github.com/coronasafe/care_fe/pull/6065/files?diff=unified&w=0#diff-f15a132265ab339453f06bc7dc6b773802090dfba335c46051a309b512de2060L22-R24))
*  Add padding to the `ul` element in the doctor video slideover component for better appearance and usability ([link](https://github.com/coronasafe/care_fe/pull/6065/files?diff=unified&w=0#diff-f15a132265ab339453f06bc7dc6b773802090dfba335c46051a309b512de2060L75-R77))
