### PR TITLE
`request`: adds type check for `TBody`

### DIFF
--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -8,7 +8,7 @@ import { PaginatedResponse } from "../Utils/request/types";
  * A fake function that returns an empty object casted to type T
  * @returns Empty object as type T
  */
-function Res<T>(): T {
+function Type<T>(): T {
   return {} as T;
 }
 
@@ -22,7 +22,7 @@ const routes = {
     path: import.meta.env.REACT_APP_CONFIG ?? "/config.json",
     method: "GET",
     noAuth: true,
-    TRes: Res<IConfig>(),
+    TRes: Type<IConfig>(),
   },
 
   // Auth Endpoints
@@ -35,8 +35,8 @@ const routes = {
   token_refresh: {
     path: "/api/v1/auth/token/refresh/",
     method: "POST",
-    TRes: Res<JwtTokenObtainPair>(),
-    TBody: Res<{ refresh: string }>(),
+    TRes: Type<JwtTokenObtainPair>(),
+    TBody: Type<{ refresh: string }>(),
   },
 
   token_verify: {
@@ -66,7 +66,7 @@ const routes = {
   // User Endpoints
   currentUser: {
     path: "/api/v1/users/getcurrentuser/",
-    TRes: Res<UserModel>(),
+    TRes: Type<UserModel>(),
   },
 
   userList: {
@@ -200,7 +200,7 @@ const routes = {
   listFacilityAssetLocation: {
     path: "/api/v1/facility/{facility_external_id}/asset_location/",
     method: "GET",
-    TRes: Res<PaginatedResponse<LocationModel>>(),
+    TRes: Type<PaginatedResponse<LocationModel>>(),
   },
   createFacilityAssetLocation: {
     path: "/api/v1/facility/{facility_external_id}/asset_location/",
@@ -806,7 +806,7 @@ const routes = {
   getAsset: {
     path: "/api/v1/asset/{external_id}/",
     method: "GET",
-    TRes: Res<AssetData>(),
+    TRes: Type<AssetData>(),
   },
   deleteAsset: {
     path: "/api/v1/asset/{external_id}/",

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -36,6 +36,7 @@ const routes = {
     path: "/api/v1/auth/token/refresh/",
     method: "POST",
     TRes: Res<JwtTokenObtainPair>(),
+    TBody: Res<{ refresh: string }>(),
   },
 
   token_verify: {

--- a/src/Utils/request/README.md
+++ b/src/Utils/request/README.md
@@ -56,7 +56,8 @@ const FooRoutes = {
     path: "/api/v1/foo/{id}/",  // 👈 The path to the endpoint. Slug parameters can be specified using curly braces.
 
     method: "GET",              // 👈 The HTTP method to use. Optional; defaults to "GET".
-    TRes: Res<Foo()>,           // 👈 The type of the response body (for type inference).
+    TRes: Type<Foo>(),          // 👈 The type of the response body (for type inference).
+    TBody: Type<Foo>(),         // 👈 The type of the request body (for type inference).
     noAuth: true,               // 👈 Whether to skip adding the Authorization header to the request.
   },
 } as const; // 👈 This is important for type inference to work properly.
@@ -78,7 +79,7 @@ const options = {
   // thrown before the request is made.
 
   query: { limit: 10 },         // 👈 The query parameters to be added to the request URL.
-  body: { name: "foo" },        // 👈 The body to be sent with the request.
+  body: { name: "foo" },        // 👈 The body to be sent with the request. Should be compatible with the TBody type of the route.
   headers: { "X-Foo": "bar" },  // 👈 Additional headers to be sent with the request. (Coming soon...)
 
   silent: true,                 // 👈 Whether to suppress notifications for this request.
@@ -103,7 +104,7 @@ The `useQuery` hook returns an object with the following properties:
 
 ```ts
 {
-  res: Res<TRes> | undefined;   // 👈 The response object. `undefined` if the request has not been made yet.
+  res: Type<TRes> | undefined;  // 👈 The response object. `undefined` if the request has not been made yet.
   
   data: TRes | null;            // 👈 The response body. `null` if the request has not been made yet.
 
@@ -129,7 +130,7 @@ import FooRoutes from "@foo/routes";
 export default async function updateFoo(id: string, object: Foo) {
   const { res, data } = await request(FooRoutes.updateFoo, {
     pathParams: { id },
-    body: object,               // 👈 The body is automatically serialized to JSON.
+    body: object,               // 👈 The body is automatically serialized to JSON. Should be compatible with the TBody type of the route.
   });
 
   if (res.status === 403) {

--- a/src/Utils/request/request.ts
+++ b/src/Utils/request/request.ts
@@ -2,12 +2,12 @@ import handleResponse from "./handleResponse";
 import { RequestOptions, RequestResult, Route } from "./types";
 import { makeHeaders, makeUrl } from "./utils";
 
-interface Options<TData> extends RequestOptions<TData> {
+interface Options<TData, TBody> extends RequestOptions<TData, TBody> {
   controller?: AbortController;
 }
 
-export default async function request<TData>(
-  { path, method, noAuth }: Route<TData>,
+export default async function request<TData, TBody>(
+  { path, method, noAuth }: Route<TData, TBody>,
   {
     query,
     body,
@@ -16,7 +16,7 @@ export default async function request<TData>(
     onResponse,
     silent,
     reattempts = 3,
-  }: Options<TData> = {}
+  }: Options<TData, TBody> = {}
 ): Promise<RequestResult<TData>> {
   const signal = controller?.signal;
   const url = makeUrl(path, query, pathParams);

--- a/src/Utils/request/types.ts
+++ b/src/Utils/request/types.ts
@@ -12,11 +12,14 @@ export interface QueryRoute<TData> extends RouteBase<TData> {
   method?: "GET";
 }
 
-export interface MutationRoute<TData> extends RouteBase<TData> {
+export interface MutationRoute<TData, TBody> extends RouteBase<TData> {
   method: "POST" | "PUT" | "PATCH" | "DELETE";
+  TBody?: TBody;
 }
 
-export type Route<TData> = QueryRoute<TData> | MutationRoute<TData>;
+export type Route<TData, TBody> =
+  | QueryRoute<TData>
+  | MutationRoute<TData, TBody>;
 
 export interface RequestResult<TData> {
   res: Response | undefined;
@@ -24,9 +27,9 @@ export interface RequestResult<TData> {
   error: undefined | Record<string, unknown>;
 }
 
-export interface RequestOptions<TData = unknown> {
+export interface RequestOptions<TData = unknown, TBody = unknown> {
   query?: QueryParams;
-  body?: object;
+  body?: TBody;
   pathParams?: Record<string, string>;
   onResponse?: (res: RequestResult<TData>) => void;
   silent?: boolean;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe1ee84</samp>

This pull request enhances the `request` function and its types to support different data types and options for the API routes. It also adds a new route for the `TBody` endpoint to enable token-based authentication.

## Proposed Changes

- Resolves #6335 

- When an incompatible type is passed as the body.
<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/6cc59a2d-52a3-45ed-b19a-8ef6ff9b2e92">


- When a compatible type is passed as the body.
<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/213f27f4-bd7e-4394-a022-41f8b3645ef7">



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe1ee84</samp>

*  Add a new route for the `TBody` endpoint to get a refresh token for the user ([link](https://github.com/coronasafe/care_fe/pull/6358/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR39))
*  Add a generic type parameter `TBody` to the `request` function and the `Options` type to accept different types of body data for different routes ([link](https://github.com/coronasafe/care_fe/pull/6358/files?diff=unified&w=0#diff-7bd2f7e8b609eb4941fb1dc52de1a53906dd0f3db951bc01edaf8f58a0111095L5-R10), [link](https://github.com/coronasafe/care_fe/pull/6358/files?diff=unified&w=0#diff-7bd2f7e8b609eb4941fb1dc52de1a53906dd0f3db951bc01edaf8f58a0111095L19-R19))
*  Add a `TBody` type parameter to the `MutationRoute` and `Route` interfaces and the `RequestOptions` interface to specify the type of the body data for mutation routes and options objects ([link](https://github.com/coronasafe/care_fe/pull/6358/files?diff=unified&w=0#diff-f04d958cd2a05e1cf7e95c20ca51c4983881868b38908b7fd5517d734b606625L15-R22), [link](https://github.com/coronasafe/care_fe/pull/6358/files?diff=unified&w=0#diff-f04d958cd2a05e1cf7e95c20ca51c4983881868b38908b7fd5517d734b606625L27-R32))
