### PR TITLE
Split routes of App Router

### DIFF
--- a/src/Components/Facility/FacilityConfigure.tsx
+++ b/src/Components/Facility/FacilityConfigure.tsx
@@ -46,7 +46,7 @@ const FormReducer = (state = initialState, action: any) => {
   }
 };
 
-export const UpdateFacilityMiddleware = (props: any) => {
+export const FacilityConfigure = (props: any) => {
   const [state, dispatch] = useReducer(FormReducer, initialState);
   const { facilityId } = props;
   const dispatchAction: any = useDispatch();

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -541,9 +541,7 @@ export const FacilityHome = (props: any) => {
                 </DropdownItem>
                 <DropdownItem
                   id="configure-facility"
-                  onClick={() =>
-                    navigate(`/facility/${facilityId}/middleware/update`)
-                  }
+                  onClick={() => navigate(`/facility/${facilityId}/configure`)}
                   authorizeFor={NonReadOnlyUsers}
                   icon={<CareIcon className="care-l-setting text-lg" />}
                 >

--- a/src/Components/Notifications/ShowPushNotification.tsx
+++ b/src/Components/Notifications/ShowPushNotification.tsx
@@ -1,13 +1,13 @@
 import { useDispatch } from "react-redux";
 import { getNotificationData } from "../../Redux/actions";
 import { useEffect } from "react";
+import { DetailRoute } from "../../Routers/types";
 
-export default function ShowPushNotification({ external_id }: any) {
+export default function ShowPushNotification({ id }: DetailRoute) {
   const dispatch: any = useDispatch();
 
   const resultUrl = async () => {
-    console.log("ID:", external_id.id);
-    const res = await dispatch(getNotificationData({ id: external_id.id }));
+    const res = await dispatch(getNotificationData({ id }));
     const data = res.data.caused_objects;
     switch (res.data.event) {
       case "PATIENT_CREATED":

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -100,7 +100,7 @@ interface FileUploadProps {
   hideBack: boolean;
   audio?: boolean;
   unspecified: boolean;
-  sampleId?: number;
+  sampleId?: string;
   claimId?: string;
 }
 

--- a/src/Components/Patient/SampleDetails.tsx
+++ b/src/Components/Patient/SampleDetails.tsx
@@ -13,14 +13,11 @@ import { getTestSample } from "../../Redux/actions";
 
 import { navigate } from "raviger";
 import { useDispatch } from "react-redux";
+import { DetailRoute } from "../../Routers/types";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
-interface SampleDetailsProps {
-  id: number;
-}
-
-export const SampleDetails = ({ id }: SampleDetailsProps) => {
+export const SampleDetails = ({ id }: DetailRoute) => {
   const dispatch: any = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const [sampleDetails, setSampleDetails] = useState<SampleTestModel>({});

--- a/src/Components/Resource/ListView.tsx
+++ b/src/Components/Resource/ListView.tsx
@@ -31,7 +31,7 @@ export default function ListView() {
   const { t } = useTranslation();
 
   const onBoardViewBtnClick = () =>
-    navigate("/resource/board-view", { query: qParams });
+    navigate("/resource/board", { query: qParams });
   const appliedFilters = formatFilter(qParams);
 
   const refreshList = () => {

--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -32,7 +32,7 @@ export default function BoardView() {
   const { t } = useTranslation();
 
   const onListViewBtnClick = () => {
-    navigate("/resource/list-view", { query: qParams });
+    navigate("/resource/list", { query: qParams });
     localStorage.setItem("defaultResourceView", "list");
   };
 

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -231,7 +231,7 @@ export default function ResourceDetails(props: { id: string }) {
     <Page
       title={"Resource details"}
       crumbsReplacements={{ [props.id]: { name: data.title } }}
-      backUrl={"/resource/board-view"}
+      backUrl={"/resource/board"}
     >
       {isPrintMode ? (
         <div className="my-4">

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -95,9 +95,7 @@ export default function BoardView() {
           <div className="flex w-full flex-col gap-2 lg:mr-4 lg:w-fit lg:flex-row lg:gap-4">
             <ButtonV2
               className="py-[11px]"
-              onClick={() =>
-                navigate("/shifting/list-view", { query: qParams })
-              }
+              onClick={() => navigate("/shifting/list", { query: qParams })}
             >
               <CareIcon className="care-l-list-ul" />
               {t("list_view")}

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -312,9 +312,7 @@ export default function ListView() {
           <div className="flex w-full flex-col gap-2 lg:w-fit lg:flex-row lg:gap-4">
             <ButtonV2
               className="py-[11px]"
-              onClick={() =>
-                navigate("/shifting/board-view", { query: qParams })
-              }
+              onClick={() => navigate("/shifting/board", { query: qParams })}
             >
               <CareIcon className="care-l-list-ul rotate-90" />
               {t("board_view")}

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -557,7 +557,7 @@ export default function ShiftDetails(props: { id: string }) {
       ) : (
         <Page
           title={t("shifting_details")}
-          backUrl="/shifting/board-view"
+          backUrl="/shifting/board"
           options={
             <div className="flex gap-2">
               <ButtonV2

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -501,7 +501,7 @@ export const sampleReport = (id: string, sampleId: string) => {
 export const getTestList = (params: object) => {
   return fireRequest("getTestSampleList", [], params);
 };
-export const getTestSample = (id: number) => {
+export const getTestSample = (id: string) => {
   return fireRequest("getTestSample", [id], {});
 };
 export const patchSample = (params: object, pathParam: object) => {

--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -1,64 +1,9 @@
 import { useRedirect, useRoutes, usePath, Redirect } from "raviger";
 import { useState, useEffect } from "react";
-import { ConsultationDetails } from "../Components/Facility/ConsultationDetails";
-import TreatmentSummary from "../Components/Facility/TreatmentSummary";
-import { ConsultationForm } from "../Components/Facility/ConsultationForm";
-import { FacilityCreate } from "../Components/Facility/FacilityCreate";
-import { FacilityHome } from "../Components/Facility/FacilityHome";
-import { HospitalList } from "../Components/Facility/HospitalList";
-import { TriageForm } from "../Components/Facility/TriageForm";
-import { DailyRounds } from "../Components/Patient/DailyRounds";
-import { PatientManager } from "../Components/Patient/ManagePatients";
-import PatientNotes from "../Components/Patient/PatientNotes";
-import { PatientHome } from "../Components/Patient/PatientHome";
-import { PatientRegister } from "../Components/Patient/PatientRegister";
-import { SampleDetails } from "../Components/Patient/SampleDetails";
-import SampleReport from "../Components/Patient/SamplePreview";
-import { SampleTest } from "../Components/Patient/SampleTest";
-import SampleViewAdmin from "../Components/Patient/SampleViewAdmin";
-import ManageUsers from "../Components/Users/ManageUsers";
-import { UserAdd } from "../Components/Users/UserAdd";
-import InventoryList from "../Components/Facility/InventoryList";
-import InventoryLog from "../Components/Facility/InventoryLog";
-import { AddInventoryForm } from "../Components/Facility/AddInventoryForm";
-import { SetInventoryForm } from "../Components/Facility/SetInventoryForm";
-import MinQuantityList from "../Components/Facility/MinQuantityList";
-import { ShiftCreate } from "../Components/Patient/ShiftCreate";
-import UserProfile from "../Components/Users/UserProfile";
-import ShiftBoardView from "../Components/Shifting/BoardView";
-import ShiftListView from "../Components/Shifting/ListView";
-import ShiftDetails from "../Components/Shifting/ShiftDetails";
-import { ShiftDetailsUpdate } from "../Components/Shifting/ShiftDetailsUpdate";
-import ResourceCreate from "../Components/Resource/ResourceCreate";
-import ResourceBoardView from "../Components/Resource/ResourceBoardView";
-import ResourceListView from "../Components/Resource/ListView";
-import ResourceDetails from "../Components/Resource/ResourceDetails";
-import { ResourceDetailsUpdate } from "../Components/Resource/ResourceDetailsUpdate";
-import ResultList from "../Components/ExternalResult/ResultList";
-import ResultItem from "../Components/ExternalResult/ResultItem";
-import ExternalResultUpload from "../Components/ExternalResult/ExternalResultUpload";
-import ResultUpdate from "../Components/ExternalResult/ResultUpdate";
-import { FileUpload } from "../Components/Patient/FileUpload";
-import Investigation from "../Components/Facility/Investigations";
-import ShowInvestigation from "../Components/Facility/Investigations/ShowInvestigation";
-import InvestigationReports from "../Components/Facility/Investigations/Reports";
-import AssetCreate from "../Components/Facility/AssetCreate";
-import DeathReport from "../Components/DeathReport/DeathReport";
-import { make as CriticalCareRecording } from "../Components/CriticalCareRecording/CriticalCareRecording.bs";
+
 import ShowPushNotification from "../Components/Notifications/ShowPushNotification";
 import { NoticeBoard } from "../Components/Notifications/NoticeBoard";
-import { AddLocationForm } from "../Components/Facility/AddLocationForm";
-import { AddBedForm } from "../Components/Facility/AddBedForm";
-import LocationManagement from "../Components/Facility/LocationManagement";
-import { BedManagement } from "../Components/Facility/BedManagement";
-import AssetsList from "../Components/Assets/AssetsList";
-import AssetManage from "../Components/Assets/AssetManage";
-import AssetConfigure from "../Components/Assets/AssetConfigure";
-import { DailyRoundListDetails } from "../Components/Patient/DailyRoundListDetails";
 import Error404 from "../Components/ErrorPages/404";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
-import FacilityUsers from "../Components/Facility/FacilityUsers";
 import {
   DesktopSidebar,
   MobileSidebar,
@@ -66,349 +11,55 @@ import {
   SidebarShrinkContext,
 } from "../Components/Common/Sidebar/Sidebar";
 import { BLACKLISTED_PATHS, LocalStorageKeys } from "../Common/constants";
-import { UpdateFacilityMiddleware } from "../Components/Facility/UpdateFacilityMiddleware";
 import useConfig from "../Common/hooks/useConfig";
-import ConsultationClaims from "../Components/Facility/ConsultationClaims";
 import { handleSignOut } from "../Utils/utils";
 import SessionExpired from "../Components/ErrorPages/SessionExpired";
-import ManagePrescriptions from "../Components/Medicine/ManagePrescriptions";
-import CentralNursingStation from "../Components/Facility/CentralNursingStation";
+
+import UserRoutes from "./routes/UserRoutes";
+import PatientRoutes from "./routes/PatientRoutes";
+import SampleRoutes from "./routes/SampleRoutes";
+import FacilityRoutes from "./routes/FacilityRoutes";
+import ConsultationRoutes from "./routes/ConsultationRoutes";
+import HCXRoutes from "./routes/HCXRoutes";
+import ShiftingRoutes from "./routes/ShiftingRoutes";
+import AssetRoutes from "./routes/AssetRoutes";
+import ResourceRoutes from "./routes/ResourceRoutes";
+import ExternalResultRoutes from "./routes/ExternalResultRoutes";
+import { DetailRoute } from "./types";
+
+const Routes = {
+  "/": () => <Redirect to="/facility" />,
+
+  ...AssetRoutes,
+  ...ConsultationRoutes,
+  ...ExternalResultRoutes,
+  ...FacilityRoutes,
+  ...PatientRoutes,
+  ...ResourceRoutes,
+  ...SampleRoutes,
+  ...ShiftingRoutes,
+  ...UserRoutes,
+
+  "/notifications/:id": ({ id }: DetailRoute) => (
+    <ShowPushNotification id={id} />
+  ),
+  "/notice_board": () => <NoticeBoard />,
+
+  "/session-expired": () => <SessionExpired />,
+  "/not-found": () => <Error404 />,
+};
 
 export default function AppRouter() {
   const { main_logo, enable_hcx } = useConfig();
 
-  const routes = {
-    "/": () => <HospitalList />,
-    "/users": () => <ManageUsers />,
-    "/users/add": () => <UserAdd />,
-    "/user/profile": () => <UserProfile />,
-    "/patients": () => <PatientManager />,
-    "/patient/:id": ({ id }: any) => <PatientHome id={id} />,
-    "/patient/:id/investigation_reports": ({ id }: any) => (
-      <InvestigationReports id={id} />
-    ),
-    "/sample": () => <SampleViewAdmin />,
-    "/sample/:id": ({ id }: any) => <SampleDetails id={id} />,
-    "/patient/:patientId/test_sample/:sampleId/icmr_sample": ({
-      patientId,
-      sampleId,
-    }: any) => <SampleReport id={patientId} sampleId={sampleId} />,
-    "/facility": () => <HospitalList />,
-    "/facility/create": () => <FacilityCreate />,
-    "/facility/:facilityId/update": ({ facilityId }: any) => (
-      <FacilityCreate facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/middleware/update": ({ facilityId }: any) => (
-      <UpdateFacilityMiddleware facilityId={facilityId} />
-    ),
-    "/facility/:facilityId": ({ facilityId }: any) => (
-      <FacilityHome facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/users": ({ facilityId }: any) => (
-      <FacilityUsers facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/resource/new": ({ facilityId }: any) => (
-      <ResourceCreate facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/triage": ({ facilityId }: any) => (
-      <TriageForm facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/patient": ({ facilityId }: any) => (
-      <PatientRegister facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/patient/:id": ({ facilityId, id }: any) => (
-      <PatientHome facilityId={facilityId} id={id} />
-    ),
-    "/facility/:facilityId/patient/:id/update": ({ facilityId, id }: any) => (
-      <PatientRegister facilityId={facilityId} id={id} />
-    ),
-    "/facility/:facilityId/patient/:patientId/sample-test": ({
-      facilityId,
-      patientId,
-    }: any) => <SampleTest facilityId={facilityId} patientId={patientId} />,
-    "/facility/:facilityId/patient/:patientId/sample/:id": ({ id }: any) => (
-      <SampleDetails id={id} />
-    ),
-    "/facility/:facilityId/patient/:patientId/notes": ({
-      facilityId,
-      patientId,
-    }: any) => <PatientNotes patientId={patientId} facilityId={facilityId} />,
-    "/facility/:facilityId/patient/:patientId/files": ({
-      facilityId,
-      patientId,
-    }: any) => (
-      <FileUpload
-        patientId={patientId}
-        facilityId={facilityId}
-        consultationId=""
-        type="PATIENT"
-        hideBack={false}
-        audio={true}
-        unspecified={true}
-      />
-    ),
-    "/facility/:facilityId/triage/:id": ({ facilityId, id }: any) => (
-      <TriageForm facilityId={facilityId} id={id} />
-    ),
-    "/facility/:facilityId/patient/:patientId/consultation": ({
-      facilityId,
-      patientId,
-    }: any) => (
-      <ConsultationForm facilityId={facilityId} patientId={patientId} />
-    ),
-    "/facility/:facilityId/patient/:patientId/consultation/:id/update": ({
-      facilityId,
-      patientId,
-      id,
-    }: any) => (
-      <ConsultationForm facilityId={facilityId} patientId={patientId} id={id} />
-    ),
-    "/facility/:facilityId/patient/:patientId/consultation/:id/files/": ({
-      facilityId,
-      patientId,
-      id,
-    }: any) => (
-      <FileUpload
-        facilityId={facilityId}
-        patientId={patientId}
-        consultationId={id}
-        type="CONSULTATION"
-        hideBack={false}
-        audio={true}
-        unspecified={true}
-      />
-    ),
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/prescriptions":
-      (path: any) => <ManagePrescriptions {...path} />,
-    "/facility/:facilityId/patient/:patientId/consultation/:id/investigation":
-      ({ facilityId, patientId, id }: any) => (
-        <Investigation
-          consultationId={id}
-          facilityId={facilityId}
-          patientId={patientId}
-        />
-      ),
-    "/facility/:facilityId/patient/:patientId/consultation/:id/investigation/:sessionId":
-      ({ facilityId, patientId, id, sessionId }: any) => (
-        <ShowInvestigation
-          consultationId={id}
-          facilityId={facilityId}
-          patientId={patientId}
-          sessionId={sessionId}
-        />
-      ),
-    "/facility/:facilityId/patient/:patientId/consultation/:id/daily-rounds": ({
-      facilityId,
-      patientId,
-      id,
-    }: any) => (
-      <DailyRounds
-        facilityId={facilityId}
-        patientId={patientId}
-        consultationId={id}
-      />
-    ),
-    ...(enable_hcx
-      ? {
-          "/facility/:facilityId/patient/:patientId/consultation/:consultationId/claims":
-            (pathParams: any) => <ConsultationClaims {...pathParams} />,
-        }
-      : {}),
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily-rounds/:id/update":
-      ({ facilityId, patientId, consultationId, id }: any) => (
-        <DailyRounds
-          facilityId={facilityId}
-          patientId={patientId}
-          consultationId={consultationId}
-          id={id}
-        />
-      ),
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily-rounds/:id":
-      ({ facilityId, patientId, consultationId, id }: any) => (
-        <DailyRoundListDetails
-          facilityId={facilityId}
-          patientId={patientId}
-          consultationId={consultationId}
-          id={id}
-        />
-      ),
+  let routes = Routes;
 
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily_rounds/:id":
-      ({ facilityId, patientId, consultationId, id }: any) => (
-        <CriticalCareRecording
-          facilityId={facilityId}
-          patientId={patientId}
-          consultationId={consultationId}
-          id={id}
-          preview={true}
-        />
-      ),
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily_rounds/:id/update":
-      ({ facilityId, patientId, consultationId, id }: any) => (
-        <CriticalCareRecording
-          facilityId={facilityId}
-          patientId={patientId}
-          consultationId={consultationId}
-          id={id}
-          preview={false}
-        />
-      ),
-    "/facility/:facilityId/patient/:patientId/shift/new": ({
-      facilityId,
-      patientId,
-    }: any) => <ShiftCreate facilityId={facilityId} patientId={patientId} />,
-    "/facility/:facilityId/inventory": ({ facilityId }: any) => (
-      <InventoryList facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/location": ({ facilityId }: any) => (
-      <LocationManagement facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/location/:locationId/beds": ({
-      facilityId,
-      locationId,
-    }: any) => (
-      <BedManagement facilityId={facilityId} locationId={locationId} />
-    ),
-    "/facility/:facilityId/inventory/add": ({ facilityId }: any) => (
-      <AddInventoryForm facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/location/add": ({ facilityId }: any) => (
-      <AddLocationForm facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/location/:locationId/update": ({
-      facilityId,
-      locationId,
-    }: any) => (
-      <AddLocationForm facilityId={facilityId} locationId={locationId} />
-    ),
-    "/facility/:facilityId/location/:locationId/beds/add": ({
-      facilityId,
-      locationId,
-    }: any) => <AddBedForm facilityId={facilityId} locationId={locationId} />,
-    "/facility/:facilityId/location/:locationId/beds/:bedId/update": ({
-      facilityId,
-      locationId,
-      bedId,
-    }: any) => (
-      <AddBedForm
-        facilityId={facilityId}
-        locationId={locationId}
-        bedId={bedId}
-      />
-    ),
-    "/facility/:facilityId/inventory/min_quantity/set": ({
-      facilityId,
-    }: any) => <SetInventoryForm facilityId={facilityId} />,
-    "/facility/:facilityId/inventory/min_quantity/list": ({
-      facilityId,
-    }: any) => <MinQuantityList facilityId={facilityId} />,
-    "/facility/:facilityId/inventory/min_quantity": ({ facilityId }: any) => (
-      <Redirect to={`/facility/${facilityId}/inventory/min_quantity/list`} />
-    ),
-    "/facility/:facilityId/inventory/:inventoryId": ({
-      facilityId,
-      inventoryId,
-    }: any) => (
-      <InventoryLog facilityId={facilityId} inventoryId={inventoryId} />
-    ),
-    "/facility/:facilityId/assets/new": ({ facilityId }: any) => (
-      <AssetCreate facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/assets/:assetId/update": ({
-      facilityId,
-      assetId,
-    }: any) => <AssetCreate facilityId={facilityId} assetId={assetId} />,
-    "/assets": () => <AssetsList />,
-    "/facility/:facilityId/assets/:assetId": ({ assetId, facilityId }: any) => (
-      <AssetManage assetId={assetId} facilityId={facilityId} />
-    ),
-    "/facility/:facilityId/assets/:assetId/configure": ({
-      assetId,
-      facilityId,
-    }: any) => <AssetConfigure assetId={assetId} facilityId={facilityId} />,
-    "/facility/:facilityId/cns": ({ facilityId }: any) => (
-      <CentralNursingStation facilityId={facilityId} />
-    ),
+  if (enable_hcx) {
+    routes = { ...routes, ...HCXRoutes };
+  }
 
-    "/shifting": () =>
-      localStorage.getItem("defaultShiftView") === "list" ? (
-        <ShiftListView />
-      ) : (
-        <DndProvider backend={HTML5Backend}>
-          <ShiftBoardView />
-        </DndProvider>
-      ),
-    "/shifting/board-view": () => (
-      <DndProvider backend={HTML5Backend}>
-        <ShiftBoardView />
-      </DndProvider>
-    ),
-    "/shifting/list-view": () => <ShiftListView />,
-    "/shifting/:id": ({ id }: any) => <ShiftDetails id={id} />,
-    "/shifting/:id/update": ({ id }: any) => <ShiftDetailsUpdate id={id} />,
-    "/resource": () =>
-      localStorage.getItem("defaultResourceView") === "list" ? (
-        <ResourceListView />
-      ) : (
-        <DndProvider backend={HTML5Backend}>
-          <ResourceBoardView />
-        </DndProvider>
-      ),
-
-    "/resource/board-view": () => (
-      <DndProvider backend={HTML5Backend}>
-        <ResourceBoardView />
-      </DndProvider>
-    ),
-    "/resource/list-view": () => <ResourceListView />,
-    "/resource/:id": ({ id }: any) => <ResourceDetails id={id} />,
-    "/resource/:id/update": ({ id }: any) => <ResourceDetailsUpdate id={id} />,
-    "/external_results": () => <ResultList />,
-    "/external_results/upload": () => <ExternalResultUpload />,
-    "/external_results/:id": ({ id }: any) => <ResultItem id={id} />,
-    "/external_results/:id/update": ({ id }: any) => <ResultUpdate id={id} />,
-    "/death_report/:id": ({ id }: any) => <DeathReport id={id} />,
-    "/notifications/:id": (id: any) => (
-      <ShowPushNotification external_id={id} />
-    ),
-    "/notice_board": () => <NoticeBoard />,
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId": ({
-      facilityId,
-      patientId,
-      consultationId,
-    }: any) => (
-      <ConsultationDetails
-        facilityId={facilityId}
-        patientId={patientId}
-        consultationId={consultationId}
-        tab={"updates"}
-      />
-    ),
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/treatment-summary":
-      ({ facilityId, patientId, consultationId }: any) => (
-        <TreatmentSummary
-          facilityId={facilityId}
-          consultationId={consultationId}
-          patientId={patientId}
-          dailyRoundsListData={[]}
-        />
-      ),
-    "/facility/:facilityId/patient/:patientId/consultation/:consultationId/:tab":
-      ({ facilityId, patientId, consultationId, tab }: any) => (
-        <ConsultationDetails
-          facilityId={facilityId}
-          patientId={patientId}
-          consultationId={consultationId}
-          tab={tab}
-        />
-      ),
-    "/session-expired": () => <SessionExpired />,
-    "/not-found": () => <Error404 />,
-  };
-
-  useRedirect("/", "/facility");
   useRedirect("/user", "/users");
-  const pages = useRoutes(routes as any) || <Error404 />;
+  const pages = useRoutes(routes) || <Error404 />;
   const path = usePath();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 

--- a/src/Routers/routes/AssetRoutes.tsx
+++ b/src/Routers/routes/AssetRoutes.tsx
@@ -1,0 +1,21 @@
+import AssetConfigure from "../../Components/Assets/AssetConfigure";
+import AssetManage from "../../Components/Assets/AssetManage";
+import AssetsList from "../../Components/Assets/AssetsList";
+import AssetCreate from "../../Components/Facility/AssetCreate";
+
+export default {
+  "/assets": () => <AssetsList />,
+
+  "/facility/:facilityId/assets/new": (params: any) => (
+    <AssetCreate {...params} />
+  ),
+  "/facility/:facilityId/assets/:assetId/update": (params: any) => (
+    <AssetCreate {...params} />
+  ),
+  "/facility/:facilityId/assets/:assetId": (params: any) => (
+    <AssetManage {...params} />
+  ),
+  "/facility/:facilityId/assets/:assetId/configure": (params: any) => (
+    <AssetConfigure {...params} />
+  ),
+};

--- a/src/Routers/routes/ConsultationRoutes.tsx
+++ b/src/Routers/routes/ConsultationRoutes.tsx
@@ -1,0 +1,141 @@
+import { ConsultationForm } from "../../Components/Facility/ConsultationForm";
+import Investigation from "../../Components/Facility/Investigations";
+import ShowInvestigation from "../../Components/Facility/Investigations/ShowInvestigation";
+import ManagePrescriptions from "../../Components/Medicine/ManagePrescriptions";
+import { DailyRoundListDetails } from "../../Components/Patient/DailyRoundListDetails";
+import { DailyRounds } from "../../Components/Patient/DailyRounds";
+import { FileUpload } from "../../Components/Patient/FileUpload";
+import { make as CriticalCareRecording } from "../../Components/CriticalCareRecording/CriticalCareRecording.bs";
+import { ConsultationDetails } from "../../Components/Facility/ConsultationDetails";
+import TreatmentSummary from "../../Components/Facility/TreatmentSummary";
+
+export default {
+  "/facility/:facilityId/patient/:patientId/consultation": ({
+    facilityId,
+    patientId,
+  }: any) => <ConsultationForm facilityId={facilityId} patientId={patientId} />,
+  "/facility/:facilityId/patient/:patientId/consultation/:id/update": ({
+    facilityId,
+    patientId,
+    id,
+  }: any) => (
+    <ConsultationForm facilityId={facilityId} patientId={patientId} id={id} />
+  ),
+  "/facility/:facilityId/patient/:patientId/consultation/:id/files/": ({
+    facilityId,
+    patientId,
+    id,
+  }: any) => (
+    <FileUpload
+      facilityId={facilityId}
+      patientId={patientId}
+      consultationId={id}
+      type="CONSULTATION"
+      hideBack={false}
+      audio={true}
+      unspecified={true}
+    />
+  ),
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/prescriptions":
+    (path: any) => <ManagePrescriptions {...path} />,
+  "/facility/:facilityId/patient/:patientId/consultation/:id/investigation": ({
+    facilityId,
+    patientId,
+    id,
+  }: any) => (
+    <Investigation
+      consultationId={id}
+      facilityId={facilityId}
+      patientId={patientId}
+    />
+  ),
+  "/facility/:facilityId/patient/:patientId/consultation/:id/investigation/:sessionId":
+    ({ facilityId, patientId, id, sessionId }: any) => (
+      <ShowInvestigation
+        consultationId={id}
+        facilityId={facilityId}
+        patientId={patientId}
+        sessionId={sessionId}
+      />
+    ),
+  "/facility/:facilityId/patient/:patientId/consultation/:id/daily-rounds": ({
+    facilityId,
+    patientId,
+    id,
+  }: any) => (
+    <DailyRounds
+      facilityId={facilityId}
+      patientId={patientId}
+      consultationId={id}
+    />
+  ),
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily-rounds/:id/update":
+    ({ facilityId, patientId, consultationId, id }: any) => (
+      <DailyRounds
+        facilityId={facilityId}
+        patientId={patientId}
+        consultationId={consultationId}
+        id={id}
+      />
+    ),
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily-rounds/:id":
+    ({ facilityId, patientId, consultationId, id }: any) => (
+      <DailyRoundListDetails
+        facilityId={facilityId}
+        patientId={patientId}
+        consultationId={consultationId}
+        id={id}
+      />
+    ),
+
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily_rounds/:id":
+    ({ facilityId, patientId, consultationId, id }: any) => (
+      <CriticalCareRecording
+        facilityId={facilityId}
+        patientId={patientId}
+        consultationId={consultationId}
+        id={id}
+        preview={true}
+      />
+    ),
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/daily_rounds/:id/update":
+    ({ facilityId, patientId, consultationId, id }: any) => (
+      <CriticalCareRecording
+        facilityId={facilityId}
+        patientId={patientId}
+        consultationId={consultationId}
+        id={id}
+        preview={false}
+      />
+    ),
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId": ({
+    facilityId,
+    patientId,
+    consultationId,
+  }: any) => (
+    <ConsultationDetails
+      facilityId={facilityId}
+      patientId={patientId}
+      consultationId={consultationId}
+      tab={"updates"}
+    />
+  ),
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/treatment-summary":
+    ({ facilityId, patientId, consultationId }: any) => (
+      <TreatmentSummary
+        facilityId={facilityId}
+        consultationId={consultationId}
+        patientId={patientId}
+        dailyRoundsListData={[]}
+      />
+    ),
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/:tab":
+    ({ facilityId, patientId, consultationId, tab }: any) => (
+      <ConsultationDetails
+        facilityId={facilityId}
+        patientId={patientId}
+        consultationId={consultationId}
+        tab={tab}
+      />
+    ),
+};

--- a/src/Routers/routes/ExternalResultRoutes.tsx
+++ b/src/Routers/routes/ExternalResultRoutes.tsx
@@ -1,0 +1,14 @@
+import ExternalResultUpload from "../../Components/ExternalResult/ExternalResultUpload";
+import ResultItem from "../../Components/ExternalResult/ResultItem";
+import ResultList from "../../Components/ExternalResult/ResultList";
+import ResultUpdate from "../../Components/ExternalResult/ResultUpdate";
+import { DetailRoute } from "../types";
+
+export default {
+  "/external_results": () => <ResultList />,
+  "/external_results/upload": () => <ExternalResultUpload />,
+  "/external_results/:id": ({ id }: DetailRoute) => <ResultItem id={id} />,
+  "/external_results/:id/update": ({ id }: DetailRoute) => (
+    <ResultUpdate id={id} />
+  ),
+};

--- a/src/Routers/routes/FacilityInventoryRoutes.tsx
+++ b/src/Routers/routes/FacilityInventoryRoutes.tsx
@@ -1,0 +1,24 @@
+import { Redirect } from "raviger";
+import InventoryList from "../../Components/Facility/InventoryList";
+import InventoryLog from "../../Components/Facility/InventoryLog";
+import MinQuantityList from "../../Components/Facility/MinQuantityList";
+import { SetInventoryForm } from "../../Components/Facility/SetInventoryForm";
+
+export default {
+  "/facility/:facilityId/inventory": ({ facilityId }: any) => (
+    <InventoryList facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/inventory/min_quantity/set": ({ facilityId }: any) => (
+    <SetInventoryForm facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/inventory/min_quantity/list": ({
+    facilityId,
+  }: any) => <MinQuantityList facilityId={facilityId} />,
+  "/facility/:facilityId/inventory/min_quantity": ({ facilityId }: any) => (
+    <Redirect to={`/facility/${facilityId}/inventory/min_quantity/list`} />
+  ),
+  "/facility/:facilityId/inventory/:inventoryId": ({
+    facilityId,
+    inventoryId,
+  }: any) => <InventoryLog facilityId={facilityId} inventoryId={inventoryId} />,
+};

--- a/src/Routers/routes/FacilityLocationRoutes.tsx
+++ b/src/Routers/routes/FacilityLocationRoutes.tsx
@@ -1,0 +1,38 @@
+import { AddBedForm } from "../../Components/Facility/AddBedForm";
+import { AddInventoryForm } from "../../Components/Facility/AddInventoryForm";
+import { AddLocationForm } from "../../Components/Facility/AddLocationForm";
+import { BedManagement } from "../../Components/Facility/BedManagement";
+import LocationManagement from "../../Components/Facility/LocationManagement";
+
+export default {
+  "/facility/:facilityId/location": ({ facilityId }: any) => (
+    <LocationManagement facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/location/:locationId/beds": ({
+    facilityId,
+    locationId,
+  }: any) => <BedManagement facilityId={facilityId} locationId={locationId} />,
+  "/facility/:facilityId/inventory/add": ({ facilityId }: any) => (
+    <AddInventoryForm facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/location/add": ({ facilityId }: any) => (
+    <AddLocationForm facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/location/:locationId/update": ({
+    facilityId,
+    locationId,
+  }: any) => (
+    <AddLocationForm facilityId={facilityId} locationId={locationId} />
+  ),
+  "/facility/:facilityId/location/:locationId/beds/add": ({
+    facilityId,
+    locationId,
+  }: any) => <AddBedForm facilityId={facilityId} locationId={locationId} />,
+  "/facility/:facilityId/location/:locationId/beds/:bedId/update": ({
+    facilityId,
+    locationId,
+    bedId,
+  }: any) => (
+    <AddBedForm facilityId={facilityId} locationId={locationId} bedId={bedId} />
+  ),
+};

--- a/src/Routers/routes/FacilityRoutes.tsx
+++ b/src/Routers/routes/FacilityRoutes.tsx
@@ -1,0 +1,45 @@
+import { FacilityConfigure } from "../../Components/Facility/FacilityConfigure";
+import { FacilityCreate } from "../../Components/Facility/FacilityCreate";
+import { FacilityHome } from "../../Components/Facility/FacilityHome";
+import FacilityUsers from "../../Components/Facility/FacilityUsers";
+import { HospitalList } from "../../Components/Facility/HospitalList";
+import { TriageForm } from "../../Components/Facility/TriageForm";
+import ResourceCreate from "../../Components/Resource/ResourceCreate";
+import CentralNursingStation from "../../Components/Facility/CentralNursingStation";
+import FacilityLocationRoutes from "./FacilityLocationRoutes";
+import FacilityInventoryRoutes from "./FacilityInventoryRoutes";
+
+export default {
+  "/facility": () => <HospitalList />,
+  "/facility/create": () => <FacilityCreate />,
+  "/facility/:facilityId/update": ({ facilityId }: any) => (
+    <FacilityCreate facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/configure": ({ facilityId }: any) => (
+    <FacilityConfigure facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/cns": ({ facilityId }: any) => (
+    <CentralNursingStation facilityId={facilityId} />
+  ),
+  "/facility/:facilityId": ({ facilityId }: any) => (
+    <FacilityHome facilityId={facilityId} />
+  ),
+
+  "/facility/:facilityId/users": ({ facilityId }: any) => (
+    <FacilityUsers facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/resource/new": ({ facilityId }: any) => (
+    <ResourceCreate facilityId={facilityId} />
+  ),
+
+  // Triage related routes
+  "/facility/:facilityId/triage": ({ facilityId }: any) => (
+    <TriageForm facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/triage/:id": ({ facilityId, id }: any) => (
+    <TriageForm facilityId={facilityId} id={id} />
+  ),
+
+  ...FacilityLocationRoutes,
+  ...FacilityInventoryRoutes,
+};

--- a/src/Routers/routes/HCXRoutes.tsx
+++ b/src/Routers/routes/HCXRoutes.tsx
@@ -1,0 +1,6 @@
+import ConsultationClaims from "../../Components/Facility/ConsultationClaims";
+
+export default {
+  "/facility/:facilityId/patient/:patientId/consultation/:consultationId/claims":
+    (pathParams: any) => <ConsultationClaims {...pathParams} />,
+};

--- a/src/Routers/routes/PatientRoutes.tsx
+++ b/src/Routers/routes/PatientRoutes.tsx
@@ -1,0 +1,46 @@
+import InvestigationReports from "../../Components/Facility/Investigations/Reports";
+import { FileUpload } from "../../Components/Patient/FileUpload";
+import { PatientManager } from "../../Components/Patient/ManagePatients";
+import { PatientHome } from "../../Components/Patient/PatientHome";
+import PatientNotes from "../../Components/Patient/PatientNotes";
+import { PatientRegister } from "../../Components/Patient/PatientRegister";
+import { DetailRoute } from "../types";
+import DeathReport from "../../Components/DeathReport/DeathReport";
+
+export default {
+  "/patients": () => <PatientManager />,
+  "/patient/:id": ({ id }: DetailRoute) => <PatientHome id={id} />,
+  "/patient/:id/investigation_reports": ({ id }: DetailRoute) => (
+    <InvestigationReports id={id} />
+  ),
+
+  // Facility Scoped Routes
+  "/facility/:facilityId/patient": ({ facilityId }: any) => (
+    <PatientRegister facilityId={facilityId} />
+  ),
+  "/facility/:facilityId/patient/:id": ({ facilityId, id }: any) => (
+    <PatientHome facilityId={facilityId} id={id} />
+  ),
+  "/facility/:facilityId/patient/:id/update": ({ facilityId, id }: any) => (
+    <PatientRegister facilityId={facilityId} id={id} />
+  ),
+  "/facility/:facilityId/patient/:patientId/notes": ({
+    facilityId,
+    patientId,
+  }: any) => <PatientNotes patientId={patientId} facilityId={facilityId} />,
+  "/facility/:facilityId/patient/:patientId/files": ({
+    facilityId,
+    patientId,
+  }: any) => (
+    <FileUpload
+      patientId={patientId}
+      facilityId={facilityId}
+      consultationId=""
+      type="PATIENT"
+      hideBack={false}
+      audio={true}
+      unspecified={true}
+    />
+  ),
+  "/death_report/:id": ({ id }: any) => <DeathReport id={id} />,
+};

--- a/src/Routers/routes/ResourceRoutes.tsx
+++ b/src/Routers/routes/ResourceRoutes.tsx
@@ -1,0 +1,25 @@
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import ResourceDetails from "../../Components/Resource/ResourceDetails";
+import { ResourceDetailsUpdate } from "../../Components/Resource/ResourceDetailsUpdate";
+import ListView from "../../Components/Resource/ListView";
+import BoardView from "../../Components/Resource/ResourceBoardView";
+import { Redirect } from "raviger";
+import { DetailRoute } from "../types";
+
+const getDefaultView = () =>
+  localStorage.getItem("defaultResourceView") === "list" ? "list" : "board";
+
+export default {
+  "/resource": () => <Redirect to={`/resource/${getDefaultView()}`} />,
+  "/resource/board": () => (
+    <DndProvider backend={HTML5Backend}>
+      <BoardView />
+    </DndProvider>
+  ),
+  "/resource/list": () => <ListView />,
+  "/resource/:id": ({ id }: DetailRoute) => <ResourceDetails id={id} />,
+  "/resource/:id/update": ({ id }: DetailRoute) => (
+    <ResourceDetailsUpdate id={id} />
+  ),
+};

--- a/src/Routers/routes/SampleRoutes.tsx
+++ b/src/Routers/routes/SampleRoutes.tsx
@@ -1,0 +1,25 @@
+import { SampleDetails } from "../../Components/Patient/SampleDetails";
+import SampleReport from "../../Components/Patient/SamplePreview";
+import { SampleTest } from "../../Components/Patient/SampleTest";
+import SampleViewAdmin from "../../Components/Patient/SampleViewAdmin";
+import { DetailRoute, RouteParams } from "../types";
+
+export default {
+  "/sample": () => <SampleViewAdmin />,
+  "/sample/:id": ({ id }: DetailRoute) => <SampleDetails id={id} />,
+  "/patient/:patientId/test_sample/:sampleId/icmr_sample": ({
+    patientId,
+    sampleId,
+  }: RouteParams<"patientId" | "sampleId">) => (
+    <SampleReport id={patientId} sampleId={sampleId} />
+  ),
+  "/facility/:facilityId/patient/:patientId/sample-test": ({
+    facilityId,
+    patientId,
+  }: RouteParams<"facilityId" | "patientId">) => (
+    <SampleTest facilityId={facilityId} patientId={patientId} />
+  ),
+  "/facility/:facilityId/patient/:patientId/sample/:id": ({
+    id,
+  }: DetailRoute) => <SampleDetails id={id} />,
+};

--- a/src/Routers/routes/ShiftingRoutes.tsx
+++ b/src/Routers/routes/ShiftingRoutes.tsx
@@ -1,0 +1,27 @@
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { ShiftCreate } from "../../Components/Patient/ShiftCreate";
+import ShiftDetails from "../../Components/Shifting/ShiftDetails";
+import { ShiftDetailsUpdate } from "../../Components/Shifting/ShiftDetailsUpdate";
+import ListView from "../../Components/Shifting/ListView";
+import BoardView from "../../Components/Shifting/BoardView";
+import { Redirect } from "raviger";
+
+const getDefaultView = () =>
+  localStorage.getItem("defaultShiftView") === "list" ? "list" : "board";
+
+export default {
+  "/shifting": () => <Redirect to={`/shifting/${getDefaultView()}`} />,
+  "/shifting/board": () => (
+    <DndProvider backend={HTML5Backend}>
+      <BoardView />
+    </DndProvider>
+  ),
+  "/shifting/list": () => <ListView />,
+  "/shifting/:id": ({ id }: any) => <ShiftDetails id={id} />,
+  "/shifting/:id/update": ({ id }: any) => <ShiftDetailsUpdate id={id} />,
+  "/facility/:facilityId/patient/:patientId/shift/new": ({
+    facilityId,
+    patientId,
+  }: any) => <ShiftCreate facilityId={facilityId} patientId={patientId} />,
+};

--- a/src/Routers/routes/UserRoutes.tsx
+++ b/src/Routers/routes/UserRoutes.tsx
@@ -1,0 +1,9 @@
+import ManageUsers from "../../Components/Users/ManageUsers";
+import { UserAdd } from "../../Components/Users/UserAdd";
+import UserProfile from "../../Components/Users/UserProfile";
+
+export default {
+  "/users": () => <ManageUsers />,
+  "/users/add": () => <UserAdd />,
+  "/user/profile": () => <UserProfile />,
+};

--- a/src/Routers/types.ts
+++ b/src/Routers/types.ts
@@ -1,0 +1,5 @@
+export type RouteParams<T extends string> = Record<T, string>;
+
+export interface DetailRoute {
+  id: string;
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa49d0d</samp>

This pull request adds new features and updates existing features for the facility management dashboard. It adds new routes and components for asset management, consultation, external result, facility inventory, facility location, and HCX features. It also updates the routes and components for facility configuration, resource, and shifting features. It improves the type consistency and naming of some components and props.

## Proposed Changes

- Fixes #6288

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa49d0d</samp>

*  Rename `UpdateFacilityMiddleware` component to `FacilityConfigure` and update its route to `/facility/:id/configure` ([link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-05f8278e8ee0b31929e50092dbc9336b93dc17b69dcc36a7d4cb9f72c413a927L49-R49), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cL544-R544), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-1c774b43c040a667158205003ee9ec69f20cb53be0601060666a47ef8fce750eR1-R45))
*  Use `DetailRoute` type for props instead of `any` or `number` in `ShowPushNotification`, `FileUpload`, and `SampleDetails` components ([link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-1ec9a1b42adcb861e59931c8de52983679c7f31176a616437cbe422580363960L4-R10), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-6624210f1e9cdff909251ba965fafd78918e3d0a95fb569b8f151e8528eca8b6L103-R103), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-11b5348acd62c4dc4f1aac97fbeac33804b5c86241edca85599e5ecc57b514b2L16-R20), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eL504-R504))
*  Change routes for resource and shifting features from `*-view` to `*` in `ListView`, `BoardView`, `ResourceDetails`, and `ShiftDetails` components ([link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-9b8688043522f05d85d852d6a8b0a6d4ee406f772f626d435136c5e357b91d00L34-R34), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-72363d4a4cc81142bd2db278c3c1e17ee14614fc4be0af317cc60db25f4be79cL35-R35), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-9bc75f1eec9edc5184b0e770a808d2cddf3ffbd8bf29bc29bdeb734c683ab43cL234-R234), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-fc18d7013fcb5787812d6865749dd91966308ccf3493ab227001b2ca0079f600L98-R98), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-e00de3a76a1f9e65a89b644054e680c35784465b0988a5b993034b83f6058366L315-R315), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-4527d63b6d6de451c456dcdf926baf86485751803245f1096d673b937d7c4862L560-R560), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-1c774b43c040a667158205003ee9ec69f20cb53be0601060666a47ef8fce750eR1-R45))
*  Add new routes for asset, consultation, external result, facility inventory, facility location, and HCX features in `AssetRoutes`, `ConsultationRoutes`, `ExternalResultRoutes`, `FacilityInventoryRoutes`, `FacilityLocationRoutes`, and `HCXRoutes` files ([link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-07123e7a030e526a42ea75ee3f523603601317f7851cfe0bd15d248a94a15c16R1-R21), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-7f7cd3879325257f8c0b086345142dc4e8e501dab940ac79820595ccb9a02816R1-R141), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-48be3d03cc3d15463f6f28bb1e111b35a91e6af2c591cb275ff1f027205f11aaR1-R14), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-48dac5234c7461d0c4931140226c9b54533933a6d3394e7b093a71cec3d29ba5R1-R24), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-3b7ce6de3074f968b44ad37624f8ddc7a689fdda357dc1a522a99d25c11b9e97R1-R38), [link](https://github.com/coronasafe/care_fe/pull/6363/files?diff=unified&w=0#diff-905470f490bde065ebe74fb443a6e0781938210f4e64a20336d7d662a51ec93aR1-R6))
