### PR TITLE
Changed priority of backUrl and history for back button in pageTitle

### DIFF
--- a/src/Common/hooks/useAppHistory.ts
+++ b/src/Common/hooks/useAppHistory.ts
@@ -10,14 +10,12 @@ export default function useAppHistory() {
   const resetHistory = useContext(ResetHistoryContext);
 
   const goBack = (fallbackUrl?: string) => {
-    if (history.length > 1)
-      // Navigate to history present in the app navigation history stack.
-      return navigate(history[1]);
-
     if (fallbackUrl)
-      // Otherwise, use provided fallback url if provided.
+      // use provided fallback url if provided.
       return navigate(fallbackUrl);
-
+    if (history.length > 1)
+      // Otherwise, navigate to history present in the app navigation history stack.
+      return navigate(history[1]);
     // Otherwise, fallback to browser's go back behaviour.
     window.history.back();
   };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c0835f</samp>

Fixed a back button bug in `useAppHistory` hook. Changed the logic of the `goBack` function to use the fallback url first if available.

## Proposed Changes

- Fixes #6233 
- changed back button to prefer backUrl over history if backurl is present

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
