### PR TITLE
Fix Patient Crud Cypress 

### DIFF
--- a/cypress/e2e/assets_spec/assets_manage.cy.ts
+++ b/cypress/e2e/assets_spec/assets_manage.cy.ts
@@ -56,7 +56,7 @@ describe("Asset", () => {
       "email@support.com",
       "Vendor's Name",
       serialNumber,
-      "2021-12-25",
+      "25122021",
       "Test note for asset creation!"
     );
 
@@ -80,7 +80,7 @@ describe("Asset", () => {
       "email@support.com",
       "Vendor's Name",
       serialNumber,
-      "2021-12-25",
+      "25122021",
       "Test note for asset creation!"
     );
 

--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -3,7 +3,8 @@ import { afterEach, before, beforeEach, cy, describe, it } from "local-cypress";
 const username = "devdistrictadmin";
 const password = "Coronasafe@123";
 const phone_number = "9" + Math.floor(100000000 + Math.random() * 900000000);
-const emergency_phone_number = "9430123487";
+const emergency_phone_number =
+  "9" + Math.floor(100000000 + Math.random() * 900000000);
 const yearOfBirth = "2023";
 let patient_url = "";
 
@@ -104,9 +105,11 @@ describe("Patient Creation with consultation", () => {
     cy.get("[data-testid=name] input").clear();
     cy.get("[data-testid=name] input").type("Test E2E User Edited");
     cy.get("#phone_number-div").clear();
-    cy.get("#phone_number-div").type("+919846856666");
+    cy.get("#phone_number-div").type("+91").type(phone_number);
     cy.get("#emergency_phone_number-div").clear();
-    cy.get("#emergency_phone_number-div").type("+919120330220");
+    cy.get("#emergency_phone_number-div")
+      .type("+91")
+      .type(emergency_phone_number);
     cy.get("#present_health").type("Severe Cough");
     cy.get("#ongoing_medication").type("Paracetamol");
     cy.get("#allergies").type("Dust");
@@ -142,10 +145,7 @@ describe("Patient Creation with consultation", () => {
       "contain",
       "Test E2E User Edited"
     );
-    cy.get("[data-testid=patient-dashboard]").should(
-      "contain",
-      "+919120330220"
-    );
+    cy.get("[data-testid=patient-dashboard]").should("contain", phone_number);
     const patientDetails_values: string[] = [
       "Severe Cough",
       "Paracetamol",
@@ -165,6 +165,7 @@ describe("Patient Creation with consultation", () => {
     cy.intercept("GET", "**/api/v1/patient/**").as("getFacilities");
     cy.visit(patient_url + "/consultation");
     cy.wait("@getFacilities").its("response.statusCode").should("eq", 200);
+    cy.get("#history_of_present_illness").scrollIntoView;
     cy.get("#history_of_present_illness").should("be.visible");
     cy.get("#history_of_present_illness").click().type("histroy");
     cy.get("#consultation_status")

--- a/cypress/e2e/users_spec/user_crud.cy.ts
+++ b/cypress/e2e/users_spec/user_crud.cy.ts
@@ -38,7 +38,7 @@ describe("User management", () => {
     cy.intercept(/\/api\/v1\/facility/).as("facility");
     cy.get("[name='facilities']")
       .click()
-      .type("cypress facility")
+      .type("Dummy Facility 1")
       .wait("@facility");
     cy.get("li[role='option']").first().click();
     cy.get("input[type='checkbox']").click();
@@ -93,7 +93,7 @@ describe("User management", () => {
       cy.get("button[id='facilities']").click();
       cy.wait("@userFacility")
         .getAttached("div[id=facility_0] > div > span")
-        .contains("cypress facility");
+        .contains("Dummy Facility 1");
     });
   });
 
@@ -102,7 +102,7 @@ describe("User management", () => {
     cy.intercept(/\/api\/v1\/facility/).as("getFacilities");
     cy.get("[name='facility']")
       .click()
-      .type("cypress facility")
+      .type("Dummy Facility 1")
       .wait("@getFacilities");
     cy.get("li[role='option']").first().click();
     cy.intercept(/\/api\/v1\/users\/\w+\/add_facility\//).as("addFacility");

--- a/cypress/pageobject/Asset/AssetCreation.ts
+++ b/cypress/pageobject/Asset/AssetCreation.ts
@@ -67,9 +67,10 @@ export class AssetPage {
     cy.get("[data-testid=asset-support-email-input] input").type(supportEmail);
     cy.get("[data-testid=asset-vendor-name-input] input").type(vendorName);
     cy.get("[data-testid=asset-serial-number-input] input").type(serialNumber);
-    cy.get("[data-testid=asset-last-serviced-on-input] input").type(
-      lastServicedOn
-    );
+    cy.get(
+      "[data-testid=asset-last-serviced-on-input] input[type='text']"
+    ).click();
+    cy.get("#date-input").click().type(lastServicedOn);
     cy.get("[data-testid=asset-notes-input] textarea").type(notes);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "@typescript-eslint/parser": "^5.61.0",
         "@vitejs/plugin-react-swc": "^3.3.2",
         "autoprefixer": "^10.4.14",
-        "cypress": "^12.17.4",
+        "cypress": "^13.1.0",
         "cypress-localstorage-commands": "^2.2.3",
         "eslint": "^8.44.0",
         "eslint-config-prettier": "^8.8.0",
@@ -2261,9 +2261,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+      "integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -7789,13 +7789,13 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -7843,7 +7843,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress-localstorage-commands": {
@@ -14564,6 +14564,8 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -15364,6 +15366,8 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -16582,6 +16586,8 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -16686,6 +16692,8 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -16753,6 +16761,8 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -16771,6 +16781,8 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -16860,6 +16872,8 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -16879,6 +16893,8 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@typescript-eslint/parser": "^5.61.0",
     "@vitejs/plugin-react-swc": "^3.3.2",
     "autoprefixer": "^10.4.14",
-    "cypress": "^12.17.4",
+    "cypress": "^13.1.0",
     "cypress-localstorage-commands": "^2.2.3",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9694e10</samp>

This pull request enhances the reliability and accuracy of the end-to-end tests for patient and user CRUD operations. It uses more realistic and varied data for the phone numbers and facility names, and fixes some element visibility and filtering issues.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9694e10</samp>

* Change the emergency phone number in the patient CRUD test to use a random number instead of a fixed one ([link](https://github.com/coronasafe/care_fe/pull/6202/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL6-R7))
* Use variables for the phone number and emergency phone number fields in the patient CRUD test instead of hard-coded values ([link](https://github.com/coronasafe/care_fe/pull/6202/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL107-R112), [link](https://github.com/coronasafe/care_fe/pull/6202/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaL145-R148))
* Add the `scrollIntoView` method to the `history_of_present_illness` element in the patient CRUD test to ensure its visibility ([link](https://github.com/coronasafe/care_fe/pull/6202/files?diff=unified&w=0#diff-85edc6c535fd4c7cef250d5a68bb562c3fd75a82654e2de0b0227413d5840bfaR168))
* Update the facility name in the user CRUD test to match the one created in the `beforeEach` hook ([link](https://github.com/coronasafe/care_fe/pull/6202/files?diff=unified&w=0#diff-e67a0213157496a67503f421a72b4e510886da71661a6cd810c2fc1c094b93f0L41-R41), [link](https://github.com/coronasafe/care_fe/pull/6202/files?diff=unified&w=0#diff-e67a0213157496a67503f421a72b4e510886da71661a6cd810c2fc1c094b93f0L96-R96), [link](https://github.com/coronasafe/care_fe/pull/6202/files?diff=unified&w=0#diff-e67a0213157496a67503f421a72b4e510886da71661a6cd810c2fc1c094b93f0L105-R105))
