### PR TITLE
Display patient age in mm dd when younger than 1y

### DIFF
--- a/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
@@ -10,7 +10,7 @@ import useVitalsAspectRatioConfig from "../../VitalsMonitor/useVitalsAspectRatio
 import { DISCHARGE_REASONS, SYMPTOM_CHOICES } from "../../../Common/constants";
 import PrescriptionsTable from "../../Medicine/PrescriptionsTable";
 import Chip from "../../../CAREUI/display/Chip";
-import { formatDate, formatDateTime } from "../../../Utils/utils";
+import { formatAge, formatDate, formatDateTime } from "../../../Utils/utils";
 import ReadMore from "../../Common/components/Readmore";
 import { DailyRoundsList } from "../Consultations/DailyRoundsList";
 
@@ -621,7 +621,12 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
                 <div>
                   Age {" - "}
                   <span className="font-semibold">
-                    {props.patientData.age ?? "-"}
+                    {props.patientData.age !== undefined // 0 is a valid age, so we need to check for undefined
+                      ? formatAge(
+                          props.patientData.age,
+                          props.patientData.date_of_birth
+                        )
+                      : "-"}
                   </span>
                 </div>
                 <div>

--- a/src/Components/Facility/Investigations/Reports/ReportTable.tsx
+++ b/src/Components/Facility/Investigations/Reports/ReportTable.tsx
@@ -2,7 +2,7 @@ import { getColorIndex, rowColor, transformData } from "./utils";
 
 import ButtonV2 from "../../../Common/components/ButtonV2";
 import { InvestigationResponse } from "./types";
