### PR TITLE
Show only ventilator in link assets to bed

### DIFF
--- a/src/Components/Common/AssetSelect.tsx
+++ b/src/Components/Common/AssetSelect.tsx
@@ -10,9 +10,10 @@ interface AssetSelectProps {
   facility?: string;
   is_working?: boolean;
   in_use_by_consultation?: boolean;
-  is_permanent?: boolean;
+  is_permanent?: boolean | null;
   multiple?: boolean;
   AssetType?: number;
+  asset_class?: string;
   showAll?: boolean;
   showNOptions?: number;
   freeText?: boolean;
@@ -34,13 +35,19 @@ export const AssetSelect = (props: AssetSelectProps) => {
     className = "",
     freeText = false,
     errors = "",
+    asset_class = "",
   } = props;
 
   const dispatchAction: any = useDispatch();
 
   const AssetSearch = useCallback(
     async (text: string) => {
-      const params = {
+      const params: Partial<AssetSelectProps> & {
+        limit: number;
+        offset: number;
+        search_text: string;
+        asset_class: string;
+      } = {
         limit: 50,
         offset: 0,
         search_text: text,
@@ -48,6 +55,7 @@ export const AssetSelect = (props: AssetSelectProps) => {
         is_working,
         in_use_by_consultation,
         is_permanent,
+        asset_class,
       };
 
       const res = await dispatchAction(listAssets(params));

--- a/src/Components/Facility/Consultations/Beds.tsx
+++ b/src/Components/Facility/Consultations/Beds.tsx
@@ -20,9 +20,12 @@ import { useDispatch } from "react-redux";
 import dayjs from "../../../Utils/dayjs";
 import { AssetSelect } from "../../Common/AssetSelect.js";
 import DialogModal from "../../Common/Dialog.js";
-import AssetsList from "../../Assets/AssetsList.js";
 import { Link } from "raviger";
-import { AssetData, assetClassProps } from "../../Assets/AssetTypes.js";
+import {
+  AssetClass,
+  AssetData,
+  assetClassProps,
+} from "../../Assets/AssetTypes.js";
 import Chip from "../../../CAREUI/display/Chip.js";
 
 interface BedsProps {
@@ -229,6 +232,7 @@ const Beds = (props: BedsProps) => {
                 setSelected={setAssets}
                 selected={assets}
                 multiple={true}
+                asset_class={AssetClass.VENTILATOR}
                 facility={facilityId}
                 in_use_by_consultation={false}
                 is_permanent={false}
@@ -271,11 +275,13 @@ const Beds = (props: BedsProps) => {
                   {bed?.bed_object?.name}
                   {bed?.assets_objects && bed.assets_objects.length > 0 && (
                     <span
-                    className={` bg-primary-500 font-semibold text-white ml-2 h-6 cursor-pointer rounded-md px-2 text-xs`}
-                    onClick={() => setShowBedDetails(bed)}
-                  >
-                    {bed.assets_objects.length}
-                  </span>
+                      className={
+                        " ml-2 h-6 cursor-pointer rounded-md bg-primary-500 px-2 text-xs font-semibold text-white"
+                      }
+                      onClick={() => setShowBedDetails(bed)}
+                    >
+                      {bed.assets_objects.length}
+                    </span>
                   )}
                 </div>
                 <div className="bg-primary-100 py-2 text-center">


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3259b41</samp>

Added a new feature to filter and assign ventilators by asset class using the `AssetSelect` component. Refactored some code in `Beds.tsx` for better style and readability.

## Proposed Changes

- Partially Fixes #6119 
![image](https://github.com/coronasafe/care_fe/assets/3626859/f6470066-d52e-40ab-9785-5151a446d48c)

Show only ventilator asset class for linking to a bed.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3259b41</samp>

*  Add `asset_class` prop to `AssetSelect` component and interface to filter assets by class ([link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-870c97b0ffbf23914872030cd7aa007357ee7a85925bdd3fb5b1d4d48756f7e4L13-R16), [link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-870c97b0ffbf23914872030cd7aa007357ee7a85925bdd3fb5b1d4d48756f7e4R38), [link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-870c97b0ffbf23914872030cd7aa007357ee7a85925bdd3fb5b1d4d48756f7e4L43-R50), [link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-870c97b0ffbf23914872030cd7aa007357ee7a85925bdd3fb5b1d4d48756f7e4R58), [link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbR235))
*  Allow `null` values for `is_permanent` prop in `AssetSelect` interface to handle missing field in API response ([link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-870c97b0ffbf23914872030cd7aa007357ee7a85925bdd3fb5b1d4d48756f7e4L13-R16))
*  Remove unused `AssetsList` import and add `AssetClass` enum import in `Beds` component ([link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbL23-R28))
*  Adjust `className` attribute of `span` element for asset count in `Beds` component to improve code style ([link](https://github.com/coronasafe/care_fe/pull/6146/files?diff=unified&w=0#diff-befff88edc6070c18bee26653a810b4168ae6d9ffde08c2334d6f005fd9053dbL274-R284))
