### PR TITLE
fixes nutrition tab showing nursing analysis

### DIFF
--- a/src/Components/Facility/ConsultationDetails/ConsultationNutritionTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationNutritionTab.tsx
@@ -4,7 +4,7 @@ import { NutritionPlots } from "../Consultations/NutritionPlots";
 
 const PageTitle = lazy(() => import("../../Common/PageTitle"));
 
-export const ConsultationNeutritionTab = (props: ConsultationTabProps) => {
+export const ConsultationNutritionTab = (props: ConsultationTabProps) => {
   return (
     <div>
       <PageTitle title="Nutrition" hideBack={true} breadcrumbs={false} />

--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -41,6 +41,7 @@ import { ConsultationVentilatorTab } from "./ConsultationVentilatorTab";
 import { ConsultationPressureSoreTab } from "./ConsultationPressureSoreTab";
 import { ConsultationDialysisTab } from "./ConsultationDialysisTab";
 import { ConsultationNeurologicalMonitoringTab } from "./ConsultationNeurologicalMonitoringTab";
+import { ConsultationNutritionTab } from "./ConsultationNutritionTab";
 
 const Loading = lazy(() => import("../../Common/Loading"));
 const PageTitle = lazy(() => import("../../Common/PageTitle"));
@@ -65,7 +66,7 @@ const TABS = {
   NURSING: ConsultationNursingTab,
   NEUROLOGICAL_MONITORING: ConsultationNeurologicalMonitoringTab,
   VENTILATOR: ConsultationVentilatorTab,
-  NUTRITION: ConsultationNursingTab,
+  NUTRITION: ConsultationNutritionTab,
   PRESSURE_SORE: ConsultationPressureSoreTab,
   DIALYSIS: ConsultationDialysisTab,
 };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cdeaa39</samp>

Added a nutrition tab to the consultation details page to display the nutrition support and advice for the patients. Fixed a spelling error in the component name `ConsultationNutritionTab`.

## Proposed Changes

- Fixes #6436 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cdeaa39</samp>

* Fix spelling error and rename component from `ConsultationNeutritionTab` to `ConsultationNutritionTab` ([link](https://github.com/coronasafe/care_fe/pull/6437/files?diff=unified&w=0#diff-ad8aaf6ddb9524594cd153c102668cfdbd1f72cc52037c69133304c88fc6d314L7-R7))
* Import renamed component in parent component index file ([link](https://github.com/coronasafe/care_fe/pull/6437/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R44))
* Replace `ConsultationNursingTab` with `ConsultationNutritionTab` for the nutrition tab in the consultation details page ([link](https://github.com/coronasafe/care_fe/pull/6437/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901L68-R69))
