### PR TITLE
Fix CSS unintentended RTL style

### DIFF
--- a/src/Components/Facility/Consultations/NeurologicalTables.tsx
+++ b/src/Components/Facility/Consultations/NeurologicalTables.tsx
@@ -28,10 +28,7 @@ const DataTable = (props: any) => {
             Right
           </div>
         </div>
-        <div
-          style={{ direction: "rtl" }}
-          className="flex flex-row overflow-x-auto"
-        >
+        <div className="flex flex-row overflow-x-auto">
           {data.map((x: any, i: any) => {
             return (
               <div
@@ -297,10 +294,7 @@ export const NeurologicalTable = (props: any) => {
       <div className="mb-6">
         <div className="text-xl font-semibold">Level Of Consciousness</div>
         <div className="w-max-content my-4 flex max-w-full flex-row divide-y divide-gray-200 overflow-hidden shadow sm:rounded-lg">
-          <div
-            style={{ direction: "rtl" }}
-            className="flex flex-row overflow-x-auto"
-          >
+          <div className="flex flex-row overflow-x-auto">
             {locData.map((x: any, i: any) => (
               <div
                 key={`loc_${i}`}
@@ -376,10 +370,7 @@ export const NeurologicalTable = (props: any) => {
                 Total
               </div>
             </div>
-            <div
-              style={{ direction: "rtl" }}
-              className="flex flex-row overflow-x-auto"
-            >
+            <div className="flex flex-row overflow-x-auto">
               {glasgowData.map((x: any, i: any) => {
                 return (
                   <div


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00a3b90</samp>

Fixed data table alignment and scrolling issues on RTL languages by removing unnecessary `style` attributes from `NeurologicalTables.tsx`.

## Proposed Changes

- Fixes RTL CSS style (cc: @nihal467 )

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00a3b90</samp>

*  Removed `style={{ direction: "rtl" }}` attribute from `div` elements that contain data tables in `NeurologicalTables.tsx` to fix alignment and scrolling issues on RTL languages ([link](https://github.com/coronasafe/care_fe/pull/6465/files?diff=unified&w=0#diff-3f2dc697ea8b52c1b3b887c76623edb0a4e6ace175573dfbd3a7476ffee979a9L31-R31), [link](https://github.com/coronasafe/care_fe/pull/6465/files?diff=unified&w=0#diff-3f2dc697ea8b52c1b3b887c76623edb0a4e6ace175573dfbd3a7476ffee979a9L300-R297), [link](https://github.com/coronasafe/care_fe/pull/6465/files?diff=unified&w=0#diff-3f2dc697ea8b52c1b3b887c76623edb0a4e6ace175573dfbd3a7476ffee979a9L379-R373))
