### PR TITLE
Plausible: Redact IDs in goal urls and removed patient id from goal trigger props

### DIFF
--- a/src/Components/Common/Plausible.tsx
+++ b/src/Components/Common/Plausible.tsx
@@ -18,7 +18,7 @@ export default function Plausible() {
     <Script
       defer
       data-domain={site_url}
-      src={`${analytics_server_url}/js/script.tagged-events.js`}
+      src={`${analytics_server_url}/js/script.manual.tagged-events.js`}
     />
   );
 }

--- a/src/Components/Common/Plausible.tsx
+++ b/src/Components/Common/Plausible.tsx
@@ -18,6 +18,9 @@ export default function Plausible() {
     <Script
       defer
       data-domain={site_url}
+      // To add another extension, combine the extension using dots. Refer: https://plausible.io/docs/script-extensions#you-can-combine-extensions-according-to-your-needs
+      // Do not accidentally remove existing extensions.
+      // `manual` extension is used for the URL to be overridden. See https://plausible.io/docs/script-extensions#scriptmanualjs
       src={`${analytics_server_url}/js/script.manual.tagged-events.js`}
     />
   );

--- a/src/Components/Common/Plausible.tsx
+++ b/src/Components/Common/Plausible.tsx
@@ -1,3 +1,4 @@
+import { useLocationChange } from "raviger";
 import useConfig from "../../Common/hooks/useConfig";
 import Script from "./Script";
 import { useEffect } from "react";
@@ -5,9 +6,13 @@ import { useEffect } from "react";
 export default function Plausible() {
   const { site_url, analytics_server_url } = useConfig();
 
+  useLocationChange(() => {
+    plausible("pageview");
+  });
+
   useEffect(() => {
     plausible("pageview");
-  }, [window.location.href]);
+  }, []);
 
   return (
     <Script

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -214,7 +214,6 @@ export const ConsultationDetails = (props: any) => {
     fetchData(status);
     triggerGoal("Patient Consultation Viewed", {
       facilityId: facilityId,
-      patientId: patientId,
       consultationId: consultationId,
       userID: currentUser.data.id,
     });
@@ -332,7 +331,6 @@ export const ConsultationDetails = (props: any) => {
                     triggerGoal("Doctor Connect Clicked", {
                       consultationId,
                       facilityId: patientData.facility,
-                      patientId: patientData.id,
                       userId: currentUser.data.id,
                       page: "ConsultationDetails",
                     });
@@ -1122,11 +1120,7 @@ export const ConsultationDetails = (props: any) => {
               hideBack={true}
               focusOnLoad={true}
             />
-            <Feed
-              facilityId={facilityId}
-              patientId={patientId}
-              consultationId={consultationId}
-            />
+            <Feed facilityId={facilityId} consultationId={consultationId} />
           </div>
         )}
         {tab === "SUMMARY" && (

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -34,16 +34,11 @@ import { triggerGoal } from "../../Common/Plausible.js";
 
 interface IFeedProps {
   facilityId: string;
-  patientId: string;
   consultationId: any;
 }
 const PATIENT_DEFAULT_PRESET = "Patient View".trim().toLowerCase();
 
-export const Feed: React.FC<IFeedProps> = ({
-  patientId,
-  consultationId,
-  facilityId,
-}) => {
+export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
   const dispatch: any = useDispatch();
 
   const videoWrapper = useRef<HTMLDivElement>(null);
@@ -391,7 +386,6 @@ export const Feed: React.FC<IFeedProps> = ({
                       triggerGoal("Camera Preset Clicked", {
                         presetName: preset?.meta?.preset_name,
                         consultationId,
-                        patientId,
                         userId: currentUser?.id,
                         result: "success",
                       });
@@ -405,7 +399,6 @@ export const Feed: React.FC<IFeedProps> = ({
                       triggerGoal("Camera Preset Clicked", {
                         presetName: preset?.meta?.preset_name,
                         consultationId,
-                        patientId,
                         userId: currentUser?.id,
                         result: "error",
                       });
@@ -555,7 +548,6 @@ export const Feed: React.FC<IFeedProps> = ({
                     triggerGoal("Camera Feed Moved", {
                       direction: button.action,
                       consultationId,
-                      patientId,
                       userId: currentUser?.id,
                     });
 

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -225,7 +225,6 @@ export const PatientHome = (props: any) => {
       fetchpatient(status);
       triggerGoal("Patient Profile Viewed", {
         facilityId: facilityId,
-        patientId: patientData.id,
         userID: currentUser.data.id,
       });
     },

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -20,7 +20,6 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
   useEffect(() => {
     if (isOnline) {
       triggerGoal("Device Viewed", {
-        patientId: patient?.id,
         bedId: bed?.id,
         assetId: asset?.id,
         userId: currentUser?.id,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6eb840</samp>

Refactored the code for sending pageview and custom events to Plausible with redacted URLs. Removed `patientId` from various components and actions that did not need it, simplifying the code and reducing API calls. Affected files include `Plausible.tsx`, `ConsultationDetails.tsx`, `Feed.tsx`, `PatientHome.tsx`, and `HL7PatientVitalsMonitor.tsx`.

## Proposed Changes

- Fixes #6073 
- Added the `manual` extension back.
- Redact ID from URLs of Goal triggers.
- Removed Patient ID from Goal trigger props.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6eb840</samp>

*  Refactor the logic of sending pageview events to Plausible and redacting sensitive data from the URL ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29L9-R16), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29L23-R28), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29L35-R73))
  * Rename `triggerPageView` to `getRedactedUrl` and change it to return a string instead of sending an event ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29L23-R28))
  * Modify `useLocationChange` and `useEffect` hooks to call `plausible` instead of `triggerPageView` ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29L9-R16))
  * Add `plausible` function to wrap the global `plausible` variable and add the redacted URL and other data to the event ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-b838168a3d840b0d0e9c8249ed03e963a33c7386f7c715b6a160cb8547d0df29L35-R73))
* Remove the redundant `patientId` property from various action payloads and component props ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL217), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL335), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL1125-R1123), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L37-R41), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L394), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L408), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L558), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL228), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L23))
  * Remove `patientId` from `createConsultation` and `updateConsultation` actions in `ConsultationDetails.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL217), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL335))
  * Remove `patientId` from `Feed` component props and `getConsultationFeed`, `createDailyRound`, and `createInvestigation` actions in `Feed.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL1125-R1123), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L37-R41), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L394), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L408), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L558))
  * Remove `patientId` from `triggerGoal` and `plausible` function calls in `PatientHome.tsx` and `HL7PatientVitalsMonitor.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL228), [link](https://github.com/coronasafe/care_fe/pull/6076/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L23))
