### PR TITLE
Disabled asset config button for users other than state and district admin

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -29,7 +29,7 @@ import { useTranslation } from "react-i18next";
 const PageTitle = lazy(() => import("../Common/PageTitle"));
 const Loading = lazy(() => import("../Common/Loading"));
 import * as Notification from "../../Utils/Notifications.js";
-import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
+import AuthorizeFor, { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import Uptime from "../Common/Uptime";
 import useAuthUser from "../../Common/hooks/useAuthUser";
 import dayjs from "dayjs";
@@ -452,7 +452,7 @@ const AssetManage = (props: AssetManageProps) => {
                   }
                   id="configure-asset"
                   data-testid="asset-configure-button"
-                  authorizeFor={NonReadOnlyUsers}
+                  authorizeFor={AuthorizeFor(["DistrictAdmin", "StateAdmin"])}
                 >
                   <CareIcon className="care-l-setting h-4" />
                   {t("configure")}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3961e13</samp>

Enhance role-based authorization for asset management using `RoleBasedComponent`. Restrict access to buttons in `AssetManage.tsx` based on user roles.

## Proposed Changes

- Fixes #6234 
- Disables config button in asset page for any user who is not district admin or state admin

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3961e13</samp>

*  Import `AuthorizeFor` component to use for conditional rendering of buttons based on user roles ([link](https://github.com/coronasafe/care_fe/pull/6259/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L32-R32))
*  Replace `authorizeFor` prop of `Button` component with `AuthorizeFor` component and an array of user roles to restrict access to configure asset button to only district and state admins ([link](https://github.com/coronasafe/care_fe/pull/6259/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L455-R455))
