### PR TITLE
Removed default empty phone filter

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -121,7 +121,7 @@ export const PatientManager = () => {
 
     if (phone_number === "+91" || phone_number === "") {
       setPhoneNumberError("");
-      updateQuery({ phone_number: "" });
+      qParams.phone_number && updateQuery({ phone_number: "" });
       return;
     }
 
@@ -138,7 +138,8 @@ export const PatientManager = () => {
 
     if (emergency_phone_number === "+91" || emergency_phone_number === "") {
       setEmergencyPhoneNumberError("");
-      updateQuery({ emergency_phone_number: "" });
+      qParams.emergency_phone_number &&
+        updateQuery({ emergency_phone_number: "" });
       return;
     }
 


### PR DESCRIPTION
### WHAT
When /patients page is visited empty filters are applied to phone_number and emergency_phone_number first, then phone_number filter is removed and only emergency_phone_number is applied causing the /patients to redirect 2 times with empty filters(happens very fast, observed in slow motion)

## Proposed Changes

- Fixes #6101 
- The filter for phone_number and emergency_phone_number are removed by default

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
Setting the default value of phone_number and emergency_phone_number as +91 is triggering onChange of PhoneNumberFormField which is updating the query params to have empty values for those parameters. Initially at /patients page the values of phone_number and emergency_phone_number of qParams are undefined. So I checked if those filters exist or not and updated the qParams only if that parameter exist.