### PR TITLE
Track camera feed views and display offline status

### DIFF
--- a/src/Common/hooks/useMSEplayer.ts
+++ b/src/Common/hooks/useMSEplayer.ts
@@ -208,6 +208,9 @@ export const useMSEMediaPlayer = ({
                 readPacket(event.data);
               }
             };
+            ws.onerror = function (event) {
+              onError && onError(event);
+            };
           },
           false
         );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1fc396</samp>

This pull request enhances the video stream feature in the `Feed` component and adds error handling for the WebSocket connection in the `useMSEMediaPlayer` hook. It improves the user experience, the analytics, and the reliability of the video stream.

Display offline status for broken feed
![image](https://github.com/coronasafe/care_fe/assets/3626859/af5f924a-ffe9-46b8-8c2b-46fb362ac6b5)

Capture the camera feed view stats for analytics.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c1fc396</samp>

*  Add error handler for WebSocket connection in `useMSEMediaPlayer` hook ([link](https://github.com/coronasafe/care_fe/pull/6408/files?diff=unified&w=0#diff-9c97aeeffdf95a04b24615b5a0842918a82f50040f9e09ca7ec69ceac2ea759bR211-R213))
*  Import and use `Spinner` component to show loading animation in `Feed` component ([link](https://github.com/coronasafe/care_fe/pull/6408/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R35), [link](https://github.com/coronasafe/care_fe/pull/6408/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L508-R531))
*  Add `statusReported` state to track and prevent duplicate reporting of stream status to analytics service in `Feed` component ([link](https://github.com/coronasafe/care_fe/pull/6408/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R61), [link](https://github.com/coronasafe/care_fe/pull/6408/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L235-R262))
*  Modify stream initialization and status update logic in `Feed` component to avoid loading flicker, report status with additional parameters, and handle reconnection attempts ([link](https://github.com/coronasafe/care_fe/pull/6408/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L235-R262))
