### PR TITLE
cypress fix: select non group ICD11 entity

### DIFF
--- a/cypress/pageobject/Patient/PatientConsultation.ts
+++ b/cypress/pageobject/Patient/PatientConsultation.ts
@@ -49,7 +49,7 @@ export class PatientConsultationPage {
       .click()
       .type("1A");
     cy.get("#icd11_diagnoses_object [role='option']")
-      .contains("1A03 Intestinal infections due to Escherichia coli")
+      .contains("1A00 Cholera")
       .scrollIntoView()
       .click();
     cy.get("label[for='icd11_diagnoses_object']").click();
@@ -57,7 +57,7 @@ export class PatientConsultationPage {
 
     cy.get("#icd11_principal_diagnosis [role='combobox']").click().type("1A");
     cy.get("#icd11_principal_diagnosis [role='option']")
-      .contains("1A03 Intestinal infections due to Escherichia coli")
+      .contains("1A00 Cholera")
       .click();
 
     cy.get("#consultation_notes").click().type(consulationNotes);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 452f580</samp>

Updated test cases for diagnosis feature in patient consultations. Changed the ICD-11 code used for testing to `1A00 Cholera` in `cypress/pageobject/Patient/PatientConsultation.ts`.

## Proposed Changes

- Fixes #6411 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 452f580</samp>

* Change the ICD-11 code for diagnosis in the test cases for patient consultation ([link](https://github.com/coronasafe/care_fe/pull/6412/files?diff=unified&w=0#diff-7fa643001511b285907c43213d442bb8b709ab276d7b050d4355e5f95cb38418L52-R52), [link](https://github.com/coronasafe/care_fe/pull/6412/files?diff=unified&w=0#diff-7fa643001511b285907c43213d442bb8b709ab276d7b050d4355e5f95cb38418L60-R60))
