### PR TITLE
Fix casing of plausible goal properties

### DIFF
--- a/src/Components/Facility/ConsultationDetails.tsx
+++ b/src/Components/Facility/ConsultationDetails.tsx
@@ -226,7 +226,7 @@ export const ConsultationDetails = (props: any) => {
     triggerGoal("Patient Consultation Viewed", {
       facilityId: facilityId,
       consultationId: consultationId,
-      userID: authUser.id,
+      userId: authUser.id,
     });
   }, []);
 

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -222,7 +222,7 @@ export const PatientHome = (props: any) => {
       fetchpatient(status);
       triggerGoal("Patient Profile Viewed", {
         facilityId: facilityId,
-        userID: authUser.id,
+        userId: authUser.id,
       });
     },
     [dispatch, fetchpatient]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a092204</samp>

Renamed `userID` to `userId` in `ConsultationDetails.tsx` and `PatientHome.tsx` to align with the backend API and the frontend naming convention. This was part of a refactoring task to standardize user-related properties across the codebase.

## Proposed Changes

- `userId` is written as `userID` for some goals. This PR fixes that. 

![image](https://github.com/coronasafe/care_fe/assets/3626859/55328922-0897-41fc-88f2-eace3165e989)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a092204</samp>

*  Rename `userID` to `userId` in `triggerGoal` function and its callers to standardize naming convention ([link](https://github.com/coronasafe/care_fe/pull/6229/files?diff=unified&w=0#diff-f6f40e1b249471f1821a43cd90bfdce470f563c22b22272a154f9bd7a2de599cL229-R229), [link](https://github.com/coronasafe/care_fe/pull/6229/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL225-R225))
