### PR TITLE
Fix asset import from excel files

### DIFF
--- a/src/Components/Assets/AssetImportModal.tsx
+++ b/src/Components/Assets/AssetImportModal.tsx
@@ -27,7 +27,8 @@ interface Props {
 const AssetImportModal = ({ open, onClose, facility }: Props) => {
   const [isImporting, setIsUploading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<any>();
-  const [preview, setPreview] = useState<AssetData[]>();
+  const [preview, setPreview] =
+    useState<(AssetData & { notes?: string; last_serviced_on?: string })[]>();
   const [location, setLocation] = useState("");
   const [locations, setLocations] = useState<any>([]);
   const dispatchAction: any = useDispatch();
@@ -129,8 +130,8 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
         manufacturer: asset.manufacturer,
         meta: { ...asset.meta },
         warranty_amc_end_of_validity: asset.warranty_amc_end_of_validity,
-        last_serviced_on: asset.last_service.serviced_on,
-        note: asset.last_service.note,
+        last_serviced_on: asset.last_serviced_on,
+        note: asset.notes,
         cancelToken: { promise: {} },
       });
 
@@ -168,8 +169,14 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
     e.preventDefault();
     dragProps.setDragOver(false);
     const dropedFile = e?.dataTransfer?.files[0];
-    if (dropedFile.type.split("/")[1] !== "json")
-      return dragProps.setFileDropError("Please drop a JSON file to upload!");
+    if (
+      !["xlsx", "csv", "json"].includes(
+        dropedFile?.name?.split(".")?.pop() || ""
+      )
+    )
+      return dragProps.setFileDropError(
+        "Please drop a JSON / Excel file to upload!"
+      );
     setSelectedFile(dropedFile);
   };
 
@@ -235,7 +242,7 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
                   />
                 </div>
               </div>
-              <div className="h-80 overflow-y-scroll rounded border border-gray-500 bg-white md:min-w-[500px]">
+              <div className="my-4 h-80 overflow-y-scroll rounded border border-gray-500 bg-white md:min-w-[500px]">
                 <div className="flex border-b p-2">
                   <div className="mr-2 p-2 font-bold">#</div>
                   <div className="mr-2 p-2 font-bold md:w-1/2">Name</div>

--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -86,7 +86,6 @@ export interface AssetData {
   manufacturer: string;
   warranty_amc_end_of_validity: string;
   last_service: AssetService;
-  note: string;
   meta?: {
     [key: string]: any;
   };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 620b760</samp>

Improved asset import modal and removed unused property from asset interface. The modal can now handle different file formats, show better feedback, and display the imported data. The `note` property was removed from `AssetData` as it was redundant.

## Proposed Changes

- Fixes import for assets from an Excel file

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 620b760</samp>

*  Add optional properties `notes` and `last_serviced_on` to the `preview` state to handle additional fields in the asset import file ([link](https://github.com/coronasafe/care_fe/pull/6182/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L30-R31))
* Rename `last_serviced_on` and `note` properties to `last_service.serviced_on` and `last_service.note` respectively to match the asset creation API ([link](https://github.com/coronasafe/care_fe/pull/6182/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L132-R134))
* Expand file type validation to allow JSON, Excel, and CSV files for asset import in `AssetImportModal.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6182/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L171-R179))
* Add margin to the preview table in `AssetImportModal.tsx` for better spacing ([link](https://github.com/coronasafe/care_fe/pull/6182/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L238-R245))
* Remove unused `note` property from the `AssetData` interface in `AssetTypes.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6182/files?diff=unified&w=0#diff-b1df14c97376139c1e0b897e944b610f11afea110738c80cd6ae9c0fd448eb6dL89))
