### PR TITLE
Make Administer Medicine responsive view

### DIFF
--- a/src/CAREUI/display/RecordMeta.tsx
+++ b/src/CAREUI/display/RecordMeta.tsx
@@ -48,7 +48,7 @@ const RecordMeta = ({ time, user, prefix, className, inlineUser }: Props) => {
         {user && inlineUser && <span>by</span>}
         {user && <CareIcon className="care-l-user" />}
         {user && inlineUser && (
-          <span className="font-medium">
+          <span className="whitespace-nowrap font-medium">
             {user.first_name} {user.last_name}
           </span>
         )}

--- a/src/Components/Medicine/AdministerMedicine.tsx
+++ b/src/Components/Medicine/AdministerMedicine.tsx
@@ -87,7 +87,7 @@ export default function AdministerMedicine({ prescription, ...props }: Props) {
           <div className="flex flex-col gap-2 lg:max-w-min">
             <CheckBoxFormField
               label="Administer for a time in the past"
-              labelClassName="whitespace-nowrap"
+              labelClassName="md:whitespace-nowrap"
               name="is_custom_time"
               value={isCustomTime}
               onChange={({ value }) => {

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -88,11 +88,18 @@ export default function PrescriptionDetailCard({
           <Detail className="col-span-5" label={t("medicine")}>
             {prescription.medicine_object?.name ?? prescription.medicine_old}
           </Detail>
-          <Detail className="col-span-5 md:col-span-2" label={t("route")}>
+          <Detail
+            className="col-span-5 overflow-hidden md:col-span-2"
+            label={t("route")}
+          >
             {prescription.route &&
               t("PRESCRIPTION_ROUTE_" + prescription.route)}
           </Detail>
-          <Detail className="col-span-4 md:col-span-2" label={t("dosage")}>
+
+          <Detail
+            className="col-span-4 overflow-hidden md:col-span-2"
+            label={t("dosage")}
+          >
             {prescription.dosage}
           </Detail>
 
@@ -120,7 +127,7 @@ export default function PrescriptionDetailCard({
           ) : (
             <>
               <Detail
-                className="col-span-4 md:col-span-2"
+                className="col-span-4 overflow-hidden md:col-span-2"
                 label={t("frequency")}
               >
                 {prescription.frequency &&
@@ -129,7 +136,10 @@ export default function PrescriptionDetailCard({
                       prescription.frequency.toUpperCase()
                   )}
               </Detail>
-              <Detail className="col-span-4 md:col-span-2" label={t("days")}>
+              <Detail
+                className="col-span-4 overflow-hidden md:col-span-2"
+                label={t("days")}
+              >
                 {prescription.days}
               </Detail>
             </>

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -84,8 +84,8 @@ export default function PrescriptionDetailCard({
           </div>
         </div>
 
-        <div className="mt-4 grid grid-cols-9 items-center gap-2">
-          <Detail className="col-span-9 md:col-span-5" label={t("medicine")}>
+        <div className="mt-4 grid grid-cols-2 items-center gap-2">
+          <Detail className="col-span-5" label={t("medicine")}>
             {prescription.medicine_object?.name ?? prescription.medicine_old}
           </Detail>
           <Detail className="col-span-5 md:col-span-2" label={t("route")}>
@@ -99,7 +99,7 @@ export default function PrescriptionDetailCard({
           {prescription.is_prn ? (
             <>
               <Detail
-                className="col-span-9 md:col-span-5"
+                className="col-span-4 md:col-span-2"
                 label={t("indicator")}
               >
                 {prescription.indicator}
@@ -111,7 +111,7 @@ export default function PrescriptionDetailCard({
                 {prescription.max_dosage}
               </Detail>
               <Detail
-                className="col-span-5 md:col-span-2"
+                className="col-span-4 md:col-span-2"
                 label={t("min_time_bw_doses")}
               >
                 {prescription.max_dosage}
@@ -119,28 +119,31 @@ export default function PrescriptionDetailCard({
             </>
           ) : (
             <>
-              <Detail className="col-span-5" label={t("frequency")}>
+              <Detail
+                className="col-span-4 md:col-span-2"
+                label={t("frequency")}
+              >
                 {prescription.frequency &&
                   t(
                     "PRESCRIPTION_FREQUENCY_" +
                       prescription.frequency.toUpperCase()
                   )}
               </Detail>
-              <Detail className="col-span-4" label={t("days")}>
+              <Detail className="col-span-4 md:col-span-2" label={t("days")}>
                 {prescription.days}
               </Detail>
             </>
           )}
 
           {prescription.notes && (
-            <Detail className="col-span-9" label={t("notes")}>
+            <Detail className="col-span-5" label={t("notes")}>
               <ReadMore text={prescription.notes} minChars={120} />
             </Detail>
           )}
 
           {prescription.discontinued && (
             <Detail
-              className="col-span-9"
+              className="col-span-2"
               label={t("reason_for_discontinuation")}
             >
               {prescription.discontinued_reason}

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -88,18 +88,13 @@ export default function PrescriptionDetailCard({
           <Detail className="col-span-5" label={t("medicine")}>
             {prescription.medicine_object?.name ?? prescription.medicine_old}
           </Detail>
-          <Detail
-            className="col-span-5 overflow-hidden md:col-span-2"
-            label={t("route")}
-          >
+
+          <Detail className="col-span-5" label={t("route")}>
             {prescription.route &&
               t("PRESCRIPTION_ROUTE_" + prescription.route)}
           </Detail>
 
-          <Detail
-            className="col-span-4 overflow-hidden md:col-span-2"
-            label={t("dosage")}
-          >
+          <Detail className="col-span-5" label={t("dosage")}>
             {prescription.dosage}
           </Detail>
 
@@ -127,7 +122,7 @@ export default function PrescriptionDetailCard({
           ) : (
             <>
               <Detail
-                className="col-span-4 overflow-hidden md:col-span-2"
+                className="col-span-5 overflow-hidden"
                 label={t("frequency")}
               >
                 {prescription.frequency &&
@@ -136,10 +131,7 @@ export default function PrescriptionDetailCard({
                       prescription.frequency.toUpperCase()
                   )}
               </Detail>
-              <Detail
-                className="col-span-4 overflow-hidden md:col-span-2"
-                label={t("days")}
-              >
+              <Detail className="col-span-5 overflow-hidden" label={t("days")}>
                 {prescription.days}
               </Detail>
             </>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 907d053</samp>

This pull request improves the responsiveness and layout of various components related to medicine and prescription details. It adjusts the grid columns, whitespace, and wrapping of text elements in `PrescriptionDetailCard.tsx`, `RecordMeta.tsx`, and `AdministerMedicine.tsx`.

## Proposed Changes

- Fixes #6459 
http://127.0.0.1:4000/facility/657c32be-d584-476c-9ce2-0412f0e7692e/patient/80e47d10-9ed8-4193-ade6-d69aa45999e9/consultation/b81e5e1f-fd11-4b38-aa51-14bea5583c76/medicines
Removed `nowrap` for modal text and changed the col-span to fit both mobile and desktop view

![image](https://github.com/coronasafe/care_fe/assets/70687348/1906a537-3ee6-43c1-bf8c-cf0764543dd5)

![image](https://github.com/coronasafe/care_fe/assets/70687348/3b3b9d96-d733-48df-a3e2-c96c1b62011a)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 907d053</samp>

*  Prevent user name from wrapping in record meta by adding `whitespace-nowrap` class to span element ([link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-f0d2ab732677f4577c5beaba451e232beca423da2365428db6644c199008447cL51-R51))
*  Make label text responsive in administer medicine form by adding `md:` prefix to `whitespace-nowrap` class in `CheckBoxFormField` component ([link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-0cff6f571c166a4b174e2180d36c81d41819d2d57cb32bef474c1718d0c70519L90-R90))
*  Make prescription details more compact and consistent in `PrescriptionDetailCard` component by modifying grid layout classes in `Detail` components ([link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L87-R88), [link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L102-R102), [link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L114-R114), [link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L122-R125), [link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L129-R132), [link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L136-R139), [link](https://github.com/coronasafe/care_fe/pull/6460/files?diff=unified&w=0#diff-5c00daca7231dea096a64831937270460d419a332ecf820075ad74c4c69e61d5L143-R146))
