### PR TITLE
Changed requested values in all the places

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -663,22 +663,22 @@ export const NURSING_CARE_FIELDS: Array<OptionsType> = [
 export const EYE_OPEN_SCALE = [
   { value: 4, text: "Spontaneous" },
   { value: 3, text: "To Speech" },
-  { value: 2, text: "Pain" },
-  { value: 1, text: "None" },
+  { value: 2, text: "To Pain" },
+  { value: 1, text: "No Response" },
 ];
 
 export const VERBAL_RESPONSE_SCALE = [
-  { value: 5, text: "Oriented/Coos/Babbles" },
+  { value: 5, text: "Oriented to Time, Place and Person" },
   { value: 4, text: "Confused/Irritable" },
   { value: 3, text: "Inappropriate words/Cry to Pain" },
   { value: 2, text: "Incomprehensible words/Moans to pain" },
-  { value: 1, text: "None" },
+  { value: 1, text: "No Response" },
 ];
 
 export const MOTOR_RESPONSE_SCALE = [
-  { value: 6, text: "Obeying commands" },
-  { value: 5, text: "Moves to localised pain" },
-  { value: 4, text: "Flexion withdrawal from pain" },
+  { value: 6, text: "Obeying commands/Normal acrivity" },
+  { value: 5, text: "Moves to localized pain" },
+  { value: 4, text: "Flexion/Withdrawal from pain" },
   { value: 3, text: "Abnormal Flexion(decorticate)" },
   { value: 2, text: "Abnormal Extension(decerebrate)" },
   { value: 1, text: "No Response" },

--- a/src/Components/CriticalCareRecording/NeurologicalMonitoring/CriticalCare__NeurologicalMonitoringEditor.res
+++ b/src/Components/CriticalCareRecording/NeurologicalMonitoring/CriticalCare__NeurologicalMonitoringEditor.res
@@ -485,7 +485,7 @@ let make = (~updateCB, ~neurologicalMonitoring, ~id, ~consultationId) => {
       <div className="my-10">
         <div className="text-3xl font-bold"> {str("Glasgow Coma Scale")} </div>
         <div className="mt-4">
-          <div className="font-bold mt-4"> {str("Eye Open")} </div>
+          <div className="font-bold mt-4"> {str("Eye Opening Response")} </div>
           <div>
             {Js.Array.mapi(
               (x, i) =>

--- a/src/Components/CriticalCareRecording/types/CriticalCare__NeurologicalMonitoring.res
+++ b/src/Components/CriticalCareRecording/types/CriticalCare__NeurologicalMonitoring.res
@@ -45,25 +45,25 @@ let make = (
   ~limbResponseLowerExtremityRight,
   ~limbResponseLowerExtremityLeft,
 ) => {
-  inPronePosition: inPronePosition,
-  consciousnessLevel: consciousnessLevel,
-  consciousnessLevelDetails: consciousnessLevelDetails,
-  leftPupilSize: leftPupilSize,
-  leftPupilSizeDetails: leftPupilSizeDetails,
-  leftPupilLightReaction: leftPupilLightReaction,
-  leftPupilLightReactionDetails: leftPupilLightReactionDetails,
-  rightPupilSize: rightPupilSize,
-  rightPupilSizeDetails: rightPupilSizeDetails,
-  rightPupilLightReaction: rightPupilLightReaction,
-  rightPupilLightReactionDetails: rightPupilLightReactionDetails,
-  glasgowEyeOpen: glasgowEyeOpen,
-  glasgowVerbalResponse: glasgowVerbalResponse,
-  glasgowMotorResponse: glasgowMotorResponse,
-  glasgowTotalCalculated: glasgowTotalCalculated,
-  limbResponseUpperExtremityRight: limbResponseUpperExtremityRight,
-  limbResponseUpperExtremityLeft: limbResponseUpperExtremityLeft,
-  limbResponseLowerExtremityRight: limbResponseLowerExtremityRight,
-  limbResponseLowerExtremityLeft: limbResponseLowerExtremityLeft,
+  inPronePosition,
+  consciousnessLevel,
+  consciousnessLevelDetails,
+  leftPupilSize,
+  leftPupilSizeDetails,
+  leftPupilLightReaction,
+  leftPupilLightReactionDetails,
+  rightPupilSize,
+  rightPupilSizeDetails,
+  rightPupilLightReaction,
+  rightPupilLightReactionDetails,
+  glasgowEyeOpen,
+  glasgowVerbalResponse,
+  glasgowMotorResponse,
+  glasgowTotalCalculated,
+  limbResponseUpperExtremityRight,
+  limbResponseUpperExtremityLeft,
+  limbResponseLowerExtremityRight,
+  limbResponseLowerExtremityLeft,
 }
 
 let makeConsciousnessLevel = consciousnessLevel => {
@@ -173,8 +173,8 @@ let limpResponseToString = limpResponse => {
 
 let eyeOpenToString = eyeOpen => {
   switch eyeOpen {
-  | 1 => "1 - None"
-  | 2 => "2 - Pain"
+  | 1 => "1 - No Response"
+  | 2 => "2 - To Pain"
   | 3 => "3 - To Speech"
   | 4 => "4 - Spontaneous"
   | _ => "Unknown"
@@ -183,23 +183,23 @@ let eyeOpenToString = eyeOpen => {
 
 let motorResposneToString = eyeOpen => {
   switch eyeOpen {
-  | 1 => "1 - None"
-  | 2 => "2 - Incomprehensible words/Moans to pain"
+  | 1 => "1 - No Response"
+  | 2 => "2 - Abnormal Extension"
   | 3 => "3 - Abnormal Flexion"
-  | 4 => "4 - Withdrawing"
-  | 5 => "5 - Localizing/Withdrawl to touch"
-  | 6 => "6 - Obeying/Normal Activity"
+  | 4 => "4 - Flexion/Withdrawal to pain"
+  | 5 => "5 - Moves to localized pain"
+  | 6 => "6 - Obeys commands/Normal Activity"
   | _ => "Unknown"
   }
 }
 
 let verbalResposneToString = eyeOpen => {
   switch eyeOpen {
-  | 1 => "1 - None"
+  | 1 => "1 - No Response"
   | 2 => "2 - Incomprehensible words/Moans to pain"
   | 3 => "3 - Inappropriate words/Cry to pain"
   | 4 => "4 - Confused/Irritable"
-  | 5 => "5 - Oriented/Coos/Babbies"
+  | 5 => "5 - Oriented to Time, Place and Person"
   | _ => "Unknown"
   }
 }

--- a/src/Components/Facility/Consultations/NeurologicalTables.tsx
+++ b/src/Components/Facility/Consultations/NeurologicalTables.tsx
@@ -411,7 +411,9 @@ export const NeurologicalTable = (props: any) => {
           <div className="my-2 text-xl font-semibold">Scale Description</div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             <div className="rounded-lg border bg-white px-4 py-2 shadow">
-              <div className="mb-2 text-xl font-semibold">Eye Open</div>
+              <div className="mb-2 text-xl font-semibold">
+                Eye Opening Response
+              </div>
               <div>
                 {EYE_OPEN_SCALE.map((x: any) => (
                   <div


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3516303</samp>

This pull request updates the code and labels for the neurological monitoring tool to use the standard Glasgow Coma Scale (GCS) terminology and scoring. This improves the accuracy, clarity, and consistency of the tool for critical care patients and users. The changes affect the `NeurologicalMonitoring` type, the `constants.tsx` file, and the `NeurologicalMonitoringEditor` and `NeurologicalTable` components.

## Proposed Changes

- Fixes #6277

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
