### PR TITLE
Added test to verify page redirection from facility details page to asset page

### DIFF
--- a/cypress/e2e/assets_spec/assets_manage.cy.ts
+++ b/cypress/e2e/assets_spec/assets_manage.cy.ts
@@ -1,10 +1,17 @@
 import { afterEach, before, beforeEach, cy, describe, it } from "local-cypress";
 import { AssetPage } from "../../pageobject/Asset/AssetCreation";
 import LoginPage from "../../pageobject/Login/LoginPage";
+import { AssetSearchPage } from "../../pageobject/Asset/AssetSearch";
+import FacilityPage from "../../pageobject/Facility/FacilityCreation";
+import { AssetFilters } from "../../pageobject/Asset/AssetFilters";
 
 describe("Asset", () => {
   const assetPage = new AssetPage();
   const loginPage = new LoginPage();
+  const facilityPage = new FacilityPage();
+  const assetSearchPage = new AssetSearchPage();
+  const assetFilters = new AssetFilters();
+  const fillFacilityName = "Dummy Facility 1";
 
   before(() => {
     loginPage.loginAsDisctrictAdmin();
@@ -21,6 +28,23 @@ describe("Asset", () => {
     assetPage.interceptDeleteAssetApi();
     assetPage.deleteAsset();
     assetPage.verifyDeleteStatus();
+  });
+
+  it("Verify Facility Asset Page Redirection", () => {
+    cy.visit("/facility");
+    assetSearchPage.typeSearchKeyword(fillFacilityName);
+    assetSearchPage.pressEnter();
+    facilityPage.verifyFacilityBadgeContent(fillFacilityName);
+    facilityPage.visitAlreadyCreatedFacility();
+    facilityPage.clickManageFacilityDropdown();
+    facilityPage.clickCreateAssetFacilityOption();
+    facilityPage.verifyfacilitycreateassetredirection();
+    facilityPage.verifyassetfacilitybackredirection();
+    facilityPage.clickManageFacilityDropdown();
+    facilityPage.clickviewAssetFacilityOption();
+    facilityPage.verifyfacilityviewassetredirection();
+    assetFilters.assertFacilityText(fillFacilityName);
+    facilityPage.verifyassetfacilitybackredirection();
   });
 
   afterEach(() => {

--- a/cypress/pageobject/Facility/FacilityCreation.ts
+++ b/cypress/pageobject/Facility/FacilityCreation.ts
@@ -120,6 +120,14 @@ class FacilityPage {
     cy.get("#configure-facility").contains("Configure Facility").click();
   }
 
+  clickCreateAssetFacilityOption() {
+    cy.get("#create-assets").contains("Create Asset").click();
+  }
+
+  clickviewAssetFacilityOption() {
+    cy.get("#view-assets").contains("View Assets").click();
+  }
+
   clickInventoryManagementOption() {
     cy.get("#inventory-management", { timeout: 10000 }).should("be.visible");
     cy.get("#inventory-management").click();
@@ -173,6 +181,33 @@ class FacilityPage {
     cy.intercept("GET", "**/api/v1/facility/**").as("getFacilities");
     cy.get("[id='facility-details']").first().click();
     cy.wait("@getFacilities").its("response.statusCode").should("eq", 200);
+  }
+
+  verifyFacilityBadgeContent(expectedText: string) {
+    cy.get("[data-testid='Facility/District Name']").should(
+      "contain",
+      expectedText
+    );
+  }
+
+  verifyfacilitycreateassetredirection() {
+    cy.intercept("GET", "**/api/v1/facility/**").as("getNewAssets");
+    cy.url().should("include", "/assets/new");
+    cy.wait("@getNewAssets").its("response.statusCode").should("eq", 200);
+  }
+
+  verifyassetfacilitybackredirection() {
+    cy.intercept("GET", "**/api/v1/facility/**").as("getManagePage");
+    cy.go("back");
+    cy.wait("@getManagePage").its("response.statusCode").should("eq", 200);
+    cy.get("#manage-facility-dropdown").scrollIntoView();
+    cy.get("#manage-facility-dropdown").should("exist");
+  }
+
+  verifyfacilityviewassetredirection() {
+    cy.intercept("GET", "**api/v1/getallfacilities/**").as("getViewAssets");
+    cy.url().should("include", "/assets?facility=");
+    cy.wait("@getViewAssets").its("response.statusCode").should("eq", 200);
   }
 
   clickManageInventory() {

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -575,6 +575,7 @@ export const FacilityHome = (props: any) => {
                   Resource Request
                 </DropdownItem>
                 <DropdownItem
+                  id="create-assets"
                   onClick={() => navigate(`/facility/${facilityId}/assets/new`)}
                   authorizeFor={NonReadOnlyUsers}
                   icon={<CareIcon className="care-l-plus-circle text-lg" />}
@@ -582,12 +583,14 @@ export const FacilityHome = (props: any) => {
                   Create Asset
                 </DropdownItem>
                 <DropdownItem
+                  id="view-assets"
                   onClick={() => navigate(`/assets?facility=${facilityId}`)}
                   icon={<CareIcon className="care-l-medkit text-lg" />}
                 >
                   View Assets
                 </DropdownItem>
                 <DropdownItem
+                  id="view-users"
                   onClick={() => navigate(`/facility/${facilityId}/users`)}
                   icon={<CareIcon className="care-l-users-alt text-lg" />}
                 >


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89d91ec</samp>

Added a new test case and methods for facility asset management. The test case verifies the navigation and filtering of assets in a facility. The methods help create and view asset facilities in the UI. Also added `id` attributes to some UI elements for testing.

## Proposed Changes

- Fixes #6307 
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89d91ec</samp>

*  Add methods to click on create asset and view asset options in the facility page ([link](https://github.com/coronasafe/care_fe/pull/6308/files?diff=unified&w=0#diff-a4a17d53a337d155d03bd531b8473e60d3cabdd6dcb1514840799f46a5a2dd0bR123-R130))
*  Add methods to verify the text, URL and status code for the facility and asset pages, and the back navigation functionality ([link](https://github.com/coronasafe/care_fe/pull/6308/files?diff=unified&w=0#diff-a4a17d53a337d155d03bd531b8473e60d3cabdd6dcb1514840799f46a5a2dd0bR186-R212))
*  Add `id` attributes to the `MenuItem` components for the create asset, view asset and view users options in the `FacilityHome` component ([link](https://github.com/coronasafe/care_fe/pull/6308/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cR578), [link](https://github.com/coronasafe/care_fe/pull/6308/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cR586), [link](https://github.com/coronasafe/care_fe/pull/6308/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cR593))
*  Add imports of `AssetSearchPage`, `FacilityPage`, `AssetFilters` and `fillFacilityName` to the test file `assets_manage.cy.ts` ([link](https://github.com/coronasafe/care_fe/pull/6308/files?diff=unified&w=0#diff-db4292fd03626d0a4e5a0e899dbceffb54fab4da3fd02e455598e6627248e746L4-R14))
*  Add a test case to verify the facility asset page redirection using the manage facility dropdown options and the asset view page filter ([link](https://github.com/coronasafe/care_fe/pull/6308/files?diff=unified&w=0#diff-db4292fd03626d0a4e5a0e899dbceffb54fab4da3fd02e455598e6627248e746R33-R49))
