### PR TITLE
Use chrome to run cypress tests in github actions

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -52,7 +52,7 @@ jobs:
           start: "npx vite preview --host"
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
-          browser: electron
+          browser: chrome
           record: true
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ab69c6</samp>

Changed the browser for cypress tests from `electron` to `chrome` to resolve a CORS bug. This affects the file `.github/workflows/cypress.yaml`.

## Proposed Changes

- Use chrome to run cypress tests in github actions

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

cc: @nihal467 

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ab69c6</samp>

* Change the browser option for cypress action to `chrome` to fix a CORS bug ([link](https://github.com/coronasafe/care_fe/pull/6133/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L55-R55))
