### PR TITLE
fix `goBack` precedence

### DIFF
--- a/src/Common/hooks/useAppHistory.ts
+++ b/src/Common/hooks/useAppHistory.ts
@@ -10,12 +10,13 @@ export default function useAppHistory() {
   const resetHistory = useContext(ResetHistoryContext);
 
   const goBack = (fallbackUrl?: string) => {
-    if (fallbackUrl)
-      // use provided fallback url if provided.
-      return navigate(fallbackUrl);
     if (history.length > 1)
       // Otherwise, navigate to history present in the app navigation history stack.
       return navigate(history[1]);
+
+    if (fallbackUrl)
+      // use provided fallback url if provided.
+      return navigate(fallbackUrl);
     // Otherwise, fallback to browser's go back behaviour.
     window.history.back();
   };

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -42,6 +42,7 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
   const [refreshPresetsHash, setRefreshPresetsHash] = useState(
     Number(new Date())
   );
+  const [refreshHash, setRefreshHash] = useState(Number(new Date()));
   const dispatch = useDispatch<any>();
 
   useEffect(() => {
@@ -89,7 +90,7 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
         Notification.Success({
           msg: "Asset Configured Successfully",
         });
-        window.location.reload();
+        setRefreshHash(Number(new Date()));
       } else {
         Notification.Error({
           msg: "Something went wrong..!",
@@ -200,6 +201,7 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
 
       {assetType === "ONVIF" ? (
         <CameraConfigure
+          key={refreshHash}
           asset={asset as AssetData}
           bed={bed}
           setBed={setBed}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09373b6</samp>

Fixed a bug in the `goBack` hook that caused incorrect navigation behavior in some scenarios. Refactored the logic of the hook to use the app history stack more reliably.

## Proposed Changes

- Fixes #6279
- Fixes #6233

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 09373b6</samp>

* Fix a bug in the `goBack` function of the `useAppHistory` hook that caused the fallback url to override the previous page in some cases ([link](https://github.com/coronasafe/care_fe/pull/6285/files?diff=unified&w=0#diff-6225e27e6b5ec1f1370c65a4a24a58aafddc188a8d31215d2100dcb95d4958e4L13-R19))
