### PR TITLE
Asset filter parameters reset on unselect

### DIFF
--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -108,9 +108,9 @@ function AssetFilter(props: any) {
   const applyFilter = () => {
     const data = {
       facility: facilityId,
-      asset_type: asset_type,
-      asset_class: asset_class,
-      status: asset_status,
+      asset_type: asset_type ?? "",
+      asset_class: asset_class ?? "",
+      status: asset_status ?? "",
       location: locationId,
     };
     onChange(data);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 062e9b1</samp>

Fixed a bug in `AssetFilter` component that caused API request to fail when some filters were not selected. Added nullish coalescing operators to `asset_type`, `asset_class`, and `status` properties of the `data` object in `src/Components/Assets/AssetFilter.tsx`.

## Proposed Changes

- Fixes #6254 
- Set the asset type, asset class and asset status to empty strings on unselecting instead of undefined.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 062e9b1</samp>

*  Add nullish coalescing operators to asset filter properties ([link](https://github.com/coronasafe/care_fe/pull/6255/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L111-R113))