-import { formatDateTime } from "../../../../Utils/utils";
+import { formatAge, formatDateTime } from "../../../../Utils/utils";
 import { FC } from "react";
 
 const ReportRow = ({ data, name, min, max }: any) => {
@@ -53,6 +53,7 @@ interface ReportTableProps {
   patientDetails?: {
     name: string;
     age: number;
+    date_of_birth: string;
     hospitalName: string;
   };
   investigationData: InvestigationResponse;
@@ -83,7 +84,14 @@ const ReportTable: FC<ReportTableProps> = ({
         {patientDetails && (
           <div className="flex flex-col gap-1 p-1">
             <p>Name: {patientDetails.name}</p>
-            <p>Age: {patientDetails.age}</p>
+            <p>
+              Age:{" "}
+              {formatAge(
+                patientDetails.age,
+                patientDetails.date_of_birth,
+                true
+              )}
+            </p>
             <p>Hospital: {patientDetails.hospitalName}</p>
           </div>
         )}

--- a/src/Components/Facility/Investigations/Reports/index.tsx
+++ b/src/Components/Facility/Investigations/Reports/index.tsx
@@ -100,8 +100,9 @@ const InvestigationReports = ({ id }: any) => {
   const [patientDetails, setPatientDetails] = useState<{
     name: string;
     age: number;
+    date_of_birth: string;
     hospitalName: string;
-  }>({ name: "", age: -1, hospitalName: "" });
+  }>({ name: "", age: -1, date_of_birth: "", hospitalName: "" });
   const [state, dispatch] = useReducer(
     investigationReportsReducer,
     initialState
@@ -220,6 +221,7 @@ const InvestigationReports = ({ id }: any) => {
           setPatientDetails({
             name: res.data.name,
             age: res.data.age,
+            date_of_birth: res.data.date_of_birth,
             hospitalName: res.data.facility_object.name,
           });
         }
@@ -227,6 +229,7 @@ const InvestigationReports = ({ id }: any) => {
         setPatientDetails({
           name: "",
           age: -1,
+          date_of_birth: "",
           hospitalName: "",
         });
       }

--- a/src/Components/Facility/LegacyMonitorCard.tsx
+++ b/src/Components/Facility/LegacyMonitorCard.tsx
@@ -4,6 +4,7 @@ import CareIcon from "../../CAREUI/icons/CareIcon";
 import { PatientModel } from "../Patient/models";
 import LegacyPatientVitalsCard from "../Patient/LegacyPatientVitalsCard";
 import { AssetLocationObject } from "../Assets/AssetTypes";
+import { formatAge } from "../../Utils/utils";
 
 interface MonitorCardProps {
   facilityId: string;
@@ -28,7 +29,7 @@ export const LegacyMonitorCard = ({
           {patient.name}
         </Link>
         <span>
-          {patient.age}y |{" "}
+          {formatAge(patient.age, patient.date_of_birth)} |{" "}
           {GENDER_TYPES.find((g) => g.id === patient.gender)?.icon}
         </span>
         <span className="flex flex-1 items-center justify-end gap-2 text-end">

--- a/src/Components/Facility/TreatmentSummary.tsx
+++ b/src/Components/Facility/TreatmentSummary.tsx
@@ -10,7 +10,7 @@ import { statusType, useAbortableEffect } from "../../Common/utils";
 import { PatientModel } from "../Patient/models";
 
 import { GENDER_TYPES } from "../../Common/constants";
-import { formatDate, formatDateTime } from "../../Utils/utils";
+import { formatAge, formatDate, formatDateTime } from "../../Utils/utils";
 const Loading = lazy(() => import("../Common/Loading"));
 
 const TreatmentSummary = (props: any) => {
@@ -132,7 +132,8 @@ const TreatmentSummary = (props: any) => {
 
               <div className="grid border-b-2 border-gray-800 print:grid-cols-3 sm:grid-cols-2 md:grid-cols-3">
                 <div className="col-span-1 border-b-2 border-gray-800 px-3 py-2 print:border-b-0 print:border-r-2 sm:border-r-2 md:border-b-0 ">
-                  <b>Age :</b> {patientData.age}
+                  <b>Age :</b>{" "}
+                  {formatAge(patientData.age, patientData.date_of_birth, true)}
                 </div>
                 <div className="col-span-1 border-b-2 border-gray-800 px-3 py-2 print:border-b-0 print:border-r-2 md:border-b-0 md:border-r-2">
                   <b>Date of admission :</b>

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -37,7 +37,7 @@ import SearchInput from "../Form/SearchInput";
 import SortDropdownMenu from "../Common/SortDropdown";
 import SwitchTabs from "../Common/components/SwitchTabs";
 import { parseOptionId } from "../../Common/utils";
-import { parsePhoneNumber } from "../../Utils/utils.js";
+import { formatAge, parsePhoneNumber } from "../../Utils/utils.js";
 import { useDispatch } from "react-redux";
 import useFilters from "../../Common/hooks/useFilters";
 import { useTranslation } from "react-i18next";
@@ -558,7 +558,9 @@ export const PatientManager = () => {
               <div className="flex w-full justify-between gap-2">
                 <div className="font-semibold">
                   <span className="text-xl capitalize">{patient.name}</span>
-                  <span className="ml-4 text-gray-800">{`${patient.age} yrs.`}</span>
+                  <span className="ml-4 text-gray-800">
+                    {formatAge(patient.age, patient.date_of_birth, true)}
+                  </span>
                 </div>
               </div>
 

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -19,7 +19,7 @@ import { ConsultationModel } from "../Facility/models";
 import { PatientModel, SampleTestModel } from "./models";
 import { SampleTestCard } from "./SampleTestCard";
 import Chip from "../../CAREUI/display/Chip";
-import { classNames, formatDateTime } from "../../Utils/utils";
+import { classNames, formatAge, formatDateTime } from "../../Utils/utils";
 import ButtonV2 from "../Common/components/ButtonV2";
 import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import RelativeDateUserMention from "../Common/RelativeDateUserMention";
@@ -476,7 +476,12 @@ export const PatientHome = (props: any) => {
               <div>
                 <div className="flex flex-row gap-4">
                   <h1 className="flex flex-row pb-3 text-2xl font-bold">
-                    {patientData.name} - {patientData.age}
+                    {patientData.name} -{" "}
+                    {formatAge(
+                      patientData.age,
+                      patientData.date_of_birth,
+                      true
+                    )}
                   </h1>
                   <div className="ml-auto mr-9 flex flex-wrap gap-3">
                     {patientData.is_vaccinated ? (

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -20,7 +20,7 @@ import { PatientModel } from "./models";
 import { getDimensionOrDash } from "../../Common/utils";
 import useConfig from "../../Common/hooks/useConfig";
 import { useState } from "react";
-import { formatDate, formatDateTime } from "../../Utils/utils.js";
+import { formatAge, formatDate, formatDateTime } from "../../Utils/utils.js";
 import dayjs from "../../Utils/dayjs";
 
 export default function PatientInfoCard(props: {
@@ -171,7 +171,7 @@ export default function PatientInfoCard(props: {
               </p>
             )}
             <p className="text-sm text-gray-900 sm:text-sm">
-              <span>{patient.age} years</span>
+              <span>{formatAge(patient.age, patient.date_of_birth, true)}</span>
               <span className="mx-2">•</span>
               <span>{patient.gender}</span>
               {consultation?.suggestion === "DC" && (

--- a/src/Components/Patient/SampleDetails.tsx
+++ b/src/Components/Patient/SampleDetails.tsx
@@ -8,7 +8,7 @@ import Card from "../../CAREUI/display/Card";
 import { FileUpload } from "./FileUpload";
 import Page from "../Common/components/Page";
 import _ from "lodash";
-import { formatDateTime } from "../../Utils/utils";
+import { formatAge, formatDateTime } from "../../Utils/utils";
 import { getTestSample } from "../../Redux/actions";
 
 import { navigate } from "raviger";
@@ -118,7 +118,7 @@ export const SampleDetails = ({ id }: SampleDetailsProps) => {
             ) : (
               <div>
                 <span className="font-semibold leading-relaxed">Age: </span>
-                {patientData?.age}
+                {formatAge(patientData.age, patientData.date_of_birth)}
               </div>
             )}
             <div>

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -12,7 +12,7 @@ import { ExportButton } from "../Common/Export";
 import ListFilter from "./ListFilter";
 import Page from "../Common/components/Page";
 import SearchInput from "../Form/SearchInput";
-import { formatDateTime } from "../../Utils/utils";
+import { formatAge, formatDateTime } from "../../Utils/utils";
 import { formatFilter } from "./Commons";
 import { navigate } from "raviger";
 import useConfig from "../../Common/hooks/useConfig";
@@ -127,7 +127,12 @@ export default function ListView() {
             <div>
               <div className="flex justify-between">
                 <div className="mb-2 text-xl font-bold capitalize">
-                  {shift.patient_object.name} - {shift.patient_object.age}
+                  {shift.patient_object.name} -{" "}
+                  {formatAge(
+                    shift.patient_object.age,
+                    shift.patient_object.date_of_birth,
+                    true
+                  )}
                 </div>
                 <div>
                   {shift.emergency && (

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -18,7 +18,7 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import Page from "../Common/components/Page";
 import QRCode from "qrcode.react";
 import RecordMeta from "../../CAREUI/display/RecordMeta";
-import { formatDateTime } from "../../Utils/utils";
+import { formatAge, formatDateTime } from "../../Utils/utils";
 import useConfig from "../../Common/hooks/useConfig";
 import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
@@ -110,7 +110,13 @@ export default function ShiftDetails(props: { id: string }) {
       "\n" +
       t("age") +
       ":" +
-      data?.patient_object?.age +
+      +(
+        formatAge(
+          data?.patient_object?.age,
+          data?.patient_object?.date_of_birth,
+          true
+        ) ?? "-"
+      ) +
       "\n" +
       t("origin_facility") +
       ":" +
@@ -195,7 +201,7 @@ export default function ShiftDetails(props: { id: string }) {
               <span className="font-semibold leading-relaxed">
                 {t("age")}:{" "}
               </span>
-              {patientData?.age}
+              {formatAge(patientData?.age, patientData?.date_of_birth, true)}
             </div>
           )}
           {patientData?.gender === 2 && patientData?.is_antenatal && (
@@ -380,7 +386,7 @@ export default function ShiftDetails(props: { id: string }) {
               <span className="font-semibold leading-relaxed">
                 {t("age")}:{" "}
               </span>
-              {patientData?.age}
+              {formatAge(patientData.age, patientData.date_of_birth, true)}
             </div>
             <div>
               <span className="font-semibold leading-relaxed">

--- a/src/Components/Shifting/ShiftingBoard.tsx
+++ b/src/Components/Shifting/ShiftingBoard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { classNames, formatDateTime } from "../../Utils/utils";
+import { classNames, formatAge, formatDateTime } from "../../Utils/utils";
 import {
   completeTransfer,
   downloadShiftRequests,
@@ -78,7 +78,12 @@ const ShiftCard = ({ shift, filter }: any) => {
           <div>
             <div className="flex justify-between">
               <div className="mb-2 text-xl font-bold capitalize">
-                {shift.patient_object.name} - {shift.patient_object.age}
+                {shift.patient_object.name} -{" "}
+                {formatAge(
+                  shift.patient_object?.age,
+                  shift.patient_object?.age.date_of_birth,
+                  true
+                )}
               </div>
               <div>
                 {shift.emergency && (

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -379,3 +379,30 @@ export const getCountryCode = (phoneNumber: string) => {
   }
   return undefined;
 };
+
+export const formatAge = (
+  age?: number,
+  date_of_birth?: string,
+  abbreviated = false
+) => {
+  if (!age && !date_of_birth) return undefined;
+  if (!age) age = 0;
+
+  const daySuffix = abbreviated ? "d" : "days";
+  const monthSuffix = abbreviated ? "mo" : "months";
+  const yearSuffix = abbreviated ? "yr" : "years";
+
+  if (age < 1 && date_of_birth) {
+    const dob = new Date(date_of_birth);
+    const today = new Date();
+    const diffTime = Math.abs(today.getTime() - dob.getTime());
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    const months = Math.floor(diffDays / 30);
+    const days = diffDays % 30;
+    if (months === 0) {
+      return `${days} ${daySuffix}`;
+    }
+    return `${months} ${monthSuffix} ${days} ${daySuffix}`;
+  }
+  return `${age} ${yearSuffix}`;
+};


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7274436</samp>

This pull request adds a new utility function `formatAge` that handles the display logic of the patient's age based on their date of birth and age in years. The function is used in various components across the application to show the patient's age more accurately and consistently with a unit suffix. The components that are updated include consultation details, investigation reports, legacy monitor card, treatment summary, patient manager, patient home, patient info card, sample details, shifting list view, shift details, and shifting board.

## Proposed Changes

- Fixes #6339

![image](https://github.com/coronasafe/care_fe/assets/3626859/a5c62748-8380-4938-b53f-337a8c4d13cf)
![image](https://github.com/coronasafe/care_fe/assets/3626859/ce34af8f-c30e-4f41-933e-65b852b441d0)
![image](https://github.com/coronasafe/care_fe/assets/3626859/46886a2b-6203-405b-aa61-75fb6ed21491)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7274436</samp>

*  Add `formatAge` function to `src/Utils/utils.ts` to display the age of the patient based on their date of birth and age in years ([link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-5903b23c9778624d9c178b9779024a4265e5fc365714fed34d49225ee6b8dc73R382-R408))
*  Import `formatAge` function from `src/Utils/utils.ts` in various components that show the age of the patient ([link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-a1ae41968a05e24ed2d94c91009fbb88f1319a60a3b965773b3395130d27658bL13-R13), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-9ce9396be65f9fd9008cafc76d8321d00574725c27d6a8ca3b0fc6324d8da141L5-R5), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-41afad0c2cc9197a2a8f3d9b16519571cc0382b6e790129033b8425c507da0edL103-R105), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-1cf2621674dd92e15049feb09306a2d1dc2867dfa0eaf8e6983d8d431148c2e4R7), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-ac9463aa3ab35a08c12bb0f4159e678378fd1bc43d37e9ce6a475437dbf63cebL13-R13), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L40-R40), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL22-R22), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L23-R23), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-11b5348acd62c4dc4f1aac97fbeac33804b5c86241edca85599e5ecc57b514b2L11-R11), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L15-R15), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-4527d63b6d6de451c456dcdf926baf86485751803245f1096d673b937d7c4862L21-R21), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L2-R2))
*  Replace `addTwoNumbers` function with `formatAge` function in `ConsultationUpdatesTab.tsx` to display the age of the patient based on their date of birth and age in years ([link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-a1ae41968a05e24ed2d94c91009fbb88f1319a60a3b965773b3395130d27658bL624-R629))
*  Fetch and assign `date_of_birth` property from the API response in `Reports/index.tsx` and pass it to the `ReportTable.tsx` component ([link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-41afad0c2cc9197a2a8f3d9b16519571cc0382b6e790129033b8425c507da0edR224), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-41afad0c2cc9197a2a8f3d9b16519571cc0382b6e790129033b8425c507da0edR232), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-9ce9396be65f9fd9008cafc76d8321d00574725c27d6a8ca3b0fc6324d8da141R56))
*  Use `formatAge` function to display the age of the patient based on their date of birth and age in years in various components, optionally adding a suffix to indicate the unit of age ([link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-9ce9396be65f9fd9008cafc76d8321d00574725c27d6a8ca3b0fc6324d8da141L86-R94), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-1cf2621674dd92e15049feb09306a2d1dc2867dfa0eaf8e6983d8d431148c2e4L31-R32), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-ac9463aa3ab35a08c12bb0f4159e678378fd1bc43d37e9ce6a475437dbf63cebL135-R136), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L561-R563), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL479-R484), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L174-R174), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-11b5348acd62c4dc4f1aac97fbeac33804b5c86241edca85599e5ecc57b514b2L121-R121), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L130-R135), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-4527d63b6d6de451c456dcdf926baf86485751803245f1096d673b937d7c4862L113-R119), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-4527d63b6d6de451c456dcdf926baf86485751803245f1096d673b937d7c4862L198-R204), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-4527d63b6d6de451c456dcdf926baf86485751803245f1096d673b937d7c4862L383-R389), [link](https://github.com/coronasafe/care_fe/pull/6342/files?diff=unified&w=0#diff-4be143cb44817c43a63dc604c87a6a6cbcf5cc433f181d4d7b8a090dfdd2efd3L81-R86))
