### PR TITLE
New Cypress Test | Search using username | User Tab

### DIFF
--- a/cypress/e2e/users_spec/user_homepage.cy.ts
+++ b/cypress/e2e/users_spec/user_homepage.cy.ts
@@ -2,7 +2,7 @@
 
 import { cy, describe, before, beforeEach, it, afterEach } from "local-cypress";
 import LoginPage from "../../pageobject/Login/LoginPage";
-import { UserPage } from "../../pageobject/Users/usersearch";
+import { UserPage } from "../../pageobject/Users/UserSearch";
 
 describe("Asset Tab", () => {
   const userPage = new UserPage();

--- a/cypress/e2e/users_spec/user_homepage.cy.ts
+++ b/cypress/e2e/users_spec/user_homepage.cy.ts
@@ -1,0 +1,39 @@
+/// <reference types="cypress" />
+
+import { cy, describe, before, beforeEach, it, afterEach } from "local-cypress";
+import LoginPage from "../../pageobject/Login/LoginPage";
+import { UserPage } from "../../pageobject/Users/usersearch";
+
+describe("Asset Tab", () => {
+  const userPage = new UserPage();
+  const usernameToTest = "devdoctor";
+  const currentuser = "devdistrictadmin";
+  const loginPage = new LoginPage();
+  before(() => {
+    loginPage.loginAsDisctrictAdmin();
+    cy.saveLocalStorage();
+  });
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.awaitUrl("/users");
+  });
+
+  it("Search by username", () => {
+    userPage.checkSearchInputVisibility();
+    userPage.typeInSearchInput(usernameToTest);
+    userPage.checkUrlForUsername(usernameToTest);
+    userPage.checkUsernameText(usernameToTest);
+    userPage.checkUsernameBadgeVisibility(true);
+    userPage.clearSearchInput();
+    userPage.checkUsernameBadgeVisibility(false);
+    userPage.typeInSearchInput(usernameToTest);
+    userPage.checkUsernameText(usernameToTest);
+    userPage.clickRemoveIcon();
+    userPage.checkUsernameBadgeVisibility(false);
+    userPage.checkUsernameText(currentuser);
+  });
+  afterEach(() => {
+    cy.saveLocalStorage();
+  });
+});

--- a/cypress/pageobject/Users/UserSearch.ts
+++ b/cypress/pageobject/Users/UserSearch.ts
@@ -1,0 +1,37 @@
+// UserPage.ts
+export class UserPage {
+  // Element selectors
+  searchByUsernameInput = "#search-by-username";
+  usernameText = "#username";
+  usernameBadge = "[data-testid='Username']";
+  removeIcon = "#removeicon";
+
+  checkSearchInputVisibility() {
+    cy.get(this.searchByUsernameInput).should("be.visible");
+  }
+
+  typeInSearchInput(text: string) {
+    cy.get(this.searchByUsernameInput).click().type(text);
+  }
+
+  clearSearchInput() {
+    cy.get(this.searchByUsernameInput).click().clear();
+  }
+
+  checkUrlForUsername(username: string) {
+    cy.url().should("include", `username=${username}`);
+  }
+
+  checkUsernameText(username: string) {
+    cy.get(this.usernameText).should("have.text", username);
+  }
+
+  checkUsernameBadgeVisibility(shouldBeVisible: boolean) {
+    const assertion = shouldBeVisible ? "be.visible" : "not.be.visible";
+    cy.get(this.usernameBadge).should(assertion);
+  }
+
+  clickRemoveIcon() {
+    cy.get(this.removeIcon).click();
+  }
+}

--- a/src/CAREUI/display/FilterBadge.tsx
+++ b/src/CAREUI/display/FilterBadge.tsx
@@ -18,6 +18,7 @@ const FilterBadge = ({ name, value, onRemove }: FilterBadgeProps) => {
     >
       {`${name}: ${value}`}
       <i
+        id="removeicon"
         className="fas fa-times ml-2 cursor-pointer rounded-full px-1 py-0.5 hover:bg-gray-500"
         onClick={onRemove}
       ></i>

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -543,6 +543,7 @@ export default function ManageUsers() {
         <div className="col-span-2 my-2 flex flex-col justify-between space-y-3 lg:flex-row lg:space-x-4 lg:space-y-0 lg:px-3">
           <div className="w-full">
             <SearchInput
+              id="search-by-username"
               name="username"
               onChange={(e) => updateQuery({ [e.name]: e.value })}
               value={qParams.username}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8520673</samp>

This pull request adds end-to-end tests and page objects for the user homepage feature, which allows searching by username. It also adds id attributes to the `FilterBadge` and `search input` elements in the `FilterBadge.tsx` and `ManageUsers.tsx` files to enable the tests.

## Proposed Changes

- Partially fix #6378 
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8520673</samp>

*  Add an end-to-end test file for the user homepage feature ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-77bfb496bf08401f8402e3ac22ac8def95e6064fb134e300c8df35d01699b93eR1-R39))
  * Import modules and page objects ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-77bfb496bf08401f8402e3ac22ac8def95e6064fb134e300c8df35d01699b93eR1-R39))
  * Set up login and local storage hooks ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-77bfb496bf08401f8402e3ac22ac8def95e6064fb134e300c8df35d01699b93eR1-R39))
  * Define a test case for searching by username ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-77bfb496bf08401f8402e3ac22ac8def95e6064fb134e300c8df35d01699b93eR1-R39))
    * Verify the visibility and functionality of the search input, the username text and badge, and the remove icon ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-77bfb496bf08401f8402e3ac22ac8def95e6064fb134e300c8df35d01699b93eR1-R39))
* Add a page object class for the user homepage feature ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-25ebb52f9d689135532584c669c34c94bebfe559cffb4f4c6a17d27d494dc2afR1-R37))
  * Define element selectors and methods for interacting with the user homepage elements ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-25ebb52f9d689135532584c669c34c94bebfe559cffb4f4c6a17d27d494dc2afR1-R37))
* Add id attributes to the FilterBadge and search input elements in the `display` and `Components` modules ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-abbedeb6451fdd5fa7c3d31e0f5defc4862964eda3dad431a23363f3cf177650R21), [link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121R546))
  * Use the id attributes to identify the elements for the user homepage feature ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-abbedeb6451fdd5fa7c3d31e0f5defc4862964eda3dad431a23363f3cf177650R21), [link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121R546))
  * Match the id attributes to the selectors defined in the page object class ([link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-abbedeb6451fdd5fa7c3d31e0f5defc4862964eda3dad431a23363f3cf177650R21), [link](https://github.com/coronasafe/care_fe/pull/6478/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121R546))
