### PR TITLE
Allow user to use a stock in inventory

### DIFF
--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -207,7 +207,7 @@ export const AddInventoryForm = (props: any) => {
           }
           return;
         case "isIncoming":
-          if (!state.form[field]) {
+          if (state.form[field] == undefined) {
             errors[field] = "Please select an option";
             invalidForm = true;
           }
@@ -297,8 +297,8 @@ export const AddInventoryForm = (props: any) => {
                   onChange={handleChange}
                   value={state.form.isIncoming}
                   options={[
-                    { id: true, name: "Add Stock" },
-                    { id: false, name: "Use Stock" },
+                    { id: 1, name: "Add Stock" },
+                    { id: 0, name: "Use Stock" },
                   ]}
                   optionValue={(inventory) => inventory.id}
                   optionLabel={(inventory) => inventory.name}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bc0424</samp>

Fix inventory form issues in `AddInventoryForm.tsx`. Ensure the `isIncoming` field uses the correct values and validates properly.

## Proposed Changes

- Fixes #6114 
http://localhost:4000/facility/657c32be-d584-476c-9ce2-0412f0e7692e/inventory/add
The form validates `Use stock` option as well.
![image](https://github.com/coronasafe/care_fe/assets/70687348/8074ddca-7269-446a-b9e6-9e8fcaf82972)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0bc0424</samp>

* Fix the validation of the `isIncoming` field in the inventory form to allow false values ([link](https://github.com/coronasafe/care_fe/pull/6115/files?diff=unified&w=0#diff-0cbcee446c25081b9cc3657703cc28e1aadc287f7d948423827bcff814f803b9L210-R210))
* Change the options for the `isIncoming` field in the inventory form to use numeric values instead of boolean values to match the backend API ([link](https://github.com/coronasafe/care_fe/pull/6115/files?diff=unified&w=0#diff-0cbcee446c25081b9cc3657703cc28e1aadc287f7d948423827bcff814f803b9L300-R301))
