### PR TITLE
Consultation Form: skip validation for `verified_by` if `suggestion` is Declare Death and fix discharge not working on create consultation

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -538,7 +538,7 @@ export const ConsultationForm = (props: any) => {
         }
 
         case "verified_by": {
-          if (!state.form[field]) {
+          if (state.form.suggestion !== "DD" && !state.form[field]) {
             errors[field] = "Please fill verified by";
             invalidForm = true;
             break;

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -618,6 +618,7 @@ export const ConsultationForm = (props: any) => {
   };
 
   const declareThePatientDead = async (
+    id: string,
     cause_of_death: string,
     death_datetime: string,
     death_confirmed_doctor: string
@@ -629,6 +630,7 @@ export const ConsultationForm = (props: any) => {
           discharge_notes: cause_of_death,
           death_datetime: death_datetime,
           death_confirmed_doctor: death_confirmed_doctor,
+          discharge_date: dayjs().toISOString(),
         },
         { id }
       )
@@ -714,6 +716,7 @@ export const ConsultationForm = (props: any) => {
 
         if (data.suggestion === "DD") {
           await declareThePatientDead(
+            res.data.id,
             state.form.cause_of_death,
             state.form.death_datetime,
             state.form.death_confirmed_doctor


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89137e8</samp>

Fix verified_by validation for discharge decisions. The change allows the consultation form to be submitted without a verified_by value if the suggestion is `DD`, as requested in issue #1729.

## Proposed Changes

- Consultation Form: skip validation for `verified_by` if `suggestion` is Declare Death
- Declare Death and fix discharge not working on create consultation #

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89137e8</samp>

*  Add a condition to skip verified_by validation for discharge decisions ([link](https://github.com/coronasafe/care_fe/pull/6248/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL541-R541))
