### PR TITLE
Medicine Administrations: Adds `administered_date` input

### DIFF
--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -28,7 +28,7 @@ describe("Patient Creation with consultation", () => {
     cy.get("#add-patient-details").should("be.visible");
     cy.get("#add-patient-details").click();
     cy.get("input[name='facilities']")
-      .type("cypress facility")
+      .type("dummy facility")
       .then(() => {
         cy.get("[role='option']").first().click();
       });

--- a/src/Components/Form/FormFields/CheckBoxFormField.tsx
+++ b/src/Components/Form/FormFields/CheckBoxFormField.tsx
@@ -14,6 +14,7 @@ export default function CheckBoxFormField(props: FormFieldBaseProps<boolean>) {
           name={field.name}
           checked={field.value}
           onChange={(e) => field.handleChange(e.target.checked)}
+          disabled={field.disabled}
         />
         <FieldLabel
           htmlFor={field.id}

--- a/src/Components/Medicine/PrescriptionAdministrationsTable.tsx
+++ b/src/Components/Medicine/PrescriptionAdministrationsTable.tsx
@@ -85,7 +85,7 @@ export default function PrescriptionAdministrationsTable({
       {state?.prescriptions && (
         <SlideOver
           title={t("administer_medicines")}
-          dialogClass="w-full max-w-sm sm:max-w-md md:max-w-[1200px]"
+          dialogClass="w-full max-w-sm sm:max-w-md md:max-w-[1300px]"
           open={showBulkAdminister}
           setOpen={setShowBulkAdminister}
         >

--- a/src/Components/Medicine/models.ts
+++ b/src/Components/Medicine/models.ts
@@ -53,8 +53,8 @@ export type MedicineAdministrationRecord = {
   readonly id?: string;
   readonly prescription?: Prescription;
   notes: string;
+  administered_date?: string;
   readonly administered_by?: PerformedByModel;
-  readonly administered_date?: string;
   readonly created_date?: string;
   readonly modified_date?: string;
 };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1269460</samp>

The pull request adds a feature to the `AdministerMedicine` component that lets the user set a custom time for medicine administration. It also refactors the `MedicineAdministrationRecord` type to align with the backend model. The changes affect the files `src/Components/Medicine/AdministerMedicine.tsx` and `src/Components/Medicine/models.ts`.

## Required Backends: 

- https://github.com/coronasafe/care/pull/1570

## Proposed Changes

- Fixes #6178 

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/cc50d1c0-7c2d-44cf-b5be-94f9d617149e">

<img width="1892" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/75269964-9c5d-4e05-8106-814021a16c62">



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1269460</samp>

*  Add a feature to administer medicine for a custom time in the past ([link](https://github.com/coronasafe/care_fe/pull/6206/files?diff=unified&w=0#diff-0cff6f571c166a4b174e2180d36c81d41819d2d57cb32bef474c1718d0c70519R12-R14), [link](https://github.com/coronasafe/care_fe/pull/6206/files?diff=unified&w=0#diff-0cff6f571c166a4b174e2180d36c81d41819d2d57cb32bef474c1718d0c70519R27-R30), [link](https://github.com/coronasafe/care_fe/pull/6206/files?diff=unified&w=0#diff-0cff6f571c166a4b174e2180d36c81d41819d2d57cb32bef474c1718d0c70519L46-R60), [link](https://github.com/coronasafe/care_fe/pull/6206/files?diff=unified&w=0#diff-0cff6f571c166a4b174e2180d36c81d41819d2d57cb32bef474c1718d0c70519L64-R111))
* Reorder the fields of the `MedicineAdministrationRecord` type to match the backend model ([link](https://github.com/coronasafe/care_fe/pull/6206/files?diff=unified&w=0#diff-b6d89e365687bdfdf20171e060aa22bd7141ac636df57d9b7b3c0ab46b180448L56-R57))
