### PR TITLE
Show asset import progress

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -81,7 +81,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add("verifyNotification", (text) => {
   cy.get(".pnotify-container").should("exist").contains(text);
-  return cy.get(".pnotify-container").click({ force: true });
+  return cy.get(".pnotify-container").contains(text).click({ force: true });
 });
 
 Cypress.on("uncaught:exception", () => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f4585a</samp>

This pull request enhances the asset import feature by adding `SelectFormField` for location selection, validating the location input, and showing appropriate errors and messages. It also resolves some UI and state bugs in `AssetImportModal.tsx`.

## Proposed Changes

- Fixes #6399

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f4585a</samp>

* Replace the `SelectMenuV2` component with the `SelectFormField` component for selecting the location for asset import in `AssetImportModal.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L11), [link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132R19), [link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L221-R263))
* Add validation and error handling for the location field using the `errors` state and show an error message if the location is not selected ([link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L28-R39), [link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L113-R128))
* Add a loading indicator for the locations data using the `locationsLoading` state and the `setLocationsLoading` function ([link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L28-R39), [link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L44-R52), [link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L196-R217))
* Change the logic for updating the `preview` state after importing each asset to use a functional update instead of a direct mutation ([link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L159-R176))
* Change the logic for handling the success and failure cases of the import process to show different notifications and actions ([link](https://github.com/coronasafe/care_fe/pull/6400/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L165-R189))
