### PR TITLE
Prescription: show prescribed on, by, and discontinued date in detail card

### DIFF
--- a/src/CAREUI/display/RecordMeta.tsx
+++ b/src/CAREUI/display/RecordMeta.tsx
@@ -11,13 +11,14 @@ interface Props {
     last_name: string;
     last_login: string | undefined;
   };
+  inlineUser?: boolean;
 }
 
 /**
  * A generic component to display relative time along with a tooltip and a user
  * if provided.
  */
-const RecordMeta = ({ time, user, prefix, className }: Props) => {
+const RecordMeta = ({ time, user, prefix, className, inlineUser }: Props) => {
   const isOnline = user && isUserOnline(user);
 
   let child = (
@@ -25,14 +26,15 @@ const RecordMeta = ({ time, user, prefix, className }: Props) => {
       <span className="underline">{relativeTime(time)}</span>
       <span className="tooltip-text tooltip-bottom flex -translate-x-1/2 gap-1 text-xs font-medium tracking-wider">
         {formatDateTime(time)}
-        {user && (
-          <>
+        {user && !inlineUser && (
+          <span className="flex items-center gap-1">
+            by
             <CareIcon className="care-l-user" />
             {user.first_name} {user.last_name}
             {isOnline && (
-              <div className="h-1 w-1 rounded-full bg-primary-500" />
+              <div className="h-1.5 w-1.5 rounded-full bg-primary-400" />
             )}
-          </>
+          </span>
         )}
       </span>
     </div>
@@ -43,7 +45,13 @@ const RecordMeta = ({ time, user, prefix, className }: Props) => {
       <div className="flex items-center gap-1">
         {prefix}
         {child}
+        {user && inlineUser && <span>by</span>}
         {user && <CareIcon className="care-l-user" />}
+        {user && inlineUser && (
+          <span className="font-medium">
+            {user.first_name} {user.last_name}
+          </span>
+        )}
       </div>
     );
   }

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -5,6 +5,7 @@ import ReadMore from "../Common/components/Readmore";
 import ButtonV2 from "../Common/components/ButtonV2";
 import { PrescriptionActions } from "../../Redux/actions";
 import { useTranslation } from "react-i18next";
+import RecordMeta from "../../CAREUI/display/RecordMeta";
 
 export default function PrescriptionDetailCard({
   prescription,
@@ -29,7 +30,7 @@ export default function PrescriptionDetailCard({
         prescription.discontinued && "bg-gray-200 opacity-80"
       )}
     >
-      <div className="flex flex-1 flex-col gap-2">
+      <div className="flex flex-1 flex-col">
         <div>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
@@ -83,7 +84,7 @@ export default function PrescriptionDetailCard({
           </div>
         </div>
 
-        <div className="mt-2 grid grid-cols-9 items-center gap-2">
+        <div className="mt-4 grid grid-cols-9 items-center gap-2">
           <Detail className="col-span-9 md:col-span-5" label={t("medicine")}>
             {prescription.medicine_object?.name ?? prescription.medicine_old}
           </Detail>
@@ -144,6 +145,23 @@ export default function PrescriptionDetailCard({
             >
               {prescription.discontinued_reason}
             </Detail>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1 text-xs text-gray-600 md:mt-3 md:flex-row md:items-center">
+          <span className="flex gap-1">
+            Prescribed
+            <RecordMeta
+              time={prescription.created_date}
+              user={prescription.prescribed_by}
+              inlineUser
+            />
+          </span>
+          {prescription.discontinued && (
+            <span className="flex gap-1">
+              and was discontinued
+              <RecordMeta time={prescription.discontinued_date} />
+            </span>
           )}
         </div>
       </div>


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b956ca</samp>

This pull request enhances the display of prescription details by using the `RecordMeta` component to show the user name of the prescriber. It also adds a prop to the `RecordMeta` component to control the placement of the user name. The changes affect the files `src/CAREUI/display/RecordMeta.tsx` and `src/Components/Medicine/PrescriptionDetailCard.tsx`.

## Proposed Changes

- Show prescribed on, by, and discontinued date in detail card

<img width="832" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/18a16217-71ee-45ed-afd1-6795ed4b1b70">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b956ca</samp>

*  Add an optional `inlineUser` prop to the `RecordMeta` component, which displays the user name either inline or in a tooltip ([link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-f0d2ab732677f4577c5beaba451e232beca423da2365428db6644c199008447cR14), [link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-f0d2ab732677f4577c5beaba451e232beca423da2365428db6644c199008447cL20-R21), [link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-f0d2ab732677f4577c5beaba451e232beca423da2365428db6644c199008447cL28-R37), [link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-f0d2ab732677f4577c5beaba451e232beca423da2365428db6644c199008447cL46-R54))
*  Import and use the `RecordMeta` component in the `PrescriptionDetailCard` component, to show the prescribed and discontinued dates and users of a prescription ([link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5R8), [link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5R150-R166))
*  Adjust the spacing and layout of the `PrescriptionDetailCard` component, by removing the redundant `flex-col` class, increasing the margin between the status and the medicine details, and adding flex, gap and text classes to the new div ([link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L32-R33), [link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L86-R87), [link](https://github.com/coronasafe/care_fe/pull/6365/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5R150-R166))
