### PR TITLE
Asset Configure: Migrate `useDispatch` to use `useQuery` (inherently fixes camera not reloading on configure saved)

### DIFF
--- a/src/Components/Assets/AssetConfigure.tsx
+++ b/src/Components/Assets/AssetConfigure.tsx
@@ -15,9 +15,7 @@ const AssetConfigure = ({ assetId, facilityId }: AssetConfigureProps) => {
     data: asset,
     loading,
     refetch,
-  } = useQuery(routes.getAsset, {
-    pathParams: { external_id: assetId },
-  });
+  } = useQuery(routes.getAsset, { pathParams: { external_id: assetId } });
 
   if (loading || !asset) {
     return <Loading />;

--- a/src/Components/Assets/AssetConfigure.tsx
+++ b/src/Components/Assets/AssetConfigure.tsx
@@ -10,9 +10,7 @@ interface AssetConfigureProps {
   facilityId: string;
 }
 
-const AssetConfigure = (props: AssetConfigureProps) => {
-  const { assetId, facilityId } = props;
-
+const AssetConfigure = ({ assetId, facilityId }: AssetConfigureProps) => {
   const {
     data: asset,
     loading,

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -18,14 +18,14 @@ import { Submit } from "../../Common/components/ButtonV2";
 import { SyntheticEvent } from "react";
 import useAuthUser from "../../../Common/hooks/useAuthUser";
 
-interface ONVIFCameraProps {
+interface Props {
   assetId: string;
   facilityId: string;
   asset: any;
+  onUpdated?: () => void;
 }
 
-const ONVIFCamera = (props: ONVIFCameraProps) => {
-  const { assetId, facilityId, asset } = props;
+const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
   const [isLoading, setIsLoading] = useState(true);
   const [assetType, setAssetType] = useState("");
   const [middlewareHostname, setMiddlewareHostname] = useState("");
@@ -43,7 +43,6 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
   const [refreshPresetsHash, setRefreshPresetsHash] = useState(
     Number(new Date())
   );
-  const [refreshHash, setRefreshHash] = useState(Number(new Date()));
   const dispatch = useDispatch<any>();
   const authUser = useAuthUser();
   useEffect(() => {
@@ -88,14 +87,10 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
         dispatch(partialUpdateAsset(assetId, data))
       );
       if (res?.status === 200) {
-        Notification.Success({
-          msg: "Asset Configured Successfully",
-        });
-        setRefreshHash(Number(new Date()));
+        Notification.Success({ msg: "Asset Configured Successfully" });
+        onUpdated?.();
       } else {
-        Notification.Error({
-          msg: "Something went wrong..!",
-        });
+        Notification.Error({ msg: "Something went wrong..!" });
       }
       setLoadingSetConfiguration(false);
     } else {
@@ -204,7 +199,6 @@ const ONVIFCamera = (props: ONVIFCameraProps) => {
 
       {assetType === "ONVIF" ? (
         <CameraConfigure
-          key={refreshHash}
           asset={asset as AssetData}
           bed={bed}
           setBed={setBed}

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -1,4 +1,5 @@
 import { IConfig } from "../Common/hooks/useConfig";
+import { AssetData } from "../Components/Assets/AssetTypes";
 import { LocationModel } from "../Components/Facility/models";
 import { UserModel } from "../Components/Users/models";
 import { PaginatedResponse } from "../Utils/request/types";
@@ -804,6 +805,7 @@ const routes = {
   getAsset: {
     path: "/api/v1/asset/{external_id}/",
     method: "GET",
+    TRes: Res<AssetData>(),
   },
   deleteAsset: {
     path: "/api/v1/asset/{external_id}/",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f62b97</samp>

Refactored and improved the `AssetConfigure` and `ONVIFCamera` components for managing and displaying asset data and configuration. Added type parameter for asset API route to enhance type safety.

## Proposed Changes

- Fixes #6325
- Part of #6326

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f62b97</samp>

*  Refactor `AssetConfigure` component to use `useQuery` hook for fetching asset data ([link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-d3e5be58b5cec11bf2c77eb084d66a5da1cac8879bb80d4b813ee048cedf9929L1-R6), [link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-d3e5be58b5cec11bf2c77eb084d66a5da1cac8879bb80d4b813ee048cedf9929L19-R33), [link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-d3e5be58b5cec11bf2c77eb084d66a5da1cac8879bb80d4b813ee048cedf9929L68-R44), [link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-d3e5be58b5cec11bf2c77eb084d66a5da1cac8879bb80d4b813ee048cedf9929L94-R75))
*  Add optional `onUpdated` prop to `ONVIFCamera` component to trigger refetch of asset data in parent component ([link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL21-R28), [link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL46), [link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL91-R93), [link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL207))
*  Specify response type for `getAsset` route as `AssetData` ([link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR2), [link](https://github.com/coronasafe/care_fe/pull/6327/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR808))
