### PR TITLE
🛠️ ✅ Fixed Responsiveness Issue in Facility List Page / Facility Card

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -48,11 +48,11 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
 
   return (
     <div key={`usr_${facility.id}`} className="w-full">
-      <div className="block h-full rounded-lg bg-white shadow hover:border-primary-500">
+      <div className="block h-full overflow-hidden rounded-lg bg-white shadow hover:border-primary-500">
         <div className="flex h-full">
           <Link
             href={`/facility/${facility.id}`}
-            className="group relative z-0 hidden w-1/4 items-center justify-center self-stretch bg-gray-300 md:flex"
+            className="group relative z-0 hidden w-1/4 min-w-[15%] items-center justify-center self-stretch bg-gray-300 md:flex"
           >
             {(facility.read_cover_image_url && (
               <img
@@ -67,7 +67,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
           <div className="h-full w-full grow">
             <Link
               href={`/facility/${facility.id}`}
-              className="group relative z-0 flex w-full items-center justify-center self-stretch bg-gray-300 md:hidden"
+              className="group relative z-0 flex w-full min-w-[15%] items-center justify-center self-stretch bg-gray-300 md:hidden"
             >
               {(facility.read_cover_image_url && (
                 <img
@@ -80,7 +80,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
               )}
             </Link>
 
-            <div className="flex h-fit w-full flex-col justify-between md:h-full">
+            <div className="flex h-fit w-full flex-col flex-wrap justify-between md:h-full">
               <div className="w-full p-4">
                 <div className="flow-root">
                   {facility.kasp_empanelled && (
@@ -88,7 +88,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                       {kasp_string}
                     </div>
                   )}
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between">
                     <Link
                       href={`/facility/${facility.id}`}
                       className="float-left text-xl font-bold capitalize text-inherit hover:text-inherit"
@@ -153,10 +153,10 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                   </a>
                 </div>
               </div>
-              <div className="flex-none border-t bg-gray-50 px-2 py-1 md:px-3">
+              <div className="flex flex-wrap border-t bg-gray-50 px-2 py-1 md:px-3">
                 <div className="flex justify-between py-2">
                   <div className="flex w-full flex-wrap justify-between gap-2">
-                    <div className="flex gap-2">
+                    <div className="flex flex-wrap gap-2">
                       <div
                         className={`tooltip ml-auto flex h-[38px] w-fit items-center justify-center rounded-md px-2 text-xl ${
                           facility.patient_count / facility.bed_count > 0.85
@@ -220,7 +220,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                         </form>
                       </DialogModal>
                     </div>
-                    <div className="flex gap-2">
+                    <div className="flex flex-wrap gap-2">
                       {userType !== "Staff" ? (
                         <ButtonV2
                           id="facility-notify"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6986ac2</samp>

Improved the responsiveness and layout of the `FacilityCard` component by applying tailwind classes. Fixed the image overflow issue by adding `overflow-hidden` to the container div.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6502

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### **Before Fix:**

![Screenshot 2023-10-27 201131](https://github.com/coronasafe/care_fe/assets/106866225/4e504543-aff0-4903-adfe-46fddc5f708d)

### **After Fix:**

![Screenshot 2023-10-27 201146](https://github.com/coronasafe/care_fe/assets/106866225/00167c79-6e0c-4be3-83dd-0be7641528ef)



## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6986ac2</samp>

*  Add `overflow-hidden` class to outer div of facility card to prevent image overflow ([link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L51-R55), [link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L70-R70))
*  Add `min-w-[15%]` class to link element to ensure minimum width for image on smaller screens ([link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L51-R55), [link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L70-R70))
*  Add `flex-wrap` class to various divs to allow content to wrap on smaller screens and avoid overflow or overlap ([link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L83-R83), [link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L91-R91), [link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L156-R159), [link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L223-R223))
*  Add `flex` class to div that contains facility actions to enable wrapping ([link](https://github.com/coronasafe/care_fe/pull/6507/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L156-R159))
