### PR TITLE
Fix action field in consultation form

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -97,7 +97,7 @@ type FormDetails = {
   procedure: ProcedureType[];
   investigation: InvestigationType[];
   is_telemedicine: BooleanStrings;
-  action?: string;
+  action?: number;
   assigned_to: string;
   assigned_to_object: UserModel | null;
   special_instruction: string;
@@ -143,7 +143,7 @@ const initForm: FormDetails = {
   procedure: [],
   investigation: [],
   is_telemedicine: "false",
-  action: "NO_ACTION",
+  action: 10,
   assigned_to: "",
   assigned_to_object: null,
   special_instruction: "",
@@ -279,15 +279,14 @@ export const ConsultationForm = (props: any) => {
         setIsLoading(true);
         const res = await dispatchAction(getPatient({ id: patientId }));
         if (res.data) {
+          if (isUpdate) {
+            dispatch({
+              type: "set_form",
+              form: { ...state.form, action: res.data.action },
+            });
+          }
           setPatientName(res.data.name);
           setFacilityName(res.data.facility_object.name);
-          if (isUpdate) {
-            const form = { ...state.form };
-            form.action = TELEMEDICINE_ACTIONS.find(
-              (a) => a.id === res.data.action
-            )?.text;
-            dispatch({ type: "set_form", form });
-          }
         }
       } else {
         setPatientName("");
@@ -301,6 +300,49 @@ export const ConsultationForm = (props: any) => {
   const hasSymptoms =
     !!state.form.symptoms.length && !state.form.symptoms.includes(1);
   const isOtherSymptomsSelected = state.form.symptoms.includes(9);
+
+  const handleFormFieldChange: FieldChangeEventHandler<unknown> = (event) => {
+    if (event.name === "consultation_status" && event.value === "1") {
+      dispatch({
+        type: "set_form",
+        form: {
+          ...state.form,
+          consultation_status: 1,
+          symptoms: [1],
+          symptoms_onset_date: new Date(),
+          category: "Critical",
+          suggestion: "DD",
+        },
+      });
+    } else if (event.name === "suggestion" && event.value === "DD") {
+      dispatch({
+        type: "set_form",
+        form: {
+          ...state.form,
+          suggestion: "DD",
+          consultation_notes: "Patient declared dead",
+          verified_by: "Declared Dead",
+        },
+      });
+    } else if (
+      event.name === "icd11_diagnoses_object" ||
+      event.name === "icd11_provisional_diagnoses_object"
+    ) {
+      dispatch({
+        type: "set_form",
+        form: {
+          ...state.form,
+          [event.name]: event.value,
+          icd11_principal_diagnosis: undefined,
+        },
+      });
+    } else {
+      dispatch({
+        type: "set_form",
+        form: { ...state.form, [event.name]: event.value },
+      });
+    }
+  };
 
   const fetchData = useCallback(
     async (status: statusType) => {
@@ -352,7 +394,7 @@ export const ConsultationForm = (props: any) => {
             death_confirmed_doctor: res.data?.death_confirmed_doctor || "",
             InvestigationAdvice: res.data.investigation,
           };
-          dispatch({ type: "set_form", form: formData });
+          dispatch({ type: "set_form", form: { ...state.form, ...formData } });
           setBed(formData.bed);
 
           if (res.data.last_daily_round) {
@@ -364,7 +406,7 @@ export const ConsultationForm = (props: any) => {
         setIsLoading(false);
       }
     },
-    [dispatchAction, id]
+    [dispatchAction, id, patientName, patientId]
   );
 
   useAbortableEffect(
@@ -742,49 +784,6 @@ export const ConsultationForm = (props: any) => {
           );
         }
       }
-    }
-  };
-
-  const handleFormFieldChange: FieldChangeEventHandler<unknown> = (event) => {
-    if (event.name === "consultation_status" && event.value === "1") {
-      dispatch({
-        type: "set_form",
-        form: {
-          ...state.form,
-          consultation_status: 1,
-          symptoms: [1],
-          symptoms_onset_date: new Date(),
-          category: "Critical",
-          suggestion: "DD",
-        },
-      });
-    } else if (event.name === "suggestion" && event.value === "DD") {
-      dispatch({
-        type: "set_form",
-        form: {
-          ...state.form,
-          suggestion: "DD",
-          consultation_notes: "Patient declared dead",
-          verified_by: "Declared Dead",
-        },
-      });
-    } else if (
-      event.name === "icd11_diagnoses_object" ||
-      event.name === "icd11_provisional_diagnoses_object"
-    ) {
-      dispatch({
-        type: "set_form",
-        form: {
-          ...state.form,
-          [event.name]: event.value,
-          icd11_principal_diagnosis: undefined,
-        },
-      });
-    } else {
-      dispatch({
-        type: "set_form",
-        form: { ...state.form, [event.name]: event.value },
-      });
     }
   };
 
@@ -1347,12 +1346,12 @@ export const ConsultationForm = (props: any) => {
                             </div>
                             <div className="flex-1" ref={fieldRef["action"]}>
                               <SelectFormField
-                                {...field("action")}
+                                {...selectField("action")}
                                 label="Action"
                                 position="above"
                                 options={TELEMEDICINE_ACTIONS}
                                 optionLabel={(option) => option.desc}
-                                optionValue={(option) => option.text}
+                                optionDescription={() => ""}
                               />
                             </div>
                           </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26eab22</samp>

The pull request improves the `ConsultationForm` component to handle numeric actions, set default values, and clear fields appropriately. It also fixes a bug and enhances the document title with patient information.

## Proposed Changes

- Fixes #6298 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26eab22</samp>

*  Change the type and initial value of the `action` property in the `FormDetails` interface and the `initForm` object to match the backend API and the `TELEMEDICINE_ACTIONS` array ([link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL100-R100), [link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL146-R146), [link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL1350-R1354))
*  Add the `handleFormFieldChange` function to handle special cases when the user changes some form fields, such as setting default values or clearing other fields ([link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR304-R346))
*  Use the `handleFormFieldChange` function as the `onChange` prop for the `SelectFormField`, `MultilineInputField`, and `TextInputField` components in the `ConsultationForm` component ([link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL748-L790))
*  Change the `set_form` action in the `fetchData` function to merge the existing form values with the API response values, instead of replacing them ([link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL355-R397))
*  Change the order of the statements in the `fetchPatientName` function to dispatch the `action` value from the API response before setting the patient name and facility name ([link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL282-R289))
*  Update the dependencies of the `useEffect` hook in the `ConsultationForm` component to include the `patientName` and `patientId` variables ([link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL367-R409))
*  Change the `SelectFormField` component for the `action` field to use the `selectField` helper function instead of the `field` helper function, and add the `optionDescription` prop ([link](https://github.com/coronasafe/care_fe/pull/6314/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL1350-R1354))
