### PR TITLE
fix responsive issue in sidebar

### DIFF
--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -116,7 +116,7 @@ const StatelessSidebar = ({
 
   return (
     <nav
-      className={`group flex h-screen flex-col bg-primary-800 py-3 md:py-5 ${
+      className={`group flex h-full flex-col bg-primary-800 py-3 md:py-5 ${
         shrinked ? "w-14" : "w-60"
       } transition-all duration-300 ease-in-out ${
         isOverflowVisible && shrinked
@@ -134,7 +134,7 @@ const StatelessSidebar = ({
         />
       </Link>
       <div className="h-3" /> {/* flexible spacing */}
-      <div className="relative mb-4 flex h-full flex-col md:mb-0">
+      <div className="relative flex h-full flex-col">
         <div className="relative flex flex-1 flex-col md:flex-none">
           <div
             ref={indicatorRef}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62c5941</samp>

Fixed sidebar height bug and improved layout in `Sidebar.tsx`. This makes the sidebar more responsive and consistent across different screen sizes.

## Proposed Changes

- Fixes #6545

Before: 
<img width="402" alt="image" src="https://github.com/coronasafe/care_fe/assets/29787772/47ac2a9f-5482-40bb-83df-74d59f337f2b">

After: 
<img width="406" alt="image" src="https://github.com/coronasafe/care_fe/assets/29787772/deb7ef0c-3588-4881-957d-d5923c2d40b4">



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 62c5941</samp>

*  Fix sidebar overflow bug by changing height class to `h-full` ([link](https://github.com/coronasafe/care_fe/pull/6547/files?diff=unified&w=0#diff-48dc1fa34cba63b7fa44e6a1318d489038c5800824c97315962ef0530f32293eL119-R119))
*  Remove unnecessary bottom margin from sidebar menu items ([link](https://github.com/coronasafe/care_fe/pull/6547/files?diff=unified&w=0#diff-48dc1fa34cba63b7fa44e6a1318d489038c5800824c97315962ef0530f32293eL137-R137))
