### PR TITLE
Refactor workflow to properly wait for migrations

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cd care
           make docker_config_file=docker-compose.pre-built.yaml up 
-          while docker-compose -f docker-compose.pre-built.yaml exec -T backend bash -c "python manage.py showmigrations | grep -q '\[ \]'"; do
+          while docker compose exec backend bash -c "python manage.py showmigrations 2>/dev/null | cat | grep -q '\[ \]'"; do
             >&2 echo "Migrations are not yet applied - sleeping"
             sleep 5
           done
@@ -101,10 +101,3 @@ jobs:
           name: cypress-screenshots
           path: cypress/screenshots
 
-      # Test run video was always captured, so this action uses "always()" condition
-      - name: Upload cypress videos 📹
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: cypress-videos
-          path: cypress/videos

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -28,10 +28,11 @@ jobs:
         run: |
           cd care
           make docker_config_file=docker-compose.pre-built.yaml up 
-          until docker-compose -f docker-compose.pre-built.yaml exec -T backend bash -c "python manage.py showmigrations | grep -q '\[ \]'"; do
+          while docker-compose -f docker-compose.pre-built.yaml exec -T backend bash -c "python manage.py showmigrations | grep -q '\[ \]'"; do
             >&2 echo "Migrations are not yet applied - sleeping"
             sleep 5
           done
+          echo "Migrations are applied"
           cd ..
 
       - name: Load dummy data into care backend 📂

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -24,14 +24,21 @@ jobs:
           repository: coronasafe/care
           path: care
 
-      - name: Run docker compose up on care 🐳
+      - name: Start care docker containers 🐳
         run: |
-          cd care  
+          cd care
           make docker_config_file=docker-compose.pre-built.yaml up 
-          sleep 60s
+          until docker-compose -f docker-compose.pre-built.yaml exec -T backend bash -c "python manage.py showmigrations | grep -q '\[ \]'"; do
+            >&2 echo "Migrations are not yet applied - sleeping"
+            sleep 5
+          done
+          cd ..
+
+      - name: Load dummy data into care backend 📂
+        run: |
+          cd care
           docker compose exec backend bash -c "python manage.py load_dummy_data"
           cd ..
-        # Voluntarily kept 60 seconds delay to wait for migrations to complete.
 
       - name: Check care is up ♻
         run: curl -o /dev/null -s -w "%{http_code}\n" http://localhost:9000


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43305da</samp>

Improved the reliability and speed of the cypress workflow by separating the steps of starting the `care` service and loading dummy data. Used a custom action to wait for the migrations to finish before proceeding.

This pull request introduces an important enhancement to the Docker setup script. Previously, the script used a fixed sleep time to wait for the database migrations to complete before loading the dummy data. This approach was not reliable because the actual time required for the migrations can vary.

The updated script now dynamically waits for all database migrations to be applied before proceeding to load the dummy data. This is achieved by continuously checking for any unapplied migrations every 5 seconds, and once all migrations have been applied, the script proceeds to load the dummy data.

![image](https://github.com/coronasafe/care_fe/assets/3626859/de759a25-9f5c-45a9-8f22-4b00482eb575)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43305da</samp>

* Wait for care service migrations to finish before loading dummy data ([link](https://github.com/coronasafe/care_fe/pull/6272/files?diff=unified&w=0#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L27-R41))
