### PR TITLE
Remove overlap of bed section with dashboard on Assets Configure page

### DIFF
--- a/src/Components/Assets/AssetType/HL7Monitor.tsx
+++ b/src/Components/Assets/AssetType/HL7Monitor.tsx
@@ -115,7 +115,7 @@ const HL7Monitor = (props: HL7MonitorProps) => {
               </div>
             </form>
           </Card>
-          <Card className="z-20">
+          <Card className="">
             {["HL7MONITOR", "VENTILATOR"].includes(assetType) && (
               <MonitorConfigure asset={asset as AssetData} />
             )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3acb7d7</samp>

Fixed a UI bug in the `HL7Monitor` component that caused it to overlap with other elements. Removed the `z-20` class from the `Card` component in `src/Components/Assets/AssetType/HL7Monitor.tsx`.

## Proposed Changes

- Fixes #6093 
http://localhost:4000/facility/657c32be-d584-476c-9ce2-0412f0e7692e/assets/d7ab1d8f-4584-4abc-9f8b-aec5390dd315/configure
Remove overlap of bed section with dashboard on Assets Configure page

![image](https://github.com/coronasafe/care_fe/assets/70687348/f7741ca9-dad7-434f-8f57-700855bbf9d9)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3acb7d7</samp>

*  Remove z-index property from `Card` component to fix UI bug ([link](https://github.com/coronasafe/care_fe/pull/6094/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL118-R118))
