### PR TITLE
🔧 Hide Camera Feed Tab for bed with no camera attached.

### DIFF
--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -133,14 +133,11 @@ export const ConsultationDetails = (props: any) => {
               bed: data?.current_bed?.bed_object?.id,
             })
           );
-          const isCameraAttachedRes =
-            assetRes.data.results.filter(
-              (asset: { asset_object: { meta: { asset_type: string } } }) => {
-                return asset?.asset_object?.meta?.asset_type === "CAMERA"
-                  ? true
-                  : false;
-              }
-            ).length >= 1;
+          const isCameraAttachedRes = assetRes.data.results.some(
+            (asset: { asset_object: { asset_class: string } }) => {
+              return asset?.asset_object?.asset_class === "ONVIF";
+            }
+          );
           setIsCameraAttached(isCameraAttachedRes);
           const id = res.data.patient;
           const patientRes = await dispatch(getPatient({ id }));

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -115,9 +115,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
               ...bedAssets.data,
               results: bedAssets.data.results.filter(
                 (asset: { asset_object: { meta: { asset_type: string } } }) => {
-                  return asset?.asset_object?.meta?.asset_type === "CAMERA"
-                    ? true
-                    : false;
+                  return asset?.asset_object?.meta?.asset_type === "CAMERA";
                 }
               ),
             },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d8a8a3</samp>

Added camera-related features for patient beds in `ConsultationDetails` component. This allows users to view live feed and initiate video calls with patients who have cameras attached to their beds.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6475
- `Camera Feed` button also be hidden when no `camera` is attached to the `bed`.

### **Before**:

![before](https://github.com/coronasafe/care_fe/assets/106866225/006b907c-f490-40c5-b36e-1823540fdfee)


### **After**:

![after](https://github.com/coronasafe/care_fe/assets/106866225/54d37295-06c3-459c-88e8-dc5cdb9a6344)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d8a8a3</samp>

*  Import `listAssetBeds` action to fetch the list of assets attached to a bed ([link](https://github.com/coronasafe/care_fe/pull/6536/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R11))
*  Declare and initialize `isCameraAttached` state variable to store the camera status of the current bed ([link](https://github.com/coronasafe/care_fe/pull/6536/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R92))
*  Dispatch `listAssetBeds` action with the current bed id and filter the response to check for camera type assets ([link](https://github.com/coronasafe/care_fe/pull/6536/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R131-R144))
*  Use `isCameraAttached` as a condition to render the "Feed" link in the `src/Components/Facility/ConsultationDetails/index.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/6536/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901L338-R354))
*  Use `isCameraAttached` as a condition to render the "Video Call" button in the `src/Components/Facility/ConsultationDetails/index.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/6536/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901R523))
