### PR TITLE
Added Cypress Test to verify Asset Filter Functionality

### DIFF
--- a/cypress/e2e/assets_spec/asset_homepage.cy.ts
+++ b/cypress/e2e/assets_spec/asset_homepage.cy.ts
@@ -62,8 +62,18 @@ describe("Asset Tab", () => {
       "Dummy Facility 1",
       "INTERNAL",
       "ACTIVE",
-      "ONVIF Camera"
+      "ONVIF Camera",
+      "Camera Loc"
     );
+    assetFilters.clickadvancefilter();
+    assetFilters.clickslideoverbackbutton(); // to verify the back button doesn't clear applied filters
+    assetFilters.assertFacilityText("Dummy Facility 1");
+    assetFilters.assertAssetTypeText("INTERNAL");
+    assetFilters.assertAssetClassText("ONVIF");
+    assetFilters.assertStatusText("ACTIVE");
+    assetFilters.assertLocationText("Camera Locations");
+    assetFilters.clickadvancefilter();
+    assetFilters.clearFilters();
   });
 
   // Verify the pagination in the page

--- a/cypress/pageobject/Asset/AssetFilters.ts
+++ b/cypress/pageobject/Asset/AssetFilters.ts
@@ -3,7 +3,8 @@ export class AssetFilters {
     facilityName: string,
     assetType: string,
     assetStatus: string,
-    assetClass: string
+    assetClass: string,
+    assetLocation: string
   ) {
     cy.contains("Advanced Filters").click();
     cy.get("input[name='Facilities']")
@@ -27,6 +28,42 @@ export class AssetFilters {
       .then(() => {
         cy.get("[role='option']").contains(assetClass).click();
       });
+    cy.get("#Facilities-location")
+      .click()
+      .type(assetLocation)
+      .then(() => {
+        cy.get("[role='option']").contains(assetLocation).click();
+      });
     cy.contains("Apply").click();
+  }
+  clearFilters() {
+    cy.intercept("GET", "**/api/v1/asset/**").as("clearAssets");
+    cy.get("#clear-filter").click();
+    cy.wait("@clearAssets").its("response.statusCode").should("eq", 200);
+    cy.url().should("match", /\/assets$/);
+  }
+  clickadvancefilter() {
+    cy.intercept("GET", "**/api/v1/getallfacilities/**").as("advancefilter");
+    cy.get("#advanced-filter").click();
+    cy.wait("@advancefilter").its("response.statusCode").should("eq", 200);
+  }
+  clickslideoverbackbutton() {
+    cy.get("#close-slide-over").click();
+  }
+  // Assertions
+  assertFacilityText(text) {
+    cy.get("[data-testid=Facility]").should("contain", text);
+  }
+  assertAssetTypeText(text) {
+    cy.get("[data-testid='Asset Type']").should("contain", text);
+  }
+  assertAssetClassText(text) {
+    cy.get("[data-testid='Asset Class']").should("contain", text);
+  }
+  assertStatusText(text) {
+    cy.get("[data-testid=Status]").should("contain", text);
+  }
+  assertLocationText(text) {
+    cy.get("[data-testid=Location]").should("contain", text);
   }
 }

--- a/cypress/pageobject/Asset/AssetSearch.ts
+++ b/cypress/pageobject/Asset/AssetSearch.ts
@@ -1,6 +1,6 @@
 export class AssetSearchPage {
   typeSearchKeyword(keyword: string) {
-    cy.get("#search").clear();
+    cy.get("#search").click().clear();
     cy.get("#search").click().type(keyword);
   }
 
@@ -9,7 +9,9 @@ export class AssetSearchPage {
   }
 
   clickAssetByName(assetName: string) {
+    cy.intercept("GET", "**/api/v1/asset/**").as("clearAssets");
     cy.get("[data-testid='created-asset-list']").contains(assetName).click();
+    cy.wait("@clearAssets").its("response.statusCode").should("eq", 200);
   }
 
   verifyBadgeContent(expectedText: string) {

--- a/src/CAREUI/interactive/SlideOver.tsx
+++ b/src/CAREUI/interactive/SlideOver.tsx
@@ -109,6 +109,7 @@ export default function SlideOver({
               >
                 <div className="flex items-center gap-2 p-2 pt-4">
                   <button
+                    id="close-slide-over"
                     className="flex h-8 w-8 items-center justify-center rounded-lg text-2xl hover:bg-black/20"
                     onClick={() => {
                       setOpen(false);

--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -148,7 +148,7 @@ function AssetFilter(props: any) {
         <div className="w-full flex-none">
           <FieldLabel>Location</FieldLabel>
           <LocationSelect
-            name="Facilities"
+            name="Facilities-location"
             setSelected={(selectedId) =>
               handleLocationSelect((selectedId as string) || "")
             }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6823d1f</samp>

This pull request adds and improves the Cypress tests for the asset filters and search features. It also fixes some bugs and inconsistencies in the page object classes and the UI components related to the asset filters. It modifies the files `cypress/pageobject/Asset/AssetFilters.ts`, `cypress/pageobject/Asset/AssetSearch.ts`, `cypress/e2e/assets_spec/asset_homepage.cy.ts`, `src/CAREUI/interactive/SlideOver.tsx`, and `src/Components/Assets/AssetFilter.tsx`.

## Proposed Changes

- Fixes #6267 
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6823d1f</samp>

* Add a new test case to verify the asset filters by location and the functionality of the back button and the clear filters button ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-44aa004b062d8eae6cc01d0acfa95b2e2dcb21d079d3215e75ed988bfa693919L65-R76))
* Add a new parameter `assetLocation` to the `applyAssetFilters` method to select the location filter from the advanced filters menu ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-e6249c519b5a93f5ff33f6d24a6621772890b8eef77518aa795b09f9c0a9c400L6-R7), [link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-e6249c519b5a93f5ff33f6d24a6621772890b8eef77518aa795b09f9c0a9c400L30-R68))
* Add a new method `clearFilters` to clear all the applied filters and verify the URL and the API response ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-e6249c519b5a93f5ff33f6d24a6621772890b8eef77518aa795b09f9c0a9c400L30-R68))
* Add other methods and assertions to the `AssetFilters` class for the filter texts, the advanced filter button, and the slide over back button ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-e6249c519b5a93f5ff33f6d24a6621772890b8eef77518aa795b09f9c0a9c400L30-R68))
* Swap the order of the `clear` and `click` commands in the `typeSearchKeyword` method to avoid the issue of the search input not being cleared properly ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-a322d1761d6effd68454f203344b97b59ed7ecb332994c9e11a0b8c8c2cb5896L3-R3))
* Add an intercept and a wait for the API call to get the asset details in the `clickAssetByName` method to ensure the asset details page is loaded ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-a322d1761d6effd68454f203344b97b59ed7ecb332994c9e11a0b8c8c2cb5896L12-R14))
* Add an id attribute to the close button of the slide over component in the `SlideOver.tsx` file to make it easier to locate and click in the tests ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-3754b24f4ce9f586a9462f079c619a3df261e3079d7fa8207fade2940dc4e4caR112))
* Change the name attribute of the location select component in the `AssetFilter.tsx` file to avoid the conflict with the facility select component and make it consistent with the id attribute ([link](https://github.com/coronasafe/care_fe/pull/6275/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L151-R151))
