### PR TITLE
Medibase Search: Skip showing selected option search results when query is present

### DIFF
--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -157,6 +157,7 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
               placeholder={props.placeholder ?? "Select"}
               displayValue={(value: any) => value?.label || ""}
               onChange={(event) => setQuery(event.target.value.toLowerCase())}
+              onBlur={() => value && setQuery("")}
               autoComplete="off"
             />
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">

--- a/src/Components/Medicine/MedibaseAutocompleteFormField.tsx
+++ b/src/Components/Medicine/MedibaseAutocompleteFormField.tsx
@@ -49,7 +49,7 @@ export default function MedibaseAutocompleteFormField(
         value={field.value}
         required
         onChange={field.handleChange}
-        options={options(field.value && [field.value])}
+        options={options(field.value && !query && [field.value])}
         optionLabel={(option) => option.name.toUpperCase()}
         optionDescription={(option) => <OptionDescription medicine={option} />}
         optionValue={(option) => option}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a91881e</samp>

This pull request improves the functionality and user experience of the `Autocomplete` component and its usage in the `MedibaseAutocompleteFormField` component. It clears the query state on blur and preserves the selected value as an option when the query is empty.

## Proposed Changes

- Fixes #6283 

<img width="663" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/7c984e49-fe62-435e-aab4-e949f59a2cb2">


<img width="704" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/ed9af328-d9fa-4ab0-97c4-cc4879f15809">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a91881e</samp>

* Clear the query state of the `Autocomplete` component when the input loses focus to prevent the query from persisting ([link](https://github.com/coronasafe/care_fe/pull/6284/files?diff=unified&w=0#diff-4cdaa989de9f639fb82eafc3775f14fffd48e63bde03839c8912aa0a8e6769e9R160))
* Return only the field value as an option when the query is empty in the `MedibaseAutocompleteFormField` component to preserve the selected value and avoid unnecessary API requests ([link](https://github.com/coronasafe/care_fe/pull/6284/files?diff=unified&w=0#diff-27f7661cf02d3f78f7bbc53331f501ddc59ad9a33c613022593b529c128c8bb4L52-R52))
