### PR TITLE
Add responsive design to Update Asset Service Record modal

### DIFF
--- a/src/Components/Assets/AssetServiceEditModal.tsx
+++ b/src/Components/Assets/AssetServiceEditModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { updateAssetService } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
-import ButtonV2 from "../Common/components/ButtonV2";
+import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
 import DialogModal from "../Common/Dialog";
 import { AssetData, AssetService, AssetServiceEdit } from "./AssetTypes";
 import dayjs from "dayjs";
@@ -199,18 +199,13 @@ export const AssetServiceEditModal = (props: {
             </div>
           </div>
         </div>
-        <div className="flex justify-end">
-          <ButtonV2
-            variant="primary"
+        <div className="flex flex-col justify-end gap-2 md:flex-row">
+          <Submit
+            label={`${isLoading ? "Updating" : "Update"}`}
             onClick={handleSubmit}
-            className="mr-2"
             loading={isLoading}
-          >
-            {isLoading ? "Updating" : "Update"}
-          </ButtonV2>
-          <ButtonV2 variant="secondary" onClick={props.handleClose}>
-            Cancel
-          </ButtonV2>
+          />
+          <Cancel onClick={props.handleClose} />
         </div>
       </div>
     </DialogModal>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4baad12</samp>

Refactor the `AssetServiceEditModal` component to use better buttons. This improves the UI and the code quality of the asset service editing feature.

## Proposed Changes

- Fixes #6165 
http://localhost:4000/facility/10c66ed2-5b95-4649-bd2f-f5766334e1cd/assets/b8a60442-1ff0-458b-b72d-a2de5b2261c1
Placed the button in column view in mobile view and used new components for the buttons.
![image](https://github.com/coronasafe/care_fe/assets/70687348/765d6a3d-8bd7-4c6b-aa6e-f76f16fb142c)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4baad12</samp>

* Import two new components, `Cancel` and `Submit`, from `ButtonV2` module to render modal buttons ([link](https://github.com/coronasafe/care_fe/pull/6166/files?diff=unified&w=0#diff-5aea9f0ca0c6dd1a0dd842d82670733dcb1958e9996fdf66760508b1c00dda5cL5-R5))
* Replace `ButtonV2` components with `Cancel` and `Submit` components in `AssetServiceEditModal.tsx` and adjust layout to use flex column or row depending on screen size ([link](https://github.com/coronasafe/care_fe/pull/6166/files?diff=unified&w=0#diff-5aea9f0ca0c6dd1a0dd842d82670733dcb1958e9996fdf66760508b1c00dda5cL202-R208))
