### PR TITLE
🛠️ ✅ Fixed User signout flow malfunctioning.

### DIFF
--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -107,8 +107,8 @@ export const handleSignOut = (forceReload: boolean) => {
   Object.values(LocalStorageKeys).forEach((key) =>
     localStorage.removeItem(key)
   );
-  navigate("/");
-  if (forceReload) window.location.reload();
+  if (forceReload) window.location.href = "/";
+  else navigate("/");
 };
 
 /**


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a735229</samp>

Fixed a sign out bug that caused the user to stay on the same page instead of being redirected to the login page. Changed `handleSignOut` function in `src/Utils/utils.ts` to use `window.location.href` instead of `window.location.reload`.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6504
- After the `Sign Out` button is clicked it shows the `loading page` and redirects to `"/"`.
- It navigates with reloading if `forceReload` param is passed to `handleSignOut`.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a735229</samp>

* Fix sign out caching issue by using `window.location.href` instead of `window.location.reload` when `forceReload` is true ([link](https://github.com/coronasafe/care_fe/pull/6509/files?diff=unified&w=0#diff-5903b23c9778624d9c178b9779024a4265e5fc365714fed34d49225ee6b8dc73L110-R111))
