### PR TITLE
New Cypress Test | Functionality test of Linking and Unlinking Facility | User Tab

### DIFF
--- a/cypress/e2e/users_spec/user_creation.cy.ts
+++ b/cypress/e2e/users_spec/user_creation.cy.ts
@@ -193,18 +193,6 @@ describe("User Creation", () => {
     userPage.verifyMultipleBadgesWithSameId(alreadylinkedusersviews);
   });
 
-  // the below commented out codes, will be used in the upcoming refactoring of this module, since it is a inter-dependent of partially converted code, currently taking it down
-
-  //   it("link facility for user", () => {
-  //     cy.contains("Linked Facilities").click();
-  //     cy.intercept(/\/api\/v1\/facility/).as("getFacilities");
-  //     cy.get("[name='facility']")
-  //       .click()
-  //       .type("Dummy Facility 1")
-  //       .wait("@getFacilities");
-  //     cy.get("li[role='option']").should("not.exist");
-  //   });
-
   afterEach(() => {
     cy.saveLocalStorage();
   });

--- a/cypress/e2e/users_spec/user_manage.cy.ts
+++ b/cypress/e2e/users_spec/user_manage.cy.ts
@@ -54,7 +54,7 @@ describe("Manage User", () => {
     userPage.typeInSearchInput(usernametolinkfacilitydoc2);
     userPage.checkUsernameText(usernametolinkfacilitydoc2);
     manageUserPage.assertHomeFacility(facilitytolinkusername);
-    // Link a new facility and unlink the facility from the user
+    // Link a new facility and unlink the facility from the doctor username (3)
     userPage.clearSearchInput();
     userPage.typeInSearchInput(usernametolinkfacilitydoc3);
     userPage.checkUsernameText(usernametolinkfacilitydoc3);

--- a/cypress/e2e/users_spec/user_manage.cy.ts
+++ b/cypress/e2e/users_spec/user_manage.cy.ts
@@ -76,6 +76,7 @@ describe("Manage User", () => {
     manageUserPage.clickDoctorConnectButton();
     manageUserPage.assertDoctorConnectVisibility(usernamerealname);
   });
+
   afterEach(() => {
     cy.saveLocalStorage();
   });

--- a/cypress/e2e/users_spec/user_manage.cy.ts
+++ b/cypress/e2e/users_spec/user_manage.cy.ts
@@ -1,0 +1,82 @@
+import { cy, describe, before, beforeEach, it, afterEach } from "local-cypress";
+import LoginPage from "../../pageobject/Login/LoginPage";
+import { UserPage } from "../../pageobject/Users/UserSearch";
+import ManageUserPage from "../../pageobject/Users/ManageUserPage";
+
+describe("Manage User", () => {
+  const loginPage = new LoginPage();
+  const userPage = new UserPage();
+  const manageUserPage = new ManageUserPage();
+  const usernametolinkfacilitydoc1 = "dummydoctor4";
+  const usernametolinkfacilitydoc2 = "dummydoctor5";
+  const usernametolinkfacilitydoc3 = "dummydoctor6";
+  const usernamerealname = "Dummy Doctor";
+  const facilitytolinkusername = "Dummy Shifting Center";
+
+  before(() => {
+    loginPage.loginAsDisctrictAdmin();
+    cy.saveLocalStorage();
+  });
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.awaitUrl("/users");
+  });
+
+  it("linking and unlinking facility for multiple users, and confirm reflection in user cards and doctor connect", () => {
+    // verify the user doesn't have any home facility
+    userPage.typeInSearchInput(usernametolinkfacilitydoc1);
+    userPage.checkUsernameText(usernametolinkfacilitydoc1);
+    manageUserPage.assertHomeFacility("No Home Facility");
+    //  Link a new facility and ensure it is under linked facility - doctor username (1)
+    manageUserPage.clickFacilitiesTab();
+    manageUserPage.typeFacilityName(facilitytolinkusername);
+    manageUserPage.selectFacilityFromDropdown(facilitytolinkusername);
+    manageUserPage.clickLinkFacility();
+    manageUserPage.assertLinkedFacility(facilitytolinkusername);
+    //  Verify in the already linked facility are not present in droplist
+    manageUserPage.assertFacilityNotInDropdown(facilitytolinkusername);
+    manageUserPage.clickCloseSlideOver();
+    //  Link a new facility and ensure it is under home facility - doctor username (2)
+    userPage.clearSearchInput();
+    userPage.typeInSearchInput(usernametolinkfacilitydoc2);
+    userPage.checkUsernameText(usernametolinkfacilitydoc2);
+    manageUserPage.clickFacilitiesTab();
+    manageUserPage.typeFacilityName(facilitytolinkusername);
+    manageUserPage.selectFacilityFromDropdown(facilitytolinkusername);
+    manageUserPage.clickLinkFacility();
+    manageUserPage.clickHomeFacilityIcon();
+    manageUserPage.assertnotLinkedFacility(facilitytolinkusername);
+    manageUserPage.assertHomeFacilitylink(facilitytolinkusername);
+    manageUserPage.clickCloseSlideOver();
+    //  verify the home facility doctor id have reflection in user card
+    userPage.clearSearchInput();
+    userPage.typeInSearchInput(usernametolinkfacilitydoc2);
+    userPage.checkUsernameText(usernametolinkfacilitydoc2);
+    manageUserPage.assertHomeFacility(facilitytolinkusername);
+    // Link a new facility and unlink the facility from the user
+    userPage.clearSearchInput();
+    userPage.typeInSearchInput(usernametolinkfacilitydoc3);
+    userPage.checkUsernameText(usernametolinkfacilitydoc3);
+    manageUserPage.clickFacilitiesTab();
+    manageUserPage.typeFacilityName(facilitytolinkusername);
+    manageUserPage.selectFacilityFromDropdown(facilitytolinkusername);
+    manageUserPage.clickLinkFacility();
+    manageUserPage.clickUnlinkFacilityButton();
+    manageUserPage.clickSubmit();
+    manageUserPage.assertnotLinkedFacility;
+    manageUserPage.linkedfacilitylistnotvisible();
+    manageUserPage.clickCloseSlideOver();
+    //  Go to particular facility doctor connect and all user-id are reflected based on there access
+    // Path will be facility page to patient page then doctor connect button
+    manageUserPage.navigateToFacility();
+    manageUserPage.typeFacilitySearch(facilitytolinkusername);
+    manageUserPage.assertFacilityInCard(facilitytolinkusername);
+    manageUserPage.clickFacilityPatients();
+    manageUserPage.clickDoctorConnectButton();
+    manageUserPage.assertDoctorConnectVisibility(usernamerealname);
+  });
+  afterEach(() => {
+    cy.saveLocalStorage();
+  });
+});

