### PR TITLE
Added max width constraint to the cards.

### DIFF
--- a/src/Components/Facility/FacilityConfigure.tsx
+++ b/src/Components/Facility/FacilityConfigure.tsx
@@ -139,28 +139,30 @@ export const FacilityConfigure = (props: IProps) => {
       }}
       className="w-full overflow-x-hidden"
     >
-      <div className="cui-card mt-4">
-        <form onSubmit={handleSubmit}>
-          <div className="mt-2 grid grid-cols-1 gap-4">
-            <div>
-              <TextFormField
-                name="middleware_address"
-                label="Facility Middleware Address"
-                required
-                value={state.form.middleware_address}
-                onChange={handleChange}
-                error={state.errors?.middleware_address}
-              />
+      <div className="mx-auto max-w-3xl">
+        <div className="cui-card mt-4">
+          <form onSubmit={handleSubmit}>
+            <div className="mt-2 grid grid-cols-1 gap-4">
+              <div>
+                <TextFormField
+                  name="middleware_address"
+                  label="Facility Middleware Address"
+                  required
+                  value={state.form.middleware_address}
+                  onChange={handleChange}
+                  error={state.errors?.middleware_address}
+                />
+              </div>
             </div>
-          </div>
-          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-            <Cancel onClick={() => navigate(`/facility/${facilityId}`)} />
-            <Submit onClick={handleSubmit} label="Update" />
-          </div>
-        </form>
-      </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Cancel onClick={() => navigate(`/facility/${facilityId}`)} />
+              <Submit onClick={handleSubmit} label="Update" />
+            </div>
+          </form>
+        </div>
 
-      <ConfigureHealthFacility facilityId={facilityId} />
+        <ConfigureHealthFacility facilityId={facilityId} />
+      </div>
     </Page>
   );
 };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab8da5d</samp>

Centered and constrained the width of the health facility configuration form and component in `FacilityConfigure.tsx` to enhance the UI and UX.

## Proposed Changes

- Fixes #6551

![image](https://github.com/coronasafe/care_fe/assets/101407963/0e48e443-ecde-4835-b005-67e9bffba2a3)
 


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab8da5d</samp>

*  Center and limit the width of the health facility configuration form and component by wrapping them in a div with `mx-auto max-w-3xl` classes ([link](https://github.com/coronasafe/care_fe/pull/6563/files?diff=unified&w=0#diff-05f8278e8ee0b31929e50092dbc9336b93dc17b69dcc36a7d4cb9f72c413a927L142-R165))
