### PR TITLE
Show chapter of diagnosis for principal diagnosis

### DIFF
--- a/src/Components/Diagnosis/ConsultationDiagnosisBuilder/ConsultationDiagnosisBuilder.tsx
+++ b/src/Components/Diagnosis/ConsultationDiagnosisBuilder/ConsultationDiagnosisBuilder.tsx
@@ -10,6 +10,7 @@ import ConsultationDiagnosisEntry from "./ConsultationDiagnosisEntry";
 import request from "../../../Utils/request/request";
 import DiagnosesRoutes from "../routes";
 import * as Notification from "../../../Utils/Notifications";
+import PrincipalDiagnosisCard from "./PrincipalDiagnosisCard";
 
 interface CreateDiagnosesProps {
   className?: string;
@@ -18,6 +19,7 @@ interface CreateDiagnosesProps {
 }
 
 export const CreateDiagnosesBuilder = (props: CreateDiagnosesProps) => {
+  const principalDiagnosis = props.value.find((d) => d.is_principal);
   return (
     <div className={props.className}>
       <div className="flex w-full flex-col items-start rounded-lg border border-gray-400">
@@ -62,6 +64,13 @@ export const CreateDiagnosesBuilder = (props: CreateDiagnosesProps) => {
           />
         </div>
       </div>
+
+      {principalDiagnosis?.diagnosis_object && (
+        <PrincipalDiagnosisCard
+          className="my-2"
+          diagnosis={principalDiagnosis.diagnosis_object}
+        />
+      )}
     </div>
   );
 };
@@ -75,6 +84,8 @@ export const EditDiagnosesBuilder = (props: EditDiagnosesProps) => {
   const consultation = useSlug("consultation");
   const [diagnoses, setDiagnoses] = useState(props.value);
 
+  const principalDiagnosis = diagnoses.find((d) => d.is_principal);
+
   return (
     <div className={props.className}>
       <div className="flex w-full flex-col items-start rounded-lg border border-gray-400">
@@ -84,6 +95,15 @@ export const EditDiagnosesBuilder = (props: EditDiagnosesProps) => {
               key={index}
               value={diagnosis}
               consultationId={consultation}
+              onChange={(action) => {
+                setDiagnoses(
+                  diagnoses.map((diagnose, i) =>
+                    i === index
+                      ? (action.value as ConsultationDiagnosis)
+                      : diagnose
+                  )
+                );
+              }}
             />
           ))}
         </div>
@@ -118,6 +138,13 @@ export const EditDiagnosesBuilder = (props: EditDiagnosesProps) => {
           />
         </div>
       </div>
+
+      {principalDiagnosis?.diagnosis_object && (
+        <PrincipalDiagnosisCard
+          className="my-2"
+          diagnosis={principalDiagnosis?.diagnosis_object}
+        />
+      )}
     </div>
   );
 };

--- a/src/Components/Diagnosis/ConsultationDiagnosisBuilder/ConsultationDiagnosisEntry.tsx
+++ b/src/Components/Diagnosis/ConsultationDiagnosisBuilder/ConsultationDiagnosisEntry.tsx
@@ -22,8 +22,6 @@ interface EditAction {
   value: CreateDiagnosis | ConsultationDiagnosis;
 }
 
-type Action = RemoveAction | EditAction;
-
 interface BaseProps {
   className?: string;
 }
@@ -31,12 +29,13 @@ interface BaseProps {
 interface ConsultationCreateProps extends BaseProps {
   consultationId?: undefined;
   value: CreateDiagnosis;
-  onChange: (action: Action) => void;
+  onChange: (action: EditAction | RemoveAction) => void;
 }
 
 interface ConsultationEditProps extends BaseProps {
   consultationId: string;
   value: ConsultationDiagnosis;
+  onChange: (action: EditAction) => void;
 }
 
 type Props = ConsultationCreateProps | ConsultationEditProps;
@@ -101,15 +100,12 @@ export default function ConsultationDiagnosisEntry(props: Props) {
               disabled={disabled}
               ghost
               border
-              onClick={() => {
+              onClick={async () => {
                 const value = { ...object, is_principal: !object.is_principal };
-
-                if (props.consultationId === undefined) {
-                  props.onChange({ type: "edit", value });
-                  return;
+                if (props.consultationId) {
+                  await handleUpdate(value as ConsultationDiagnosis);
                 }
-
-                handleUpdate(value as ConsultationDiagnosis);
+                props.onChange({ type: "edit", value });
               }}
               tooltip={object.is_principal ? t("unmark_as_principal") : ""}
               tooltipClassName="tooltip-bottom -translate-x-1/2 translate-y-1 text-xs"
@@ -141,18 +137,15 @@ export default function ConsultationDiagnosisEntry(props: Props) {
                   ? ActiveConditionVerificationStatuses
                   : ConditionVerificationStatuses
               }
-              onSelect={(verification_status) => {
+              onSelect={async (verification_status) => {
                 const value = { ...object, verification_status };
-
-                if (props.consultationId === undefined) {
-                  props.onChange({
-                    type: "edit",
-                    value: value as CreateDiagnosis,
-                  });
-                  return;
+                if (props.consultationId) {
+                  await handleUpdate(value as ConsultationDiagnosis);
                 }
-
-                handleUpdate(value as ConsultationDiagnosis);
+                props.onChange({
+                  type: "edit",
+                  value: value as CreateDiagnosis | ConsultationDiagnosis,
+                });
               }}
               onRemove={
                 props.consultationId === undefined

--- a/src/Components/Diagnosis/ConsultationDiagnosisBuilder/PrincipalDiagnosisCard.tsx
+++ b/src/Components/Diagnosis/ConsultationDiagnosisBuilder/PrincipalDiagnosisCard.tsx
@@ -1,0 +1,25 @@
+import { ICD11DiagnosisModel } from "../types";
+
+interface Props {
+  className?: string;
+  diagnosis: ICD11DiagnosisModel;
+}
+
+export default function PrincipalDiagnosisCard(props: Props) {
+  return (
+    <div className={props.className}>
+      <div className="rounded-lg border border-gray-400 bg-gray-200 p-4">
+        <h3 className="text-lg font-semibold">Principal Diagnosis</h3>
+        <span className="mt-2 flex w-full flex-col items-center gap-2 text-center text-gray-900">
+          <span className="cui-input-base text-base font-bold">
+            {props.diagnosis.label}
+          </span>
+          <span className="flex flex-wrap gap-x-1 px-2">
+            <p>This encounter will be categorised under:</p>
+            <p className="font-bold">{props.diagnosis.chapter}</p>
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Diagnosis/types.ts
+++ b/src/Components/Diagnosis/types.ts
@@ -3,6 +3,7 @@ import { PerformedByModel } from "../HCX/misc";
 export type ICD11DiagnosisModel = {
   id: string;
   label: string;
+  chapter: string;
 };
 
 export const ActiveConditionVerificationStatuses = [


### PR DESCRIPTION
Branched from https://github.com/coronasafe/care_fe/commit/0f1e07907ecfd389cbbc04b8b45fad948f652581 of [consultation_diagnoses_m2m](https://github.com/coronasafe/care_fe/tree/consultation_diagnoses_m2m) branch

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bfdc56</samp>

This pull request adds a new feature to display and update the principal diagnosis of a consultation using the ICD11 classification system. It introduces a new component `PrincipalDiagnosisCard` and modifies the existing components `ConsultationDiagnosisBuilder` and `ConsultationDiagnosisEntry`. It also updates the `ICD11DiagnosisModel` type to include the chapter of the diagnosis.

## Required Backends
- https://github.com/coronasafe/care/pull/1696

## Proposed Changes

- Fixes #6529 

<img width="1709" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/3cc9100c-b58f-4a22-a298-2cfcacd15038">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bfdc56</samp>

*  Add `PrincipalDiagnosisCard` component to display the principal diagnosis of a consultation in a card format ([link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-0c796d3b02cdffab6c4c262a0d9ddce9f7a5ef11bf1ea0ba4424381064c4f0e6R1-R25), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-302d20b396b0e97f0a61800742905e54194281d0f2f6dfb11b6fda4eebcb54eaR13), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-302d20b396b0e97f0a61800742905e54194281d0f2f6dfb11b6fda4eebcb54eaR67-R73), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-302d20b396b0e97f0a61800742905e54194281d0f2f6dfb11b6fda4eebcb54eaR141-R147))
*  Modify `ConsultationDiagnosisEntry` component to handle changes in the diagnosis object for the edit scenario and update the backend accordingly ([link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-e5557d4c2283a33c9c0c3eba4429d7679f7b6534349caeb91de24c4d9fa44e75L25-L26), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-e5557d4c2283a33c9c0c3eba4429d7679f7b6534349caeb91de24c4d9fa44e75L34-R32), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-e5557d4c2283a33c9c0c3eba4429d7679f7b6534349caeb91de24c4d9fa44e75R38), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-e5557d4c2283a33c9c0c3eba4429d7679f7b6534349caeb91de24c4d9fa44e75L104-R108), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-e5557d4c2283a33c9c0c3eba4429d7679f7b6534349caeb91de24c4d9fa44e75L144-R148))
*  Modify `ConsultationDiagnosisBuilder` component to use `setDiagnoses` function to update the state array of diagnoses ([link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-302d20b396b0e97f0a61800742905e54194281d0f2f6dfb11b6fda4eebcb54eaR22), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-302d20b396b0e97f0a61800742905e54194281d0f2f6dfb11b6fda4eebcb54eaR87-R88), [link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-302d20b396b0e97f0a61800742905e54194281d0f2f6dfb11b6fda4eebcb54eaR98-R106))
*  Add `chapter` property to `ICD11DiagnosisModel` type to represent the chapter of the ICD11 classification system ([link](https://github.com/coronasafe/care_fe/pull/6541/files?diff=unified&w=0#diff-3076c81700fa66db9000ace521cbb0f3451ceb979b9c490f039c5ea199a7e1c6R6))
