### PR TITLE
Fix date range end picker

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -113,6 +113,7 @@ const DateInputV2: React.FC<Props> = ({
         )
       );
     close();
+    setIsOpen?.(false);
   };
 
   const getDayCount = (date: Date) => {
@@ -212,13 +213,7 @@ const DateInputV2: React.FC<Props> = ({
         <Popover className="relative">
           {({ open, close }) => (
             <div>
-              <Popover.Button
-                disabled={disabled}
-                className="w-full"
-                onClick={() => {
-                  setIsOpen?.(!isOpen);
-                }}
-              >
+              <Popover.Button disabled={disabled} className="w-full">
                 <input type="hidden" name="date" />
                 <input
                   id={id}
@@ -237,9 +232,6 @@ const DateInputV2: React.FC<Props> = ({
 
               {(open || isOpen) && (
                 <Popover.Panel
-                  onBlur={() => {
-                    setIsOpen?.(false);
-                  }}
                   static
                   className={classNames(
                     "cui-dropdown-base absolute mt-0.5 w-72 divide-y-0 p-4",


### PR DESCRIPTION
Fixes #6414

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3592a7</samp>

Simplify and improve `DateInputV2` component by using `Popover` and closing on date selection.

## Proposed Changes

![image](https://github.com/coronasafe/care_fe/assets/3626859/5c3bb3c2-34ad-4a7a-bab9-db1681257c4e)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3592a7</samp>

*  Close date picker popover on date selection ([link](https://github.com/coronasafe/care_fe/pull/6413/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bR116))
*  Remove unnecessary `onClick` and `onBlur` handlers from `Popover.Button` and input element ([link](https://github.com/coronasafe/care_fe/pull/6413/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL215-R216), [link](https://github.com/coronasafe/care_fe/pull/6413/files?diff=unified&w=0#diff-277f47613d077cedcaf477f502fdbe6f452f7da1410e81ac6741b61b255d8f7bL240-L242))
