### PR TITLE
Fixes JWT token refresh interval default fallback to 5 mins (instead of 15 mins)

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -5,12 +5,12 @@
     "site_url": "care.coronasafe.in",
     "analytics_server_url": "https://plausible.10bedicu.in",
     "header_logo": {
-        "light":"https://cdn.coronasafe.network/header_logo.png",
-        "dark":"https://cdn.coronasafe.network/header_logo.png"
+        "light": "https://cdn.coronasafe.network/header_logo.png",
+        "dark": "https://cdn.coronasafe.network/header_logo.png"
     },
     "main_logo": {
-        "light":"https://cdn.coronasafe.network/light-logo.svg",
-        "dark":"https://cdn.coronasafe.network/black-logo.svg"
+        "light": "https://cdn.coronasafe.network/light-logo.svg",
+        "dark": "https://cdn.coronasafe.network/black-logo.svg"
     },
     "gmaps_api_key": "AIzaSyDsBAc3y7deI5ZO3NtK5GuzKwtUzQNJNUk",
     "gov_data_api_key": "579b464db66ec23bdd000001cdd3946e44ce4aad7209ff7b23ac571b",
@@ -22,6 +22,5 @@
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",
     "sample_format_asset_import": "https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=11JaEhNHdyCHth4YQs_44YaRlP77Rrqe81VSEfg1glko&exportFormat=xlsx",
     "sample_format_external_result_import": "https://docs.google.com/spreadsheets/d/17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE/export?format=csv&id=17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE",
-    "enable_abdm": true,
-    "jwt_token_refresh_interval": 300000
+    "enable_abdm": true
 }

--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -28,7 +28,7 @@ export default function AuthUserProvider({ children, unauthorized }: Props) {
     updateRefreshToken(true);
     setInterval(
       () => updateRefreshToken(),
-      jwt_token_refresh_interval ?? 5 * 60 * 3000
+      jwt_token_refresh_interval ?? 5 * 60 * 1000
     );
   }, [data, jwt_token_refresh_interval]);
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d54ce49</samp>

Reduced the JWT token refresh interval to prevent authentication errors. Changed the `setInterval` function in `src/Providers/AuthUserProvider.tsx` to use a variable or a default value of 5 minutes.

## Proposed Changes

- Fixes JWT token refresh interval default fallback to 5 mins (instead of 15 mins)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d54ce49</samp>

* Reduce the interval for refreshing the JWT token to 5 minutes or the value of `jwt_token_refresh_interval` ([link](https://github.com/coronasafe/care_fe/pull/6466/files?diff=unified&w=0#diff-00d942293097c16fe81554bec1730431967475b745ba22d430568701d8241023L31-R31)). This prevents the token from expiring and causing authentication errors.
