### PR TITLE
Temporarily expose abdm health facility config directly

### DIFF
--- a/src/Components/ABDM/ConfigureHealthFacility.tsx
+++ b/src/Components/ABDM/ConfigureHealthFacility.tsx
@@ -6,6 +6,7 @@ import * as Notification from "../../Utils/Notifications.js";
 import { navigate } from "raviger";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import TextFormField from "../Form/FormFields/TextFormField";
+import { classNames } from "../../Utils/utils";
 const Loading = lazy(() => import("../Common/Loading"));
 
 const initForm = {
@@ -84,6 +85,32 @@ export const ConfigureHealthFacility = (props: any) => {
           hf_id: state.form.hf_id,
         })
       );
+    } else if (state.form.hf_id === state.form.health_facility?.hf_id) {
+      res = await dispatchAction(
+        healthFacilityActions.registerService(facilityId)
+      );
+
+      if (res?.status === 200 && res?.data) {
+        if (res.data?.registered) {
+          dispatch({
+            type: "set_form",
+            form: {
+              ...state.form,
+              health_facility: {
+                ...state.form?.health_facility,
+                registered: res.data.registered,
+              },
+            },
+          });
+
+          return;
+        }
+      }
+
+      Notification.Error({
+        msg: "Service registration failed, please try again later",
+      });
+      return;
     } else {
       res = await dispatchAction(
         healthFacilityActions.create({
@@ -127,6 +154,49 @@ export const ConfigureHealthFacility = (props: any) => {
             <TextFormField
               name="hf_id"
               label="Health Facility Id"
+              trailing={
+                <p
+                  className={classNames(
+                    "tooltip cursor-pointer text-sm",
+                    state.form.health_facility?.registered
+                      ? "text-primary-600 hover:text-primary-800"
+                      : "text-warning-600 hover:text-warning-800"
+                  )}
+                >
+                  {state.form.health_facility?.registered ? (
+                    <>
+                      <div className="tooltip-text tooltip-top -left-48 flex flex-col gap-4">
+                        <span className="text-gray-100">
+                          The ABDM health facility is successfully linked with
+                          care{" "}
+                          <strong>and registered as a service in bridge</strong>
+                        </span>
+                        <span className="text-green-100">
+                          No Action Required.
+                        </span>
+                      </div>
+                      Registered
+                    </>
+                  ) : (
+                    <>
+                      <div className="tooltip-text tooltip-top -left-48 flex flex-col gap-4">
+                        <span className="text-gray-100">
+                          The ABDM health facility is successfully linked with
+                          care{" "}
+                          <strong>
+                            but not registered as a service in bridge
+                          </strong>
+                        </span>
+                        <span className="text-warning-100">
+                          Click on <strong>Link Health Facility</strong> to
+                          register the service
+                        </span>
+                      </div>
+                      Not Registered
+                    </>
+                  )}
+                </p>
+              }
               required
               value={state.form.hf_id}
               onChange={(e) => handleChange(e)}
@@ -136,7 +206,14 @@ export const ConfigureHealthFacility = (props: any) => {
         </div>
         <div className="flex flex-col gap-3 sm:flex-row sm:justify-between">
           <Cancel onClick={() => navigate(`/facility/${facilityId}`)} />
-          <Submit onClick={handleSubmit} label="Update" />
+          <Submit
+            onClick={handleSubmit}
+            disabled={
+              state.form.hf_id === state.form.health_facility?.hf_id &&
+              state.form.health_facility?.registered
+            }
+            label="Link Health Facility"
+          />
         </div>
       </form>
     </div>

--- a/src/Components/ABDM/ConfigureHealthFacility.tsx
+++ b/src/Components/ABDM/ConfigureHealthFacility.tsx
@@ -47,7 +47,7 @@ export const ConfigureHealthFacility = (props: any) => {
       setIsLoading(true);
       const res = await dispatchAction(healthFacilityActions.read(facilityId));
 
-      if (res.status === 200 && res?.data) {
+      if (res?.status === 200 && res?.data) {
         const formData = {
           ...state.form,
           hf_id: res.data.hf_id,

--- a/src/Components/Facility/UpdateFacilityMiddleware.tsx
+++ b/src/Components/Facility/UpdateFacilityMiddleware.tsx
@@ -11,7 +11,6 @@ import { navigate } from "raviger";
 import { Cancel, Submit } from "../Common/components/ButtonV2";
 import TextFormField from "../Form/FormFields/TextFormField";
 import Page from "../Common/components/Page";
-import useConfig from "../../Common/hooks/useConfig";
 import { ConfigureHealthFacility } from "../ABDM/ConfigureHealthFacility";
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -52,7 +51,6 @@ export const UpdateFacilityMiddleware = (props: any) => {
   const { facilityId } = props;
   const dispatchAction: any = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
-  const config = useConfig();
 
   const fetchData = useCallback(
     async (status: statusType) => {
@@ -169,11 +167,8 @@ export const UpdateFacilityMiddleware = (props: any) => {
           </div>
         </form>
       </div>
-      {config.enable_abdm ? (
-        <ConfigureHealthFacility facilityId={facilityId} />
-      ) : (
-        <></>
-      )}
+
+      <ConfigureHealthFacility facilityId={facilityId} />
     </Page>
   );
 };

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -975,6 +975,15 @@ export const healthFacilityActions = {
       facility_id: id,
     });
   },
+
+  registerService: (id: string) => {
+    return fireRequest(
+      "registerHealthFacilityAsService",
+      [],
+      {},
+      { facility_id: id }
+    );
+  },
 };
 
 export const listAssetAvailability = (params: object) =>

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -931,6 +931,11 @@ const routes: Routes = {
     method: "PATCH",
   },
 
+  registerHealthFacilityAsService: {
+    path: "/api/v1/abdm/health_facility/{facility_id}/register_service/",
+    method: "POST",
+  },
+
   // Asset Availability endpoints
 
   listAssetAvailability: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eaf27f</samp>

This pull request simplifies and refactors the code for updating and configuring health facilities. It removes an unnecessary feature flag and uses optional chaining to handle API responses.

## Proposed Changes

- Temporarily expose ABDM health facility config directly for the ops team to link ABDM health facilities
- Added UI to show weather the health facility is registered as a service.
- Depends on https://github.com/coronasafe/care/pull/1569

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3eaf27f</samp>

*  Remove the use of the config.enable_abdm flag and the useConfig hook from the UpdateFacilityMiddleware component ([link](https://github.com/coronasafe/care_fe/pull/6197/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL14), [link](https://github.com/coronasafe/care_fe/pull/6197/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL55), [link](https://github.com/coronasafe/care_fe/pull/6197/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL172-R171))
*  Always render the ConfigureHealthFacility component after the form in the `UpdateFacilityMiddleware.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/6197/files?diff=unified&w=0#diff-c4349f2c92ec1e90e8adf4b2a72e12795c1ec44fb575a12663a2262aa6ae9adeL172-R171))
*  Refactor the status check of the health facility API response to use optional chaining in the `ConfigureHealthFacility.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/6197/files?diff=unified&w=0#diff-82ab3a1b124e696b6416145151d2a8c2e3883275674526de3a812d431ce801f3L50-R50))
