### PR TITLE
Replaced date-fns utility functions from DateInputV2 component with day.js

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -1,5 +1,4 @@
 import { MutableRefObject, useEffect, useState } from "react";
-import { getDay, getDaysInMonth, isEqual } from "date-fns";
 
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { Popover } from "@headlessui/react";
@@ -89,11 +88,11 @@ const DateInputV2: React.FC<Props> = ({
   };
 
   const isSelectedDate = (date: number) => {
-    if (value)
-      return isEqual(
-        new Date(value.getFullYear(), value.getMonth(), date),
-        value
-      );
+    if (value) {
+      return dayjs(
+        new Date(value.getFullYear(), value.getMonth(), date)
+      ).isSame(dayjs(value));
+    }
   };
 
   type CloseFunction = (
@@ -114,9 +113,11 @@ const DateInputV2: React.FC<Props> = ({
   };
 
   const getDayCount = (date: Date) => {
-    const daysInMonth = getDaysInMonth(date);
+    const daysInMonth = dayjs(date).daysInMonth();
 
-    const dayOfWeek = getDay(new Date(date.getFullYear(), date.getMonth(), 1));
+    const dayOfWeek = dayjs(
+      new Date(date.getFullYear(), date.getMonth(), 1)
+    ).day();
     const blankDaysArray = [];
     for (let i = 1; i <= dayOfWeek; i++) {
       blankDaysArray.push(i);

--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -1,14 +1,5 @@
 import { MutableRefObject, useEffect, useState } from "react";
-import {
-  addMonths,
-  addYears,
-  format,
-  getDay,
-  getDaysInMonth,
-  isEqual,
-  subMonths,
-  subYears,
-} from "date-fns";
+import { getDay, getDaysInMonth, isEqual } from "date-fns";
 
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { Popover } from "@headlessui/react";
@@ -64,14 +55,20 @@ const DateInputV2: React.FC<Props> = ({
   const decrement = () => {
     switch (type) {
       case "date":
-        setDatePickerHeaderDate((prev) => subMonths(prev, 1));
+        setDatePickerHeaderDate((prev) =>
+          dayjs(prev).subtract(1, "month").toDate()
+        );
         break;
       case "month":
-        setDatePickerHeaderDate((prev) => subYears(prev, 1));
+        setDatePickerHeaderDate((prev) =>
+          dayjs(prev).subtract(1, "year").toDate()
+        );
         break;
       case "year":
-        setDatePickerHeaderDate((prev) => subYears(prev, 1));
-        setYear((prev) => subYears(prev, 10));
+        setDatePickerHeaderDate((prev) =>
+          dayjs(prev).subtract(1, "year").toDate()
+        );
+        setYear((prev) => dayjs(prev).subtract(10, "year").toDate());
         break;
     }
   };
@@ -79,14 +76,14 @@ const DateInputV2: React.FC<Props> = ({
   const increment = () => {
     switch (type) {
       case "date":
-        setDatePickerHeaderDate((prev) => addMonths(prev, 1));
+        setDatePickerHeaderDate((prev) => dayjs(prev).add(1, "month").toDate());
         break;
       case "month":
-        setDatePickerHeaderDate((prev) => addYears(prev, 1));
+        setDatePickerHeaderDate((prev) => dayjs(prev).add(1, "year").toDate());
         break;
       case "year":
-        setDatePickerHeaderDate((prev) => addYears(prev, 1));
-        setYear((prev) => addYears(prev, 10));
+        setDatePickerHeaderDate((prev) => dayjs(prev).add(1, "year").toDate());
+        setYear((prev) => dayjs(prev).add(10, "year").toDate());
         break;
     }
   };
@@ -282,7 +279,7 @@ const DateInputV2: React.FC<Props> = ({
                             onClick={showMonthPicker}
                             className="cursor-pointer rounded px-3 py-1 text-center font-medium text-black hover:bg-gray-300"
                           >
-                            {format(datePickerHeaderDate, "MMMM")}
+                            {dayjs(datePickerHeaderDate).format("MMMM")}
                           </div>
                         )}
                         <div
@@ -292,7 +289,7 @@ const DateInputV2: React.FC<Props> = ({
                           <p className="text-center">
                             {type == "year"
                               ? year.getFullYear()
-                              : format(datePickerHeaderDate, "yyyy")}
+                              : dayjs(datePickerHeaderDate).format("YYYY")}
                           </p>
                         </div>
                       </div>
@@ -371,14 +368,9 @@ const DateInputV2: React.FC<Props> = ({
                             )}
                             onClick={setMonthValue(i)}
                           >
-                            {format(
-                              new Date(
-                                datePickerHeaderDate.getFullYear(),
-                                i,
-                                1
-                              ),
-                              "MMM"
-                            )}
+                            {dayjs(
+                              new Date(datePickerHeaderDate.getFullYear(), i, 1)
+                            ).format("MMM")}
                           </div>
                         ))}
                     </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9a3a54</samp>

Refactored date input component to use dayjs library instead of date-fns. This improves consistency and compatibility with other components that use dayjs. Modified `DateInputV2.tsx` and related files to use dayjs methods for date operations and display.

## Proposed Changes

- Fixes #6305?
- Replaced date-fns utility functions with dayjs functions in DateInputV2 component

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a9a3a54</samp>

* Replace date-fns library with dayjs library for date manipulation and formatting in `DateInputV2.tsx` component ([link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL2-L11))
* Update switch cases for handling left and right arrow clicks on the date picker to use dayjs methods for subtracting and adding months, years, and decades ([link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL68-R71), [link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL83-R86))
* Update functions for checking selected date and getting day count and blank days array to use dayjs methods for comparing and getting dates ([link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL96-R96), [link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL120-R120))
* Update div and p elements for displaying month and year on the date picker header and grid to use dayjs methods for formatting dates ([link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL299-R297), [link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL309-R307), [link](https://github.com/coronasafe/care_fe/pull/6405/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL388-R388))
