### PR TITLE
Vitals Monitor: Shows relative time for blood pressure and hide if stale (30 mins)

### DIFF
--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -8,6 +8,15 @@ import { classNames } from "../../Utils/utils";
 import { IVitalsComponentProps, VitalsValueBase } from "./types";
 import { triggerGoal } from "../../Integrations/Plausible";
 import useAuthUser from "../../Common/hooks/useAuthUser";
+import dayjs from "dayjs";
+
+const minutesAgo = (timestamp: string) => {
+  return `${dayjs().diff(dayjs(timestamp), "minute")}m ago`;
+};
+
+const isWithinMinutes = (timestamp: string, minutes: number) => {
+  return dayjs().diff(dayjs(timestamp), "minute") < minutes;
+};
 
 export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
   const { connect, waveformCanvas, data, isOnline } = useHL7VitalsMonitor(
@@ -29,6 +38,10 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
   useEffect(() => {
     connect(props.socketUrl);
   }, [props.socketUrl]);
+
+  const bpWithinMaxPersistence = !!(
+    data.bp?.["date-time"] && isWithinMinutes(data.bp?.["date-time"], 30)
+  );
 
   return (
     <div className="flex flex-col gap-1 rounded bg-[#020617] p-2">
@@ -97,24 +110,37 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
 
           {/* Blood Pressure */}
           <div className="flex flex-col p-1">
-            <div className="flex w-full gap-2 font-bold text-orange-500">
+            <div className="flex w-full justify-between gap-2 font-bold text-orange-500">
               <span className="text-sm">NIBP</span>
-              <span className="text-xs">{data.bp?.systolic.unit ?? "--"}</span>
+              <span className="text-xs">
+                {bpWithinMaxPersistence ? data.bp?.systolic.unit ?? "--" : "--"}
+              </span>
+              <span className="text-xs">
+                {data.bp?.["date-time"] && minutesAgo(data.bp?.["date-time"])}
+              </span>
             </div>
             <div className="flex w-full justify-center text-sm font-medium text-orange-500">
               Sys / Dia
             </div>
             <div className="flex w-full justify-center text-2xl font-black text-orange-300 md:text-4xl">
-              <span>{data.bp?.systolic.value ?? "--"}</span>
+              <span>
+                {bpWithinMaxPersistence
+                  ? data.bp?.systolic.value ?? "--"
+                  : "--"}
+              </span>
               <span>/</span>
-              <span>{data.bp?.diastolic.value ?? "--"}</span>
+              <span>
+                {bpWithinMaxPersistence
+                  ? data.bp?.diastolic.value ?? "--"
+                  : "--"}
+              </span>
             </div>
             <div className="flex items-end">
               <span className="flex-1 text-sm font-bold text-orange-500">
                 Mean
               </span>
               <span className="flex-1 text-xl font-bold text-gray-300">
-                {data.bp?.map.value ?? "--"}
+                {bpWithinMaxPersistence ? data.bp?.map.value ?? "--" : "--"}
               </span>
             </div>
           </div>

--- a/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
+++ b/src/Components/VitalsMonitor/HL7PatientVitalsMonitor.tsx
@@ -40,7 +40,7 @@ export default function HL7PatientVitalsMonitor(props: IVitalsComponentProps) {
   }, [props.socketUrl]);
 
   const bpWithinMaxPersistence = !!(
-    data.bp?.["date-time"] && isWithinMinutes(data.bp?.["date-time"], 30)
+    (data.bp?.["date-time"] && isWithinMinutes(data.bp?.["date-time"], 30)) // Max blood pressure persistence is 30 minutes
   );
 
   return (

--- a/src/Components/VitalsMonitor/types.ts
+++ b/src/Components/VitalsMonitor/types.ts
@@ -8,7 +8,7 @@ export interface VitalsDataBase {
   "patient-name": string;
 }
 
-export interface VitalsValueBase {
+export interface VitalsValueBase extends VitalsDataBase {
   value: number;
   unit: string;
   interpretation: string;

--- a/src/Components/VitalsMonitor/useHL7VitalsMonitor.ts
+++ b/src/Components/VitalsMonitor/useHL7VitalsMonitor.ts
@@ -8,11 +8,12 @@ import useCanvas from "../../Common/hooks/useCanvas";
 import {
   ChannelOptions,
   IVitalsComponentProps,
+  VitalsDataBase,
   VitalsValueBase as VitalsValue,
 } from "./types";
 import { getChannel, getVitalsCanvasSizeAndDuration } from "./utils";
 
-interface VitalsBPValue {
+interface VitalsBPValue extends VitalsDataBase {
   systolic: VitalsValue;
   diastolic: VitalsValue;
   map: VitalsValue;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a465cce</samp>

Added a feature to hide outdated blood pressure data in the `HL7PatientVitalsMonitor` component. This involved adding a `date-time` property to the vitals data interfaces and using the `dayjs` library to compare the timestamps. The affected files were `HL7PatientVitalsMonitor.tsx`, `types.ts`, and `useHL7VitalsMonitor.ts`.

## Proposed Changes

- Part of #6393

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/82b15407-506a-48b7-8720-f1016b27aa0d">



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a465cce</samp>

*  Add `date-time` property to vitals data interfaces to store and access the timestamp of the data ([link](https://github.com/coronasafe/care_fe/pull/6407/files?diff=unified&w=0#diff-feda63a5a3cad0832ad09097bb20ec4786cf119d37354f99be40a385ab506f61L11-R11), [link](https://github.com/coronasafe/care_fe/pull/6407/files?diff=unified&w=0#diff-01ca34fd32f0d2eae4cc9bd85e5897fe2794c872b6901d8321cd337b56845a13L11-R16))
* Import `dayjs` library and define helper functions to format and check the timestamp of the blood pressure data in `HL7PatientVitalsMonitor.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6407/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L11-R20))
* Conditionally render the blood pressure values, units, and timestamp based on whether the data is within 30 minutes of the current time using the `bpWithinMaxPersistence` variable ([link](https://github.com/coronasafe/care_fe/pull/6407/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8R42-R45), [link](https://github.com/coronasafe/care_fe/pull/6407/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L100-R120), [link](https://github.com/coronasafe/care_fe/pull/6407/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L108-R136), [link](https://github.com/coronasafe/care_fe/pull/6407/files?diff=unified&w=0#diff-d27bcfa41f9f44dbc974e1c9def92d0b6a2a699177dc915b731c4fd5ab4ed6d8L117-R143))
