### PR TITLE
Added padding to count card on patients page

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -853,13 +853,13 @@ export const PatientManager = () => {
 
       <div className="manualGrid my-4 mb-[-12px] mt-5 grid-cols-1 gap-3 px-2 sm:grid-cols-4 md:px-0">
         <div className="mt-2 flex h-full flex-col gap-3 xl:flex-row">
-          <div className="flex-1 pb-10">
+          <div className="flex-1">
             <CountBlock
               text="Total Patients"
               count={totalCount}
               loading={isLoading}
               icon="l-user-injured"
-              className="flex-1"
+              className="pb-12"
             />
           </div>
         </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ebfa6e</samp>

Adjusted the layout of the patient manager page to improve the appearance of the `CountBlock` components. Modified the `div` element and the `CountBlock` component in `src/Components/Patient/ManagePatients.tsx`.

## Proposed Changes

- Fixes #6047
- Added bottom padding to count card

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
@rithviknishad
