### PR TITLE
Track patient card button clicks

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -465,7 +465,7 @@ export default function PatientInfoCard(props: {
                             triggerGoal("Patient Card Button Clicked", {
                               buttonName: action[1],
                               consultationId: consultation?.id,
-                              userId: authUser.id,
+                              userId: authUser?.id,
                             });
                           }}
                         >
@@ -500,7 +500,7 @@ export default function PatientInfoCard(props: {
                               triggerGoal("Patient Card Button Clicked", {
                                 buttonName: "Show ABHA Profile",
                                 consultationId: consultation?.id,
-                                userId: authUser.id,
+                                userId: authUser?.id,
                               });
                             }}
                           >
@@ -513,7 +513,7 @@ export default function PatientInfoCard(props: {
                               triggerGoal("Patient Card Button Clicked", {
                                 buttonName: "Link Care Context",
                                 consultationId: consultation?.id,
-                                userId: authUser.id,
+                                userId: authUser?.id,
                               });
                               close();
                               setShowLinkCareContext(true);
@@ -553,7 +553,7 @@ export default function PatientInfoCard(props: {
                     triggerGoal("Patient Card Button Clicked", {
                       buttonName: "Medico Legal Case",
                       consultationId: consultation?.id,
-                      userId: authUser.id,
+                      userId: authUser?.id,
                     });
                     setMedicoLegalCase(checked);
                     switchMedicoLegalCase(checked);

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -8,7 +8,7 @@ import {
   TELEMEDICINE_ACTIONS,
 } from "../../Common/constants";
 import { ConsultationModel, PatientCategory } from "../Facility/models";
-import { Switch } from "@headlessui/react";
+import { Switch, Menu } from "@headlessui/react";
 
 import { Link } from "raviger";
 import { useState } from "react";
@@ -26,8 +26,9 @@ import Beds from "../Facility/Consultations/Beds";
 import { PatientModel } from "./models";
 import request from "../../Utils/request/request.js";
 import routes from "../../Redux/api.js";
-import { Menu } from "@headlessui/react";
 import DropdownMenu from "../Common/components/Menu.js";
+import { triggerGoal } from "../../Integrations/Plausible.js";
+import useAuthUser from "../../Common/hooks/useAuthUser.js";
 
 export default function PatientInfoCard(props: {
   patient: PatientModel;
@@ -36,6 +37,8 @@ export default function PatientInfoCard(props: {
   consultationId: string;
   showAbhaProfile?: boolean;
 }) {
+  const authUser = useAuthUser();
+
   const [open, setOpen] = useState(false);
   const [showLinkABHANumber, setShowLinkABHANumber] = useState(false);
   const [showABHAProfile, setShowABHAProfile] = useState(
@@ -459,6 +462,11 @@ export default function PatientInfoCard(props: {
                               });
                               setOpen(true);
                             }
+                            triggerGoal("Patient Card Button Clicked", {
+                              buttonName: action[1],
+                              consultationId: consultation?.id,
+                              userId: authUser.id,
+                            });
                           }}
                         >
                           <CareIcon
@@ -489,6 +497,11 @@ export default function PatientInfoCard(props: {
                             onClick={() => {
                               close();
                               setShowABHAProfile(true);
+                              triggerGoal("Patient Card Button Clicked", {
+                                buttonName: "Show ABHA Profile",
+                                consultationId: consultation?.id,
+                                userId: authUser.id,
+                              });
                             }}
                           >
                             <CareIcon className="care-l-user-square text-lg text-primary-500" />
@@ -497,6 +510,11 @@ export default function PatientInfoCard(props: {
                           <div
                             className="dropdown-item-primary pointer-events-auto m-2 flex cursor-pointer items-center justify-start gap-2 rounded border-0 p-2 text-sm font-normal transition-all duration-200 ease-in-out"
                             onClick={() => {
+                              triggerGoal("Patient Card Button Clicked", {
+                                buttonName: "Link Care Context",
+                                consultationId: consultation?.id,
+                                userId: authUser.id,
+                              });
                               close();
                               setShowLinkCareContext(true);
                             }}
@@ -532,6 +550,11 @@ export default function PatientInfoCard(props: {
                 <Switch
                   checked={medicoLegalCase}
                   onChange={(checked) => {
+                    triggerGoal("Patient Card Button Clicked", {
+                      buttonName: "Medico Legal Case",
+                      consultationId: consultation?.id,
+                      userId: authUser.id,
+                    });
                     setMedicoLegalCase(checked);
                     switchMedicoLegalCase(checked);
                   }}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6d44be</samp>

This file adds user action tracking and a dropdown menu to the patient card component. It uses `triggerGoal` to log the actions and `useAuthUser` to get the current user information.

Adds plausible tracking for button clicks on patient info card.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6d44be</samp>

* Import `Menu` component from `@headlessui/react` to use in patient card dropdown menu ([link](https://github.com/coronasafe/care_fe/pull/6521/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L11-R11))
* Import `triggerGoal` function from `../../Integrations/Plausible.js` and `useAuthUser` hook from `../../Common/hooks/useAuthUser.js` to track user actions and goals on patient card ([link](https://github.com/coronasafe/care_fe/pull/6521/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L29-R31))
* Declare `authUser` variable using `useAuthUser` hook to get current logged in user's id ([link](https://github.com/coronasafe/care_fe/pull/6521/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948R40-R41))
* Call `triggerGoal` function with `buttonName`, `consultationId`, and `userId` parameters to track user clicks on patient card action buttons ([link](https://github.com/coronasafe/care_fe/pull/6521/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948R465-R469), [link](https://github.com/coronasafe/care_fe/pull/6521/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948R500-R504), [link](https://github.com/coronasafe/care_fe/pull/6521/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948R513-R517), [link](https://github.com/coronasafe/care_fe/pull/6521/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948R553-R557))
