### PR TITLE
Fixed responsive issue of 'Update Log' button in patient dashboard

### DIFF
--- a/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
@@ -25,7 +25,7 @@ const DefaultLogUpdateCard = ({ round, ...props }: Props) => {
 
   return (
     <div
-      className={`flex w-full flex-col gap-4 rounded-lg p-4 shadow ${
+      className={`flex w-full flex-col gap-4 rounded-lg p-4 shadow @container ${
         telemedicine_doctor_update ? "bg-purple-200" : "bg-white"
       }`}
     >
@@ -36,7 +36,7 @@ const DefaultLogUpdateCard = ({ round, ...props }: Props) => {
           </div>
           <span className="flex gap-1 whitespace-nowrap pr-3 text-sm tracking-wider">
             <span className="font-semibold">{`${by?.first_name} ${by?.last_name}`}</span>
-            <span className="hidden font-medium md:block">
+            <span className="hidden font-medium @xs:block">
               ({by?.user_type})
             </span>
           </span>
@@ -65,7 +65,7 @@ const DefaultLogUpdateCard = ({ round, ...props }: Props) => {
           attributeValue={round.other_details}
         />
 
-        <div className="mt-2 flex flex-col space-x-0 space-y-2 md:flex-row md:space-x-2 md:space-y-0">
+        <div className="mt-2 flex flex-col space-x-0 space-y-2 @xs:flex-row @xs:space-x-2 @xs:space-y-0">
           <ButtonV2
             variant="secondary"
             border


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb6abc0</samp>

Improved the responsiveness of the `DefaultLogUpdateCard` component by adding bootstrap classes. This component displays the daily rounds update for a consultation in the facility dashboard.

## Proposed Changes

- Fixes #6049 
- Fixed responsiveness issue of 'Update Log' button in patient consultation page

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb6abc0</samp>

*  Add responsive container layout to the card component for better alignment and spacing on different screen sizes ([link](https://github.com/coronasafe/care_fe/pull/6113/files?diff=unified&w=0#diff-dd6193fcd7f9bfeb6ed50d55385f1ccd2b8f7c73bdd54955a7bf1afe9f852c4bL28-R28))
*  Show user type of the person who updated the daily rounds on extra small screens for more accessibility ([link](https://github.com/coronasafe/care_fe/pull/6113/files?diff=unified&w=0#diff-dd6193fcd7f9bfeb6ed50d55385f1ccd2b8f7c73bdd54955a7bf1afe9f852c4bL39-R39))
*  Display buttons for editing and deleting the daily rounds update in a row instead of a column on extra small screens for more compactness and consistency ([link](https://github.com/coronasafe/care_fe/pull/6113/files?diff=unified&w=0#diff-dd6193fcd7f9bfeb6ed50d55385f1ccd2b8f7c73bdd54955a7bf1afe9f852c4bL68-R68))
