### PR TITLE
Consultation Form: Capture Date & Time of Admisison

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1145,17 +1145,24 @@ export const ConsultationForm = (props: any) => {
                         className="col-span-6"
                         ref={fieldRef["admission_date"]}
                       >
-                        <DateFormField
-                          {...field("admission_date")}
-                          required
-                          disableFuture
-                          label={
-                            state.form.suggestion === "A"
-                              ? "Date of Admission"
-                              : "Domiciliary Care Start Date"
-                          }
-                          position="LEFT"
-                        />
+                        {state.form.suggestion === "DC" && (
+                          <DateFormField
+                            {...field("admission_date")}
+                            required
+                            disableFuture
+                            label="Domiciliary Care Start Date"
+                            position="LEFT"
+                          />
+                        )}
+                        {state.form.suggestion === "A" && (
+                          <TextFormField
+                            {...field("admission_date")}
+                            required
+                            label="Date & Time Admission"
+                            type="datetime-local"
+                            max={dayjs().format("YYYY-MM-DDTHH:mm")}
+                          />
+                        )}
                       </div>
 
                       {!isUpdate && (

--- a/src/Components/Facility/TreatmentSummary.tsx
+++ b/src/Components/Facility/TreatmentSummary.tsx
@@ -139,7 +139,7 @@ const TreatmentSummary = (props: any) => {
                   <b>Date of admission :</b>
                   <span>
                     {consultationData.admitted
-                      ? formatDate(consultationData.admission_date)
+                      ? formatDateTime(consultationData.admission_date)
                       : " --/--/----"}
                   </span>
                 </div>

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -239,7 +239,7 @@ export default function PatientInfoCard(props: {
                       )?.text
                     }{" "}
                     on{" "}
-                    {formatDate(
+                    {formatDateTime(
                       ["A", "DC"].includes(consultation?.suggestion ?? "")
                         ? consultation?.admission_date
                         : consultation?.created_date

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -78,8 +78,20 @@ const DATE_TIME_FORMAT = `${TIME_FORMAT}; ${DATE_FORMAT}`;
 
 type DateLike = Parameters<typeof dayjs>[0];
 
-export const formatDateTime = (date: DateLike, format = DATE_TIME_FORMAT) =>
-  dayjs(date).format(format);
+export const formatDateTime = (date: DateLike, format?: string) => {
+  const obj = dayjs(date);
+
+  if (format) {
+    return obj.format(format);
+  }
+
+  // formatDate if hours, minutes and seconds are 0
+  if (obj.hour() === 0 && obj.minute() === 0 && obj.second() === 0) {
+    return obj.format(DATE_FORMAT);
+  }
+
+  return obj.format(DATE_TIME_FORMAT);
+};
 
 export const formatDate = (date: DateLike, format = DATE_FORMAT) =>
   formatDateTime(date, format);

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -85,8 +85,9 @@ export const formatDateTime = (date: DateLike, format?: string) => {
     return obj.format(format);
   }
 
-  // formatDate if hours, minutes and seconds are 0
-  if (obj.hour() === 0 && obj.minute() === 0 && obj.second() === 0) {
+  // formatDate if hours, minutes and seconds are 0 (after timezone correction)
+  const utc = obj.subtract(obj.utcOffset(), "minute");
+  if (utc.hour() === 0 && utc.minute() === 0 && utc.second() === 0) {
     return obj.format(DATE_FORMAT);
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c361bd</samp>

This pull request modifies the `ConsultationForm`, `TreatmentSummary`, and `PatientInfoCard` components to show the time of admission for patients who are admitted to a facility, as well as the `formatDateTime` function in `utils.ts` to handle different date formats. This is done to address issue #1729, which requests more accurate admission date information.

## Required Backends
- https://github.com/coronasafe/care/pull/1672

## Proposed Changes

- Part 1 of #6280

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c361bd</samp>

*  Modify `ConsultationForm` component to render different input fields for `admission_date` based on `suggestion` value ([link](https://github.com/coronasafe/care_fe/pull/6444/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL1148-R1165))
*  Use `formatDateTime` function to display `admission_date` value in `TreatmentSummary` and `PatientInfoCard` components ([link](https://github.com/coronasafe/care_fe/pull/6444/files?diff=unified&w=0#diff-ac9463aa3ab35a08c12bb0f4159e678378fd1bc43d37e9ce6a475437dbf63cebL142-R142), [link](https://github.com/coronasafe/care_fe/pull/6444/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L242-R242))
*  Add optional `format` parameter and zero-time check to `formatDateTime` function in `utils.ts` file ([link](https://github.com/coronasafe/care_fe/pull/6444/files?diff=unified&w=0#diff-5903b23c9778624d9c178b9779024a4265e5fc365714fed34d49225ee6b8dc73L81-R96))
