### PR TITLE
Renamed "Verified By" to "Treating Physician"

### DIFF
--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -402,7 +402,7 @@ export const ConsultationDetails = (props: any) => {
                   consultationData.deprecated_verified_by) && (
                   <div className="mt-2 text-sm">
                     <span className="font-semibold leading-relaxed">
-                      Verified By:{" "}
+                      Treating Physician:{" "}
                     </span>
                     {consultationData.verified_by_object
                       ? `${consultationData.verified_by_object.first_name} ${consultationData.verified_by_object.last_name}`

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -539,7 +539,7 @@ export const ConsultationForm = (props: any) => {
 
         case "verified_by": {
           if (state.form.suggestion !== "DD" && !state.form[field]) {
-            errors[field] = "Please fill verified by";
+            errors[field] = "Please fill treating physician";
             invalidForm = true;
             break;
           }
@@ -1321,7 +1321,7 @@ export const ConsultationForm = (props: any) => {
                           >
                             <UserAutocompleteFormField
                               name={"verified_by"}
-                              label="Verified by"
+                              label="Treating Physician"
                               placeholder="Attending Doctors Name and Designation"
                               required
                               value={state.form.verified_by_object ?? undefined}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 032a9cc</samp>

Changed the label of the `verified by` field in the consultation form and details components to `treating physician`, to avoid confusion and align with the terminology used by the medical staff.

## Proposed Changes

- Fixes #6278 
- Renamed "Verified By" label to "Treating Physician"

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 032a9cc</samp>

* Change the label and error message for the verified by field in the consultation form and details components to treating physician, to reflect the role of the doctor who is managing the patient's care. ([link](https://github.com/coronasafe/care_fe/pull/6300/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901L405-R405), [link](https://github.com/coronasafe/care_fe/pull/6300/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL542-R542), [link](https://github.com/coronasafe/care_fe/pull/6300/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL1324-R1324))
