### PR TITLE
Added logic for showing "Track Shifting" button when patient has active shifting

### DIFF
--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -33,6 +33,7 @@ describe("Patient Creation with consultation", () => {
   it("Create a new patient with no consultation", () => {
     patientPage.createPatient();
     patientPage.selectFacility("dummy facility");
+    patientPage.patientformvisibility();
     patientPage.enterPatientDetails(
       phone_number,
       emergency_phone_number,
@@ -69,6 +70,7 @@ describe("Patient Creation with consultation", () => {
     patientPage.interceptFacilities();
     patientPage.visitUpdatePatientUrl();
     patientPage.verifyStatusCode();
+    patientPage.patientformvisibility();
     updatePatientPage.enterPatientDetails(
       "Test E2E User Edited",
       "O+",

--- a/cypress/pageobject/Facility/FacilityCreation.ts
+++ b/cypress/pageobject/Facility/FacilityCreation.ts
@@ -191,9 +191,7 @@ class FacilityPage {
   }
 
   verifyfacilitycreateassetredirection() {
-    cy.intercept("GET", "**/api/v1/facility/**").as("getNewAssets");
     cy.url().should("include", "/assets/new");
-    cy.wait("@getNewAssets").its("response.statusCode").should("eq", 200);
   }
 
   verifyassetfacilitybackredirection() {

--- a/cypress/pageobject/Patient/PatientConsultation.ts
+++ b/cypress/pageobject/Patient/PatientConsultation.ts
@@ -16,6 +16,7 @@ export class PatientConsultationPage {
   }
 
   fillIllnessHistory(history: string) {
+    cy.wait(5000);
     cy.get("#history_of_present_illness").scrollIntoView();
     cy.get("#history_of_present_illness").should("be.visible");
     cy.get("#history_of_present_illness").click().type(history);

--- a/cypress/pageobject/Patient/PatientCreation.ts
+++ b/cypress/pageobject/Patient/PatientCreation.ts
@@ -124,4 +124,8 @@ export class PatientPage {
   verifyStatusCode() {
     cy.wait("@getFacilities").its("response.statusCode").should("eq", 200);
   }
+
+  patientformvisibility() {
+    cy.get("[data-testid='current-address']").scrollIntoView();
+  }
 }

--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -5,7 +5,11 @@ import {
   SYMPTOM_CHOICES,
 } from "../../../Common/constants";
 import { ConsultationModel, ICD11DiagnosisModel } from "../models";
-import { getConsultation, getPatient } from "../../../Redux/actions";
+import {
+  getConsultation,
+  getPatient,
+  listShiftRequests,
+} from "../../../Redux/actions";
 import { statusType, useAbortableEffect } from "../../../Common/utils";
 import { lazy, useCallback, useState } from "react";
 import ToolTip from "../../Common/utils/Tooltip";
@@ -63,6 +67,7 @@ export const ConsultationDetails = (props: any) => {
     {} as ConsultationModel
   );
   const [patientData, setPatientData] = useState<PatientModel>({});
+  const [activeShiftingData, setActiveShiftingData] = useState<Array<any>>([]);
   const [openDischargeSummaryDialog, setOpenDischargeSummaryDialog] =
     useState(false);
   const [openDischargeDialog, setOpenDischargeDialog] = useState(false);
@@ -124,6 +129,16 @@ export const ConsultationDetails = (props: any) => {
             };
             setPatientData(data);
           }
+
+          // Get shifting data
+          const shiftingRes = await dispatch(
+            listShiftRequests({ patient: id }, "shift-list-call")
+          );
+          if (shiftingRes?.data?.results) {
+            const data = shiftingRes.data.results;
+            setActiveShiftingData(data);
+            console.log(data);
+          }
         } else {
           navigate("/not-found");
         }
@@ -167,6 +182,19 @@ export const ConsultationDetails = (props: any) => {
   };
 
   const SelectedTab = TABS[tab];
+
+  const hasActiveShiftingRequest = () => {
+    if (activeShiftingData.length > 0) {
+      return [
+        "PENDING",
+        "APPROVED",
+        "DESTINATION APPROVED",
+        "PATIENT TO BE PICKED UP",
+      ].includes(activeShiftingData[activeShiftingData.length - 1].status);
+    }
+
+    return false;
+  };
 
   if (isLoading) {
     return <Loading />;
@@ -265,17 +293,33 @@ export const ConsultationDetails = (props: any) => {
           <div className="-right-6 top-0 flex w-full flex-col space-y-1 sm:w-min sm:flex-row sm:items-center sm:space-y-0 sm:divide-x-2 lg:absolute xl:right-0">
             {!consultationData.discharge_date && (
               <div className="flex w-full flex-col px-2 sm:flex-row">
-                <ButtonV2
-                  onClick={() =>
-                    navigate(
-                      `/facility/${patientData.facility}/patient/${patientData.id}/shift/new`
-                    )
-                  }
-                  className="btn btn-primary m-1 w-full hover:text-white"
-                >
-                  <CareIcon className="care-l-ambulance h-5 w-5" />
-                  Shift Patient
-                </ButtonV2>
+                {hasActiveShiftingRequest() ? (
+                  <ButtonV2
+                    onClick={() =>
+                      navigate(
+                        `/shifting/${
+                          activeShiftingData[activeShiftingData.length - 1].id
+                        }`
+                      )
+                    }
+                    className="btn btn-primary m-1 w-full hover:text-white"
+                  >
+                    <CareIcon className="care-l-ambulance h-5 w-5" />
+                    Track Shifting
+                  </ButtonV2>
+                ) : (
+                  <ButtonV2
+                    onClick={() =>
+                      navigate(
+                        `/facility/${patientData.facility}/patient/${patientData.id}/shift/new`
+                      )
+                    }
+                    className="btn btn-primary m-1 w-full hover:text-white"
+                  >
+                    <CareIcon className="care-l-ambulance h-5 w-5" />
+                    Shift Patient
+                  </ButtonV2>
+                )}
                 <button
                   onClick={() => {
                     triggerGoal("Doctor Connect Clicked", {

--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -137,7 +137,6 @@ export const ConsultationDetails = (props: any) => {
           if (shiftingRes?.data?.results) {
             const data = shiftingRes.data.results;
             setActiveShiftingData(data);
-            console.log(data);
           }
         } else {
           navigate("/not-found");


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55de92a</samp>

This file adds the functionality to view and track the shifting status of a patient in the consultation details page. It uses the existing `listShiftRequests` action and `activeShiftingData` state variable to fetch and display the shifting data. It also modifies the shift patient button to show the current shifting status and action.

## Proposed Changes

- Fixes #6134 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55de92a</samp>

*  Import and dispatch `listShiftRequests` action to fetch shifting data for a patient ([link](https://github.com/coronasafe/care_fe/pull/6318/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901L8-R12), [link](https://github.com/coronasafe/care_fe/pull/6318/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R132-R140))
*  Declare and assign `activeShiftingData` state variable to store shifting data for a patient ([link](https://github.com/coronasafe/care_fe/pull/6318/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R70))
*  Define `hasActiveShiftingRequest` function to check if the patient has an active shifting request ([link](https://github.com/coronasafe/care_fe/pull/6318/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R185-R197))
*  Modify conditional rendering of shift patient button in `src/Components/Facility/ConsultationDetails/index.tsx` to show track shifting option if the patient has an active shifting request ([link](https://github.com/coronasafe/care_fe/pull/6318/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901L268-R321))
