### PR TITLE
Lint CI: Show errors only and fix existing lint errors

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,16 +16,16 @@ jobs:
       statuses: write
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: '18'
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Run lint
-      run: npm run lint
+      - name: Run lint
+        run: npm run lint --quiet

--- a/src/CAREUI/interactive/FiltersSlideover.tsx
+++ b/src/CAREUI/interactive/FiltersSlideover.tsx
@@ -3,11 +3,12 @@ import useFilters from "../../Common/hooks/useFilters";
 import ButtonV2 from "../../Components/Common/components/ButtonV2";
 import CareIcon from "../icons/CareIcon";
 import SlideOver from "./SlideOver";
+import { ReactNode } from "react";
 
 type AdvancedFilter = ReturnType<typeof useFilters>["advancedFilter"];
 
 interface Props {
-  children: any;
+  children: ReactNode | ReactNode[];
   advancedFilter: AdvancedFilter;
   onClear?: () => void;
   onApply?: () => void;

--- a/src/Components/Assets/AssetImportModal.tsx
+++ b/src/Components/Assets/AssetImportModal.tsx
@@ -33,23 +33,18 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
   const [errors, setErrors] = useState<any>({
     location: "",
   });
-  const [locations, setLocations] = useState<any>([]);
   const { sample_format_asset_import } = useConfig();
-  const [locationsLoading, setLocationsLoading] = useState(false);
 
   const closeModal = () => {
     setPreview(undefined);
     setSelectedFile(undefined);
     onClose && onClose();
   };
-  useQuery(routes.listFacilityAssetLocation, {
+  const { data, loading } = useQuery(routes.listFacilityAssetLocation, {
     pathParams: { facility_external_id: `${facility.id}` },
-    onResponse: ({ res, data }) => {
-      if (res?.status === 200 && data) {
-        setLocations(data.results);
-      }
-    },
   });
+
+  const locations = data?.results || [];
 
   useEffect(() => {
     const readFile = async () => {
@@ -209,7 +204,7 @@ const AssetImportModal = ({ open, onClose, facility }: Props) => {
       fixedWidth={false}
     >
       <span className="mt-1 text-gray-700">{facility.name}</span>
-      {!locationsLoading && locations.length === 0 ? (
+      {!loading && locations.length === 0 ? (
         <>
           <div className="flex h-full flex-col items-center justify-center">
             <h1 className="m-7 text-2xl font-medium text-gray-700">

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -18,7 +18,6 @@ import useQuery from "../../../Utils/request/useQuery";
 
 import CareIcon from "../../../CAREUI/icons/CareIcon";
 
-
 interface Props {
   assetId: string;
   facilityId: string;
@@ -135,7 +134,7 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
     }
     setLoadingAddPreset(false);
   };
-  
+
   if (isLoading || loading || !facility) return <Loading />;
 
   const fallbackMiddleware =


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2733a66</samp>

This pull request improves the code quality and performance of some components in the `src/Components/Assets` folder, fixes some formatting issues in the linter workflow, and refines the prop type of the `FiltersSlideover` component.

## Proposed Changes

- Annotate lint errors only (skip warnings, as we have 2K+ warnings and would show up on all non-related PRs)
- Fix existing lint errors.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2733a66</samp>

*  Fix indentation and add `--quiet` flag to linter workflow ([link](https://github.com/coronasafe/care_fe/pull/6494/files?diff=unified&w=0#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L19-R31))
*  Change `children` prop type from `any` to `ReactNode | ReactNode[]` in `FiltersSlideover` component ([link](https://github.com/coronasafe/care_fe/pull/6494/files?diff=unified&w=0#diff-5020fbd9bdc19f8fac9938efbe0f199406977ca3b30b40c2d9065a6bd48c7ac5L6-R11))
*  Remove unused states and simplify `useQuery` hook in `AssetImportModal` component ([link](https://github.com/coronasafe/care_fe/pull/6494/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L36-R36), [link](https://github.com/coronasafe/care_fe/pull/6494/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L45-R48), [link](https://github.com/coronasafe/care_fe/pull/6494/files?diff=unified&w=0#diff-abdb9a86f18dd154c547c5b8884c695e30d12d0e9b8775bbff93cdcfcd7b6132L212-R207))
*  Remove empty line and trailing whitespace in `ONVIFCamera` component ([link](https://github.com/coronasafe/care_fe/pull/6494/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL21), [link](https://github.com/coronasafe/care_fe/pull/6494/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL138-R137))
