### PR TITLE
Fix Add Multiple Bed checkbox bug

### DIFF
--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -215,8 +215,8 @@ export const AddBedForm = (props: BedFormProps) => {
                 <CheckBoxFormField
                   label="Do you want to make multiple beds?"
                   onChange={() => {
+                    if (multipleBeds) setNumberOfBeds(1);
                     setMultipleBeds(!multipleBeds);
-                    if (!multipleBeds) setNumberOfBeds(1);
                   }}
                   name={"multipleBeds"}
                 />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7cd6a4a</samp>

Fixed a bug in `AddBedForm` that reset the number of beds to 1 when unchecking `multipleBeds`. Improved the user experience of creating new bed types for a facility.

## Proposed Changes

- Fixes #6110 
http://localhost:4000/facility/657c32be-d584-476c-9ce2-0412f0e7692e/location/7f0c2bba-face-47f1-a547-87617a8c9b04/beds/add
When the `Multiple Beds` checkbox is unchecked, the value of the field `number of beds` is reset to 1

[Video demonstration](https://github.com/coronasafe/care_fe/assets/70687348/931f85be-ddcf-47b5-8098-82beb8fc690a)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7cd6a4a</samp>

* Fix a bug that resets the number of beds to 1 when unchecking the multiple beds option in the add bed form ([link](https://github.com/coronasafe/care_fe/pull/6111/files?diff=unified&w=0#diff-c3725e9874032f1cdb18f7c6b15f978b17a7306d49ce27104377ac1ccaaa4b8cL218-R219))
