### PR TITLE
Restrict Access to Asset Configurations for Specific Admin Roles

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -28,7 +28,7 @@ import RecordMeta from "../../CAREUI/display/RecordMeta";
 import { useTranslation } from "react-i18next";
 const Loading = lazy(() => import("../Common/Loading"));
 import * as Notification from "../../Utils/Notifications.js";
-import AuthorizeFor, { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
+import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import Uptime from "../Common/Uptime";
 import useAuthUser from "../../Common/hooks/useAuthUser";
 import dayjs from "dayjs";
@@ -453,7 +453,6 @@ const AssetManage = (props: AssetManageProps) => {
                   }
                   id="configure-asset"
                   data-testid="asset-configure-button"
-                  authorizeFor={AuthorizeFor(["DistrictAdmin", "StateAdmin"])}
                 >
                   <CareIcon className="care-l-setting h-4" />
                   {t("configure")}

--- a/src/Components/Assets/AssetType/HL7Monitor.tsx
+++ b/src/Components/Assets/AssetType/HL7Monitor.tsx
@@ -15,6 +15,7 @@ import CareIcon from "../../../CAREUI/icons/CareIcon";
 import TextFormField from "../../Form/FormFields/TextFormField";
 import HL7PatientVitalsMonitor from "../../VitalsMonitor/HL7PatientVitalsMonitor";
 import VentilatorPatientVitalsMonitor from "../../VitalsMonitor/VentilatorPatientVitalsMonitor";
+import useAuthUser from "../../../Common/hooks/useAuthUser";
 
 interface HL7MonitorProps {
   assetId: string;
@@ -31,7 +32,7 @@ const HL7Monitor = (props: HL7MonitorProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [localipAddress, setLocalIPAddress] = useState("");
   const [ipadrdress_error, setIpAddress_error] = useState("");
-
+  const authUser = useAuthUser();
   const dispatch = useDispatch<any>();
 
   useEffect(() => {
@@ -87,40 +88,42 @@ const HL7Monitor = (props: HL7MonitorProps) => {
   return (
     <div className="mx-auto flex w-full xl:mt-8">
       <div className="mx-auto flex flex-col gap-4 xl:flex-row-reverse">
-        <div className="flex w-full shrink-0 flex-col gap-4 xl:max-w-xs">
-          <Card className="flex w-full flex-col">
-            <form onSubmit={handleSubmit}>
-              <h2 className="mb-2 text-lg font-bold">Connection</h2>
-              <div className="flex flex-col">
-                <TextFormField
-                  name="middlewareHostname"
-                  label="Middleware Hostname"
-                  placeholder={facilityMiddlewareHostname}
-                  value={middlewareHostname}
-                  onChange={(e) => setMiddlewareHostname(e.value)}
-                  errorClassName="hidden"
-                />
-                <TextFormField
-                  name="localipAddress"
-                  label="Local IP Address"
-                  value={localipAddress}
-                  onChange={(e) => setLocalIPAddress(e.value)}
-                  required
-                  error={ipadrdress_error}
-                />
-                <Submit className="w-full">
-                  <CareIcon className="care-l-save" />
-                  <span>Save Configuration</span>
-                </Submit>
-              </div>
-            </form>
-          </Card>
-          {["HL7MONITOR"].includes(assetType) && (
-            <Card>
-              <MonitorConfigure asset={asset as AssetData} />
+        {["DistrictAdmin", "StateAdmin"].includes(authUser.user_type) && (
+          <div className="flex w-full shrink-0 flex-col gap-4 xl:max-w-xs">
+            <Card className="flex w-full flex-col">
+              <form onSubmit={handleSubmit}>
+                <h2 className="mb-2 text-lg font-bold">Connection</h2>
+                <div className="flex flex-col">
+                  <TextFormField
+                    name="middlewareHostname"
+                    label="Middleware Hostname"
+                    placeholder={facilityMiddlewareHostname}
+                    value={middlewareHostname}
+                    onChange={(e) => setMiddlewareHostname(e.value)}
+                    errorClassName="hidden"
+                  />
+                  <TextFormField
+                    name="localipAddress"
+                    label="Local IP Address"
+                    value={localipAddress}
+                    onChange={(e) => setLocalIPAddress(e.value)}
+                    required
+                    error={ipadrdress_error}
+                  />
+                  <Submit className="w-full">
+                    <CareIcon className="care-l-save" />
+                    <span>Save Configuration</span>
+                  </Submit>
+                </div>
+              </form>
             </Card>
-          )}
-        </div>
+            {["HL7MONITOR"].includes(assetType) && (
+              <Card>
+                <MonitorConfigure asset={asset as AssetData} />
+              </Card>
+            )}
+          </div>
+        )}
 
         {assetType === "HL7MONITOR" && (
           <HL7PatientVitalsMonitor

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -16,6 +16,7 @@ import { checkIfValidIP } from "../../../Common/validation";
 import TextFormField from "../../Form/FormFields/TextFormField";
 import { Submit } from "../../Common/components/ButtonV2";
 import { SyntheticEvent } from "react";
+import useAuthUser from "../../../Common/hooks/useAuthUser";
 
 interface ONVIFCameraProps {
   assetId: string;
@@ -44,7 +45,7 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
   );
   const [refreshHash, setRefreshHash] = useState(Number(new Date()));
   const dispatch = useDispatch<any>();
-
+  const authUser = useAuthUser();
   useEffect(() => {
     const fetchFacility = async () => {
       const res = await dispatch(getPermittedFacility(facilityId));
@@ -147,57 +148,59 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
 
   return (
     <div className="space-y-6">
-      <form className="rounded bg-white p-8 shadow" onSubmit={handleSubmit}>
-        <div className="grid grid-cols-1 gap-x-4 lg:grid-cols-2">
-          <TextFormField
-            name="middleware_hostname"
-            label="Hospital Middleware Hostname"
-            autoComplete="off"
-            value={middlewareHostname}
-            onChange={({ value }) => setMiddlewareHostname(value)}
-          />
-          <TextFormField
-            name="camera_address"
-            label="Local IP Address"
-            autoComplete="off"
-            value={cameraAddress}
-            onChange={({ value }) => setCameraAddress(value)}
-            error={ipadrdress_error}
-          />
-          <TextFormField
-            name="username"
-            label="Username"
-            autoComplete="off"
-            value={username}
-            onChange={({ value }) => setUsername(value)}
-          />
-          <TextFormField
-            name="password"
-            label="Password"
-            autoComplete="off"
-            type="password"
-            value={password}
-            onChange={({ value }) => setPassword(value)}
-          />
-          <TextFormField
-            name="stream_uuid"
-            label="Stream UUID"
-            autoComplete="off"
-            value={streamUuid}
-            type="password"
-            className="tracking-widest"
-            labelClassName="tracking-normal"
-            onChange={({ value }) => setStreamUuid(value)}
-          />
-        </div>
-        <div className="flex justify-end">
-          <Submit
-            disabled={loadingSetConfiguration}
-            className="w-full md:w-auto"
-            label="Set Configuration"
-          />
-        </div>
-      </form>
+      {["DistrictAdmin", "StateAdmin"].includes(authUser.user_type) && (
+        <form className="rounded bg-white p-8 shadow" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-x-4 lg:grid-cols-2">
+            <TextFormField
+              name="middleware_hostname"
+              label="Hospital Middleware Hostname"
+              autoComplete="off"
+              value={middlewareHostname}
+              onChange={({ value }) => setMiddlewareHostname(value)}
+            />
+            <TextFormField
+              name="camera_address"
+              label="Local IP Address"
+              autoComplete="off"
+              value={cameraAddress}
+              onChange={({ value }) => setCameraAddress(value)}
+              error={ipadrdress_error}
+            />
+            <TextFormField
+              name="username"
+              label="Username"
+              autoComplete="off"
+              value={username}
+              onChange={({ value }) => setUsername(value)}
+            />
+            <TextFormField
+              name="password"
+              label="Password"
+              autoComplete="off"
+              type="password"
+              value={password}
+              onChange={({ value }) => setPassword(value)}
+            />
+            <TextFormField
+              name="stream_uuid"
+              label="Stream UUID"
+              autoComplete="off"
+              value={streamUuid}
+              type="password"
+              className="tracking-widest"
+              labelClassName="tracking-normal"
+              onChange={({ value }) => setStreamUuid(value)}
+            />
+          </div>
+          <div className="flex justify-end">
+            <Submit
+              disabled={loadingSetConfiguration}
+              className="w-full md:w-auto"
+              label="Set Configuration"
+            />
+          </div>
+        </form>
+      )}
 
       {assetType === "ONVIF" ? (
         <CameraConfigure


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0078dca</samp>

This pull request improves the authorization logic for managing different asset types in the `AssetManage` component. It uses the `useAuthUser` hook to check the user roles and restrict the access to the configuration forms for `HL7Monitor` and `ONVIFCamera` components to admin users only.

## Proposed Changes

- Fixes #6297 


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0078dca</samp>

*  Restrict access to asset configuration forms based on user role ([link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L31-R31), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L456), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacR18), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL34-R35), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL90-R126), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR19), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL47-R48), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL150-R203))
  * Import `useAuthUser` hook in `HL7Monitor.tsx` and `ONVIFCamera.tsx` to get the current user's type and role ([link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacR18), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR19))
  * Declare `authUser` variable using the hook in both components ([link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL34-R35), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL47-R48))
  * Wrap the components with a conditional rendering based on `authUser`, to only show the forms to users with `DistrictAdmin` or `StateAdmin` roles ([link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL90-R126), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL150-R203))
  * Remove the `authorizeFor` prop from the `AssetManage` component in `AssetManage.tsx`, since the authorization logic is handled by the child components ([link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L31-R31), [link](https://github.com/coronasafe/care_fe/pull/6309/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L456))
