### PR TITLE
Added cypress test to verify warranty expiry label on an asset

### DIFF
--- a/cypress/e2e/assets_spec/assets_manage.cy.ts
+++ b/cypress/e2e/assets_spec/assets_manage.cy.ts
@@ -32,7 +32,7 @@ describe("Asset", () => {
     cy.awaitUrl("/assets");
   });
 
-  it("Verify Asset Service History Alert", () => {
+  it("Verify Asset Warranty Expiry Label", () => {
     assetSearchPage.typeSearchKeyword(assetname);
     assetSearchPage.pressEnter();
     assetSearchPage.verifyBadgeContent(assetname);
@@ -52,11 +52,10 @@ describe("Asset", () => {
     assetPage.enterWarrantyExpiryDate(addDaysToDate(20)); // less than 1 month
     assetPage.clickassetupdatebutton();
     assetPage.verifyWarrantyExpiryLabel("1 month");
-    // assetPage.clickupdatedetailbutton(); // Can't check for expired warranty as it will fail since we can set only future dates for warranty expiry
-    // assetPage.scrollintoWarrantyDetails();
-    // assetPage.enterWarrantyExpiryDate(addDaysToDate(-10)); // expired
-    // assetPage.clickassetupdatebutton();
-    // assetPage.verifyWarrantyExpiryLabel("expired");
+    assetPage.clickupdatedetailbutton();
+    assetPage.scrollintoWarrantyDetails();
+    assetPage.enterWarrantyExpiryDate(addDaysToDate(100)); // check for greater than 3 months again to verify the label is removed
+    assetPage.clickassetupdatebutton();
   });
 
   it("Create & Edit a service history and verify reflection", () => {

--- a/cypress/e2e/assets_spec/assets_manage.cy.ts
+++ b/cypress/e2e/assets_spec/assets_manage.cy.ts
@@ -56,6 +56,7 @@ describe("Asset", () => {
     assetPage.scrollintoWarrantyDetails();
     assetPage.enterWarrantyExpiryDate(addDaysToDate(100)); // check for greater than 3 months again to verify the label is removed
     assetPage.clickassetupdatebutton();
+    assetPage.verifyWarrantyExpiryLabel("");
   });
 
   it("Create & Edit a service history and verify reflection", () => {

--- a/cypress/e2e/assets_spec/assets_manage.cy.ts
+++ b/cypress/e2e/assets_spec/assets_manage.cy.ts
@@ -5,6 +5,12 @@ import { AssetSearchPage } from "../../pageobject/Asset/AssetSearch";
 import FacilityPage from "../../pageobject/Facility/FacilityCreation";
 import { AssetFilters } from "../../pageobject/Asset/AssetFilters";
 
+function addDaysToDate(numberOfDays: number) {
+  const inputDate = new Date();
+  inputDate.setDate(inputDate.getDate() + numberOfDays);
+  return inputDate.toISOString().split("T")[0];
+}
+
 describe("Asset", () => {
   const assetPage = new AssetPage();
   const loginPage = new LoginPage();
@@ -24,6 +30,33 @@ describe("Asset", () => {
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.awaitUrl("/assets");
+  });
+
+  it("Verify Asset Service History Alert", () => {
+    assetSearchPage.typeSearchKeyword(assetname);
+    assetSearchPage.pressEnter();
+    assetSearchPage.verifyBadgeContent(assetname);
+    assetSearchPage.clickAssetByName(assetname);
+    assetPage.clickupdatedetailbutton();
+    assetPage.scrollintoWarrantyDetails();
+    assetPage.enterWarrantyExpiryDate(addDaysToDate(100)); // greater than 3 months
+    assetPage.clickassetupdatebutton();
+    assetPage.verifyWarrantyExpiryLabel("");
+    assetPage.clickupdatedetailbutton();
+    assetPage.scrollintoWarrantyDetails();
+    assetPage.enterWarrantyExpiryDate(addDaysToDate(80)); // less than 3 months
+    assetPage.clickassetupdatebutton();
+    assetPage.verifyWarrantyExpiryLabel("3 months");
+    assetPage.clickupdatedetailbutton();
+    assetPage.scrollintoWarrantyDetails();
+    assetPage.enterWarrantyExpiryDate(addDaysToDate(20)); // less than 1 month
+    assetPage.clickassetupdatebutton();
+    assetPage.verifyWarrantyExpiryLabel("1 month");
+    // assetPage.clickupdatedetailbutton(); // Can't check for expired warranty as it will fail since we can set only future dates for warranty expiry
+    // assetPage.scrollintoWarrantyDetails();
+    // assetPage.enterWarrantyExpiryDate(addDaysToDate(-10)); // expired
+    // assetPage.clickassetupdatebutton();
+    // assetPage.verifyWarrantyExpiryLabel("expired");
   });
 
   it("Create & Edit a service history and verify reflection", () => {

--- a/cypress/pageobject/Asset/AssetCreation.ts
+++ b/cypress/pageobject/Asset/AssetCreation.ts
@@ -285,14 +285,37 @@ export class AssetPage {
     cy.get("#notes").scrollIntoView();
   }
 
-  enterAssetNotes(text) {
+  enterAssetNotes(text: string) {
     cy.get("#notes").click().clear();
     cy.get("#notes").click().type(text);
   }
 
-  enterAssetservicedate(text) {
+  enterAssetservicedate(text: string) {
     cy.get("input[name='last_serviced_on']").click();
     cy.get("#date-input").click().type(text);
+  }
+
+  scrollintoWarrantyDetails() {
+    cy.get("#warranty-details").scrollIntoView();
+  }
+
+  enterWarrantyExpiryDate(text: string) {
+    cy.get("#WarrantyAMCExpiry").click();
+    cy.get("#WarrantyAMCExpiry").click().type(text);
+  }
+
+  verifyWarrantyExpiryLabel(duration: string) {
+    if (duration === "") {
+      cy.get("#warranty-amc-expired-red").should("not.exist");
+      cy.get("#warranty-amc-expiring-soon-orange").should("not.exist");
+      cy.get("#warranty-amc-expiring-soon-yellow").should("not.exist");
+    } else if (duration === "expired") {
+      cy.get("#warranty-amc-expired-red").should("be.visible");
+    } else if (duration === "1 month") {
+      cy.get("#warranty-amc-expiring-soon-orange").should("be.visible");
+    } else if (duration === "3 months") {
+      cy.get("#warranty-amc-expiring-soon-yellow").should("be.visible");
+    }
   }
 
   clickassetupdatebutton() {

--- a/src/CAREUI/display/Chip.tsx
+++ b/src/CAREUI/display/Chip.tsx
@@ -11,6 +11,7 @@ interface Props {
   text: string;
   tooltip?: string;
   className?: string;
+  id?: string;
 }
 
 export default function Chip({
@@ -21,6 +22,7 @@ export default function Chip({
 }: Props) {
   return (
     <span
+      id={props?.id}
       className={classNames(
         "inline-flex items-center gap-2 font-medium leading-4",
 

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -516,6 +516,7 @@ export const warrantyAmcValidityChip = (
   if (warrantyAmcEndDate < today) {
     return (
       <Chip
+        id="warranty-amc-expired-red"
         variant="danger"
         startIcon="l-times-circle"
         text="AMC/Warranty Expired"
@@ -524,6 +525,7 @@ export const warrantyAmcValidityChip = (
   } else if (days <= 30) {
     return (
       <Chip
+        id="warranty-amc-expiring-soon-orange"
         variant="custom"
         className="border-orange-300 bg-orange-100 text-orange-900"
         startIcon="l-exclamation-circle"
@@ -533,6 +535,7 @@ export const warrantyAmcValidityChip = (
   } else if (days <= 90) {
     return (
       <Chip
+        id="warranty-amc-expiring-soon-yellow"
         variant="warning"
         startIcon="l-exclamation-triangle"
         text="AMC/Warranty Expiring Soon"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6b8259</samp>

Added a new test case and helper methods to verify the asset service history alert feature based on the warranty expiry date. Modified the `Chip` and `AssetsList` components to add ids for testing. Added type annotations to some methods in the `AssetPage` class.

## Proposed Changes

- Fixes #6422

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6b8259</samp>

*  Add a new test case to verify the asset service history alert feature ([link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-db4292fd03626d0a4e5a0e899dbceffb54fab4da3fd02e455598e6627248e746R35-R61))
  - Use a helper function to generate different warranty expiry dates ([link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-db4292fd03626d0a4e5a0e899dbceffb54fab4da3fd02e455598e6627248e746R8-R13))
  - Use a page object class to enter the warranty expiry dates and scroll to the warranty details section ([link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-af0a7140a23fb3b1c3379fe2880ce31bab589501929f22c83d2b253753971707L288-R320))
  - Use a component file to assign unique ids to the chip components that display the alert labels ([link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-ed230d036a5f0e362a8c5bffca9945fbb3c89c672e5a990512837768dec6b258R14), [link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-ed230d036a5f0e362a8c5bffca9945fbb3c89c672e5a990512837768dec6b258R25), [link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R519), [link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R528), [link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R538))
  - Use a helper function to verify the alert labels based on the warranty expiry dates ([link](https://github.com/coronasafe/care_fe/pull/6428/files?diff=unified&w=0#diff-db4292fd03626d0a4e5a0e899dbceffb54fab4da3fd02e455598e6627248e746R35-R61))
