### PR TITLE
☑️ Added Loading component while the assets are being fetched.

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -65,7 +65,7 @@ const AssetsList = () => {
     status: qParams.status || "",
   };
 
-  useQuery(routes.listAssets, {
+  const { loading } = useQuery(routes.listAssets, {
     query: params,
     onResponse: ({ res, data }) => {
       if (res?.status === 200 && data) {
@@ -176,7 +176,13 @@ const AssetsList = () => {
     );
 
   let manageAssets = null;
-  if (assetsExist) {
+  if (loading) {
+    manageAssets = (
+      <div className="col-span-3 w-full py-8 text-center">
+        <Loading />
+      </div>
+    );
+  } else if (assetsExist) {
     manageAssets = (
       <div className="grid grid-cols-1 gap-2 md:-mx-8 md:grid-cols-2 lg:grid-cols-3">
         {assets.map((asset: AssetData) => (
@@ -309,7 +315,7 @@ const AssetsList = () => {
         <CountBlock
           text="Total Assets"
           count={totalCount}
-          loading={isLoading}
+          loading={loading}
           icon="l-monitor-heart-rate"
           className="flex-1"
         />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f9b7d0</samp>

Improved loading feedback for assets list and count card. Added `loading` state and components to `AssetsList.tsx`.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6505

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f9b7d0</samp>

*  Add `loading` state variable to track the loading status of the assets list query ([link](https://github.com/coronasafe/care_fe/pull/6532/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L68-R68))
*  Render `Loading` component when the assets list query is loading, instead of showing an empty list ([link](https://github.com/coronasafe/care_fe/pull/6532/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L179-R186))
*  Pass `loading` state variable to `CountCard` component to show loading indicator when the total assets count is loading ([link](https://github.com/coronasafe/care_fe/pull/6532/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L312-R318))
