### PR TITLE
Fix unlinking skills

### DIFF
--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -55,10 +55,6 @@ export default ({ show, setShow, username }: IProps) => {
         Notification.Error({
           msg: "Error while adding skill",
         });
-      } else {
-        Notification.Success({
-          msg: "Skill added successfully",
-        });
       }
       setSelectedSkill(null);
       setIsLoading(false);
@@ -69,7 +65,12 @@ export default ({ show, setShow, username }: IProps) => {
 
   const removeSkill = useCallback(
     async (username: string, skillId: string) => {
-      await dispatch(deleteUserSkill(username, skillId));
+      const res = await dispatch(deleteUserSkill(username, skillId));
+      if (res?.status !== 204) {
+        Notification.Error({
+          msg: "Error while unlinking skill",
+        });
+      }
       setDeleteSkill(null);
       fetchSkills(username);
     },
@@ -100,7 +101,9 @@ export default ({ show, setShow, username }: IProps) => {
       )}
       <SlideOverCustom
         open={show}
-        setOpen={setShow}
+        setOpen={(openState) => {
+          !deleteSkill && setShow(openState);
+        }}
         slideFrom="right"
         title="Skills"
         dialogClass="md:w-[400px]"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff44f79</samp>

This pull request enhances the skills management feature in the `SkillsSlideOver` component. It fixes some bugs, handles errors, and improves the user experience.

## Proposed Changes

- Fixes #6121
![image](https://github.com/coronasafe/care_fe/assets/3626859/79fa22f2-2678-4aef-acb8-1f9375b306b5)
- Note: Success message for adding skills has been silenced to match the design with Linking/Unlinking Facility. Error is still shown when required.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff44f79</samp>

* Remove success notification when adding a skill to a user ([link](https://github.com/coronasafe/care_fe/pull/6124/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L58-L61))
* Add error handling when deleting a skill from a user ([link](https://github.com/coronasafe/care_fe/pull/6124/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L72-R73))
* Prevent slide over panel from closing when confirming skill deletion ([link](https://github.com/coronasafe/care_fe/pull/6124/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L103-R106))
