### PR TITLE
Fix C-PAP / PSV selector in critical care

### DIFF
--- a/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor__Invasive.res
+++ b/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor__Invasive.res
@@ -157,7 +157,7 @@ let make = (~state: VentilatorParameters.state, ~send: VentilatorParameters.acti
       <Radio
         id={"psv"}
         label={"C-PAP/ Pressure Support Ventilation (PSV)"}
-        checked={state.ventilator_mode == PSV}
+        checked={parentVentilatorMode == UNKNOWN}
         onChange={_ => {
           setParentVentilatorMode(_ => UNKNOWN)
           send(SetVentilatorMode(PSV))


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6d3c11</samp>

Fixed a bug and simplified the logic for the `psv` checkbox in the `CriticalCare__VentilatorParametersEditor__Invasive` component. Changed the `checked` and `onChange` props to use and update the `parentVentilatorMode` state.

## Proposed Changes

- Fixes #6142 
![image](https://github.com/coronasafe/care_fe/assets/3626859/bc239694-ea17-41a1-ae4e-6a9ac12f54af)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f6d3c11</samp>

*  Fixed a bug where the `psv` checkbox would not reflect the correct value of the parent component's state by using the `parentVentilatorMode` state instead of the `state.ventilator_mode` state for the `checked` prop of the `Checkbox` component ([link](https://github.com/coronasafe/care_fe/pull/6148/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14L160-R160))
* Simplified the logic for updating the `parentVentilatorMode` state when the `psv` checkbox is changed by setting it to `UNKNOWN` instead of using a callback function for the `onChange` prop of the `Checkbox` component ([link](https://github.com/coronasafe/care_fe/pull/6148/files?diff=unified&w=0#diff-bf6c0a4934e6a37cab5e07c9c3004ab14570b788ed9c72aba9bb4cef5de85a14L160-R160))
