### PR TITLE
Fix Flaky Cypress test in Facility Module 

### DIFF
--- a/cypress/e2e/facility_spec/locations.cy.ts
+++ b/cypress/e2e/facility_spec/locations.cy.ts
@@ -13,6 +13,7 @@ describe("Location Management Section", () => {
     cy.intercept("GET", "**/api/v1/facility/**").as("getFacilities");
     cy.get("[id='facility-details']").first().click();
     cy.wait("@getFacilities").its("response.statusCode").should("eq", 200);
+    cy.get("h1.text-3xl.font-bold", { timeout: 10000 }).should("be.visible");
     cy.get("#manage-facility-dropdown button").should("be.visible");
     cy.get("[id='manage-facility-dropdown']").scrollIntoView().click();
     cy.get("[id=location-management]").click();

--- a/cypress/pageobject/Facility/FacilityCreation.ts
+++ b/cypress/pageobject/Facility/FacilityCreation.ts
@@ -106,7 +106,7 @@ class FacilityPage {
   }
 
   clickManageFacilityDropdown() {
-    cy.get("h1.text-3xl.font-bold", { timeout: 10000 }).should("be.visible");
+    cy.get("h1.text-3xl.font-bold", { timeout: 20000 }).should("be.visible");
     cy.get("#manage-facility-dropdown button").scrollIntoView();
     cy.get("#manage-facility-dropdown button")
       .contains("Manage Facility")
@@ -199,8 +199,6 @@ class FacilityPage {
     cy.intercept("GET", "**/api/v1/facility/**").as("getManagePage");
     cy.go("back");
     cy.wait("@getManagePage").its("response.statusCode").should("eq", 200);
-    cy.get("#manage-facility-dropdown").scrollIntoView();
-    cy.get("#manage-facility-dropdown").should("exist");
   }
 
   verifyfacilityviewassetredirection() {

--- a/cypress/pageobject/Facility/FacilityCreation.ts
+++ b/cypress/pageobject/Facility/FacilityCreation.ts
@@ -106,6 +106,7 @@ class FacilityPage {
   }
 
   clickManageFacilityDropdown() {
+    cy.get("h1.text-3xl.font-bold", { timeout: 10000 }).should("be.visible");
     cy.get("#manage-facility-dropdown button").scrollIntoView();
     cy.get("#manage-facility-dropdown button")
       .contains("Manage Facility")


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61411f9</samp>

This pull request adds a new assertion to the facility creation test case and page object. The assertion verifies that the `Create Facility` header is visible on the facility creation page.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61411f9</samp>

*  Add assertion to check header visibility on facility creation page ([link](https://github.com/coronasafe/care_fe/pull/6384/files?diff=unified&w=0#diff-17ca2f22944fbfa7160b994170aa488e94d25d713006e94f1655776101cf5e55R16), [link](https://github.com/coronasafe/care_fe/pull/6384/files?diff=unified&w=0#diff-a4a17d53a337d155d03bd531b8473e60d3cabdd6dcb1514840799f46a5a2dd0bR109))
