### PR TITLE
added ui to add and update health facility id

### DIFF
--- a/src/Components/ABDM/ConfigureHealthFacility.tsx
+++ b/src/Components/ABDM/ConfigureHealthFacility.tsx
@@ -1,0 +1,153 @@
+import { lazy, useCallback, useEffect, useReducer, useState } from "react";
+import { useDispatch } from "react-redux";
+
+import { healthFacilityActions } from "../../Redux/actions";
+import * as Notification from "../../Utils/Notifications.js";
+import { navigate } from "raviger";
+import { Cancel, Submit } from "../Common/components/ButtonV2";
+import TextFormField from "../Form/FormFields/TextFormField";
+import Page from "../Common/components/Page";
+const Loading = lazy(() => import("../Common/Loading"));
+
+const initForm = {
+  health_facility: null,
+  hf_id: "",
+};
+const initialState = {
+  form: { ...initForm },
+  errors: {},
+};
+
+const FormReducer = (state = initialState, action: any) => {
+  switch (action.type) {
+    case "set_form": {
+      return {
+        ...state,
+        form: action.form,
+      };
+    }
+    case "set_error": {
+      return {
+        ...state,
+        errors: action.errors,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export const ConfigureHealthFacility = (props: any) => {
+  const [state, dispatch] = useReducer(FormReducer, initialState);
+  const { facilityId } = props;
+  const dispatchAction: any = useDispatch();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (facilityId) {
+      setIsLoading(true);
+      const res = await dispatchAction(healthFacilityActions.read(facilityId));
+
+      if (res?.data) {
+        const formData = {
+          ...state.form,
+          hf_id: res.data.hf_id,
+          health_facility: res.data,
+        };
+        dispatch({ type: "set_form", form: formData });
+      }
+
+      setIsLoading(false);
+    }
+  }, [dispatchAction, facilityId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [dispatch, fetchData]);
+
+  const handleSubmit = async (e: any) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    if (!state.form.hf_id) {
+      dispatch({
+        type: "set_error",
+        errors: { hf_id: ["Health Facility Id is required"] },
+      });
+      setIsLoading(false);
+      return;
+    }
+
+    let res = null;
+    if (state.form.health_facility) {
+      res = await dispatchAction(
+        healthFacilityActions.partialUpdate(facilityId, {
+          hf_id: state.form.hf_id,
+        })
+      );
+    } else {
+      res = await dispatchAction(
+        healthFacilityActions.create({
+          facility: facilityId,
+          hf_id: state.form.hf_id,
+        })
+      );
+    }
+
+    setIsLoading(false);
+    if (res && res.data) {
+      Notification.Success({
+        msg: "Health Facility config updated successfully",
+      });
+      navigate(`/facility/${facilityId}`);
+    } else {
+      if (res?.data)
+        Notification.Error({
+          msg: "Something went wrong: " + (res.data.detail || ""),
+        });
+    }
+    setIsLoading(false);
+  };
+
+  const handleChange = (e: any) => {
+    dispatch({
+      type: "set_form",
+      form: { ...state.form, [e.name]: e.value },
+    });
+  };
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <Page
+      title="Configure Health Facility"
+      crumbsReplacements={{
+        [facilityId]: { name: state.form.name },
+      }}
+      className="mx-auto max-w-3xl"
+    >
+      <div className="cui-card mt-4">
+        <form onSubmit={(e) => handleSubmit(e)}>
+          <div className="mt-2 grid grid-cols-1 gap-4">
+            <div>
+              <TextFormField
+                name="hf_id"
+                label="Health Facility Id"
+                required
+                value={state.form.hf_id}
+                onChange={(e) => handleChange(e)}
+                error={state.errors?.hf_id}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-between">
+            <Cancel onClick={() => navigate(`/facility/${facilityId}`)} />
+            <Submit onClick={handleSubmit} label="Update" />
+          </div>
+        </form>
+      </div>
+    </Page>
+  );
+};

--- a/src/Components/ABDM/ConfigureHealthFacility.tsx
+++ b/src/Components/ABDM/ConfigureHealthFacility.tsx
@@ -48,7 +48,7 @@ export const ConfigureHealthFacility = (props: any) => {
       setIsLoading(true);
       const res = await dispatchAction(healthFacilityActions.read(facilityId));
 
-      if (res?.data) {
+      if (res.status === 200 && res?.data) {
         const formData = {
           ...state.form,
           hf_id: res.data.hf_id,

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../Redux/actions";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { lazy, useCallback, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { BedCapacity } from "./BedCapacity";
 import BedTypeCard from "./BedTypeCard";
 import ButtonV2 from "../Common/components/ButtonV2";
@@ -549,6 +549,20 @@ export const FacilityHome = (props: any) => {
                 >
                   Configure Facility
                 </DropdownItem>
+                {config.enable_abdm ? (
+                  <DropdownItem
+                    id="configure-health-facility"
+                    onClick={() =>
+                      navigate(`/facility/${facilityId}/health_facility`)
+                    }
+                    authorizeFor={NonReadOnlyUsers}
+                    icon={<CareIcon className="care-l-setting text-lg" />}
+                  >
+                    Configure Health Facility
+                  </DropdownItem>
+                ) : (
+                  <></>
+                )}
                 <DropdownItem
                   id="inventory-management"
                   onClick={() => navigate(`/facility/${facilityId}/inventory`)}

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -933,7 +933,14 @@ export const healthFacilityActions = {
   },
 
   read: (id: string) => {
-    return fireRequest("getHealthFacility", [], {}, { facility_id: id });
+    return fireRequest(
+      "getHealthFacility",
+      [],
+      {},
+      { facility_id: id },
+      undefined,
+      true
+    );
   },
 
   update: (id: string, data: object) => {

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -923,6 +923,32 @@ export const getAbhaCard = (patient: string, type: "pdf" | "png") => {
   });
 };
 
+export const healthFacilityActions = {
+  list: (params: object) => {
+    return fireRequest("listHealthFacilities", [], params);
+  },
+
+  create: (data: object) => {
+    return fireRequest("createHealthFacility", [], data);
+  },
+
+  read: (id: string) => {
+    return fireRequest("getHealthFacility", [], {}, { facility_id: id });
+  },
+
+  update: (id: string, data: object) => {
+    return fireRequest("updateHealthFacility", [], data, {
+      facility_id: id,
+    });
+  },
+
+  partialUpdate: (id: string, data: object) => {
+    return fireRequest("partialUpdateHealthFacility", [], data, {
+      facility_id: id,
+    });
+  },
+};
+
 export const listAssetAvailability = (params: object) =>
   fireRequest("listAssetAvailability", [], params);
 export const getAssetAvailability = (id: string) =>

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -888,6 +888,34 @@ const routes: Routes = {
     path: "/api/v1/abdm/healthid/get_abha_card/",
     method: "POST",
   },
+
+  // ABDM Health Facility
+
+  listHealthFacility: {
+    path: "/api/v1/abdm/health_facility/",
+    method: "GET",
+  },
+
+  createHealthFacility: {
+    path: "/api/v1/abdm/health_facility/",
+    method: "POST",
+  },
+
+  getHealthFacility: {
+    path: "/api/v1/abdm/health_facility/{facility_id}/",
+    method: "GET",
+  },
+
+  updateHealthFacility: {
+    path: "/api/v1/abdm/health_facility/{facility_id}/",
+    method: "PUT",
+  },
+
+  partialUpdateHealthFacility: {
+    path: "/api/v1/abdm/health_facility/{facility_id}/",
+    method: "PATCH",
+  },
+
   // Asset Availability endpoints
 
   listAssetAvailability: {

--- a/src/Router/AppRouter.tsx
+++ b/src/Router/AppRouter.tsx
@@ -73,9 +73,10 @@ import { handleSignOut } from "../Utils/utils";
 import SessionExpired from "../Components/ErrorPages/SessionExpired";
 import ManagePrescriptions from "../Components/Medicine/ManagePrescriptions";
 import CentralNursingStation from "../Components/Facility/CentralNursingStation";
+import { ConfigureHealthFacility } from "../Components/ABDM/ConfigureHealthFacility";
 
 export default function AppRouter() {
-  const { main_logo, enable_hcx } = useConfig();
+  const { main_logo, enable_hcx, enable_abdm } = useConfig();
 
   const routes = {
     "/": () => <HospitalList />,
@@ -98,6 +99,15 @@ export default function AppRouter() {
     "/facility/:facilityId/update": ({ facilityId }: any) => (
       <FacilityCreate facilityId={facilityId} />
     ),
+    ...(enable_abdm
+      ? {
+          "/facility/:facilityId/health_facility": ({
+            facilityId,
+          }: {
+            facilityId: string;
+          }) => <ConfigureHealthFacility facilityId={facilityId} />,
+        }
+      : {}),
     "/facility/:facilityId/middleware/update": ({ facilityId }: any) => (
       <UpdateFacilityMiddleware facilityId={facilityId} />
     ),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef4dd19</samp>

This pull request adds a new feature to the frontend that allows ABDM-enabled users to configure health facilities. It introduces a new component, `ConfigureHealthFacility`, and a new route to access it. It also adds new actions and API endpoints to handle the backend communication for the feature.

## Proposed Changes

- Fixes #6117
- added ui to add and update health facility id
- depends on https://github.com/coronasafe/care/pull/1550

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef4dd19</samp>

*  Add a new component `ConfigureHealthFacility` to create or update health facility configurations for facilities ([link](https://github.com/coronasafe/care_fe/pull/6136/files?diff=unified&w=0#diff-82ab3a1b124e696b6416145151d2a8c2e3883275674526de3a812d431ce801f3R1-R153))
  * Import the component in `src/Router/AppRouter.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6136/files?diff=unified&w=0#diff-54de9c6ab4bf014bd5f50afa466003ba1a5ae1537a615261440d158cd59187f1L76-R79))
* Add a new route to render the `ConfigureHealthFacility` component ([link](https://github.com/coronasafe/care_fe/pull/6136/files?diff=unified&w=0#diff-54de9c6ab4bf014bd5f50afa466003ba1a5ae1537a615261440d158cd59187f1R102-R110))
* Add a new dropdown item to the facility home page to navigate to the `ConfigureHealthFacility` component ([link](https://github.com/coronasafe/care_fe/pull/6136/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cR552-R565))
* Add a new set of actions and API endpoints to handle the health facility configuration ([link](https://github.com/coronasafe/care_fe/pull/6136/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eR926-R951), [link](https://github.com/coronasafe/care_fe/pull/6136/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR891-R918))
* Remove the unused `useSelector` import from `src/Components/Facility/FacilityHome.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6136/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cL26-R26))
