### PR TITLE
Enable clearing 'referred to' in discharge modal

### DIFF
--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -75,7 +75,7 @@ const DischargeModal = ({
   const [latestClaim, setLatestClaim] = useState<HCXClaimModel>();
   const [isCreateClaimLoading, setIsCreateClaimLoading] = useState(false);
   const [isSendingDischargeApi, setIsSendingDischargeApi] = useState(false);
-  const [facility, setFacility] = useState<FacilityModel>({ id: 0, name: "" }); // for referred to external
+  const [facility, setFacility] = useState<FacilityModel>();
   const [errors, setErrors] = useState<any>({});
 
   const fetchLatestClaim = useCallback(async () => {
@@ -186,12 +186,13 @@ const DischargeModal = ({
   const prescriptionActions = PrescriptionActions(consultationData.id ?? "");
 
   const handleFacilitySelect = (selected: FacilityModel) => {
-    setFacility(selected ? selected : facility);
-    const { id, name } = selected;
+    setFacility(selected);
+    const { id, name } = selected || {};
     const isExternal = id === -1;
     setPreDischargeForm((prev) => ({
       ...prev,
-      ...(isExternal ? { referred_to_external: name } : { referred_to: id }),
+      referred_to: isExternal ? null : id,
+      referred_to_external: isExternal ? name : null,
     }));
   };
 
@@ -238,8 +239,8 @@ const DischargeModal = ({
                 handleFacilitySelect(selected as FacilityModel)
               }
               selected={facility}
-              showAll={true}
-              freeText={true}
+              showAll
+              freeText
               multiple={false}
               errors={errors?.referred_to}
               className="mb-4"

--- a/src/Components/Form/AutoCompleteAsync.tsx
+++ b/src/Components/Form/AutoCompleteAsync.tsx
@@ -7,6 +7,7 @@ import {
   MultiSelectOptionChip,
   dropdownOptionClassNames,
 } from "./MultiSelectMenuV2";
+import { useTranslation } from "react-i18next";
 
 interface Props {
   name?: string;
@@ -23,6 +24,7 @@ interface Props {
   placeholder?: string;
   disabled?: boolean;
   error?: string;
+  required?: boolean;
   onBlur?: () => void;
   onFocus?: () => void;
 }
@@ -42,11 +44,13 @@ const AutoCompleteAsync = (props: Props) => {
     className = "",
     placeholder,
     disabled = false,
+    required = false,
     error,
   } = props;
   const [data, setData] = useState([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
+  const { t } = useTranslation();
 
   const hasSelection =
     (!multiple && selected) || (multiple && selected?.length > 0);
@@ -86,9 +90,7 @@ const AutoCompleteAsync = (props: Props) => {
                   : placeholder || "Start typing to search..."
               }
               displayValue={() =>
-                hasSelection && !multiple
-                  ? optionLabel && optionLabel(selected)
-                  : ""
+                hasSelection && !multiple ? optionLabel?.(selected) : ""
               }
               onChange={({ target }) => setQuery(target.value)}
               onFocus={props.onFocus}
@@ -100,6 +102,20 @@ const AutoCompleteAsync = (props: Props) => {
             />
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
               <div className="absolute right-0 top-1 mr-2 flex items-center text-lg text-secondary-900">
+                {hasSelection && !loading && !required && (
+                  <div className="tooltip">
+                    <CareIcon
+                      className="care-l-times-circle mb-[-5px] h-4 w-4 text-gray-800 transition-colors duration-200 ease-in-out hover:text-gray-500"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        onChange(null);
+                      }}
+                    />
+                    <span className="tooltip-text tooltip-bottom -translate-x-1/2 text-xs">
+                      {t("clear_selection")}
+                    </span>
+                  </div>
+                )}
                 {loading ? (
                   <CareIcon className="care-l-spinner -mb-1.5 animate-spin" />
                 ) : (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c387da</samp>

This pull request enhances the user interface and functionality of the discharge modal and the `AutoCompleteAsync` component. It fixes a bug in the facility selection, adds internationalization and validation support, and allows clearing the selected option. The changes affect the files `DischargeModal.tsx` and `AutoCompleteAsync.tsx`.

## Proposed Changes

- Fixes #6301
- 
This PR resolves the issue #6301, where users were unable to clear the 'referred to' field in the discharge pop-up.

Previously, when discharging a patient and marking the reason for discharge as 'referred', users were unable to clear the selected hospital in the 'referred to' field. This behavior was inconsistent with the field's non-mandatory nature.

With this fix, users can now clear the 'referred to' field as expected. This change improves the user experience by providing the necessary flexibility in the discharge process.

![image](https://github.com/coronasafe/care_fe/assets/3626859/7374cd7e-746a-4a5e-a62d-fcad0a092755)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c387da</samp>

*  Add `useTranslation` hook and `t` function to `AutoCompleteAsync` component to enable internationalization of text strings ([link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8R10), [link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8R53))
*  Add `required` prop to `AutoCompleteAsync` component to allow parent component to indicate mandatory or optional selection ([link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8R27), [link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8R47))
*  Render clear icon with tooltip in `AutoCompleteAsync` component when selection is not loading or required, and use `t` function to translate icon and tooltip text ([link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8R105-R118))
*  Use optional chaining operator in `optionLabel` function of `AutoCompleteAsync` component to avoid errors when function is undefined or null ([link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-9e6ecb483e64bf3d105856333925ff3c7a5edf635f9436fb10ca55b25c61b1e8L89-R93))
*  Change initial state of `facility` variable in `DischargeModal` component from default object to undefined to avoid blank option in facility select component ([link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L78-R78))
*  Change logic of `handleFacilitySelect` function in `DischargeModal` component to handle null or undefined selection and set or null `referred_to` and `referred_to_external` fields of `preDischargeForm` state accordingly ([link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L189-R195))
*  Simplify boolean props `showAll` and `freeText` of `AutoCompleteAsync` component to use shorthand syntax without explicit values ([link](https://github.com/coronasafe/care_fe/pull/6337/files?diff=unified&w=0#diff-ad38d96db62f6d8302226491a72c518ad76ebac1f3f2efbf1b4ca9754d01e764L241-R243))
