### PR TITLE
Set page title to medicine

### DIFF
--- a/src/Components/Facility/ConsultationDetails/ConsultationMedicinesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationMedicinesTab.tsx
@@ -1,9 +1,12 @@
 import { ConsultationTabProps } from "./index";
 import PrescriptionAdministrationsTable from "../../Medicine/PrescriptionAdministrationsTable";
+import PageTitle from "../../Common/PageHeadTitle";
 
 export const ConsultationMedicinesTab = (props: ConsultationTabProps) => {
   return (
     <div className="my-4 flex flex-col gap-16">
+      {/* eslint-disable-next-line i18next/no-literal-string */}
+      <PageTitle title="Medicines" />
       <PrescriptionAdministrationsTable
         consultation_id={props.consultationId}
         readonly={!!props.consultationData.discharge_date}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1df29bf</samp>

Added `PageTitle` component to `ConsultationMedicinesTab` component to show the tab name. This improves the UI and UX of the consultation details page.

## Proposed Changes

- Fixes #6425 
- Add PageTitle component which sets the browser title
- The title is set to Medicine

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1df29bf</samp>

*  Add a title component to the consultation medicines tab ([link](https://github.com/coronasafe/care_fe/pull/6431/files?diff=unified&w=0#diff-7e2d81fb339fd5a24de7c07f5ec063c2404d191885c1d078a05017c0769cf5c5L3-R9))
