### PR TITLE
Fix passing silent argument to linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,4 +28,4 @@ jobs:
         run: npm ci
 
       - name: Run lint
-        run: npm run lint --quiet
+        run: npm run lint -- --quiet


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f24f67</samp>

Moved `--quiet` flag in linter workflow to show only errors. This improves the output readability and clarity.

![image](https://github.com/coronasafe/care_fe/assets/3626859/c9188bba-4f16-49e8-86b0-6d454c271a90)
![image](https://github.com/coronasafe/care_fe/assets/3626859/fc843fe3-67bd-4f0c-bfd9-79e042c823d4)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f24f67</samp>

*  Suppress linting warnings and show only errors by moving `--quiet` flag to the end of the command ([link](https://github.com/coronasafe/care_fe/pull/6499/files?diff=unified&w=0#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L31-R31))
