### PR TITLE
Placed Non-waveform data above waveforms in mobile view

### DIFF
--- a/src/Components/Assets/AssetType/HL7Monitor.tsx
+++ b/src/Components/Assets/AssetType/HL7Monitor.tsx
@@ -115,7 +115,7 @@ const HL7Monitor = (props: HL7MonitorProps) => {
               </div>
             </form>
           </Card>
-          <Card>
+          <Card className="z-20">
             {["HL7MONITOR", "VENTILATOR"].includes(assetType) && (
               <MonitorConfigure asset={asset as AssetData} />
             )}

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -85,44 +85,7 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
           </div>
         </div>
       )}
-      <div className="relative flex flex-col gap-2 divide-x-0 divide-y divide-blue-600 md:flex-row md:justify-between md:divide-x md:divide-y-0">
-        <div>
-          <div
-            className={classNames(
-              "flex flex-col items-center justify-center gap-1 p-1 text-center font-mono font-medium text-warning-500",
-              isOnline && "hidden"
-            )}
-            style={waveformCanvas.size}
-          >
-            <CareIcon className="care-l-cloud-times mb-2 animate-pulse text-4xl" />
-            <span className="font-bold">No incoming data from HL7 Monitor</span>
-          </div>
-          <div
-            className={classNames("relative", !isOnline && "hidden")}
-            style={waveformCanvas.size}
-          >
-            <WaveformLabels
-              labels={{
-                ECG: "text-lime-300",
-                ECG_CHANNEL_2: "invisible",
-                Pleth: "text-yellow-300",
-                Resp: "text-sky-300",
-              }}
-            />
-            <canvas
-              className="absolute left-0 top-0"
-              ref={waveformCanvas.background.canvasRef}
-              style={waveformCanvas.size}
-              {...waveformCanvas.size}
-            />
-            <canvas
-              className="absolute left-0 top-0"
-              ref={waveformCanvas.foreground.canvasRef}
-              style={waveformCanvas.size}
-              {...waveformCanvas.size}
-            />
-          </div>
-        </div>
+      <div className="relative flex flex-col gap-2 md:flex-row md:justify-between">
         <VitalsNonWaveformContent>
           {/* Pulse Rate */}
           <NonWaveformData
@@ -206,6 +169,43 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
             </div>
           </div>
         </VitalsNonWaveformContent>
+        <div>
+          <div
+            className={classNames(
+              "flex flex-col items-center justify-center gap-1 p-1 text-center font-mono font-medium text-warning-500",
+              isOnline && "hidden"
+            )}
+            style={waveformCanvas.size}
+          >
+            <CareIcon className="care-l-cloud-times mb-2 animate-pulse text-4xl" />
+            <span className="font-bold">No incoming data from HL7 Monitor</span>
+          </div>
+          <div
+            className={classNames("relative", !isOnline && "hidden")}
+            style={waveformCanvas.size}
+          >
+            <WaveformLabels
+              labels={{
+                ECG: "text-lime-300",
+                ECG_CHANNEL_2: "invisible",
+                Pleth: "text-yellow-300",
+                Resp: "text-sky-300",
+              }}
+            />
+            <canvas
+              className="absolute left-0 top-0"
+              ref={waveformCanvas.background.canvasRef}
+              style={waveformCanvas.size}
+              {...waveformCanvas.size}
+            />
+            <canvas
+              className="absolute left-0 top-0"
+              ref={waveformCanvas.foreground.canvasRef}
+              style={waveformCanvas.size}
+              {...waveformCanvas.size}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -216,7 +216,7 @@ export const VitalsNonWaveformContent = ({
 }: {
   children: JSX.Element | JSX.Element[];
 }) => (
-  <div className="grid grid-cols-2 gap-x-8 gap-y-4 divide-blue-600 bg-[#020617] tracking-wider text-white md:absolute md:inset-y-0 md:right-0 md:grid-cols-1 md:gap-0 md:divide-y">
+  <div className="z-10 grid grid-cols-2 gap-x-8 gap-y-4 divide-blue-600 border-b border-blue-600 bg-[#020617] tracking-wider text-white md:absolute md:inset-y-0 md:right-0 md:grid-cols-1 md:gap-0 md:divide-y md:border-b-0 md:border-l">
     {children}
   </div>
 );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b90d4f</samp>

This pull request improves the user interface and performance of the HL7 monitor, a component that shows vital signs from external devices. It extracts the waveform rendering logic into a `WaveformCanvas` component and updates the styling and layout of the other vitals. It also fixes a z-index issue with the `MonitorConfigure` component by adding a `className` prop to the `Card` component in `HL7Monitor.tsx`.

## Proposed Changes

- Fixes #5984 
- Placed VitalsNonWaveformContent component before the waveform so that it is placed on top in mobile view
- Adjusted the border widths and color accordingly

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b90d4f</samp>

* Extract the waveform logic from `HL7PatientVitalsMonitor` component into a reusable `WaveformCanvas` component ([link](https://github.com/coronasafe/care_fe/pull/6066/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L88-R88))
* Use the `WaveformCanvas` component in the `HL7Monitor` component to render the waveform and the offline message ([link](https://github.com/coronasafe/care_fe/pull/6066/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8R172-R208))
* Adjust the styling and layout of the non-waveform vitals in the `VitalsNonWaveformContent` component to match the design and the waveform canvas ([link](https://github.com/coronasafe/care_fe/pull/6066/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L219-R219))
* Increase the z-index of the `Card` component that wraps the `MonitorConfigure` component in the `AssetType` component to avoid overlapping with the waveform canvas ([link](https://github.com/coronasafe/care_fe/pull/6066/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL118-R118))
