### PR TITLE
rename assets dir to avoid conflicts with /assets/ route

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
   ],
   build: {
     outDir: "build",
+    assetsDir: "bundle",
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63d9d8f</samp>

Set `assetsDir` to "bundle" in `vite.config.ts` to fix static asset serving on subpath deployment.

## Proposed Changes

rename directory for generated js assets to avoid route conflict in nginx

- Fixes #6500

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63d9d8f</samp>

* Set the `assetsDir` option to "bundle" in the vite config file `vite.config.ts` to fix the issue of static assets not being served correctly on a subpath ([link](https://github.com/coronasafe/care_fe/pull/6501/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR57))
