### PR TITLE
Cam reset

### DIFF
--- a/src/Common/hooks/useHLSPlayer.ts
+++ b/src/Common/hooks/useHLSPlayer.ts
@@ -4,7 +4,7 @@ import { IOptions } from "./useMSEplayer";
 export const useHLSPLayer = (ref: ReactPlayer | null) => {
   const startStream = ({ onSuccess, onError }: IOptions = {}) => {
     try {
-      ref && ref.forceUpdate();
+      ref?.setState({ url: ref?.props.url + "&t=" + Date.now() });
       onSuccess && onSuccess(undefined);
     } catch (err) {
       onError && onError(err);

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -240,7 +240,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
   }, []);
 
   useEffect(() => {
-    if (streamStatus === StreamStatus.Playing) {
+    if (!currentPreset && streamStatus === StreamStatus.Playing) {
       setLoading(CAMERA_STATES.MOVING.GENERIC);
       const preset =
         bedPresets?.find(
@@ -506,7 +506,6 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
         <div className="absolute right-8 top-8 z-10 flex flex-col gap-4">
           {["fullScreen", "reset", "updatePreset", "zoomIn", "zoomOut"].map(
             (button, index) => {
-              if (isIOS && button === "reset") return null;
               const option = cameraPTZ.find(
                 (option) => option.action === button
               );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6292499</samp>

This pull request enhances the camera control and streaming features in the `Feed` component and the `useHLSPlayer` hook. It reduces unnecessary data fetching, avoids caching problems, and handles edge cases more gracefully.

## Proposed Changes

- when the camera is reloaded don't reset the preset.
- added auto reset for feed when delay is greater than 5seconds

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6292499</samp>

*  Append timestamp to HLS stream url to avoid caching issues and ensure freshness ([link](https://github.com/coronasafe/care_fe/pull/6286/files?diff=unified&w=0#diff-b653b060e81c4fbd50cfffcdbf00effecc2019e4e37ddd8b3361121afe30ff38L7-R7))
*  Add condition to check if currentPreset is defined before setting loading state and fetching preset data in Feed component ([link](https://github.com/coronasafe/care_fe/pull/6286/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L243-R243))
*  Remove redundant condition for iOS and reset button in renderButton function in Feed component ([link](https://github.com/coronasafe/care_fe/pull/6286/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L509))
