### PR TITLE
Remove redundant facility selection pop-up for single facility users

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -479,7 +479,10 @@ export const PatientManager = () => {
     [fetchFacilityBadgeName, fetchLocationBadgeName]
   );
 
-  const { data: permittedData } = useQuery(routes.getPermittedFacilities, {});
+  const { data: permittedFacilities } = useQuery(
+    routes.getPermittedFacilities,
+    {}
+  );
 
   const LastAdmittedToTypeBadges = () => {
     const badge = (key: string, value: any, id: string) => {
@@ -787,8 +790,10 @@ export const PatientManager = () => {
               onClick={() => {
                 if (qParams.facility)
                   navigate(`/facility/${qParams.facility}/patient`);
-                else if (permittedData?.results.length === 1)
-                  navigate(`/facility/${permittedData?.results[0].id}/patient`);
+                else if (permittedFacilities?.results.length === 1)
+                  navigate(
+                    `/facility/${permittedFacilities?.results[0].id}/patient`
+                  );
                 else setShowDialog(true);
               }}
               className="w-full lg:w-fit"

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -49,6 +49,8 @@ import Page from "../Common/components/Page.js";
 import dayjs from "dayjs";
 import { triggerGoal } from "../../Integrations/Plausible.js";
 import useAuthUser from "../../Common/hooks/useAuthUser.js";
+import useQuery from "../../Utils/request/useQuery.js";
+import routes from "../../Redux/api.js";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -477,6 +479,8 @@ export const PatientManager = () => {
     [fetchFacilityBadgeName, fetchLocationBadgeName]
   );
 
+  const { data: permittedData } = useQuery(routes.getPermittedFacilities, {});
+
   const LastAdmittedToTypeBadges = () => {
     const badge = (key: string, value: any, id: string) => {
       return (
@@ -781,9 +785,11 @@ export const PatientManager = () => {
             <ButtonV2
               id="add-patient-details"
               onClick={() => {
-                qParams.facility
-                  ? navigate(`/facility/${qParams.facility}/patient`)
-                  : setShowDialog(true);
+                if (qParams.facility)
+                  navigate(`/facility/${qParams.facility}/patient`);
+                else if (permittedData?.results.length === 1)
+                  navigate(`/facility/${permittedData?.results[0].id}/patient`);
+                else setShowDialog(true);
               }}
               className="w-full lg:w-fit"
             >

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -222,6 +222,7 @@ const routes = {
 
   getPermittedFacilities: {
     path: "/api/v1/facility/",
+    TRes: Type<PaginatedResponse<FacilityModel>>(),
   },
 
   getAllFacilities: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05d165a</samp>

Added `useQuery` to fetch user permissions and facilities in `ManagePatients.tsx`. Added response type to `getPermittedFacilities` route in `api.tsx`.

## Proposed Changes

- Fixes #6518 ?
- I have removed the unnecessary facility selection pop-up that appeared for users with access to only one facility when attempting to register a new patient. This change streamlines the patient registration process by automatically assigning the single available facility to the new patient.


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 05d165a</samp>

*  Add `useQuery` hook and `routes` object to fetch and access API endpoints ([link](https://github.com/coronasafe/care_fe/pull/6535/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R52-R53))
*  Declare `permittedData` variable to store the response from `getPermittedFacilities` endpoint ([link](https://github.com/coronasafe/care_fe/pull/6535/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R482-R483))
*  Modify `onClick` handler for `add-patient-details` button to check user's facility permission and navigate accordingly ([link](https://github.com/coronasafe/care_fe/pull/6535/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L784-R792))
*  Add `TRes` property to `getPermittedFacilities` route definition to specify the expected response type ([link](https://github.com/coronasafe/care_fe/pull/6535/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR225))
