### PR TITLE
add auto deployment for staging gcp deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -180,6 +180,48 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  deploy-gcp-staging:
+    needs: build-production
+    name: Deploy to staging GCP cluster
+    runs-on: ubuntu-latest
+    environment:
+      name: Staging-GCP
+      url: https://care-staging.ohc.network/
+    steps:
+      - name: Checkout Kube Config
+        uses: actions/checkout@v3
+        with:
+          repository: coronasafe/care-staging-gcp
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          path: kube
+          ref: main
+
+      # Setup gcloud CLI
+      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+        with:
+          service_account_key: ${{ secrets.GKE_SA_KEY }}
+          project_id: ${{ secrets.GKE_PROJECT }}
+
+      # Get the GKE credentials so we can deploy to the cluster
+      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+        with:
+          cluster_name: ${{ secrets.GKE_CLUSTER }}
+          location: ${{ secrets.GKE_ZONE }}
+          credentials: ${{ secrets.GKE_SA_KEY }}
+
+      - name: install kubectl
+        uses: azure/setup-kubectl@v3.0
+        with:
+          version: "v1.23.6"
+        id: install
+
+      - name: Deploy Care Fe Production
+        run: |
+          mkdir -p $HOME/.kube/
+          cd kube/deployments/
+          sed -i -e "s/_BUILD_NUMBER_/${GITHUB_RUN_NUMBER}/g" care-fe.yaml
+          kubectl apply -f care-fe.yaml
+
   deploy-production-manipur:
     needs: build-production
     name: Deploy to GKE Manipur

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -180,7 +180,7 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  deploy-gcp-staging:
+  deploy-staging-gcp:
     needs: build-production
     name: Deploy to staging GCP cluster
     runs-on: ubuntu-latest


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70ba393</samp>

This change adds a new deployment option for the care frontend application to a staging GCP cluster. It uses the existing `build-production` job to create a docker image and then runs a new job `deploy-gcp-staging` to deploy it.

## Proposed Changes

- add auto deployment for staging gcp deployment
@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70ba393</samp>

* Add a new workflow job to deploy the care frontend to a staging GCP cluster ([link](https://github.com/coronasafe/care_fe/pull/6519/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R183-R224))
