### PR TITLE
Remove extra loader and add success notification on link skills page

### DIFF
--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -55,6 +55,10 @@ export default ({ show, setShow, username }: IProps) => {
         Notification.Error({
           msg: "Error while adding skill",
         });
+      } else {
+        Notification.Success({
+          msg: "Skill added successfully",
+        });
       }
       setSelectedSkill(null);
       setIsLoading(false);
@@ -110,21 +114,19 @@ export default ({ show, setShow, username }: IProps) => {
       >
         <div>
           <div className="col-span-full sm:col-span-3 sm:col-start-2">
-            <div className="tooltip flex items-center gap-2">
-              <SkillSelect
-                multiple={false}
-                name="skill"
-                disabled={!authorizeForAddSkill}
-                showAll={true}
-                showNOptions={Infinity}
-                selected={selectedSkill}
-                setSelected={setSelectedSkill}
-                errors=""
-                username={username}
-              />
-              {isLoading ? (
-                <CircularProgress className="h-5 w-5" />
-              ) : (
+            {!isLoading && (
+              <div className="tooltip flex items-center gap-2">
+                <SkillSelect
+                  multiple={false}
+                  name="skill"
+                  disabled={!authorizeForAddSkill}
+                  showAll={true}
+                  showNOptions={Infinity}
+                  selected={selectedSkill}
+                  setSelected={setSelectedSkill}
+                  errors=""
+                  username={username}
+                />
                 <ButtonV2
                   disabled={!authorizeForAddSkill}
                   onClick={() => addSkill(username, selectedSkill)}
@@ -132,14 +134,13 @@ export default ({ show, setShow, username }: IProps) => {
                 >
                   {t("add")}
                 </ButtonV2>
-              )}
-              {!authorizeForAddSkill && (
-                <span className="tooltip-text tooltip-bottom -translate-x-24 translate-y-2">
-                  {t("contact_your_admin_to_add_skills")}
-                </span>
-              )}
-            </div>
-            {/* While loading skills, we display an additional circular progress to show we are fetching the information*/}
+                {!authorizeForAddSkill && (
+                  <span className="tooltip-text tooltip-bottom -translate-x-24 translate-y-2">
+                    {t("contact_your_admin_to_add_skills")}
+                  </span>
+                )}
+              </div>
+            )}
             {isLoading ? (
               <div className="mt-4 flex justify-center">
                 <CircularProgress />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77c103e</samp>

This pull request enhances the skills management feature for users in `care_fe`. It improves the UI and feedback in `SkillsSlideOver.tsx` and fixes some minor bugs.

## Proposed Changes

- Fixes #6209 
http://localhost:4000/users
Removed extra loaders and added a success Notification when a skill is added successfully.

![Screenshot from 2023-09-03 14-20-40](https://github.com/coronasafe/care_fe/assets/70687348/5f1574ec-83df-4ab5-b7f3-e6a1b8cf8552)
![image](https://github.com/coronasafe/care_fe/assets/70687348/281b5128-f9d1-4bf9-abc3-256dcee8d3c4)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77c103e</samp>

* Add a success notification when a skill is added to a user ([link](https://github.com/coronasafe/care_fe/pull/6210/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8R58-R61))
* Prevent the UI from jumping and showing an empty select while fetching the skills by moving the loading indicator inside the tooltip div and rendering the skill select and the add button only when the loading is finished ([link](https://github.com/coronasafe/care_fe/pull/6210/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L113-R129))
* Avoid showing the tooltip text when the user can add skills by moving it inside the button div and rendering it only when the button is disabled ([link](https://github.com/coronasafe/care_fe/pull/6210/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L135-R143))
