### PR TITLE
Revert "Prescriptions: Shrink discontinued prescriptions + Flip MAR t…

### DIFF
--- a/src/Common/hooks/useRangePagination.ts
+++ b/src/Common/hooks/useRangePagination.ts
@@ -9,18 +9,17 @@ interface Props {
   bounds: DateRange;
   perPage: number;
   slots?: number;
-  snapToLatest?: boolean;
-  reverse?: boolean;
+  defaultEnd?: boolean;
 }
 
 const useRangePagination = ({ bounds, perPage, ...props }: Props) => {
   const [currentRange, setCurrentRange] = useState(
-    getInitialBounds(bounds, perPage, props.snapToLatest)
+    getInitialBounds(bounds, perPage, props.defaultEnd)
   );
 
   useEffect(() => {
-    setCurrentRange(getInitialBounds(bounds, perPage, props.snapToLatest));
-  }, [bounds, perPage, props.snapToLatest]);
+    setCurrentRange(getInitialBounds(bounds, perPage, props.defaultEnd));
+  }, [bounds, perPage, props.defaultEnd]);
 
   const next = () => {
     const { end } = currentRange;
@@ -63,24 +62,17 @@ const useRangePagination = ({ bounds, perPage, ...props }: Props) => {
     }
 
     const slots: DateRange[] = [];
-    const { start, end } = currentRange;
+    const { start } = currentRange;
     const delta = perPage / props.slots;
 
     for (let i = 0; i < props.slots; i++) {
-      if (props.snapToLatest) {
-        slots.push({
-          start: new Date(end.valueOf() - delta * (i - 1)),
-          end: new Date(end.valueOf() - delta * i),
-        });
-      } else {
-        slots.push({
-          start: new Date(start.valueOf() + delta * i),
-          end: new Date(start.valueOf() + delta * (i + 1)),
-        });
-      }
+      slots.push({
+        start: new Date(start.valueOf() + delta * i),
+        end: new Date(start.valueOf() + delta * (i + 1)),
+      });
     }
 
-    return props.reverse ? slots.reverse() : slots;
+    return slots;
   }, [currentRange, props.slots, perPage]);
 
   return {
@@ -98,7 +90,7 @@ export default useRangePagination;
 const getInitialBounds = (
   bounds: DateRange,
   perPage: number,
-  snapToLatest?: boolean
+  defaultEnd?: boolean
 ) => {
   const deltaBounds = bounds.end.valueOf() - bounds.start.valueOf();
 
@@ -106,7 +98,7 @@ const getInitialBounds = (
     return bounds;
   }
 
-  if (snapToLatest) {
+  if (defaultEnd) {
     return {
       start: new Date(bounds.end.valueOf() - perPage),
       end: bounds.end,

--- a/src/Components/Medicine/PrescriptionAdministrationsTable.tsx
+++ b/src/Components/Medicine/PrescriptionAdministrationsTable.tsx
@@ -47,10 +47,6 @@ export default function PrescriptionAdministrationsTable({
   const { t } = useTranslation();
 
   const [state, setState] = useState<State>();
-
-  const [showDiscontinued, setShowDiscontinued] = useState(false);
-  const [discontinuedCount, setDiscontinuedCount] = useState<number>();
-
   const pagination = useRangePagination({
     bounds: state?.administrationsTimeBounds ?? {
       start: new Date(),
@@ -58,8 +54,7 @@ export default function PrescriptionAdministrationsTable({
     },
     perPage: 24 * 60 * 60 * 1000,
     slots: 24,
-    snapToLatest: true,
-    reverse: true,
+    defaultEnd: true,
   });
   const [showBulkAdminister, setShowBulkAdminister] = useState(false);
 
@@ -69,13 +64,8 @@ export default function PrescriptionAdministrationsTable({
   );
 
   const refetch = useCallback(async () => {
-    const filters = {
-      is_prn: prn,
-      prescription_type: "REGULAR",
-    };
-
     const res = await dispatch(
-      list(showDiscontinued ? filters : { ...filters, discontinued: false })
+      list({ is_prn: prn, prescription_type: "REGULAR" })
     );
 
     setState({
@@ -84,14 +74,7 @@ export default function PrescriptionAdministrationsTable({
       ),
       administrationsTimeBounds: getAdministrationBounds(res.data.results),
     });
-
-    if (showDiscontinued === false) {
-      const discontinuedRes = await dispatch(
-        list({ ...filters, discontinued: true, limit: 0 })
-      );
-      setDiscontinuedCount(discontinuedRes.data.count);
-    }
-  }, [consultation_id, showDiscontinued, dispatch]);
+  }, [consultation_id, dispatch]);
 
   useEffect(() => {
     refetch();
@@ -158,22 +141,17 @@ export default function PrescriptionAdministrationsTable({
         }
       />
 
-      <div className="relative overflow-x-auto rounded border border-white shadow">
-        <table className="w-full whitespace-nowrap rounded">
+      <div className="overflow-x-auto rounded border border-white shadow">
+        <table className="w-full overflow-x-scroll whitespace-nowrap rounded">
           <thead className="bg-white text-xs font-medium text-black">
             <tr>
-              <th className="sticky left-0 z-10 bg-white py-3 pl-4 text-left">
-                <div className="flex justify-between gap-2">
-                  <span className="text-sm">{t("medicine")}</span>
-                  <span className="hidden px-2 text-center text-xs leading-none lg:block">
-                    <p>Dosage &</p>
-                    <p>
-                      {!state?.prescriptions[0]?.is_prn
-                        ? "Frequency"
-                        : "Indicator"}
-                    </p>
-                  </span>
-                </div>
+              <th className="py-3 pl-4 text-left text-sm">{t("medicine")}</th>
+
+              <th className="px-2 text-center leading-none">
+                <p>Dosage &</p>
+                <p>
+                  {!state?.prescriptions[0]?.is_prn ? "Frequency" : "Indicator"}
+                </p>
               </th>
 
               <th>
@@ -184,10 +162,8 @@ export default function PrescriptionAdministrationsTable({
                   border
                   className="mx-2 px-1"
                   variant="secondary"
-                  disabled={!pagination.hasNext}
-                  onClick={pagination.next}
-                  tooltip="Next 24 hours"
-                  tooltipClassName="tooltip-bottom -translate-x-1/2 text-xs"
+                  disabled={!pagination.hasPrevious}
+                  onClick={pagination.previous}
                 >
                   <CareIcon icon="l-angle-left-b" className="text-base" />
                 </ButtonV2>
@@ -201,26 +177,24 @@ export default function PrescriptionAdministrationsTable({
                       <p className="h-4 w-6 animate-pulse rounded bg-gray-500" />
                     </th>
                   ))
-                : pagination.slots
-                    ?.map(({ start, end }, index) => (
-                      <th
-                        className="tooltip px-0.5 py-2 text-center font-semibold leading-none text-gray-900"
-                        key={index}
-                      >
-                        <p>{formatDateTime(end, "DD/MM")}</p>
-                        <p>{formatDateTime(end, "HH:mm")}</p>
+                : pagination.slots?.map(({ start, end }, index) => (
+                    <th
+                      className="tooltip px-0.5 py-2 text-center font-semibold leading-none text-gray-900"
+                      key={index}
+                    >
+                      <p>{formatDateTime(start, "DD/MM")}</p>
+                      <p>{formatDateTime(start, "HH:mm")}</p>
 
-                        <span className="tooltip-text tooltip-top -translate-x-1/2 text-xs font-normal">
-                          Administration(s) between
-                          <br />
-                          <strong>{formatTime(start)}</strong> and{" "}
-                          <strong>{formatTime(end)}</strong>
-                          <br />
-                          on <strong>{formatDate(start)}</strong>
-                        </span>
-                      </th>
-                    ))
-                    .reverse()}
+                      <span className="tooltip-text tooltip-top -translate-x-1/2 text-xs font-normal">
+                        Administration(s) between
+                        <br />
+                        <strong>{formatTime(start)}</strong> and{" "}
+                        <strong>{formatTime(end)}</strong>
+                        <br />
+                        on <strong>{formatDate(start)}</strong>
+                      </span>
+                    </th>
+                  ))}
               <th>
                 <ButtonV2
                   size="small"
@@ -229,10 +203,8 @@ export default function PrescriptionAdministrationsTable({
                   border
                   className="mx-2 px-1"
                   variant="secondary"
-                  disabled={!pagination.hasPrevious}
-                  onClick={pagination.previous}
-                  tooltip="Previous 24 hours"
-                  tooltipClassName="tooltip-bottom -translate-x-1/2 text-xs"
+                  disabled={!pagination.hasNext}
+                  onClick={pagination.next}
                 >
                   <CareIcon icon="l-angle-right-b" className="text-base" />
                 </ButtonV2>
@@ -254,23 +226,6 @@ export default function PrescriptionAdministrationsTable({
             ))}
           </tbody>
         </table>
-
-        {showDiscontinued === false && !!discontinuedCount && (
-          <ButtonV2
-            variant="secondary"
-            className="sticky left-0 z-10 w-full"
-            ghost
-            onClick={() => setShowDiscontinued(true)}
-          >
-            <span className="flex w-full justify-start gap-1 text-sm">
-              <CareIcon icon="l-eye" className="text-lg" />
-              <span>
-                Show <strong>{discontinuedCount}</strong> other discontinued
-                prescription(s)
-              </span>
-            </span>
-          </ButtonV2>
-        )}
 
         {state?.prescriptions.length === 0 && (
           <div className="my-16 flex w-full flex-col items-center justify-center gap-4 text-gray-500">
@@ -328,7 +283,12 @@ const PrescriptionRow = ({ prescription, ...props }: PrescriptionRowProps) => {
   }, [prescription.id, dispatch, props.intervals]);
 
   return (
-    <>
+    <tr
+      className={classNames(
+        "border-separate border border-gray-300 bg-gray-100 transition-all duration-200 ease-in-out hover:border-primary-300 hover:bg-primary-100"
+        // prescription.discontinued && "opacity-60"
+      )}
+    >
       {showDiscontinue && (
         <DiscontinuePrescription
           prescription={prescription}
@@ -396,89 +356,77 @@ const PrescriptionRow = ({ prescription, ...props }: PrescriptionRowProps) => {
           </div>
         </DialogModal>
       )}
-      <tr
-        className={classNames(
-          "group border-separate border border-gray-300 bg-gray-100 transition-all duration-200 ease-in-out hover:border-primary-300 hover:bg-primary-100"
-          // prescription.discontinued && "opacity-60"
-        )}
+      <td
+        className="cursor-pointer py-3 pl-4 text-left"
+        onClick={() => setShowDetails(true)}
       >
-        <td
-          className="sticky left-0 z-10 cursor-pointer bg-gray-100 py-3 pl-4 text-left transition-all duration-200 ease-in-out group-hover:bg-primary-100"
-          onClick={() => setShowDetails(true)}
-        >
-          <div className="flex flex-col gap-1 lg:flex-row lg:justify-between lg:gap-2">
-            <div className="flex items-center gap-2">
-              <span
-                className={classNames(
-                  "text-sm font-semibold",
-                  prescription.discontinued ? "text-gray-700" : "text-gray-900"
-                )}
-              >
-                {prescription.medicine_object?.name ??
-                  prescription.medicine_old}
-              </span>
-
-              {prescription.discontinued && (
-                <span className="hidden rounded-full border border-gray-500 bg-gray-200 px-1.5 text-xs font-medium text-gray-700 lg:block">
-                  {t("discontinued")}
-                </span>
-              )}
-
-              {prescription.route && (
-                <span className="hidden rounded-full border border-blue-500 bg-blue-100 px-1.5 text-xs font-medium text-blue-700 lg:block">
-                  {t(prescription.route)}
-                </span>
-              )}
-            </div>
-
-            <div className="flex gap-1 text-xs font-semibold text-gray-900 lg:flex-col lg:px-2 lg:text-center">
-              <p>{prescription.dosage}</p>
-              <p>
-                {!prescription.is_prn
-                  ? t("PRESCRIPTION_FREQUENCY_" + prescription.frequency)
-                  : prescription.indicator}
-              </p>
-            </div>
-          </div>
-        </td>
-
-        <td />
-        {/* Administration Cells */}
-        {props.intervals
-          .map(({ start, end }, index) => (
-            <td className="text-center" key={index}>
-              {administrations === undefined ? (
-                <CareIcon
-                  icon="l-spinner"
-                  className="animate-spin text-lg text-gray-500"
-                />
-              ) : (
-                <AdministrationCell
-                  administrations={administrations}
-                  interval={{ start, end }}
-                  prescription={prescription}
-                />
-              )}
-            </td>
-          ))
-          .reverse()}
-        <td />
-
-        {/* Action Buttons */}
-        <td className="space-x-1 pr-2 text-right">
-          <ButtonV2
-            type="button"
-            size="small"
-            disabled={prescription.discontinued}
-            ghost
-            border
-            onClick={() => setShowAdminister(true)}
+        <div className="flex items-center gap-2">
+          <span
+            className={classNames(
+              "text-sm font-semibold",
+              prescription.discontinued ? "text-gray-700" : "text-gray-900"
+            )}
           >
-            {t("administer")}
-          </ButtonV2>
+            {prescription.medicine_object?.name ?? prescription.medicine_old}
+          </span>
+
+          {prescription.discontinued && (
+            <span className="rounded-full border border-gray-500 bg-gray-200 px-1.5 text-xs font-medium text-gray-700">
+              {t("discontinued")}
+            </span>
+          )}
+
+          {prescription.route && (
+            <span className="rounded-full border border-blue-500 bg-blue-100 px-1.5 text-xs font-medium text-blue-700">
+              {t(prescription.route)}
+            </span>
+          )}
+        </div>
+      </td>
+
+      <td className="text-center text-xs font-semibold text-gray-900">
+        <p>{prescription.dosage}</p>
+        <p>
+          {!prescription.is_prn
+            ? t("PRESCRIPTION_FREQUENCY_" + prescription.frequency)
+            : prescription.indicator}
+        </p>
+      </td>
+
+      <td />
+      {/* Administration Cells */}
+      {props.intervals.map(({ start, end }, index) => (
+        <td className="text-center" key={index}>
+          {administrations === undefined ? (
+            <CareIcon
+              icon="l-spinner"
+              className="animate-spin text-lg text-gray-500"
+            />
+          ) : (
+            <AdministrationCell
+              administrations={administrations}
+              interval={{ start, end }}
+              prescription={prescription}
+            />
+          )}
         </td>
-      </tr>
-    </>
+      ))}
+      <td />
+
+      {/* Action Buttons */}
+      <td className="space-x-1 pr-2 text-right">
+        <ButtonV2
+          type="button"
+          size="small"
+          disabled={prescription.discontinued}
+          ghost
+          border
+          onClick={() => setShowAdminister(true)}
+        >
+          {t("administer")}
+        </ButtonV2>
+      </td>
+    </tr>
   );
 };
 

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -1003,7 +1003,7 @@ export const PrescriptionActions = (consultation_external_id: string) => {
   const pathParams = { consultation_external_id };
 
   return {
-    list: (query?: Record<string, string | boolean | number>) => {
+    list: (query?: Partial<Prescription>) => {
       let altKey;
       if (query?.is_prn !== undefined) {
         altKey = query?.is_prn


### PR DESCRIPTION
…imeline + Freeze primary columns in horizontal scroll (#6282)"

This reverts commit 5009a86abfb96e9b21f8371635176e4c3f73c5a7.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ec4368</samp>

This pull request refactors and simplifies the pagination logic and components for the prescription administrations feature. It removes the discontinued prescriptions feature, which was not working as expected, and makes the pagination more consistent and type-safe. It also improves the performance and appearance of the `PrescriptionRow` component.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ec4368</samp>

*  Simplify the interface and logic of the `useRangePagination` hook by replacing the `snapToLatest` and `reverse` props with a single `defaultEnd` prop ([link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-66225f28661e7393b8c87eae8c80d8a00d7f05b4ac49eb926b4da36ae53f8128L12-R22), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-66225f28661e7393b8c87eae8c80d8a00d7f05b4ac49eb926b4da36ae53f8128L66-R75), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-66225f28661e7393b8c87eae8c80d8a00d7f05b4ac49eb926b4da36ae53f8128L101-R93), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-66225f28661e7393b8c87eae8c80d8a00d7f05b4ac49eb926b4da36ae53f8128L109-R101))
*  Update the `PrescriptionAdministrationsTable` component to use the new `defaultEnd` prop of the `useRangePagination` hook and remove the unnecessary states and logic related to the discontinued prescriptions and the pagination tooltips ([link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L50-L53), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L61-R57), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L72-R68), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L87-R78), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L161-R154), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L187-R166), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L204-R197), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L232-R207), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L258-L274), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L331-R291), [link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-72e4733fee5da36cd347a741a637541d37363b7ecd2280dcc5ce01d6aa173150L399-R429))
*  Change the type of the `query` parameter of the `list` action in `src/Redux/actions.tsx` to `Partial<Prescription>` for better type safety and consistency ([link](https://github.com/coronasafe/care_fe/pull/6386/files?diff=unified&w=0#diff-a0c88ccc2116ceb542bc9be228c54ed98b0bc89e2d9daf66c941f1a0305e626eL1006-R1006))
