### PR TITLE
Refactor middleware hostname in Feed component

### DIFF
--- a/src/Common/hooks/useMSEplayer.ts
+++ b/src/Common/hooks/useMSEplayer.ts
@@ -20,6 +20,8 @@ interface UseMSEMediaPlayerOption {
 export interface ICameraAssetState {
   id: string;
   accessKey: string;
+  middleware_address: string;
+  location_middleware: string;
 }
 
 export enum StreamStatus {

--- a/src/Components/Assets/AssetType/ONVIFCamera.tsx
+++ b/src/Components/Assets/AssetType/ONVIFCamera.tsx
@@ -53,6 +53,11 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
     }
   }, [facility, facilityId]);
 
+  const fallbackMiddleware =
+    asset?.location_object?.middleware_address || facilityMiddlewareHostname;
+
+  const currentMiddleware = middlewareHostname || fallbackMiddleware;
+
   useEffect(() => {
     if (asset) {
       setAssetType(asset?.asset_class);
@@ -105,7 +110,7 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
     try {
       setLoadingAddPreset(true);
       const presetData = await axios.get(
-        `https://${facilityMiddlewareHostname}/status?hostname=${config.hostname}&port=${config.port}&username=${config.username}&password=${config.password}`
+        `https://${currentMiddleware}/status?hostname=${config.hostname}&port=${config.port}&username=${config.username}&password=${config.password}`
       );
 
       const { res } = await request(routes.createAssetBed, {
@@ -135,9 +140,6 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
     setLoadingAddPreset(false);
   };
   if (isLoading || loading || !facility) return <Loading />;
-
-  const fallbackMiddleware =
-    asset?.location_object?.middleware_address || facilityMiddlewareHostname;
 
   return (
     <div className="space-y-6">
@@ -223,7 +225,7 @@ const ONVIFCamera = ({ assetId, facilityId, asset, onUpdated }: Props) => {
           addPreset={addPreset}
           isLoading={loadingAddPreset}
           refreshPresetsHash={refreshPresetsHash}
-          facilityMiddlewareHostname={facilityMiddlewareHostname}
+          facilityMiddlewareHostname={currentMiddleware}
         />
       ) : null}
     </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8fba4f2</samp>

This pull request enhances the camera stream functionality by adding logic to handle different middleware server scenarios. It introduces new props, constants, and state variables to store and select the appropriate middleware hostname for each camera. It also updates the API calls and the UI components to use the new logic. It affects the files `ONVIFCamera.tsx`, `Feed.tsx`, and `useMSEplayer.ts`.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8fba4f2</samp>

*  Add `middleware_address` and `location_middleware` properties to `ICameraAssetState` interface to store the hostnames of the middleware servers for the camera stream and the location of the camera ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-9c97aeeffdf95a04b24615b5a0842918a82f50040f9e09ca7ec69ceac2ea759bR23-R24))
*  Define `fallbackMiddleware` and `currentMiddleware` constants to provide a default middleware hostname for the camera stream based on the availability of the `middlewareHostname` prop and the `asset` object in the `ONVIFCamera` component ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbR56-R60))
*  Use `currentMiddleware` constant instead of `facilityMiddlewareHostname` in the API calls to get the preset data and to pass the prop to the `AddPresetModal` component in the `ONVIFCamera` component ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL108-R113), [link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL226-R228))
*  Remove the definition of `fallbackMiddleware` constant from the `ONVIFCamera` component as it is now passed as a prop from the `Feed` component ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-1d65a996f952fb6cd0b8721be6e07b3b0bc719c35adb7ddd256b3e550a02a7dbL139-L141))
*  Rename `cameraMiddlewareHostname` state variable to `facilityMiddlewareHostname` and add `middleware_address` and `location_middleware` properties to `cameraAsset` state object to store the hostnames of the middleware servers for the camera stream and the location of the camera in the `Feed` component ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L51-R55), [link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R142-R147))
*  Set the value of `facilityMiddlewareHostname` state variable to the value of `res.data.middleware_address` in the API call to get the facility details in the `Feed` component ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L69-R72))
*  Define `fallbackMiddleware` and `currentMiddleware` constants to provide a default middleware hostname for the camera stream based on the availability of the `cameraAsset.middleware_address` and the `cameraAsset.location_middleware` properties in the `Feed` component ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2R79-R84))
*  Use `currentMiddleware` constant instead of `facilityMiddlewareHostname` in the URL for the camera stream, the config object passed to the `useMSEMediaPlayer` hook, and the dependency array of the `useEffect` hook that calls the `getBedPresets` function in the `Feed` component ([link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L173-R189), [link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L185-R200), [link](https://github.com/coronasafe/care_fe/pull/6538/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L232-R247))
