### PR TITLE
Asset Create More: fix reset of `is_working` state

### DIFF
--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -306,7 +306,7 @@ const AssetCreate = (props: AssetProps) => {
     setLocation("");
     setAssetType(assetTypeInitial);
     setAssetClass(assetClassInitial);
-    setIsWorking("");
+    setIsWorking(undefined);
     setNotWorkingReason("");
     setSerialNumber("");
     setVendorName("");


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6af935</samp>

Fixed a bug in `AssetCreate.tsx` where the `isWorking` state was initialized with an empty string instead of `undefined`. This improves the clarity and correctness of the code.

## Proposed Changes

- Fixes #6397

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6af935</samp>

* Change the initial value of `isWorking` state to `undefined` instead of an empty string to avoid confusion and errors ([link](https://github.com/coronasafe/care_fe/pull/6398/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L309-R309))
