### PR TITLE
Minor UI Fix: Add responsiveness to virtual nursing assistant card

### DIFF
--- a/src/Components/Facility/Consultations/DailyRounds/LogUpdateCardAttribute.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/LogUpdateCardAttribute.tsx
@@ -26,7 +26,7 @@ const LogUpdateCardAttribute = <T extends keyof DailyRoundsModel>({
 
     case "patient_category":
       return (
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-center gap-2 md:flex-row">
           <AttributeLabel attributeKey={attributeKey} />
           <PatientCategoryBadge category={attributeValue} />
         </div>
@@ -34,7 +34,7 @@ const LogUpdateCardAttribute = <T extends keyof DailyRoundsModel>({
 
     case "bp":
       return (
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-center gap-2 md:flex-row">
           <AttributeLabel attributeKey={attributeKey} />
           <span className="text-sm font-semibold text-gray-700">
             {attributeValue.systolic}/{attributeValue.diastolic} mmHg
@@ -44,7 +44,7 @@ const LogUpdateCardAttribute = <T extends keyof DailyRoundsModel>({
 
     case "output":
       return (
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 md:flex-row">
           <AttributeLabel attributeKey={attributeKey} />
           <span className="flex flex-wrap gap-x-2 gap-y-1 text-sm text-gray-700">
             {attributeValue.map((output: any) => (
@@ -58,7 +58,7 @@ const LogUpdateCardAttribute = <T extends keyof DailyRoundsModel>({
 
     default:
       return (
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-center gap-2 md:flex-row">
           <AttributeLabel attributeKey={attributeKey} />
           <span className="text-sm font-semibold text-gray-700">
             {typeof attributeValue === "object"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d971214</samp>

Refactored `LogUpdateCardAttribute` component to use flex layout for better UI design.

## Proposed Changes
https://care.coronasafe.in/facility/657c32be-d584-476c-9ce2-0412f0e7692e/patient/245f222e-63b2-493b-a0c2-60a4fd109aa6/consultation/2c386338-1ae5-4cec-a175-9243556f9e39
The fields of the Virtual Nursing Assistant card are going out of view in mobile view. They are placed in column view in mobile mode and row view in desktop mode.

Before:
![image](https://github.com/coronasafe/care_fe/assets/70687348/2243ebc6-b123-42f5-a052-caace952b8f7)

After:
![image](https://github.com/coronasafe/care_fe/assets/70687348/de2e1be1-31d6-4ef1-8c46-682f48a1ec07)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d971214</samp>

*  Modify the `LogUpdateCardAttribute` component to use a responsive flex layout for different attribute cases ([link](https://github.com/coronasafe/care_fe/pull/6130/files?diff=unified&w=0#diff-422ad7e458875cbee305833a156db4cd9ac05acf670b2f43a03a49ae50ef41a3L29-R29), [link](https://github.com/coronasafe/care_fe/pull/6130/files?diff=unified&w=0#diff-422ad7e458875cbee305833a156db4cd9ac05acf670b2f43a03a49ae50ef41a3L37-R37), [link](https://github.com/coronasafe/care_fe/pull/6130/files?diff=unified&w=0#diff-422ad7e458875cbee305833a156db4cd9ac05acf670b2f43a03a49ae50ef41a3L47-R47), [link](https://github.com/coronasafe/care_fe/pull/6130/files?diff=unified&w=0#diff-422ad7e458875cbee305833a156db4cd9ac05acf670b2f43a03a49ae50ef41a3L61-R61))
