### PR TITLE
Fix: Asset tab facility and location badges are malfunctioning

### DIFF
--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -46,14 +46,6 @@ function AssetFilter(props: any) {
     prefetch: !!facilityId,
   });
 
-  useQuery(routes.getFacilityAssetLocation, {
-    pathParams: {
-      facility_external_id: String(facilityId),
-      external_id: String(locationId),
-    },
-    prefetch: !!(facilityId && locationId),
-  });
-
   useEffect(() => {
     setFacilityId(facility?.id ? `${facility?.id}` : "");
     setLocationId(

--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -3,7 +3,7 @@ import { navigate, useQueryParams } from "raviger";
 import { FacilitySelect } from "../Common/FacilitySelect";
 import { FacilityModel } from "../Facility/models";
 import { LocationSelect } from "../Common/LocationSelect";
-import { AssetClass, AssetLocationObject } from "./AssetTypes";
+import { AssetClass } from "./AssetTypes";
 import { FieldLabel } from "../Form/FormFields/FormField";
 import { SelectFormField } from "../Form/FormFields/SelectFormField";
 import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
@@ -15,24 +15,12 @@ import { FieldChangeEvent } from "../Form/FormFields/Utils";
 import { DateRange } from "../Common/DateRangeInputV2";
 import { dateQueryString } from "../../Utils/utils";
 
-const initialLocation = {
-  id: "",
-  name: "",
-  description: "",
-  facility: {
-    id: "",
-    name: "",
-  },
-};
-
 const getDate = (value: any) =>
   value && dayjs(value).isValid() && dayjs(value).toDate();
 
 function AssetFilter(props: any) {
   const { filter, onChange, closeFilter } = props;
   const [facility, setFacility] = useState<FacilityModel>({ name: "" });
-  const [location, setLocation] =
-    useState<AssetLocationObject>(initialLocation);
   const [asset_type, setAssetType] = useState<string>(
     filter.asset_type ? filter.asset_type : ""
   );
@@ -60,13 +48,8 @@ function AssetFilter(props: any) {
 
   useQuery(routes.getFacilityAssetLocation, {
     pathParams: {
-      facilityId: String(facilityId),
-      locationId: String(locationId),
-    },
-    onResponse: ({ res, data }) => {
-      if (res?.status === 200 && data) {
-        setLocation(data);
-      }
+      facility_external_id: String(facilityId),
+      external_id: String(locationId),
     },
     prefetch: !!(facilityId && locationId),
   });
@@ -76,10 +59,9 @@ function AssetFilter(props: any) {
     setLocationId(
       facility?.id === qParams.facility ? qParams.location ?? "" : ""
     );
-  }, [facility, location]);
+  }, [facility.id, qParams.facility, qParams.location]);
 
   const clearFilter = useCallback(() => {
-    setLocation(initialLocation);
     setFacility({ name: "" });
     setAssetType("");
     setAssetStatus("");
@@ -98,7 +80,7 @@ function AssetFilter(props: any) {
       asset_type: asset_type ?? "",
       asset_class: asset_class ?? "",
       status: asset_status ?? "",
-      location: locationId,
+      location: locationId ?? "",
       warranty_amc_end_of_validity_before: dateQueryString(
         warrantyExpiry.before
       ),

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -46,8 +46,6 @@ const AssetsList = () => {
   const [facility, setFacility] = useState<FacilityModel>();
   const [asset_type, setAssetType] = useState<string>();
   const [status, setStatus] = useState<string>();
-  const [facilityName, setFacilityName] = useState<string>();
-  const [facility_location, setLocation] = useState("");
   const [asset_class, setAssetClass] = useState<string>();
   const [importAssetModalOpen, setImportAssetModalOpen] = useState(false);
   const assetsExist = assets.length > 0 && Object.keys(assets[0]).length > 0;
@@ -77,21 +75,16 @@ const AssetsList = () => {
     },
   });
 
-  useQuery(routes.getAnyFacility, {
+  const { data: facilityObject } = useQuery(routes.getAnyFacility, {
     pathParams: { id: qParams.facility },
     onResponse: ({ res, data }) => {
       if (res?.status === 200 && data) {
         setFacility(data);
         setSelectedFacility(data);
-        setFacilityName(data.name);
       }
     },
     prefetch: !!qParams.facility,
   });
-
-  useEffect(() => {
-    setFacilityName(qParams.facility);
-  }, [qParams.facility]);
 
   useEffect(() => {
     setAssetType(qParams.asset_type);
@@ -105,22 +98,13 @@ const AssetsList = () => {
     setAssetClass(qParams.asset_class);
   }, [qParams.asset_class]);
 
-  useQuery(routes.getFacilityAssetLocation, {
+  const { data: locationObject } = useQuery(routes.getFacilityAssetLocation, {
     pathParams: {
       facility_external_id: String(qParams.facility),
       external_id: String(qParams.location),
     },
-    onResponse: ({ res, data }) => {
-      if (res?.status === 200 && data) {
-        setLocation(data?.name);
-      }
-    },
     prefetch: !!(qParams.facility && qParams.location),
   });
-
-  useEffect(() => {
-    setLocation(qParams?.location ?? "");
-  }, [qParams.location]);
 
   const getAssetIdFromQR = async (assetUrl: string) => {
     try {
@@ -379,12 +363,20 @@ const AssetsList = () => {
         <>
           <FilterBadges
             badges={({ badge, value }) => [
-              value("Facility", "facility", facilityName ?? ""),
+              value(
+                "Facility",
+                "facility",
+                qParams.facility && facilityObject?.name
+              ),
               badge("Name/Serial No./QR ID", "search"),
               value("Asset Type", "asset_type", asset_type ?? ""),
               value("Asset Class", "asset_class", asset_class ?? ""),
               value("Status", "status", status?.replace(/_/g, " ") ?? ""),
-              value("Location", "location", facility_location ?? ""),
+              value(
+                "Location",
+                "location",
+                qParams.facility && locationObject?.name
+              ),
               value(
                 "Warranty AMC End Of Validity Before",
                 "warranty_amc_end_of_validity_before",

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -105,18 +105,17 @@ const AssetsList = () => {
     setAssetClass(qParams.asset_class);
   }, [qParams.asset_class]);
 
-  const { data: locationData } = useQuery(routes.getFacilityAssetLocation, {
+  const { data: location } = useQuery(routes.getFacilityAssetLocation, {
     pathParams: {
       facility_external_id: String(qParams.facility),
       external_id: String(qParams.location),
     },
-    prefetch: !!(qParams.facility && qParams.location),
-    refetchOnUpdate: true,
+    prefetch: qParams.facility || qParams.location,
   });
 
   useEffect(() => {
-    setLocation(locationData?.name ?? "");
-  }, [locationData]);
+    setLocation(location?.name ?? "");
+  }, [location]);
 
   const getAssetIdFromQR = async (assetUrl: string) => {
     try {

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -105,17 +105,22 @@ const AssetsList = () => {
     setAssetClass(qParams.asset_class);
   }, [qParams.asset_class]);
 
-  const { data: location } = useQuery(routes.getFacilityAssetLocation, {
+  useQuery(routes.getFacilityAssetLocation, {
     pathParams: {
       facility_external_id: String(qParams.facility),
       external_id: String(qParams.location),
+    },
+    onResponse: ({ res, data }) => {
+      if (res?.status === 200 && data) {
+        setLocation(data?.name);
+      }
     },
     prefetch: !!(qParams.facility && qParams.location),
   });
 
   useEffect(() => {
-    setLocation(location?.name ?? "");
-  }, [location]);
+    setLocation(qParams?.location ?? "");
+  }, [qParams.location]);
 
   const getAssetIdFromQR = async (assetUrl: string) => {
     try {

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -110,7 +110,7 @@ const AssetsList = () => {
       facility_external_id: String(qParams.facility),
       external_id: String(qParams.location),
     },
-    prefetch: qParams.facility || qParams.location,
+    prefetch: !!(qParams.facility && qParams.location),
   });
 
   useEffect(() => {

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -375,7 +375,7 @@ const AssetsList = () => {
               value(
                 "Location",
                 "location",
-                qParams.facility && locationObject?.name
+                qParams.location && locationObject?.name
               ),
               value(
                 "Warranty AMC End Of Validity Before",

--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -47,6 +47,7 @@ const AssetsList = () => {
   const [asset_type, setAssetType] = useState<string>();
   const [status, setStatus] = useState<string>();
   const [facilityName, setFacilityName] = useState<string>();
+  const [facility_location, setLocation] = useState("");
   const [asset_class, setAssetClass] = useState<string>();
   const [importAssetModalOpen, setImportAssetModalOpen] = useState(false);
   const assetsExist = assets.length > 0 && Object.keys(assets[0]).length > 0;
@@ -89,6 +90,10 @@ const AssetsList = () => {
   });
 
   useEffect(() => {
+    setFacilityName(qParams.facility);
+  }, [qParams.facility]);
+
+  useEffect(() => {
     setAssetType(qParams.asset_type);
   }, [qParams.asset_type]);
 
@@ -100,13 +105,18 @@ const AssetsList = () => {
     setAssetClass(qParams.asset_class);
   }, [qParams.asset_class]);
 
-  const { data: location } = useQuery(routes.getFacilityAssetLocation, {
+  const { data: locationData } = useQuery(routes.getFacilityAssetLocation, {
     pathParams: {
       facility_external_id: String(qParams.facility),
       external_id: String(qParams.location),
     },
     prefetch: !!(qParams.facility && qParams.location),
+    refetchOnUpdate: true,
   });
+
+  useEffect(() => {
+    setLocation(locationData?.name ?? "");
+  }, [locationData]);
 
   const getAssetIdFromQR = async (assetUrl: string) => {
     try {
@@ -370,7 +380,7 @@ const AssetsList = () => {
               value("Asset Type", "asset_type", asset_type ?? ""),
               value("Asset Class", "asset_class", asset_class ?? ""),
               value("Status", "status", status?.replace(/_/g, " ") ?? ""),
-              value("Location", "location", location?.name ?? ""),
+              value("Location", "location", facility_location ?? ""),
               value(
                 "Warranty AMC End Of Validity Before",
                 "warranty_amc_end_of_validity_before",

--- a/src/Utils/request/useQuery.ts
+++ b/src/Utils/request/useQuery.ts
@@ -6,7 +6,6 @@ import { mergeRequestOptions } from "./utils";
 export interface QueryOptions<TData> extends RequestOptions<TData> {
   prefetch?: boolean;
   refetchOnWindowFocus?: boolean;
-  refetchOnUpdate?: boolean;
 }
 
 export default function useQuery<TData>(
@@ -42,16 +41,6 @@ export default function useQuery<TData>(
       runQuery();
     }
   }, [runQuery, options?.prefetch]);
-
-  useEffect(() => {
-    if (options?.refetchOnUpdate) {
-      runQuery();
-
-      // window.addEventListener("focus", onFocus);
-
-      // return () => window.removeEventListener("focus", onFocus);
-    }
-  }, [runQuery, options?.refetchOnUpdate]);
 
   useEffect(() => {
     if (options?.refetchOnWindowFocus) {

--- a/src/Utils/request/useQuery.ts
+++ b/src/Utils/request/useQuery.ts
@@ -6,6 +6,7 @@ import { mergeRequestOptions } from "./utils";
 export interface QueryOptions<TData> extends RequestOptions<TData> {
   prefetch?: boolean;
   refetchOnWindowFocus?: boolean;
+  refetchOnUpdate?: boolean;
 }
 
 export default function useQuery<TData>(
@@ -41,6 +42,16 @@ export default function useQuery<TData>(
       runQuery();
     }
   }, [runQuery, options?.prefetch]);
+
+  useEffect(() => {
+    if (options?.refetchOnUpdate) {
+      runQuery();
+
+      // window.addEventListener("focus", onFocus);
+
+      // return () => window.removeEventListener("focus", onFocus);
+    }
+  }, [runQuery, options?.refetchOnUpdate]);
 
   useEffect(() => {
     if (options?.refetchOnWindowFocus) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91b364d</samp>

This pull request improves the user interface and functionality of the assets list component. It adds state variables to show the facility name and location in the filter section, and uses the `useQuery` hook to refetch data based on filter changes.

## Proposed Changes

- Fixes #6473 
http://127.0.0.1:4000/assets?page=1&limit=18&facility=df1a22fb-1875-4949-af85-15d1917b8bfd&asset_type=&asset_class=&status=&location=&warranty_amc_end_of_validity_before=&warranty_amc_end_of_validity_after=
Remove the facility and location filter when the cross is clicked
![image](https://github.com/coronasafe/care_fe/assets/70687348/d2e4bef7-8261-4065-bf80-5c9fc03d46b0)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91b364d</samp>

*  Add a state variable `facility_location` to store and display the location name of the selected facility in the assets list ([link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R50), [link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L109-R120), [link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L373-R383))
*  Add a state variable `facility_name` to store and display the facility name of the selected facility in the assets list ([link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R93-R96))
*  Rename the variable `location` to `locationData` to avoid confusion with `facility_location` in `AssetsList.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L103-R108))
*  Add a new option `refetchOnUpdate` to the `QueryOptions` interface in `useQuery.ts` to allow refetching the query data when the query parameters change ([link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-ae7e6ee23684c1a7b8169be4f7177ecca78ddfaa070ec81231db9534ff483a32R9))
*  Use the `refetchOnUpdate` option in the query to get the facility asset location in `AssetsList.tsx` to update the location name when the facility changes ([link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L109-R120), [link](https://github.com/coronasafe/care_fe/pull/6474/files?diff=unified&w=0#diff-ae7e6ee23684c1a7b8169be4f7177ecca78ddfaa070ec81231db9534ff483a32R47-R56))
