### PR TITLE
add consultation bed specific asset relations

### DIFF
--- a/src/Components/Assets/AssetType/HL7Monitor.tsx
+++ b/src/Components/Assets/AssetType/HL7Monitor.tsx
@@ -115,11 +115,11 @@ const HL7Monitor = (props: HL7MonitorProps) => {
               </div>
             </form>
           </Card>
-          <Card className="z-20">
-            {["HL7MONITOR", "VENTILATOR"].includes(assetType) && (
+          {["HL7MONITOR"].includes(assetType) && (
+            <Card className="z-20">
               <MonitorConfigure asset={asset as AssetData} />
-            )}
-          </Card>
+            </Card>
+          )}
         </div>
 
         {assetType === "HL7MONITOR" && (

--- a/src/Components/Common/AssetSelect.tsx
+++ b/src/Components/Common/AssetSelect.tsx
@@ -1,0 +1,75 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { listAssets } from "../../Redux/actions";
+import AutoCompleteAsync from "../Form/AutoCompleteAsync";
+
+interface AssetSelectProps {
+  name: string;
+  errors?: string | undefined;
+  className?: string;
+  facility?: string;
+  is_working?: boolean;
+  in_use_by_consultation?: boolean;
+  multiple?: boolean;
+  AssetType?: number;
+  showAll?: boolean;
+  showNOptions?: number;
+  freeText?: boolean;
+  selected: any;
+  setSelected: (selected: any) => void;
+}
+
+export const AssetSelect = (props: AssetSelectProps) => {
+  const {
+    name,
+    multiple,
+    selected,
+    setSelected,
+    facility,
+    is_working = true,
+    in_use_by_consultation = false,
+    showNOptions = 10,
+    className = "",
+    freeText = false,
+    errors = "",
+  } = props;
+
+  const dispatchAction: any = useDispatch();
+
+  const AssetSearch = useCallback(
+    async (text: string) => {
+      const params = {
+        limit: 50,
+        offset: 0,
+        search_text: text,
+        facility,
+        is_working,
+        in_use_by_consultation,
+      };
+
+      const res = await dispatchAction(listAssets(params));
+      if (freeText)
+        res?.data?.results?.push({
+          id: -1,
+          name: text,
+        });
+      return res?.data?.results;
+    },
+    [dispatchAction]
+  );
+
+  return (
+    <AutoCompleteAsync
+      name={name}
+      multiple={multiple}
+      selected={selected}
+      onChange={setSelected}
+      fetchData={AssetSearch}
+      showNOptions={showNOptions}
+      optionLabel={(option: any) => option.name}
+      compareBy="id"
+      className={className}
+      error={errors}
+    />
+  );
+};

--- a/src/Components/Common/AssetSelect.tsx
+++ b/src/Components/Common/AssetSelect.tsx
@@ -10,6 +10,7 @@ interface AssetSelectProps {
   facility?: string;
   is_working?: boolean;
   in_use_by_consultation?: boolean;
+  is_permanent?: boolean;
   multiple?: boolean;
   AssetType?: number;
   showAll?: boolean;
@@ -28,6 +29,7 @@ export const AssetSelect = (props: AssetSelectProps) => {
     facility,
     is_working = true,
     in_use_by_consultation = false,
+    is_permanent = null,
     showNOptions = 10,
     className = "",
     freeText = false,
@@ -45,6 +47,7 @@ export const AssetSelect = (props: AssetSelectProps) => {
         facility,
         is_working,
         in_use_by_consultation,
+        is_permanent,
       };
 
       const res = await dispatchAction(listAssets(params));

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -136,9 +136,20 @@ export const ConsultationDetails = (props: any) => {
         );
       }
 
-      const ventilatorBedData = assetBeds.find(
-        (i) => i.asset_object.asset_class === AssetClass.VENTILATOR
-      );
+      const consultationBedVentilator = consultationData?.current_bed?.assets_objects?.find(
+        (i) => i.asset_class === AssetClass.VENTILATOR
+      )
+      let ventilatorBedData;
+      if (consultationBedVentilator) {
+        ventilatorBedData = {
+          asset_object: consultationBedVentilator,
+          bed_object: consultationData?.current_bed?.bed_object,
+        } as AssetBedModel;
+      } else {
+        ventilatorBedData = assetBeds.find(
+          (i) => i.asset_object.asset_class === AssetClass.VENTILATOR
+        );
+      }
       setVentilatorBedData(ventilatorBedData);
       const ventilatorMeta = ventilatorBedData?.asset_object?.meta;
       const ventilatorMiddleware =

--- a/src/Components/Facility/Consultations/Beds.tsx
+++ b/src/Components/Facility/Consultations/Beds.tsx
@@ -62,7 +62,9 @@ const Beds = (props: BedsProps) => {
             msg: "Something went wrong..!",
           });
         else {
-          setConsultationBeds(bedsData?.data?.results);
+          setConsultationBeds(bedsData.data.results);
+          setBed(bedsData.data.results[0]?.bed_object || {});
+          setAssets(bedsData.data.results[0]?.assets_objects || []);
         }
       }
     },
@@ -228,6 +230,8 @@ const Beds = (props: BedsProps) => {
                 selected={assets}
                 multiple={true}
                 facility={facilityId}
+                in_use_by_consultation={false}
+                is_permanent={false}
               />
             </div>
           </div>
@@ -266,10 +270,12 @@ const Beds = (props: BedsProps) => {
                 <div className="break-words bg-primary-100 p-2 text-center">
                   {bed?.bed_object?.name}
                   {bed?.assets_objects && bed.assets_objects.length > 0 && (
-                    <i
-                      className="fas fa-info-circle ml-2 cursor-pointer "
-                      onClick={() => setShowBedDetails(bed)}
-                    />
+                    <span
+                    className={` bg-primary-500 font-semibold text-white ml-2 h-6 cursor-pointer rounded-md px-2 text-xs`}
+                    onClick={() => setShowBedDetails(bed)}
+                  >
+                    {bed.assets_objects.length}
+                  </span>
                   )}
                 </div>
                 <div className="bg-primary-100 py-2 text-center">

--- a/src/Components/Facility/Consultations/Beds.tsx
+++ b/src/Components/Facility/Consultations/Beds.tsx
@@ -18,6 +18,12 @@ import TextFormField from "../../Form/FormFields/TextFormField";
 import { formatDateTime } from "../../../Utils/utils";
 import { useDispatch } from "react-redux";
 import dayjs from "../../../Utils/dayjs";
+import { AssetSelect } from "../../Common/AssetSelect.js";
+import DialogModal from "../../Common/Dialog.js";
+import AssetsList from "../../Assets/AssetsList.js";
+import { Link } from "raviger";
+import { AssetData, assetClassProps } from "../../Assets/AssetTypes.js";
+import Chip from "../../../CAREUI/display/Chip.js";
 
 interface BedsProps {
   facilityId: string;
@@ -37,9 +43,11 @@ const Beds = (props: BedsProps) => {
   const [startDate, setStartDate] = useState<string>(
     dayjs().format("YYYY-MM-DDTHH:mm")
   );
+  const [assets, setAssets] = useState<any[]>([]);
   const [consultationBeds, setConsultationBeds] = useState<CurrentBed[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [key, setKey] = useState(0);
+  const [showBedDetails, setShowBedDetails] = useState<CurrentBed | null>(null);
 
   const fetchData = useCallback(
     async (status: statusType) => {
@@ -76,7 +84,11 @@ const Beds = (props: BedsProps) => {
       });
 
     const res: any = await dispatch(
-      createConsultationBed({ start_date: startDate }, consultationId, bed?.id)
+      createConsultationBed(
+        { start_date: startDate, assets: assets.map((asset) => asset.id) },
+        consultationId,
+        bed?.id
+      )
     );
 
     if (res && res.status === 201) {
@@ -102,6 +114,70 @@ const Beds = (props: BedsProps) => {
 
   return (
     <div>
+      <DialogModal
+        title={showBedDetails?.bed_object.name}
+        show={showBedDetails !== null}
+        onClose={() => setShowBedDetails(null)}
+        className="md:max-w-2xl"
+      >
+        <div>Linked Assets:</div>
+        {showBedDetails?.assets_objects?.length === 0 && (
+          <div className="text-center">No assets linked</div>
+        )}
+        {showBedDetails?.assets_objects?.map((asset: AssetData) => (
+          <Link
+            key={asset.id}
+            href={`/facility/${asset?.location_object.facility.id}/assets/${asset.id}`}
+            className="mx-2 text-inherit"
+            data-testid="created-asset-list"
+          >
+            <div
+              key={asset.id}
+              className="border-1 w-full cursor-pointer items-center justify-center rounded-lg border border-transparent bg-white p-5 shadow hover:border-primary-500"
+            >
+              <div className="md:flex">
+                <p className="flex break-words text-xl font-medium capitalize">
+                  <span className="mr-2 text-primary-500">
+                    <CareIcon
+                      className={`care-l-${
+                        (
+                          (asset.asset_class &&
+                            assetClassProps[asset.asset_class]) ||
+                          assetClassProps.NONE
+                        ).icon
+                      } text-2xl`}
+                    />
+                  </span>
+                  <p
+                    className="w-48 truncate"
+                    data-testid="created-asset-list-name"
+                  >
+                    {asset.name}
+                  </p>
+                </p>
+              </div>
+              <p className="text-sm font-normal">
+                <span className="text-sm font-medium">
+                  <CareIcon className="care-l-location-point mr-1 text-primary-500" />
+                  {asset?.location_object?.name}
+                </span>
+                <span className="ml-2 text-sm font-medium">
+                  <CareIcon className="care-l-hospital mr-1 text-primary-500" />
+                  {asset?.location_object?.facility?.name}
+                </span>
+              </p>
+
+              <div className="mt-2 flex flex-wrap gap-2">
+                {asset.is_working ? (
+                  <Chip startIcon="l-cog" text="Working" />
+                ) : (
+                  <Chip variant="danger" startIcon="l-cog" text="Not Working" />
+                )}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </DialogModal>
       {!props.hideTitle && (
         <div className="mb-4 flex items-center justify-between">
           <div className="font-bold text-secondary-500">
@@ -144,6 +220,16 @@ const Beds = (props: BedsProps) => {
               max={dayjs().format("YYYY-MM-DDTHH:mm")}
               error=""
             />
+            <div>
+              <FieldLabel id="assets-link-label">Link Assets</FieldLabel>
+              <AssetSelect
+                name="assets"
+                setSelected={setAssets}
+                selected={assets}
+                multiple={true}
+                facility={facilityId}
+              />
+            </div>
           </div>
           <div className="mt-4 flex flex-row justify-center">
             <div>
@@ -179,6 +265,12 @@ const Beds = (props: BedsProps) => {
               <div className="grid grid-cols-4 gap-[1px]" key={bed?.id}>
                 <div className="break-words bg-primary-100 p-2 text-center">
                   {bed?.bed_object?.name}
+                  {bed?.assets_objects && bed.assets_objects.length > 0 && (
+                    <i
+                      className="fas fa-info-circle ml-2 cursor-pointer "
+                      onClick={() => setShowBedDetails(bed)}
+                    />
+                  )}
                 </div>
                 <div className="bg-primary-100 py-2 text-center">
                   {bed?.bed_object?.location_object?.name}

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -1,6 +1,7 @@
 import { AssignedToObjectModel } from "../Patient/models";
 import { ProcedureType } from "../Common/prescription-builder/ProcedureBuilder";
 import { NormalPrescription, PRNPrescription } from "../Medicine/models";
+import { AssetData } from "../Assets/AssetTypes";
 
 export interface LocalBodyModel {
   name: string;
@@ -205,6 +206,7 @@ export interface CurrentBed {
   consultation: string;
   bed?: string;
   bed_object: BedModel;
+  assets_objects?: AssetData[];
   created_date: string;
   modified_date: string;
   start_date: string;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9126c01</samp>

This pull request enables the linking of assets to beds in a facility consultation. It adds a new component `AssetSelect` to select assets, and modifies the `Beds` component and the `createConsultationBed` action to handle the asset data. It also updates the facility data model and the `Beds.tsx` and `models.tsx` files accordingly. It also adds a modal dialog to view the asset details.

## Proposed Change

- remove the ability to permanently link ventilators to bed
- added a dropdown to select assets to link to a consultation_bed
- Fixes #6086
- Dependent backend change coronasafe/care#1524

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9126c01</samp>

*  Add a new component `AssetSelect` to allow selecting assets from a facility ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-870c97b0ffbf23914872030cd7aa007357ee7a85925bdd3fb5b1d4d48756f7e4R1-R75))
* Import `AssetSelect` and other dependencies to `Beds` component ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbR21-R26))
* Add `assets` and `showBedDetails` state variables to `Beds` component to store selected assets and current bed object ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbL40-R50))
* Modify payload of `createConsultationBed` action to include `assets` array ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbL79-R91))
* Add a new `DialogModal` component to `Beds` component to show bed details and linked assets in a modal ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbR117-R180))
* Add a new `AssetSelect` component to `Beds` component to select assets for a bed ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbR223-R232))
* Add a new icon to `Beds` component to trigger bed details modal ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbR268-R273))
* Import `AssetData` type from `AssetTypes` module to `models` module ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfR4))
* Add `assets_objects` property to `CurrentBed` interface ([link](https://github.com/coronasafe/care_fe/pull/6087/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfR209))


<img width="841" alt="Screenshot 2023-08-16 at 8 07 26 PM" src="https://github.com/coronasafe/care_fe/assets/46787056/f38a0de2-12a3-4347-b38e-1a0adbefe136">
<img width="834" alt="Screenshot 2023-08-16 at 8 07 49 PM" src="https://github.com/coronasafe/care_fe/assets/46787056/24619ad6-d226-46ea-aa6e-152b7934fcf1">


