### PR TITLE
Improve Prescriptions table when No Medicines prescribed

### DIFF
--- a/src/Components/Medicine/PrescriptionAdministrationsTable.tsx
+++ b/src/Components/Medicine/PrescriptionAdministrationsTable.tsx
@@ -126,6 +126,9 @@ export default function PrescriptionAdministrationsTable({
                 border
                 onClick={() => setShowBulkAdminister(true)}
                 className="w-full"
+                disabled={
+                  state === undefined || state.prescriptions.length === 0
+                }
               >
                 <CareIcon className="care-l-syringe text-lg" />
                 <span className="hidden lg:block">
@@ -221,18 +224,19 @@ export default function PrescriptionAdministrationsTable({
                 refetch={refetch}
               />
             ))}
-            {state?.prescriptions.length === 0 && (
-              <div className="my-16 flex flex-col items-center justify-center gap-4 text-gray-500">
-                <CareIcon className="care-l-tablets text-5xl" />
-                <h3 className="text-lg font-medium">
-                  {prn
-                    ? "No PRN Prescriptions Prescribed"
-                    : "No Prescriptions Prescribed"}
-                </h3>
-              </div>
-            )}
           </tbody>
         </table>
+
+        {state?.prescriptions.length === 0 && (
+          <div className="my-16 flex w-full flex-col items-center justify-center gap-4 text-gray-500">
+            <CareIcon className="care-l-tablets text-5xl" />
+            <h3 className="text-lg font-medium">
+              {prn
+                ? "No PRN Prescriptions Prescribed"
+                : "No Prescriptions Prescribed"}
+            </h3>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -547,7 +551,7 @@ function getAdministrationBounds(prescriptions: Prescription[]) {
           curr.last_administered_on && curr.last_administered_on > latest
             ? curr.last_administered_on
             : latest,
-        prescriptions[0].created_date ?? new Date()
+        prescriptions[0]?.created_date ?? new Date()
       )
   );
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6b9ebf</samp>

Fix UI and logic bugs in `PrescriptionAdministrationsTable` component. Improve user experience and error handling for medicine administration data.

## Proposed Changes

- Fixes #6199
- Fixes #6193

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/d20e956c-5042-480a-b2b7-dbab9b7aa450">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6b9ebf</samp>

* Disable export button when prescriptions are empty or undefined ([link](https://github.com/coronasafe/care_fe/pull/6200/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150R129-R131))
* Move empty state message outside of table element and make it fill full width ([link](https://github.com/coronasafe/care_fe/pull/6200/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L224-R239))
* Add optional chaining operator to prevent error when accessing `created_date` property of prescriptions array ([link](https://github.com/coronasafe/care_fe/pull/6200/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L550-R554))
