### PR TITLE
Fix Set Min quantity for inventory Notification malfunction

### DIFF
--- a/src/Components/Facility/SetInventoryForm.tsx
+++ b/src/Components/Facility/SetInventoryForm.tsx
@@ -113,7 +113,7 @@ export const SetInventoryForm = (props: any) => {
 
     const res = await dispatchAction(setMinQuantity(data, { facilityId }));
     setIsLoading(false);
-    if (res && res.data) {
+    if (res && res.data && res.data.id) {
       Notification.Success({
         msg: "Minimum quantiy updated successfully",
       });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ba13ba</samp>

Fix success notification bug in `SetInventoryForm.tsx`. Add a check for `id` in response data before showing notification.

## Proposed Changes

- Fixes #6099 
http://localhost:4000/facility/657c32be-d584-476c-9ce2-0412f0e7692e/inventory/min_quantity/list
Throw only 1 Notification- an error when the user tries to add a Min quantity for an inventory item that already has a minimum set.
![image](https://github.com/coronasafe/care_fe/assets/70687348/41d7f824-efdc-4c7e-883b-304e0e26ed00)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ba13ba</samp>

*  Add a check for the `id` property of the response data object before showing the success notification ([link](https://github.com/coronasafe/care_fe/pull/6100/files?diff=unified&w=0#diff-837c529568a2b29b677ea4a7e22eaaf8b0e26b841bd3569593d70ceb8dbb5df0L116-R116))
