### PR TITLE
Disable Import Asset button until a file is uploaded

### DIFF
--- a/src/Components/Assets/AssetImportModal.tsx
+++ b/src/Components/Assets/AssetImportModal.tsx
@@ -64,6 +64,7 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
                     msg: `Please check the row ${error.row} of column ${error.column}`,
                   });
                 });
+                setSelectedFile(undefined);
               } else {
                 setPreview(parsedData.rows as AssetData[]);
               }

--- a/src/Components/Assets/AssetImportModal.tsx
+++ b/src/Components/Assets/AssetImportModal.tsx
@@ -89,6 +89,7 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
         Notification.Error({
           msg: "Invalid file",
         });
+        setSelectedFile(undefined);
       }
     };
     readFile();
@@ -327,7 +328,10 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
               }}
               disabled={isImporting}
             />
-            <Submit onClick={handleUpload} disabled={isImporting}>
+            <Submit
+              onClick={handleUpload}
+              disabled={isImporting || !selectedFile}
+            >
               {isImporting ? (
                 <i className="fa-solid fa-spinner animate-spin" />
               ) : (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d96f8fc</samp>

Improve UX and functionality of `AssetImportModal` component. Reset and disable the file input field based on the import status and validation.

## Proposed Changes

- Fixes #6156 
http://localhost:4000/assets
The `Import` asset button is disabled in the Import Asset Modal until a file is uploaded to prevent the form from closing abruptly.
![image](https://github.com/coronasafe/care_fe/assets/70687348/870a237e-2a24-4428-a193-15ddabe48b44)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d96f8fc</samp>

* Reset the selected file state to undefined when the modal is closed or the import is successful ([link](https://github.com/coronasafe/care_fe/pull/6157/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132R67), [link](https://github.com/coronasafe/care_fe/pull/6157/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132R93)). This avoids showing the previous file when the modal is reopened and clears the file input field.
