### PR TITLE
Fixed bed number coming up two time in patients page.

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -533,7 +533,6 @@ export const PatientManager = () => {
                     </span>
                   </span>
                   <span className="w-full truncate px-1 text-center text-base font-bold">
-                    {patient?.last_consultation?.current_bed?.bed_object.name}
                     <span className="tooltip-text tooltip-bottom">
                       {
                         patient?.last_consultation?.current_bed?.bed_object

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -519,26 +519,23 @@ export const PatientManager = () => {
             <div className="h-20 w-full min-w-[5rem] rounded-lg border border-gray-300 bg-gray-50 md:w-20">
               {patient?.last_consultation?.current_bed &&
               patient?.last_consultation?.discharge_date === null ? (
-                <div className="flex h-full flex-col items-center justify-center">
-                  <span className="tooltip w-full truncate px-1 text-center text-sm text-gray-900">
+                <div className="tooltip flex h-full flex-col items-center justify-center">
+                  <span className="w-full truncate px-1 text-center text-sm text-gray-900">
                     {
                       patient?.last_consultation?.current_bed?.bed_object
                         ?.location_object?.name
                     }
-                    <span className="tooltip-text tooltip-bottom">
-                      {
-                        patient?.last_consultation?.current_bed?.bed_object
-                          ?.location_object?.name
-                      }
-                    </span>
                   </span>
                   <span className="w-full truncate px-1 text-center text-base font-bold">
-                    <span className="tooltip-text tooltip-bottom">
-                      {
-                        patient?.last_consultation?.current_bed?.bed_object
-                          ?.name
-                      }
-                    </span>
+                    {patient?.last_consultation?.current_bed?.bed_object?.name}
+                  </span>
+                  <span className="tooltip-text tooltip-bottom text-sm font-medium lg:-translate-y-1/2">
+                    {
+                      patient?.last_consultation?.current_bed?.bed_object
+                        ?.location_object?.name
+                    }
+                    <br />
+                    {patient?.last_consultation?.current_bed?.bed_object?.name}
                   </span>
                 </div>
               ) : patient.last_consultation?.suggestion === "DC" ? (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5289ad2</samp>

Removed current bed name from patient manager component. This is part of a UI/UX improvement for the patient dashboard and consultation details.

## Proposed Changes

- Fixes #6525
- Just removed a duplicate copy of bed data component which is causing the patients page to display the bed data 2 times.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5289ad2</samp>

* Remove display of current bed name in patient manager component ([link](https://github.com/coronasafe/care_fe/pull/6526/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L536))