--- a/cypress/pageobject/Users/ManageUserPage.ts
+++ b/cypress/pageobject/Users/ManageUserPage.ts
@@ -1,0 +1,85 @@
+export class ManageUserPage {
+  assertHomeFacility(expectedText) {
+    cy.get("#home_facility").should("contain.text", expectedText);
+  }
+
+  clickFacilitiesTab() {
+    cy.get("#facilities").click();
+  }
+
+  typeFacilityName(facilityName) {
+    cy.get("input[name='facility']").click().type(facilityName);
+  }
+
+  selectFacilityFromDropdown(facilityName) {
+    cy.get("[role='option']").contains(facilityName).click();
+  }
+
+  clickLinkFacility() {
+    cy.get("#link-facility").click();
+  }
+
+  assertLinkedFacility(facilityName) {
+    cy.get("#linked-facility-list").should("contain.text", facilityName);
+  }
+
+  assertnotLinkedFacility(facilityName) {
+    cy.get("#linked-facility-list").should("not.contain", facilityName);
+  }
+
+  linkedfacilitylistnotvisible() {
+    cy.get("#linked-facility-list").should("not.exist");
+  }
+
+  assertHomeFacilitylink(facilityName) {
+    cy.get("#home-facility").should("contain.text", facilityName);
+  }
+
+  assertFacilityNotInDropdown(facilityName) {
+    this.typeFacilityName(facilityName);
+    cy.get("[role='option']").should("not.exist");
+  }
+
+  clickCloseSlideOver() {
+    cy.get("#close-slide-over").click();
+  }
+
+  clickHomeFacilityIcon() {
+    cy.get("#home-facility-icon").click();
+  }
+
+  clickUnlinkFacilityButton() {
+    cy.get("#unlink-facility-button").click();
+  }
+
+  clickSubmit() {
+    cy.get("#submit").click();
+  }
+
+  navigateToFacility() {
+    cy.visit("/facility");
+  }
+
+  typeFacilitySearch(facilityName) {
+    cy.get("#search").click().type(facilityName);
+  }
+
+  assertFacilityInCard(facilityName) {
+    cy.get("#facility-name-card").should("contain", facilityName);
+  }
+
+  clickFacilityPatients() {
+    cy.get("#facility-patients").click();
+  }
+
+  clickDoctorConnectButton() {
+    cy.get("#doctor-connect-patient-button").click();
+  }
+
+  assertDoctorConnectVisibility(realName) {
+    cy.get("#Doctor-connect-homedoctor").should("contain.text", realName);
+    cy.get("#Doctor-connect-remotedoctor").should("contain.text", realName);
+  }
+}
+
+export default ManageUserPage;

