### PR TITLE
Minor UI Fix: Button background should not appear when loading

### DIFF
--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -121,18 +121,17 @@ export default ({ show, setShow, username }: IProps) => {
                 setSelected={setSelectedSkill}
                 errors=""
               />
-              <ButtonV2
-                disabled={!authorizeForAddSkill}
-                onClick={() => addSkill(username, selectedSkill)}
-                className="w-6rem"
-              >
-                {/* Replace "Add" in button with CircularProgress */}
-                {isLoading ? (
-                  <CircularProgress className="h-5 w-5" />
-                ) : (
-                  t("add")
-                )}
-              </ButtonV2>
+              {isLoading ? (
+                <CircularProgress className="h-5 w-5" />
+              ) : (
+                <ButtonV2
+                  disabled={!authorizeForAddSkill}
+                  onClick={() => addSkill(username, selectedSkill)}
+                  className="w-6rem"
+                >
+                  {t("add")}
+                </ButtonV2>
+              )}
               {!authorizeForAddSkill && (
                 <span className="tooltip-text tooltip-bottom -translate-x-24 translate-y-2">
                   {t("contact_your_admin_to_add_skills")}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7b992a</samp>

Improved the UI of the skills slide over component by adding a circular progress indicator for skill addition requests. Modified `src/Components/Users/SkillsSlideOver.tsx` to implement this feature.

## Proposed Changes
https://care.coronasafe.in/users
The Loader on the Add Skills to a User doesn't look good.
Removed the green background behind the loader

Steps:
1. Open the URL
2. Click on `Linked Skills` of any user
3. Try to add a skill that has already been added
4. See the loader

Before:
![image](https://github.com/coronasafe/care_fe/assets/70687348/6e1dc619-97cc-487b-9c0b-24ce0ab88c19)

Now:
![image](https://github.com/coronasafe/care_fe/assets/70687348/a2c8902b-6103-46f7-9eb2-eeea49535ea4)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7b992a</samp>

* Show a circular progress indicator instead of the "Add" button when adding a skill ([link](https://github.com/coronasafe/care_fe/pull/6172/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L124-R134))
