### PR TITLE
changed all dispatch requests with useQuery and request in asset module

### DIFF
--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -3,11 +3,6 @@ import { useAbortableEffect, statusType } from "../../Common/utils";
 import { navigate, useQueryParams } from "raviger";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { FacilityModel } from "../Facility/models";
-// import { useDispatch } from "react-redux";
-// import {
-//   getFacilityAssetLocation,
-//   getPermittedFacility,
-// } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
 import { LocationSelect } from "../Common/LocationSelect";
 import { AssetClass, AssetLocationObject } from "./AssetTypes";
@@ -84,11 +79,6 @@ function AssetFilter(props: any) {
   const fetchLocation = useCallback(
     async (status: statusType) => {
       if (locationId && facilityId) {
-        // const [locationData]: any = await Promise.all([
-        //   dispatch(
-        //     getFacilityAssetLocation(String(facilityId), String(locationId))
-        //   ),
-        // ]);
         const { data } = await request(routes.getFacilityAssetLocation, {
           pathParams: {
             facilityId: String(facilityId),

--- a/src/Components/Assets/AssetServiceEditModal.tsx
+++ b/src/Components/Assets/AssetServiceEditModal.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
-import { updateAssetService } from "../../Redux/actions";
 import * as Notification from "../../Utils/Notifications.js";
 import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
 import DialogModal from "../Common/Dialog";
@@ -11,6 +9,8 @@ import DateInputV2 from "../Common/DateInputV2";
 import { FieldLabel } from "../Form/FormFields/FormField";
 import { formatDate, formatDateTime } from "../../Utils/utils";
 import CareIcon from "../../CAREUI/icons/CareIcon";
+import request from "../../Utils/request/request";
+import routes from "../../Redux/api";
 
 export const AssetServiceEditModal = (props: {
   asset?: AssetData;
@@ -24,23 +24,28 @@ export const AssetServiceEditModal = (props: {
     serviced_on: props.service_record?.serviced_on,
     note: props.service_record?.note,
   });
-  const dispatchAction: any = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const [editRecord, setEditRecord] = useState<AssetServiceEdit>();
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
     setIsLoading(true);
-    const data = {
+    const body = {
       serviced_on: form.serviced_on,
       note: form.note,
     };
-
-    const res = await dispatchAction(
-      updateAssetService(props.asset?.id ?? "", props.service_record.id, data)
-    );
+    const { data } = await request(routes.updateAssetService, {
+      pathParams: {
+        asset_external_id: props.asset?.id ?? "",
+        external_id: props.service_record.id,
+      },
+      body: body,
+    });
+    // const res = await dispatchAction(
+    //   updateAssetService(props.asset?.id ?? "", props.service_record.id, data)
+    // );
     setIsLoading(false);
-    if (res?.data) {
+    if (data) {
       Notification.Success({
         msg: "Asset service record updated successfully",
       });

--- a/src/Components/Assets/AssetType/HL7Monitor.tsx
+++ b/src/Components/Assets/AssetType/HL7Monitor.tsx
@@ -1,10 +1,10 @@
 import { SyntheticEvent, useEffect, useState } from "react";
 import { AssetData } from "../AssetTypes";
-import { useDispatch } from "react-redux";
-import {
-  partialUpdateAsset,
-  getPermittedFacility,
-} from "../../../Redux/actions";
+// import { useDispatch } from "react-redux";
+// import {
+//   partialUpdateAsset,
+//   getPermittedFacility,
+// } from "../../../Redux/actions";
 import * as Notification from "../../../Utils/Notifications.js";
 import MonitorConfigure from "../configure/MonitorConfigure";
 import Loading from "../../Common/Loading";
@@ -16,6 +16,8 @@ import TextFormField from "../../Form/FormFields/TextFormField";
 import HL7PatientVitalsMonitor from "../../VitalsMonitor/HL7PatientVitalsMonitor";
 import VentilatorPatientVitalsMonitor from "../../VitalsMonitor/VentilatorPatientVitalsMonitor";
 import useAuthUser from "../../../Common/hooks/useAuthUser";
+import request from "../../../Utils/request/request";
+import routes from "../../../Redux/api";
 
 interface HL7MonitorProps {
   assetId: string;
@@ -33,19 +35,22 @@ const HL7Monitor = (props: HL7MonitorProps) => {
   const [localipAddress, setLocalIPAddress] = useState("");
   const [ipadrdress_error, setIpAddress_error] = useState("");
   const authUser = useAuthUser();
-  const dispatch = useDispatch<any>();
+  // const dispatch = useDispatch<any>();
 
   useEffect(() => {
     const fetchFacility = async () => {
-      const res = await dispatch(getPermittedFacility(facilityId));
+      // const res = await dispatch(getPermittedFacility(facilityId));
+      const { res, data } = await request(routes.getPermittedFacility, {
+        body: { facilityId },
+      });
 
-      if (res.status === 200 && res.data) {
-        setFacilityMiddlewareHostname(res.data.middleware_address);
+      if (res?.status === 200 && data?.middleware_address) {
+        setFacilityMiddlewareHostname(data.middleware_address);
       }
     };
 
     if (facilityId) fetchFacility();
-  }, [dispatch, facilityId]);
+  }, [facilityId]);
 
   useEffect(() => {
     setAssetType(asset?.asset_class);
@@ -65,9 +70,12 @@ const HL7Monitor = (props: HL7MonitorProps) => {
           local_ip_address: localipAddress,
         },
       };
-      const res: any = await Promise.resolve(
-        dispatch(partialUpdateAsset(assetId, data))
-      );
+      // const res: any = await Promise.resolve(
+      //   dispatch(partialUpdateAsset(assetId, data))
+      // );
+      const { res } = await request(routes.partialUpdateAsset, {
+        body: { assetId, data },
+      });
       if (res?.status === 200) {
         Notification.Success({
           msg: "Asset Configured Successfully",

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState } from "react";
 import { AssetData } from "../AssetTypes";
-import { useDispatch } from "react-redux";
-import {
-  partialUpdateAsset,
-  createAssetBed,
-  getPermittedFacility,
-} from "../../../Redux/actions";
 import * as Notification from "../../../Utils/Notifications.js";
 import { BedModel } from "../../Facility/models";
 import axios from "axios";
@@ -17,6 +11,9 @@ import TextFormField from "../../Form/FormFields/TextFormField";
 import { Submit } from "../../Common/components/ButtonV2";
 import { SyntheticEvent } from "react";
 import useAuthUser from "../../../Common/hooks/useAuthUser";
+import request from "../../../Utils/request/request";
+import routes from "../../../Redux/api";
+import useQuery from "../../../Utils/request/useQuery";
 
 interface Props {
   assetId: string;
@@ -43,19 +40,21 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
   const [refreshPresetsHash, setRefreshPresetsHash] = useState(
     Number(new Date())
   );
-  const dispatch = useDispatch<any>();
+  const {
+    data: facility,
+    loading,
+    refetch,
+  } = useQuery(routes.getPermittedFacility, {
+    pathParams: { id: facilityId },
+  });
   const authUser = useAuthUser();
   useEffect(() => {
-    const fetchFacility = async () => {
-      const res = await dispatch(getPermittedFacility(facilityId));
-
-      if (res.status === 200 && res.data) {
-        setFacilityMiddlewareHostname(res.data.middleware_address);
-      }
-    };
-
-    if (facilityId) fetchFacility();
-  }, [dispatch, facilityId]);
+    if (facility?.middleware_address) {
+      setFacilityMiddlewareHostname(facility.middleware_address);
+    } else {
+      () => refetch();
+    }
+  }, [facility, facilityId, refetch]);
 
   useEffect(() => {
     if (asset) {
@@ -83,9 +82,10 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
           camera_access_key: `${username}:${password}:${streamUuid}`,
         },
       };
-      const res: any = await Promise.resolve(
-        dispatch(partialUpdateAsset(assetId, data))
-      );
+      const { res } = await request(routes.partialUpdateAsset, {
+        pathParams: { external_id: assetId },
+        body: data,
+      });
       if (res?.status === 200) {
         Notification.Success({ msg: "Asset Configured Successfully" });
         onUpdated?.();
@@ -110,15 +110,19 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
       const presetData = await axios.get(
         `https://${facilityMiddlewareHostname}/status?hostname=${config.hostname}&port=${config.port}&username=${config.username}&password=${config.password}`
       );
-      const res: any = await Promise.resolve(
-        dispatch(
-          createAssetBed(
-            { meta: { ...data, ...presetData.data } },
-            assetId,
-            bed?.id as string
-          )
-        )
-      );
+      // const res: any = await Promise.resolve(
+      //   dispatch(
+      //     createAssetBed(
+      //       { meta: { ...data, ...presetData.data } },
+      //       assetId,
+      //       bed?.id as string
+      //     )
+      //   )
+      // );
+      const { res } = await request(routes.createAssetBed, {
+        pathParams: { external_id: assetId },
+        body: { meta: { ...data, ...presetData.data } },
+      });
       if (res?.status === 201) {
         Notification.Success({
           msg: "Preset Added Successfully",
@@ -139,7 +143,7 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
     setLoadingAddPreset(false);
   };
 
-  if (isLoading) return <Loading />;
+  if (isLoading || loading || !facility) return <Loading />;
 
   return (
     <div className="space-y-6">

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -1,5 +1,8 @@
 import { IConfig } from "../Common/hooks/useConfig";
-import { AssetData } from "../Components/Assets/AssetTypes";
+import {
+  AssetData,
+  AssetLocationObject,
+} from "../Components/Assets/AssetTypes";
 import { FacilityModel, LocationModel } from "../Components/Facility/models";
 import { UserModel } from "../Components/Users/models";
 import { PaginatedResponse } from "../Utils/request/types";
@@ -210,6 +213,7 @@ const routes = {
   getFacilityAssetLocation: {
     path: "/api/v1/facility/{facility_external_id}/asset_location/{external_id}/",
     method: "GET",
+    TRes: Res<AssetLocationObject>(),
   },
   updateFacilityAssetLocation: {
     path: "/api/v1/facility/{facility_external_id}/asset_location/{external_id}/",

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -228,6 +228,7 @@ const routes = {
   createAssetBed: {
     path: "/api/v1/assetbed/",
     method: "POST",
+    TRes: Res<AssetData>(),
   },
   getAssetBed: {
     path: "/api/v1/assetbed/{external_id}/",

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -1,7 +1,10 @@
 import { IConfig } from "../Common/hooks/useConfig";
 import {
+  AssetBedModel,
   AssetData,
   AssetLocationObject,
+  AssetService,
+  AssetTransaction,
 } from "../Components/Assets/AssetTypes";
 import { FacilityModel, LocationModel } from "../Components/Facility/models";
 import { UserModel } from "../Components/Users/models";
@@ -180,6 +183,8 @@ const routes = {
 
   getAnyFacility: {
     path: "/api/v1/getallfacilities/{id}/",
+    method: "GET",
+    TRes: Res<FacilityModel>(),
   },
 
   updateFacility: {
@@ -228,6 +233,7 @@ const routes = {
   listAssetBeds: {
     path: "/api/v1/assetbed/",
     method: "GET",
+    TRes: Res<PaginatedResponse<AssetBedModel>>(),
   },
   createAssetBed: {
     path: "/api/v1/assetbed/",
@@ -245,6 +251,7 @@ const routes = {
   partialUpdateAssetBed: {
     path: "/api/v1/assetbed/{external_id}/",
     method: "PATCH",
+    TRes: Res<AssetBedModel>(),
   },
   deleteAssetBed: {
     path: "/api/v1/assetbed/{external_id}/",
@@ -796,6 +803,7 @@ const routes = {
   listAssets: {
     path: "/api/v1/asset",
     method: "GET",
+    TRes: Res<PaginatedResponse<AssetData>>(),
   },
   createAsset: {
     path: "/api/v1/asset/",
@@ -817,6 +825,7 @@ const routes = {
   deleteAsset: {
     path: "/api/v1/asset/{external_id}/",
     method: "DELETE",
+    TRes: Res<AssetData>(),
   },
   updateAsset: {
     path: "/api/v1/asset/{external_id}/",
@@ -833,6 +842,7 @@ const routes = {
   listAssetTransaction: {
     path: "/api/v1/asset_transaction/",
     method: "GET",
+    TRes: Res<PaginatedResponse<AssetTransaction>>(),
   },
   getAssetTransaction: {
     path: "/api/v1/asset_transaction/{id}",
@@ -844,6 +854,7 @@ const routes = {
   listAssetService: {
     path: "/api/v1/asset/{asset_external_id}/service_records/",
     method: "GET",
+    TRes: Res<PaginatedResponse<AssetService>>(),
   },
   getAssetService: {
     path: "/api/v1/asset/{asset_external_id}/service_records/{external_id}",
@@ -852,6 +863,7 @@ const routes = {
   updateAssetService: {
     path: "/api/v1/asset/{asset_external_id}/service_records/{external_id}",
     method: "PUT",
+    TRes: Res<AssetService>(),
   },
 
   // ABDM HealthID endpoints

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -1,6 +1,6 @@
 import { IConfig } from "../Common/hooks/useConfig";
 import { AssetData } from "../Components/Assets/AssetTypes";
-import { LocationModel } from "../Components/Facility/models";
+import { FacilityModel, LocationModel } from "../Components/Facility/models";
 import { UserModel } from "../Components/Users/models";
 import { PaginatedResponse } from "../Utils/request/types";
 
@@ -171,6 +171,8 @@ const routes = {
 
   getPermittedFacility: {
     path: "/api/v1/facility/{id}/",
+    method: "GET",
+    TRes: Res<FacilityModel>(),
   },
 
   getAnyFacility: {
@@ -818,6 +820,7 @@ const routes = {
   partialUpdateAsset: {
     path: "/api/v1/asset/{external_id}/",
     method: "PATCH",
+    TRes: Res<AssetData>(),
   },
 
   // Asset transaction endpoints


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f06879</samp>

The pull request refactors the code for various components related to assets management, using the `request` utility function and the `useQuery` hook for making API calls instead of the `dispatch` action and the action creators. This simplifies the code, reduces the number of imports, and fixes some issues with the API paths and parameters. The pull request also adds response type definitions for the asset and facility API routes in the `src/Redux/api.tsx` file, using the `Res` generic function and the imported interfaces.

## Proposed Changes

- Fixes #6326 
- Replaced dispatch with useQuery and request in Assets module

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f06879</samp>

*  Refactor the API calls in the asset components to use the `request` utility function and the `useQuery` hook instead of the `dispatch` action and the `useEffect` hook ([link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L6-L10),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96R12-R13),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L30),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L41-R42),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L69-R76),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L83-R94),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L101-R101),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L8-L9),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132R18-R20),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L34),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L42-R56),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132R188-R189),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L10-L16),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20R31-R32),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L67),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L78-R81),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L89-R99),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L119-R122),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L126-R129),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L326-R334),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-5aea9f0ca0c6dd1a0dd842d82670733dcb1958e9996fdf66760508b1c00dda5cL2-L3),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-5aea9f0ca0c6dd1a0dd842d82670733dcb1958e9996fdf66760508b1c00dda5cR12-R13),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-5aea9f0ca0c6dd1a0dd842d82670733dcb1958e9996fdf66760508b1c00dda5cL27),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-5aea9f0ca0c6dd1a0dd842d82670733dcb1958e9996fdf66760508b1c00dda5cL34-R48),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L1-R4),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R25-R26),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L57),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L78-R75),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L89-R91),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L106),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L126-R135),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L141-R143),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L147-R149),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L154-R167),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L181-R189),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L190-R204),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL3-L7),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacR14-R16),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL36-R49),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL68-R71),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-0db7341a4ab59f3de6f15a05a264db1fba11009c12b2c3158eacc06506567bacL87-R88),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL3-L8),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR14-R16),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL46-R58),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL86-R88),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL113-R125),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL142-R146),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1345524aad460805e3a92f217ff1e65d65dd14f9eabdf0c8d850fa27ecf08259L1-R31),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1345524aad460805e3a92f217ff1e65d65dd14f9eabdf0c8d850fa27ecf08259L42-R48),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-1345524aad460805e3a92f217ff1e65d65dd14f9eabdf0c8d850fa27ecf08259L69-R71))
*  Add the response types for the asset-related API routes using the `Res` generic function and the interfaces for the asset models ([link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cL2-R9),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cL174-R187),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR221),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cL225-R241),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR254),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR806),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR828),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR837),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR845),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR857),[link](https://github.com/coronasafe/care_fe/pull/6370/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR866))
