### PR TITLE
Fix session expiry detection

### DIFF
--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -98,8 +98,8 @@ export const fireRequest = (
       if (access_token) {
         config.headers["Authorization"] = "Bearer " + access_token;
       } else {
-        // We do not have access token, so we need to redirect to session expired page
-        window.location.href = "/session-expired";
+        // The access token is missing from the local storage. Redirect to login page.
+        window.location.href = "/";
         return;
       }
     }

--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -93,11 +93,15 @@ export const fireRequest = (
     const config: any = {
       headers: {},
     };
-    if (!request.noAuth && localStorage.getItem(LocalStorageKeys.accessToken)) {
-      config.headers["Authorization"] =
-        "Bearer " + localStorage.getItem(LocalStorageKeys.accessToken);
-    } else {
-      // TODO: get access token
+    if (!request.noAuth) {
+      const access_token = localStorage.getItem(LocalStorageKeys.accessToken);
+      if (access_token) {
+        config.headers["Authorization"] = "Bearer " + access_token;
+      } else {
+        // We do not have access token, so we need to redirect to session expired page
+        window.location.href = "/session-expired";
+        return;
+      }
     }
     const axiosApiCall: any = axios.create(config);
 

--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -65,7 +65,12 @@ export default function AppRouter() {
 
   useEffect(() => {
     addEventListener("storage", (event: any) => {
-      if (event.key === LocalStorageKeys.accessToken && !event.newValue) {
+      if (
+        [LocalStorageKeys.accessToken, LocalStorageKeys.refreshToken].includes(
+          event.key
+        ) &&
+        !event.newValue
+      ) {
         handleSignOut(true);
       }
     });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c30cab</samp>

Added a check for access token before API calls in `fireRequest.tsx`. Redirected users to a session expired page if the token is missing.

## Proposed Changes

- Fixes #6471
![image](https://github.com/coronasafe/care_fe/assets/3626859/77fa7ed7-7154-4fa1-a432-9eb129b95e30)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c30cab</samp>

*  Add a check for the access token in the local storage before setting the authorization header for the API call ([link](https://github.com/coronasafe/care_fe/pull/6472/files?diff=unified&w=0#diff-e2c5c73d556d02503d5adc253828ddf5bad94f6fb9fba25df333d5ca6b9b5c56L96-R104))
