### PR TITLE
Remove default selection of patient category

### DIFF
--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -115,6 +115,7 @@ describe("Patient Creation with consultation", () => {
     patientConsultationPage.selectSymptoms("ASYMPTOMATIC");
 
     patientConsultationPage.enterConsultationDetails(
+      "Stable",
       "Examination details and Clinical conditions",
       "70",
       "170",

--- a/cypress/pageobject/Patient/PatientConsultation.ts
+++ b/cypress/pageobject/Patient/PatientConsultation.ts
@@ -23,6 +23,7 @@ export class PatientConsultationPage {
   }
 
   enterConsultationDetails(
+    category: string,
     examinationDetails: string,
     weight: string,
     height: string,
@@ -31,6 +32,11 @@ export class PatientConsultationPage {
     verificationBy: string
   ) {
     cy.get("#symptoms").click();
+    cy.get("#category")
+      .click()
+      .then(() => {
+        cy.get("[role='option']").contains(category).click();
+      });
     cy.get("#examination_details").click().type(examinationDetails);
     cy.get("#weight").click().type(height);
     cy.get("#height").click().type(weight);
@@ -39,10 +45,12 @@ export class PatientConsultationPage {
     cy.get(
       "#icd11_diagnoses_object input[placeholder='Select'][role='combobox']"
     )
+      .scrollIntoView()
       .click()
       .type("1A");
     cy.get("#icd11_diagnoses_object [role='option']")
       .contains("1A03 Intestinal infections due to Escherichia coli")
+      .scrollIntoView()
       .click();
     cy.get("label[for='icd11_diagnoses_object']").click();
     cy.wait("@getIcdResults").its("response.statusCode").should("eq", 200);

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -123,7 +123,7 @@ const initForm: FormDetails = {
   facility: "",
   admitted: "false",
   admitted_to: "",
-  category: "Comfort",
+  category: "",
   admission_date: new Date(),
   discharge_date: null,
   referred_to: "",
@@ -373,8 +373,8 @@ export const ConsultationForm = (props: any) => {
             admitted_to: res.data.admitted_to ? res.data.admitted_to : "",
             category: res.data.category
               ? PATIENT_CATEGORIES.find((i) => i.text === res.data.category)
-                  ?.id ?? "Comfort"
-              : "Comfort",
+                  ?.id ?? ""
+              : "",
             patient_no: res.data.patient_no ?? "",
             OPconsultation: res.data.consultation_notes,
             is_telemedicine: `${res.data.is_telemedicine}`,

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -42,7 +42,7 @@ const initForm: any = {
   other_symptoms: "",
   physical_examination_info: "",
   other_details: "",
-  patient_category: "Comfort",
+  patient_category: "",
   current_health: 0,
   recommend_discharge: false,
   action: null,
@@ -142,14 +142,14 @@ export const DailyRounds = (props: any) => {
       );
 
       if (!status.aborted) {
-        if (res && res.data) {
+        if (res?.data) {
           const data = {
             ...res.data,
             patient_category: res.data.patient_category
               ? PATIENT_CATEGORIES.find(
                   (i) => i.text === res.data.patient_category
-                )?.id || "Comfort"
-              : "Comfort",
+                )?.id ?? ""
+              : "",
             rhythm:
               (res.data.rhythm &&
                 RHYTHM_CHOICES.find((i) => i.text === res.data.rhythm)?.id) ||
@@ -186,8 +186,8 @@ export const DailyRounds = (props: any) => {
             patient_category: res.data.patient_category
               ? PATIENT_CATEGORIES.find(
                   (i) => i.text === res.data.patient_category
-                )?.id || "Comfort"
-              : "Comfort",
+                )?.id ?? ""
+              : "",
             rhythm:
               (res.data.rhythm &&
                 RHYTHM_CHOICES.find((i) => i.text === res.data.rhythm)?.id) ||
@@ -205,6 +205,12 @@ export const DailyRounds = (props: any) => {
     let invalidForm = false;
     Object.keys(state.form).forEach((field) => {
       switch (field) {
+        case "patient_category":
+          if (!state.form[field]) {
+            errors[field] = "Please select a category";
+            invalidForm = true;
+          }
+          return;
         case "other_symptoms":
           if (
             state.form.additional_symptoms?.includes(9) &&


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a336f5f</samp>

The pull request makes the `category` and `patient_category` fields mandatory in the consultation and daily rounds forms, respectively, to ensure accurate and consistent data entry. It also fixes a bug in the default value of `patient_category` in the `DailyRounds` component.

## Proposed Changes

- Fixes #6346 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a336f5f</samp>

*  Change the default value of the `category` and `patient_category` fields from "Comfort" to an empty string in the `ConsultationForm` and `DailyRounds` components to avoid pre-selecting a category for the patient and to make it mandatory for the user to choose one ([link](https://github.com/coronasafe/care_fe/pull/6354/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL126-R126), [link](https://github.com/coronasafe/care_fe/pull/6354/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL376-R377), [link](https://github.com/coronasafe/care_fe/pull/6354/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L45-R45), [link](https://github.com/coronasafe/care_fe/pull/6354/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L151-R152), [link](https://github.com/coronasafe/care_fe/pull/6354/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L189-R190))
*  Add a validation case for the `patient_category` field in the `DailyRounds` component to check if it has a value and if not, add an error message and set the `invalidForm` flag to true ([link](https://github.com/coronasafe/care_fe/pull/6354/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612R208-R213))
*  Use the optional chaining operator (`?.`) to check if `res.data` exists before accessing its properties in the `DailyRounds` component to prevent errors if `res.data` is undefined or null ([link](https://github.com/coronasafe/care_fe/pull/6354/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L145-R145))
