### PR TITLE
Improve BedTypeCard responsiveness

### DIFF
--- a/src/Components/Facility/BedTypeCard.tsx
+++ b/src/Components/Facility/BedTypeCard.tsx
@@ -90,7 +90,7 @@ export const BedTypeCard: React.FC<BedTypeCardProps> = ({
         <p
           className={`${
             facilityId ? "font-medium" : "font-bold"
-          } mb-2 h-12 text-center text-xl text-slate-900 md:mb-4`}
+          } mb-2 text-center text-xl text-slate-900 md:mb-4`}
         >
           {label}
         </p>
@@ -133,7 +133,7 @@ export const BedTypeCard: React.FC<BedTypeCardProps> = ({
               </div>
             </div>
             <div className="mt-4 flex h-1/3 flex-col items-center justify-center gap-4 text-center lg:flex-row">
-              <div className="w-1/2 overflow-x-auto">
+              <div className="overflow-x-auto">
                 <p className="text-lg font-medium text-slate-500 xl:text-xl">
                   Used:
                   <animated.span className="ml-2 text-lg font-semibold text-slate-700">
@@ -141,7 +141,7 @@ export const BedTypeCard: React.FC<BedTypeCardProps> = ({
                   </animated.span>
                 </p>
               </div>
-              <div className="w-1/2 overflow-x-auto">
+              <div className="overflow-x-auto">
                 <p className="text-lg font-medium text-slate-500 xl:text-xl">
                   Total:
                   <animated.span className="ml-2 text-lg font-semibold text-slate-700">

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -176,7 +176,7 @@ export const FacilityHome = (props: any) => {
     });
 
     capacityList = (
-      <div className="mt-4 grid w-full gap-7 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <div className="mt-4 grid w-full gap-7 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
         <BedTypeCard
           label="Total Beds"
           used={totalOccupiedBedCount}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 703b329</samp>

Improved the responsiveness and layout of the `BedTypeCard` and `FacilityHome` components by adjusting the width, height, and grid columns of their elements based on screen size. These changes enhance the user interface and prevent text overflow and excessive scrolling.

## Proposed Changes

- Fixes #6039 
![image](https://github.com/coronasafe/care_fe/assets/3626859/2f37e2a3-c25e-4b7d-9acf-566238820c17)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 703b329</samp>

*  Remove fixed height and width classes from `BedTypeCard` component to prevent text and number overflow on small screens ([link](https://github.com/coronasafe/care_fe/pull/6080/files?diff=unified&w=0#diff-3e2c418dd8e53aee655a4657524f2c6f440898592179b3167fee4a7086a11837L93-R93), [link](https://github.com/coronasafe/care_fe/pull/6080/files?diff=unified&w=0#diff-3e2c418dd8e53aee655a4657524f2c6f440898592179b3167fee4a7086a11837L136-R136), [link](https://github.com/coronasafe/care_fe/pull/6080/files?diff=unified&w=0#diff-3e2c418dd8e53aee655a4657524f2c6f440898592179b3167fee4a7086a11837L144-R144))
*  Increase the number of columns in the grid layout of `FacilityHome` component's capacity list on larger screens to improve responsiveness and readability ([link](https://github.com/coronasafe/care_fe/pull/6080/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cL179-R179))
