### PR TITLE
Fix Ambulance Phone Number validation in Shifting

### DIFF
--- a/src/Components/Patient/ShiftCreate.tsx
+++ b/src/Components/Patient/ShiftCreate.tsx
@@ -145,6 +145,11 @@ export const ShiftCreate = (props: patientShiftProps) => {
           errors: action.errors,
         };
       }
+      case "set_field":
+        return {
+          form: { ...state.form, [action.name]: action.value },
+          errors: { ...state.errors, [action.name]: action.error },
+        };
       default:
         return state;
     }
@@ -188,8 +193,10 @@ export const ShiftCreate = (props: patientShiftProps) => {
 
   const handleFormFieldChange = (event: FieldChangeEvent<unknown>) => {
     dispatch({
-      type: "set_form",
-      form: { ...state.form, [event.name]: event.value },
+      type: "set_field",
+      name: event.name,
+      value: event.value,
+      error: "",
     });
   };
 

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -253,6 +253,8 @@ export interface CountryData {
 }
 
 export const parsePhoneNumber = (phoneNumber: string, countryCode?: string) => {
+  if (!phoneNumber) return "";
+  if (phoneNumber === "+91") return "";
   const phoneCodes: Record<string, CountryData> = phoneCodesJson;
   let parsedNumber = phoneNumber.replace(/[-+() ]/g, "");
   if (countryCode && phoneCodes[countryCode]) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a8abef</samp>

This pull request enhances the user experience and performance of the patient shift creation form by fixing some bugs and optimizing the state management. It modifies the `ShiftCreate` component in `src/Components/Patient/ShiftCreate.tsx` and the `formatPhoneNumber` function in `src/Utils/utils.ts`.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a8abef</samp>

*  Add a new reducer case to handle individual form field updates in `ShiftCreate` component ([link](https://github.com/coronasafe/care_fe/pull/6332/files?diff=unified&w=0#diff-7ec03dd8838e59d1d7ef0aa4f42c6ed82aa5f086d5d280b42617974f674f561fR148-R152))
*  Modify `handleFormFieldChange` function to dispatch the new `set_field` action instead of `set_form` action ([link](https://github.com/coronasafe/care_fe/pull/6332/files?diff=unified&w=0#diff-7ec03dd8838e59d1d7ef0aa4f42c6ed82aa5f086d5d280b42617974f674f561fL191-R199))
*  Prevent `formatPhoneNumber` function from returning empty string when phone number is null, undefined, or only country code ([link](https://github.com/coronasafe/care_fe/pull/6332/files?diff=unified&w=0#diff-5903b23c9778624d9c178b9779024a4265e5fc365714fed34d49225ee6b8dc73R256-R257))
