### PR TITLE
Remove extra space on Add Triage form

### DIFF
--- a/src/Components/Facility/TriageForm.tsx
+++ b/src/Components/Facility/TriageForm.tsx
@@ -283,20 +283,20 @@ export const TriageForm = (props: triageFormProps) => {
                 handleSubmit();
               }}
             >
-              <div className="max-w-[250px] pb-4">
-                <DateFormField
-                  required
-                  name="entry_date"
-                  label="Entry Date"
-                  value={state.form.entry_date}
-                  disableFuture
-                  onChange={handleFormFieldChange}
-                  position="LEFT"
-                  placeholder="Entry Date"
-                  error={state.errors.entry_date}
-                />
-              </div>
               <div className="mt-2 grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div className="pb-4">
+                  <DateFormField
+                    required
+                    name="entry_date"
+                    label="Entry Date"
+                    value={state.form.entry_date}
+                    disableFuture
+                    onChange={handleFormFieldChange}
+                    position="LEFT"
+                    placeholder="Entry Date"
+                    error={state.errors.entry_date}
+                  />
+                </div>
                 <div>
                   <TextFormField
                     name="num_patients_visited"
@@ -348,7 +348,7 @@ export const TriageForm = (props: triageFormProps) => {
                   />
                 </div>
               </div>
-              <div className="mt-4 flex flex-col justify-between gap-2 md:flex-row">
+              <div className="mt-4 flex flex-col justify-end gap-2 md:flex-row">
                 <Cancel onClick={() => goBack()} />
                 <Submit label={buttonText} />
               </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 179ea65</samp>

Improved the UI of the triage form component in `TriageForm.tsx` by rearranging the fields and buttons for better readability and usability.

## Proposed Changes

- Fixes #6214 
http://localhost:4000/facility/7ab27974-32c8-4e36-bdf9-dbf102524718/triage
Removed extra space and placed the buttons to the right to be consistent with the site.
![image](https://github.com/coronasafe/care_fe/assets/70687348/51349c5b-6125-4ce4-92d6-1a07a1fe2844)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 179ea65</samp>

*  Moved the entry date field to the first column of the grid layout for better alignment and responsiveness (`[link](https://github.com/coronasafe/care_fe/pull/6215/files?diff=unified&w=0#diff-f93cec80e3e6d3ceaf340ad221fdba7c079b646a2c55e832a660ef267568d7e7L286-R299)`)
