### PR TITLE
fixes #6159; fix misalignment in option chips of async autocomplete.

### DIFF
--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -3,7 +3,10 @@ import { Combobox } from "@headlessui/react";
 import { debounce } from "lodash";
 import { DropdownTransition } from "../Common/components/HelperComponents";
 import CareIcon from "../../CAREUI/icons/CareIcon";
-import { dropdownOptionClassNames } from "./MultiSelectMenuV2";
+import {
+  MultiSelectOptionChip,
+  dropdownOptionClassNames,
+} from "./MultiSelectMenuV2";
 
 interface Props {
   name?: string;
@@ -143,19 +146,14 @@ const AutoCompleteAsync = (props: Props) => {
           {multiple && selected?.length > 0 && (
             <div className="flex flex-wrap gap-2 p-2">
               {selected?.map((option: any) => (
-                <span className="rounded-full border border-gray-400 bg-gray-200 px-2 py-1 text-xs text-gray-800">
-                  {optionLabel(option)}
-                  <i
-                    className="ml-1 h-3 w-3 cursor-pointer text-lg text-gray-700"
-                    onClick={() => {
-                      onChange(
-                        selected.filter((item: any) => item.id !== option.id)
-                      );
-                    }}
-                  >
-                    <CareIcon className="care-l-multiply" />
-                  </i>
-                </span>
+                <MultiSelectOptionChip
+                  label={optionLabel(option)}
+                  onRemove={() =>
+                    onChange(
+                      selected.filter((item: any) => item.id !== option.id)
+                    )
+                  }
+                />
               ))}
             </div>
           )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 595c28a</samp>

Refactored option chips in `AutoCompleteAsync` component to use a common component `MultiSelectOptionChip`. This enhances the UI and code quality of the form component.

## Proposed Changes

- fixes #6159; fix misalignment in option chips of async autocomplete.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 595c28a</samp>

* Replace the custom span element for rendering the selected options in the `AutoCompleteAsync` component with the `MultiSelectOptionChip` component, which provides a consistent and reusable way to display the option chips with a remove icon and a label. ([link](https://github.com/coronasafe/care_fe/pull/6160/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8L6-R9), [link](https://github.com/coronasafe/care_fe/pull/6160/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8L146-R156))
* Import the `MultiSelectOptionChip` component from `./MultiSelectMenuV2` in the `AutoCompleteAsync.tsx` file. ([link](https://github.com/coronasafe/care_fe/pull/6160/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8L6-R9))
