### PR TITLE
Show camera feed button only  for specific roles

### DIFF
--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -335,14 +335,17 @@ export const ConsultationDetails = (props: any) => {
                 >
                   Doctor Connect
                 </button>
-                {patientData.last_consultation?.id && (
-                  <Link
-                    href={`/facility/${patientData.facility}/patient/${patientData.id}/consultation/${patientData.last_consultation?.id}/feed`}
-                    className="btn btn-primary m-1 w-full hover:text-white"
-                  >
-                    Camera Feed
-                  </Link>
-                )}
+                {patientData.last_consultation?.id &&
+                  ["DistrictAdmin", "StateAdmin", "Doctor"].includes(
+                    authUser.user_type
+                  ) && (
+                    <Link
+                      href={`/facility/${patientData.facility}/patient/${patientData.id}/consultation/${patientData.last_consultation?.id}/feed`}
+                      className="btn btn-primary m-1 w-full hover:text-white"
+                    >
+                      Camera Feed
+                    </Link>
+                  )}
               </>
             )}
             <Link


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ae3bb6</samp>

Added a `Camera Feed` button to the consultation details page for authorized users. This button allows users to view the live video of the patient's last consultation.

## Proposed Changes

- Fixes #6539

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ae3bb6</samp>

*  Add a `Camera Feed` button to the consultation details page for authorized users ([link](https://github.com/coronasafe/care_fe/pull/6540/files?diff=unified&w=0#diff-8a3d15fd6d3361688d96f67af80b867cc60bfbd6bc7642555fd6b5fd04d63901L338-R348))
