### PR TITLE
 Don't show Skills with already linked to the user

### DIFF
--- a/src/Components/Common/SkillSelect.tsx
+++ b/src/Components/Common/SkillSelect.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useDispatch } from "react-redux";
-import { getAllSkills } from "../../Redux/actions";
+import { getAllSkills, getUserListSkills } from "../../Redux/actions";
 import AutoCompleteAsync from "../Form/AutoCompleteAsync";
 import { SkillObjectModel } from "../Users/models";
 
@@ -15,6 +15,7 @@ interface SkillSelectProps {
   disabled?: boolean;
   selected: SkillObjectModel | SkillObjectModel[] | null;
   setSelected: (selected: SkillObjectModel) => void;
+  username?: string;
 }
 
 export const SkillSelect = (props: SkillSelectProps) => {
@@ -29,6 +30,7 @@ export const SkillSelect = (props: SkillSelectProps) => {
     disabled = false,
     className = "",
     errors = "",
+    username,
   } = props;
 
   const dispatchAction: any = useDispatch();
@@ -44,7 +46,18 @@ export const SkillSelect = (props: SkillSelectProps) => {
 
       const res = await dispatchAction(getAllSkills(params));
 
-      return res?.data?.results;
+      const linkedSkills = await dispatchAction(
+        getUserListSkills({ username: username })
+      );
+
+      const skillsList = linkedSkills?.data?.results;
+      const skillsID: string[] = [];
+      skillsList.map((skill: any) => skillsID.push(skill.skill_object.id));
+      const skills = res?.data?.results.filter(
+        (skill: any) => !skillsID.includes(skill.id)
+      );
+
+      return skills;
     },
     [dispatchAction, searchAll, showAll]
   );

--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -117,6 +117,7 @@ export default ({ show, setShow, username }: IProps) => {
                 selected={selectedSkill}
                 setSelected={setSelectedSkill}
                 errors=""
+                username={username}
               />
               <ButtonV2
                 disabled={!authorizeForAddSkill}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1b4e3c</samp>

Updated the `SkillSelect` component to filter out the skills already assigned to a user. Passed the `username` prop from the `SkillsSlideOver` component to enable this functionality.

## Proposed Changes

- Fixes #6145 
http://localhost:4000/users
Only show Skills that aren't linked to the user
![image](https://github.com/coronasafe/care_fe/assets/70687348/e1893a85-5a48-487d-90a5-ef4084092658)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1b4e3c</samp>

*  Add `username` prop to `SkillSelect` component and use it to filter out skills that are already linked to the user ([link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-92f854d0bfdfb15b1d6f1886f3448daf7039364de119fb28a7a77bf1dd9a7896L3-R3), [link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-92f854d0bfdfb15b1d6f1886f3448daf7039364de119fb28a7a77bf1dd9a7896R18), [link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-92f854d0bfdfb15b1d6f1886f3448daf7039364de119fb28a7a77bf1dd9a7896R33), [link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-92f854d0bfdfb15b1d6f1886f3448daf7039364de119fb28a7a77bf1dd9a7896L47-R60), [link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8R120))
  * Import `getUserListSkills` action from `../../Redux/actions` to fetch the user's skills ([link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-92f854d0bfdfb15b1d6f1886f3448daf7039364de119fb28a7a77bf1dd9a7896L3-R3))
  * Destructure `username` from the `props` parameter of `SkillSelect` ([link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-92f854d0bfdfb15b1d6f1886f3448daf7039364de119fb28a7a77bf1dd9a7896R33))
  * Pass `username` prop to `SkillSelect` in `SkillsSlideOver` component ([link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8R120))
  * Modify `loadOptions` function in `SkillSelect` to dispatch `getUserListSkills` with `username` and compare the skill ids with the ones returned by `getAllSkills` ([link](https://github.com/coronasafe/care_fe/pull/6147/files?diff=unified&w=0#diff-92f854d0bfdfb15b1d6f1886f3448daf7039364de119fb28a7a77bf1dd9a7896L47-R60))
