### PR TITLE
add test to search asset by qr and serial number

### DIFF
--- a/cypress/e2e/assets_spec/asset_homepage.cy.ts
+++ b/cypress/e2e/assets_spec/asset_homepage.cy.ts
@@ -5,15 +5,17 @@ import { AssetSearchPage } from "../../pageobject/Asset/AssetSearch";
 import { AssetQRScanPage } from "../../pageobject/Asset/AssetQRScan";
 import { AssetPagination } from "../../pageobject/Asset/AssetPagination";
 import { AssetFilters } from "../../pageobject/Asset/AssetFilters";
+import LoginPage from "../../pageobject/Login/LoginPage";
 
 describe("Asset Tab", () => {
   const assetSearchPage = new AssetSearchPage();
   const assetQRScanPage = new AssetQRScanPage();
   const assetPagination = new AssetPagination();
   const assetFilters = new AssetFilters();
+  const loginPage = new LoginPage();
 
   before(() => {
-    cy.loginByApi("devdistrictadmin", "Coronasafe@123");
+    loginPage.loginAsDisctrictAdmin();
     cy.saveLocalStorage();
   });
 
@@ -24,11 +26,27 @@ describe("Asset Tab", () => {
 
   // search for a element
 
-  it("Search Asset Name", () => {
-    const initialUrl = cy.url();
-    assetSearchPage.typeSearchKeyword("dummy camera 30");
+  it("Search Asset Name/QR_ID/Serial_number", () => {
+    assetSearchPage.typeSearchKeyword("dummy camera 10");
     assetSearchPage.pressEnter();
-    assetSearchPage.verifyUrlChanged(initialUrl);
+    assetSearchPage.verifyBadgeContent(
+      "Name/Serial No./QR ID: dummy camera 10"
+    );
+    assetSearchPage.clickAssetByName("Dummy Camera 10");
+    assetSearchPage.clickUpdateButton();
+    assetSearchPage.clearAndTypeQRCode("340543-05935-04953-05234-04");
+    assetSearchPage.clearAndTypeSerialNumber("8989898989898");
+    assetSearchPage.clickAssetSubmitButton();
+    assetSearchPage.visitAssetsPage();
+    assetSearchPage.typeSearchKeyword("340543-05935-04953-05234-04");
+    assetSearchPage.pressEnter();
+    assetSearchPage.verifyAssetListContains("Dummy Camera 10");
+    assetSearchPage.verifyBadgeContent(
+      "Name/Serial No./QR ID: 340543-05935-04953-05234-04"
+    );
+    assetSearchPage.typeSearchKeyword("8989898989898");
+    assetSearchPage.verifyAssetListContains("Dummy Camera 10");
+    assetSearchPage.verifyBadgeContent("Name/Serial No./QR ID: 8989898989898");
   });
 
   // scan a asset qr code

--- a/cypress/e2e/assets_spec/asset_homepage.cy.ts
+++ b/cypress/e2e/assets_spec/asset_homepage.cy.ts
@@ -6,6 +6,7 @@ import { AssetQRScanPage } from "../../pageobject/Asset/AssetQRScan";
 import { AssetPagination } from "../../pageobject/Asset/AssetPagination";
 import { AssetFilters } from "../../pageobject/Asset/AssetFilters";
 import LoginPage from "../../pageobject/Login/LoginPage";
+import { v4 as uuidv4 } from "uuid";
 
 describe("Asset Tab", () => {
   const assetSearchPage = new AssetSearchPage();
@@ -13,6 +14,9 @@ describe("Asset Tab", () => {
   const assetPagination = new AssetPagination();
   const assetFilters = new AssetFilters();
   const loginPage = new LoginPage();
+  const assetName = "Dummy Camera 10";
+  const qrCode = uuidv4();
+  const serialNumber = Math.floor(Math.random() * 10 ** 10).toString();
 
   before(() => {
     loginPage.loginAsDisctrictAdmin();
@@ -27,26 +31,22 @@ describe("Asset Tab", () => {
   // search for a element
 
   it("Search Asset Name/QR_ID/Serial_number", () => {
-    assetSearchPage.typeSearchKeyword("dummy camera 10");
+    assetSearchPage.typeSearchKeyword(assetName);
     assetSearchPage.pressEnter();
-    assetSearchPage.verifyBadgeContent(
-      "Name/Serial No./QR ID: dummy camera 10"
-    );
-    assetSearchPage.clickAssetByName("Dummy Camera 10");
+    assetSearchPage.verifyBadgeContent(assetName);
+    assetSearchPage.clickAssetByName(assetName);
     assetSearchPage.clickUpdateButton();
-    assetSearchPage.clearAndTypeQRCode("340543-05935-04953-05234-04");
-    assetSearchPage.clearAndTypeSerialNumber("8989898989898");
+    assetSearchPage.clearAndTypeQRCode(qrCode);
+    assetSearchPage.clearAndTypeSerialNumber(serialNumber);
     assetSearchPage.clickAssetSubmitButton();
     assetSearchPage.visitAssetsPage();
-    assetSearchPage.typeSearchKeyword("340543-05935-04953-05234-04");
+    assetSearchPage.typeSearchKeyword(qrCode);
     assetSearchPage.pressEnter();
-    assetSearchPage.verifyAssetListContains("Dummy Camera 10");
-    assetSearchPage.verifyBadgeContent(
-      "Name/Serial No./QR ID: 340543-05935-04953-05234-04"
-    );
-    assetSearchPage.typeSearchKeyword("8989898989898");
-    assetSearchPage.verifyAssetListContains("Dummy Camera 10");
-    assetSearchPage.verifyBadgeContent("Name/Serial No./QR ID: 8989898989898");
+    assetSearchPage.verifyAssetListContains(assetName);
+    assetSearchPage.verifyBadgeContent(qrCode);
+    assetSearchPage.typeSearchKeyword(serialNumber);
+    assetSearchPage.verifyAssetListContains(assetName);
+    assetSearchPage.verifyBadgeContent(serialNumber);
   });
 
   // scan a asset qr code

--- a/cypress/pageobject/Asset/AssetSearch.ts
+++ b/cypress/pageobject/Asset/AssetSearch.ts
@@ -1,21 +1,58 @@
 export class AssetSearchPage {
   typeSearchKeyword(keyword: string) {
-    cy.get("[name='search']").type(keyword);
+    cy.get("#search").clear();
+    cy.get("#search").click().type(keyword);
   }
 
   pressEnter() {
     cy.get("[name='search']").type("{enter}");
   }
 
-  verifyUrlChanged(initialUrl: string) {
-    cy.url().should((currentUrl) => {
-      expect(currentUrl).not.to.equal(initialUrl);
-    });
+  clickAssetByName(assetName: string) {
+    cy.get("[data-testid='created-asset-list']").contains(assetName).click();
+  }
+
+  verifyBadgeContent(expectedText: string) {
+    cy.get("[data-testid='Name/Serial No./QR ID']").should(
+      "have.text",
+      expectedText
+    );
   }
 
   verifyAssetIsPresent(assetName: string) {
     cy.get("[data-testid=created-asset-list]")
       .first()
       .should("contain", assetName);
+  }
+
+  clickUpdateButton() {
+    cy.get("[data-testid='asset-update-button']").contains("Update").click();
+  }
+
+  clearAndTypeQRCode(qrCode: string) {
+    cy.get("#qr_code_id").clear();
+    cy.get("#qr_code_id").click().type(qrCode);
+  }
+
+  clearAndTypeSerialNumber(serialNumber: string) {
+    cy.get("#serial-number").clear();
+    cy.get("#serial-number").click().type(serialNumber);
+  }
+
+  clickAssetSubmitButton() {
+    cy.intercept("GET", "**/api/v1/asset/**").as("getAssets");
+    cy.get("#submit").click();
+    cy.wait("@getAssets").its("response.statusCode").should("eq", 200);
+  }
+
+  visitAssetsPage() {
+    cy.visit("/assets");
+  }
+
+  verifyAssetListContains(dummyCameraText: string) {
+    cy.get("[data-testid='created-asset-list']").should(
+      "contain",
+      dummyCameraText
+    );
   }
 }

--- a/cypress/pageobject/Asset/AssetSearch.ts
+++ b/cypress/pageobject/Asset/AssetSearch.ts
@@ -14,7 +14,7 @@ export class AssetSearchPage {
 
   verifyBadgeContent(expectedText: string) {
     cy.get("[data-testid='Name/Serial No./QR ID']").should(
-      "have.text",
+      "contain",
       expectedText
     );
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 16b0bd8</samp>

This pull request improves the cypress tests for the asset homepage and search features. It refactors the login process, adds more fields and validations to the asset search test, and enhances the `AssetSearchPage` class with new methods and assertions.

## Proposed Changes

- Fixes #6265 
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 16b0bd8</samp>

*  Import `LoginPage` class from `Login` page object module to use its methods for logging in as different types of users ([link](https://github.com/coronasafe/care_fe/pull/6266/files?diff=unified&w=0#diff-44aa004b062d8eae6cc01d0acfa95b2e2dcb21d079d3215e75ed988bfa693919R8))
* Replace `cy.loginByApi` method with `loginPage.loginAsDistrictAdmin` method to log in as a district admin user through the UI instead of using the API ([link](https://github.com/coronasafe/care_fe/pull/6266/files?diff=unified&w=0#diff-44aa004b062d8eae6cc01d0acfa95b2e2dcb21d079d3215e75ed988bfa693919L14-R18))
* Modify test case for searching an asset by name, QR ID, and serial number in `asset_homepage.cy.ts` file ([link](https://github.com/coronasafe/care_fe/pull/6266/files?diff=unified&w=0#diff-44aa004b062d8eae6cc01d0acfa95b2e2dcb21d079d3215e75ed988bfa693919L27-R49))
* Modify `typeSearchKeyword` method in `AssetSearchPage` class to clear the search input field before typing the keyword, and use `#search` selector instead of `[name='search']` selector ([link](https://github.com/coronasafe/care_fe/pull/6266/files?diff=unified&w=0#diff-a322d1761d6effd68454f203344b97b59ed7ecb332994c9e11a0b8c8c2cb5896L3-R4))
* Add `clickAssetByName` and `verifyBadgeContent` methods to `AssetSearchPage` class to click on an asset with the given name from the asset list, and assert that the badge element has the expected text ([link](https://github.com/coronasafe/care_fe/pull/6266/files?diff=unified&w=0#diff-a322d1761d6effd68454f203344b97b59ed7ecb332994c9e11a0b8c8c2cb5896L10-R21))
* Add `clickUpdateButton`, `clearAndTypeQRCode`, `clearAndTypeSerialNumber`, `clickAssetSubmitButton`, `visitAssetsPage`, and `verifyAssetListContains` methods to `AssetSearchPage` class to update the QR ID and serial number of an asset, and verify the changes in the asset list ([link](https://github.com/coronasafe/care_fe/pull/6266/files?diff=unified&w=0#diff-a322d1761d6effd68454f203344b97b59ed7ecb332994c9e11a0b8c8c2cb5896R27-R57))
