### PR TITLE
Diagnosis: Adds field Principal Diagnosis

### DIFF
--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -186,21 +186,24 @@ describe("Patient Creation with consultation", () => {
     cy.get("#weight").click().type("70");
     cy.get("#height").click().type("170");
     cy.get("#patient_no").type("IP007");
+
+    cy.intercept("GET", "**/icd/**").as("getIcdResults");
     cy.get(
       "#icd11_diagnoses_object input[placeholder='Select'][role='combobox']"
     )
       .click()
       .type("1A");
-    cy.wait(1000);
     cy.get("#icd11_diagnoses_object [role='option']")
       .contains("1A03 Intestinal infections due to Escherichia coli")
       .click();
-    cy.wait(1000);
+    cy.get("label[for='icd11_diagnoses_object']").click();
+    cy.wait("@getIcdResults").its("response.statusCode").should("eq", 200);
+
     cy.get("#icd11_principal_diagnosis [role='combobox']").click().type("1A");
-    cy.wait(1000);
     cy.get("#icd11_principal_diagnosis [role='option']")
       .contains("1A03 Intestinal infections due to Escherichia coli")
       .click();
+
     cy.get("#consultation_notes").click().type("generalnote");
     cy.get("#verified_by").click().type("generalnote");
     cy.get("#submit").click();

--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -195,6 +195,11 @@ describe("Patient Creation with consultation", () => {
     cy.get("#icd11_diagnoses_object [role='option']")
       .contains("1A03 Intestinal infections due to Escherichia coli")
       .click();
+    cy.get("#icd11_principal_diagnosis [role='combobox']").click().type("1A");
+    cy.wait(1000);
+    cy.get("#icd11_principal_diagnosis [role='option']")
+      .contains("1A03 Intestinal infections due to Escherichia coli")
+      .click();
     cy.get("#consultation_notes").click().type("generalnote");
     cy.get("#verified_by").click().type("generalnote");
     cy.get("#submit").click();

--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -195,6 +195,7 @@ describe("Patient Creation with consultation", () => {
     cy.get("#icd11_diagnoses_object [role='option']")
       .contains("1A03 Intestinal infections due to Escherichia coli")
       .click();
+    cy.wait(1000);
     cy.get("#icd11_principal_diagnosis [role='combobox']").click().type("1A");
     cy.wait(1000);
     cy.get("#icd11_principal_diagnosis [role='option']")

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -432,7 +432,7 @@ export const ConsultationDetails = (props: any) => {
 
                 {consultationData.icd11_principal_diagnosis && (
                   <ShowDiagnosis
-                    label="Principle Diagnosis (as per ICD-11 recommended by WHO)"
+                    label="Principal Diagnosis (as per ICD-11 recommended by WHO)"
                     diagnoses={[
                       [
                         ...(consultationData?.icd11_diagnoses_object ?? []),

--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -430,6 +430,22 @@ export const ConsultationDetails = (props: any) => {
                   </div>
                 )*/}
 
+                {consultationData.icd11_principal_diagnosis && (
+                  <ShowDiagnosis
+                    label="Principle Diagnosis (as per ICD-11 recommended by WHO)"
+                    diagnoses={[
+                      [
+                        ...(consultationData?.icd11_diagnoses_object ?? []),
+                        ...(consultationData?.icd11_provisional_diagnoses_object ??
+                          []),
+                      ].find(
+                        (d) =>
+                          d.id === consultationData.icd11_principal_diagnosis
+                      )!,
+                    ]}
+                  />
+                )}
+
                 <ShowDiagnosis
                   diagnoses={
                     consultationData?.icd11_provisional_diagnoses_object

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -112,7 +112,7 @@ export interface ConsultationModel {
   diagnosis?: string;
   icd11_diagnoses_object?: ICD11DiagnosisModel[];
   icd11_provisional_diagnoses_object?: ICD11DiagnosisModel[];
-  icd11_principal_diagnosis_object?: ICD11DiagnosisModel;
+  icd11_principal_diagnosis?: ICD11DiagnosisModel["id"];
   verified_by?: string;
   suggestion_text?: string;
   symptoms?: Array<number>;

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -112,6 +112,7 @@ export interface ConsultationModel {
   diagnosis?: string;
   icd11_diagnoses_object?: ICD11DiagnosisModel[];
   icd11_provisional_diagnoses_object?: ICD11DiagnosisModel[];
+  icd11_principal_diagnosis_object?: ICD11DiagnosisModel;
   verified_by?: string;
   suggestion_text?: string;
   symptoms?: Array<number>;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5fc8d2</samp>

This pull request adds a feature to capture and display the principal diagnosis of a consultation, following the ICD-11 standard. It modifies the `ConsultationForm` component to include a new required field, the `ConsultationDetails` component to show the diagnosis, and the `ConsultationModel` interface to store the diagnosis id.

## Proposed Changes

- Fixes #6144 

<img width="938" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/3c771bb8-1c31-4924-b270-add6745f57a9">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a5fc8d2</samp>

*  Add a new component `ShowDiagnosis` to display the principal diagnosis of the consultation ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cR433-R448))
*  Import the `AutocompleteFormField` component to create a searchable dropdown field for selecting the principal diagnosis ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR60))
*  Add a new property `icd11_principal_diagnosis` to the `FormDetails` type and the `ConsultationModel` interface to store the id of the selected diagnosis object ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR84), [link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfR115))
*  Initialize the `icd11_principal_diagnosis` property to undefined in the `initForm` function ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR129))
*  Add a new case for validating the `icd11_principal_diagnosis` field in the `validateForm` function, which requires the field to be non-empty and match one of the final or provisional diagnoses ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR544-R579))
*  Add the `icd11_principal_diagnosis` property to the payload object that is sent to the API when updating or creating a consultation ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR659))
*  Reset the `icd11_principal_diagnosis` property to undefined when the final or provisional diagnoses arrays are changed in the form ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR748-R759))
*  Add a new `AutocompleteFormField` component to the consultation form, with the name `icd11_principal_diagnosis` and the label `Principal Diagnosis`, using the final or provisional diagnoses arrays as the options ([link](https://github.com/coronasafe/care_fe/pull/6218/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR1191-R1206))