--- a/cypress/pageobject/Users/ManageUserPage.ts
+++ b/cypress/pageobject/Users/ManageUserPage.ts
@@ -77,8 +77,8 @@ export class ManageUserPage {
   }
 
   assertDoctorConnectVisibility(realName) {
-    cy.get("#Doctor-connect-homedoctor").should("contain.text", realName);
-    cy.get("#Doctor-connect-remotedoctor").should("contain.text", realName);
+    cy.get("#doctor-connect-home-doctor").should("contain.text", realName);
+    cy.get("#doctor-connect-remote-doctor").should("contain.text", realName);
   }
 }
 

--- a/src/Components/Facility/DoctorVideoSlideover.tsx
+++ b/src/Components/Facility/DoctorVideoSlideover.tsx
@@ -56,19 +56,22 @@ export default function DoctorVideoSlideover(props: {
           title: "Doctors",
           user_type: "Doctor",
           home: true,
+          id: "Doctor-connect-homedoctor",
         },
         {
           title: "Staff",
           user_type: "Staff",
           home: true,
+          id: "Doctor-connect-homestaff",
         },
         {
           title: "TeleICU Hub",
           user_type: "Doctor",
           home: false,
+          id: "Doctor-connect-remotedoctor",
         },
       ].map((type, i) => (
-        <div key={i} className="mb-4">
+        <div key={i} className="mb-4" id={type.id}>
           <div>
             <span className="text-lg font-semibold">{type.title}</span>
           </div>

--- a/src/Components/Facility/DoctorVideoSlideover.tsx
+++ b/src/Components/Facility/DoctorVideoSlideover.tsx
@@ -56,22 +56,25 @@ export default function DoctorVideoSlideover(props: {
           title: "Doctors",
           user_type: "Doctor",
           home: true,
-          id: "Doctor-connect-homedoctor",
         },
         {
           title: "Staff",
           user_type: "Staff",
           home: true,
-          id: "Doctor-connect-homestaff",
         },
         {
           title: "TeleICU Hub",
           user_type: "Doctor",
           home: false,
-          id: "Doctor-connect-remotedoctor",
         },
       ].map((type, i) => (
-        <div key={i} className="mb-4" id={type.id}>
+        <div
+          key={i}
+          className="mb-4"
+          id={`doctor-connect-${
+            type.home ? "home" : "remote"
+          }-${type.user_type.toLowerCase()}`}
+        >
           <div>
             <span className="text-lg font-semibold">{type.title}</span>
           </div>

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -88,7 +88,10 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                       {kasp_string}
                     </div>
                   )}
-                  <div className="flex flex-wrap items-center justify-between">
+                  <div
+                    className="flex flex-wrap items-center justify-between"
+                    id="facility-name-card"
+                  >
                     <Link
                       href={`/facility/${facility.id}`}
                       className="float-left text-xl font-bold capitalize text-inherit hover:text-inherit"

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -629,6 +629,7 @@ export const FacilityHome = (props: any) => {
                 <span className="text-sm">Add Details of a Patient</span>
               </ButtonV2>
               <ButtonV2
+                id="view-patient-facility-list"
                 variant="primary"
                 ghost
                 border

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -803,6 +803,7 @@ export const PatientManager = () => {
             />
             {showDoctorConnect && (
               <ButtonV2
+                id="doctor-connect-patient-button"
                 onClick={() => {
                   triggerGoal("Doctor Connect Clicked", {
                     facilityId: qParams.facility,

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -731,7 +731,7 @@ function UserFacilities(props: { user: any }) {
         <div className="flex flex-col">
           {/* Home Facility section */}
           {user?.home_facility_object && (
-            <div className="mt-2">
+            <div className="mt-2" id="home-facility">
               <div className="mb-2 ml-2 text-lg font-bold">Home Facility</div>
               <div className="relative rounded p-2 transition hover:bg-gray-200 focus:bg-gray-200 md:rounded-lg">
                 <div className="flex items-center justify-between">
@@ -762,7 +762,7 @@ function UserFacilities(props: { user: any }) {
 
           {/* Linked Facilities section */}
           {facilities.length > 0 && (
-            <div className="mt-2">
+            <div className="mt-2" id="linked-facility-list">
               <div className="mb-2 ml-2 text-lg font-bold">
                 Linked Facilities
               </div>
@@ -785,6 +785,7 @@ function UserFacilities(props: { user: any }) {
                         <div className="flex items-center gap-2">
                           <button
                             className="tooltip text-lg hover:text-primary-500"
+                            id="home-facility-icon"
                             onClick={() => {
                               if (user?.home_facility_object) {
                                 // has previous home facility
@@ -806,6 +807,7 @@ function UserFacilities(props: { user: any }) {
                             </span>
                           </button>
                           <button
+                            id="unlink-facility-button"
                             className="tooltip text-lg text-red-600"
                             onClick={() =>
                               setUnlinkFacilityData({


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc60aab</samp>

This pull request adds id attributes to various elements in the frontend components, and adds a new test file and a new page object file for the user manage feature. The id attributes are needed for testing purposes, and the new test file and page object file test the functionality of linking and unlinking facilities for users. The pull request also removes some unused code and adds id attributes to some elements in the facility and patient components.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bc60aab</samp>

*  Add new test file and page object file for user manage feature, which covers linking and unlinking facilities for multiple users and verifying the changes in user cards and doctor connect feature ([link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-01a6f60229b907af33145f82ce02b748944b5b0055250e3ffb808fef068a6adbR1-R82), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-6f5fc8a8e198279f426615195b23f2cc356307e1b39c2baa06f33af167d39c5fR1-R85))
* Remove unused commented out code block from user creation test file ([link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-53cd1dd4d96308738f7704668d33e3ab45330d8389e03aa7046f81dc42187cfbL196-L207))
* Add id attributes to various elements in the facility card, facility home, patient manager, user facilities, and doctor video slide over components, which are used for locating the elements in the test file ([link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-f15a132265ab339453f06bc7dc6b773802090dfba335c46051a309b512de2060R59), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-f15a132265ab339453f06bc7dc6b773802090dfba335c46051a309b512de2060R65), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-f15a132265ab339453f06bc7dc6b773802090dfba335c46051a309b512de2060L69-R74), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L91-R94), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cR632), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575R806), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121L734-R734), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121L765-R765), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121R788), [link](https://github.com/coronasafe/care_fe/pull/6564/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121R810))
