### PR TITLE
Fix password reset

### DIFF
--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -151,7 +151,7 @@ export const Login = (props: { forgot?: boolean }) => {
         body: { ...valid },
       });
       setLoading(false);
-      if (res && res.statusText === "OK") {
+      if (res?.ok) {
         Notification.Success({
           msg: t("password_sent"),
         });

--- a/src/Components/Auth/ResetPassword.tsx
+++ b/src/Components/Auth/ResetPassword.tsx
@@ -72,7 +72,7 @@ export const ResetPassword = (props: any) => {
       const { res, error } = await request(routes.resetPassword, {
         body: { ...valid },
       });
-      if (res && res.statusText === "OK") {
+      if (res?.ok) {
         localStorage.removeItem(LocalStorageKeys.accessToken);
         Notification.Success({
           msg: t("password_reset_success"),
@@ -89,7 +89,7 @@ export const ResetPassword = (props: any) => {
       const { res } = await request(routes.checkResetToken, {
         body: { token: props.token },
       });
-      if (!res || res.statusText !== "OK") {
+      if (!res || res.ok) {
         navigate("/invalid-reset");
       }
     };

--- a/src/Components/Auth/ResetPassword.tsx
+++ b/src/Components/Auth/ResetPassword.tsx
@@ -89,7 +89,7 @@ export const ResetPassword = (props: any) => {
       const { res } = await request(routes.checkResetToken, {
         body: { token: props.token },
       });
-      if (!res || res.ok) {
+      if (!res || !res.ok) {
         navigate("/invalid-reset");
       }
     };

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -55,6 +55,7 @@ const routes = {
   checkResetToken: {
     path: "/api/v1/password_reset/check/",
     method: "POST",
+    noAuth: true,
     TRes: Type<Record<string, never>>(),
     TBody: Type<{ token: string }>(),
   },
@@ -62,6 +63,7 @@ const routes = {
   resetPassword: {
     path: "/api/v1/password_reset/confirm/",
     method: "POST",
+    noAuth: true,
     TRes: Type<Record<string, never>>(),
     TBody: Type<{ password: string; confirm: string }>(),
   },
@@ -69,6 +71,7 @@ const routes = {
   forgotPassword: {
     path: "/api/v1/password_reset/",
     method: "POST",
+    noAuth: true,
     TRes: Type<Record<string, never>>(),
     TBody: Type<{ username: string }>(),
   },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75dceaa</samp>

Allowed unauthenticated access to some authentication-related routes in `api.tsx`. This enables users to log in, reset their passwords, or request a password reset link without being logged in.

## Proposed Changes

- Fixes #6403

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75dceaa</samp>

*  Add `noAuth` property to routes that do not require authentication ([link](https://github.com/coronasafe/care_fe/pull/6404/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR58), [link](https://github.com/coronasafe/care_fe/pull/6404/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR66), [link](https://github.com/coronasafe/care_fe/pull/6404/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR74)) in `src/Redux/api.tsx`
