### PR TITLE
Replaced export button Icon with relevant Export Icon

### DIFF
--- a/src/Components/Common/Export.tsx
+++ b/src/Components/Common/Export.tsx
@@ -44,7 +44,7 @@ export const ExportMenu = ({
       <DropdownMenu
         disabled={isExporting || disabled}
         title={isExporting ? "Exporting..." : label}
-        icon={<CareIcon className="care-l-import" />}
+        icon={<CareIcon className="care-l-export" />}
         className="tooltip border-primary-500 bg-white text-primary-500 hover:bg-primary-100 enabled:border"
       >
         {exportItems.map((item) => (

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -815,7 +815,7 @@ export const PatientManager = () => {
                   }}
                   className="mr-5 w-full lg:w-fit"
                 >
-                  <CareIcon className="care-l-import" />
+                  <CareIcon className="care-l-export" />
                   <span className="lg:my-[3px]">Export</span>
                 </ButtonV2>
               ) : (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8cf4da</samp>

Changed the icons for the export menu and button from import to export icons in `Export.tsx` and `ManagePatients.tsx`. This improves the user interface and avoids confusion.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6438

### **Before change***

![Screenshot 2023-10-15 203207](https://github.com/coronasafe/care_fe/assets/106866225/630f55bf-9f7c-4c96-ae3b-28101e7ea2f5)

### **After change***

![Screenshot 2023-10-15 203312](https://github.com/coronasafe/care_fe/assets/106866225/1728156d-4991-41fd-b235-34865b19001d)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8cf4da</samp>

* Change the export menu and button icons from `care-l-import` to `care-l-export` to match the functionality and label of the menu and button ([link](https://github.com/coronasafe/care_fe/pull/6451/files?diff=unified&w=0#diff-376ad6d16f7f4cef25791aafc63205b7dda4e3d85102c6b23e4f6fd88d731d56L47-R47), [link](https://github.com/coronasafe/care_fe/pull/6451/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L818-R818))
