### PR TITLE
Remove phone duplication check on patient update

### DIFF
--- a/src/Components/ExternalResult/FacilitiesSelectDialogue.tsx
+++ b/src/Components/ExternalResult/FacilitiesSelectDialogue.tsx
@@ -34,7 +34,7 @@ const FacilitiesSelectDialog = (props: Props) => {
         <Cancel onClick={handleCancel} />
         <Submit
           onClick={handleOk}
-          disabled={!selectedFacility.id}
+          disabled={!selectedFacility?.id}
           label={t("select")}
           data-testid="submit-button"
         />

--- a/src/Components/Form/Form.tsx
+++ b/src/Components/Form/Form.tsx
@@ -13,7 +13,7 @@ type Props<T extends FormDetails> = {
   defaults: T;
   asyncGetDefaults?: (() => Promise<T>) | false;
   onlyChild?: boolean;
-  validate?: (form: T) => FormErrors<T> | Promise<FormErrors<T>>;
+  validate?: (form: T) => FormErrors<T>;
   onSubmit: (form: T) => Promise<FormErrors<T> | void>;
   onCancel?: () => void;
   noPadding?: true;
@@ -47,8 +47,7 @@ const Form = <T extends FormDetails>({
     event.stopPropagation();
 
     if (validate) {
-      const validationResult = await Promise.resolve(validate(state.form));
-      const errors = omitBy(validationResult, isEmpty) as FormErrors<T>;
+      const errors = omitBy(validate(state.form), isEmpty) as FormErrors<T>;
 
       if (Object.keys(errors).length) {
         dispatch({ type: "set_errors", errors });

--- a/src/Components/Form/Form.tsx
+++ b/src/Components/Form/Form.tsx
@@ -13,7 +13,7 @@ type Props<T extends FormDetails> = {
   defaults: T;
   asyncGetDefaults?: (() => Promise<T>) | false;
   onlyChild?: boolean;
-  validate?: (form: T) => FormErrors<T>;
+  validate?: (form: T) => FormErrors<T> | Promise<FormErrors<T>>;
   onSubmit: (form: T) => Promise<FormErrors<T> | void>;
   onCancel?: () => void;
   noPadding?: true;
@@ -47,7 +47,8 @@ const Form = <T extends FormDetails>({
     event.stopPropagation();
 
     if (validate) {
-      const errors = omitBy(validate(state.form), isEmpty) as FormErrors<T>;
+      const validationResult = await Promise.resolve(validate(state.form));
+      const errors = omitBy(validationResult, isEmpty) as FormErrors<T>;
 
       if (Object.keys(errors).length) {
         dispatch({ type: "set_errors", errors });

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -72,8 +72,6 @@ import { FormContextValue } from "../Form/FormContext.js";
 const Loading = lazy(() => import("../Common/Loading"));
 const PageTitle = lazy(() => import("../Common/PageTitle"));
 
-// const debounce = require("lodash.debounce");
-
 interface PatientRegisterProps extends PatientModel {
   facilityId: string;
 }
@@ -1260,7 +1258,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                               required
                               label="Phone Number"
                               onChange={(event) => {
-                                duplicateCheck(event.value);
+                                if (!id) duplicateCheck(event.value);
                                 field("phone_number").onChange(event);
                               }}
                               types={["mobile", "landline"]}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1fc93a7</samp>

Improved form validation for patient registration. Added support for `async` validation functions in the `Form` component and used it to check for duplicate phone numbers in the `PatientRegister` component. Removed unnecessary `debounce` logic.

## Proposed Changes

- Fixes #6347

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1fc93a7</samp>

*  Allow asynchronous validation in `Form` component by changing `validate` prop type to accept a function that returns a promise of errors ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-1c65fcfe59a39c2fa19c4b333f9dd48e6a8d3c933e82585253b941f8bec98d3eL16-R16))
*  Await the result of `validate` function and assign it to `validationResult` variable before omitting empty errors and checking error keys in `Form` component ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-1c65fcfe59a39c2fa19c4b333f9dd48e6a8d3c933e82585253b941f8bec98d3eL50-R51))
*  Remove unused `debounce` import and require statement from `PatientRegister` component ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L64-L65), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L71-R71))
*  Change `validateForm` function to an `async` function and use `for...of` loop instead of `forEach` to iterate over form fields in `PatientRegister` component ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L555-R550), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L563-R558))
*  Replace `return` statements with `break` statements inside `switch` cases to avoid exiting `validateForm` function prematurely in `PatientRegister` component ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L571-R596), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L621-R619), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L632-R630), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L642-R645), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L664-R662), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L671-R669), [link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L681-R688))
*  Call and await `duplicateCheck` function inside `phone_number` case and add error message if duplicate phone number is found in `validateForm` function in `PatientRegister` component ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L611-R609))
*  Change `duplicateCheck` function from a debounced function to a regular `async` function that returns a boolean value in `PatientRegister` component ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L967-R990))
*  Remove call to `duplicateCheck` function from `onChange` handler of `PhoneNumberField` component in `PatientRegister` component ([link](https://github.com/coronasafe/care_fe/pull/6359/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L1263))
