### PR TITLE
Show only those facilties that aren't linked to user

### DIFF
--- a/src/Components/Common/FacilitySelect.tsx
+++ b/src/Components/Common/FacilitySelect.tsx
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 import { useDispatch } from "react-redux";
-import { getAllFacilities, getPermittedFacilities } from "../../Redux/actions";
+import {
+  getAllFacilities,
+  getPermittedFacilities,
+  getUserListFacility,
+} from "../../Redux/actions";
 import AutoCompleteAsync from "../Form/AutoCompleteAsync";
 import { FacilityModel } from "../Facility/models";
 
@@ -15,6 +19,7 @@ interface FacilitySelectProps {
   showAll?: boolean;
   showNOptions?: number;
   freeText?: boolean;
+  username?: string;
   selected: FacilityModel | FacilityModel[] | null;
   setSelected: (selected: FacilityModel | FacilityModel[] | null) => void;
 }
@@ -33,6 +38,7 @@ export const FacilitySelect = (props: FacilitySelectProps) => {
     district,
     freeText = false,
     errors = "",
+    username,
   } = props;
 
   const dispatchAction: any = useDispatch();
@@ -51,12 +57,21 @@ export const FacilitySelect = (props: FacilitySelectProps) => {
       const res = await dispatchAction(
         showAll ? getAllFacilities(params) : getPermittedFacilities(params)
       );
+
+      const linkedFacilities = await dispatchAction(
+        getUserListFacility({ username })
+      );
+      const linkedIDs: string[] = [];
+      linkedFacilities.data.map((fac: any) => linkedIDs.push(fac.id));
+
       if (freeText)
         res?.data?.results?.push({
           id: -1,
           name: text,
         });
-      return res?.data?.results;
+      return res?.data?.results.filter(
+        (facility: any) => !linkedIDs.includes(facility.id)
+      );
     },
     [dispatchAction, searchAll, showAll, facilityType, district]
   );

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -701,6 +701,7 @@ function UserFacilities(props: { user: any }) {
           setSelected={setFacility}
           errors=""
           className="z-40"
+          username={username}
         />
         <ButtonV2
           id="link-facility"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97c2bb7</samp>

Added a feature to exclude the facilities that are already linked to a user from the facility select options in the `UserFacilities` component. This required passing the `username` prop from the `ManageUsers` component and modifying the `FacilitySelect` component.

## Proposed Changes

- Fixes #6190 
http://localhost:4000/users
Only shows those facilities in the drop-down that are not linked to the user.
![image](https://github.com/coronasafe/care_fe/assets/70687348/1c878354-9b27-4919-b7b2-26b85882be6b)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97c2bb7</samp>

*  Add `username` prop to `FacilitySelectProps` interface and `FacilitySelect` component to filter out linked facilities from facility select options ([link](https://github.com/coronasafe/care_fe/pull/6191/files?diff=unified&w=0#diff-f2f4af4b241c14bc928b5b78882a6a010ae731f7828bdb30472eac45db7014feR22), [link](https://github.com/coronasafe/care_fe/pull/6191/files?diff=unified&w=0#diff-f2f4af4b241c14bc928b5b78882a6a010ae731f7828bdb30472eac45db7014feR41))
* Import `getUserListFacility` action from Redux actions module and dispatch it with `username` parameter to get the linked facilities of a user ([link](https://github.com/coronasafe/care_fe/pull/6191/files?diff=unified&w=0#diff-f2f4af4b241c14bc928b5b78882a6a010ae731f7828bdb30472eac45db7014feL3-R7), [link](https://github.com/coronasafe/care_fe/pull/6191/files?diff=unified&w=0#diff-f2f4af4b241c14bc928b5b78882a6a010ae731f7828bdb30472eac45db7014feR60-R66))
* Declare `linkedFacilities` and `linkedIDs` variables to store the results of the action and the ids of the linked facilities ([link](https://github.com/coronasafe/care_fe/pull/6191/files?diff=unified&w=0#diff-f2f4af4b241c14bc928b5b78882a6a010ae731f7828bdb30472eac45db7014feR60-R66))
* Modify the `loadOptions` function of the `AutoCompleteAsync` component to use the `filter` method on the `res?.data?.results` array and exclude the facilities that have ids matching the `linkedIDs` array ([link](https://github.com/coronasafe/care_fe/pull/6191/files?diff=unified&w=0#diff-f2f4af4b241c14bc928b5b78882a6a010ae731f7828bdb30472eac45db7014feL59-R74))
* Pass the `username` prop from the `user` object to the `UserFacilities` component in the `ManageUsers` component ([link](https://github.com/coronasafe/care_fe/pull/6191/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121R704))
