### PR TITLE
Open pdf file preview in new tab

### DIFF
--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -481,15 +481,20 @@ export const FileUpload = (props: FileUploadProps) => {
     };
     const responseData = await dispatch(retrieveUpload(data, id));
     const file_extension = getExtension(responseData.data.read_signed_url);
-    setFileState({
-      ...file_state,
-      open: true,
-      name: responseData.data.name,
-      extension: file_extension,
-      isImage: ExtImage.includes(file_extension),
-    });
-    downloadFileUrl(responseData.data.read_signed_url);
-    setFileUrl(responseData.data.read_signed_url);
+    if (file_extension === "pdf") {
+      window.open(responseData.data.read_signed_url, "_blank");
+      setFileState({ ...file_state, open: false });
+    } else {
+      setFileState({
+        ...file_state,
+        open: true,
+        name: responseData.data.name,
+        extension: file_extension,
+        isImage: ExtImage.includes(file_extension),
+      });
+      downloadFileUrl(responseData.data.read_signed_url);
+      setFileUrl(responseData.data.read_signed_url);
+    }
   };
 
   const validateEditFileName = (name: any) => {
@@ -1457,7 +1462,7 @@ export const FileUpload = (props: FileUploadProps) => {
                       </ButtonV2>
                     </div>
                   )}
-                  <div className="flex flex-col md:flex-row items-center gap-4">
+                  <div className="flex flex-col items-center gap-4 md:flex-row">
                     <VoiceRecorder
                       createAudioBlob={createAudioBlob}
                       confirmAudioBlobExists={confirmAudioBlobExists}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00bf8aa</samp>

Enhance file upload component for patient files. Add pdf viewer, fix voice recorder layout, and enable file access and download in `FileUpload.tsx`.

## Proposed Changes

- Fixes #6155

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00bf8aa</samp>

* Add conditional logic to open pdf files in a new tab instead of a modal ([link](https://github.com/coronasafe/care_fe/pull/6226/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L484-R497))
* Swap the order of flex-direction classes for the voice recorder and upload button div ([link](https://github.com/coronasafe/care_fe/pull/6226/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L1460-R1465))
