### PR TITLE
New Cypress Test | Functionality test of Adding working hour to user and verify its reflection | User Tab

### DIFF
--- a/cypress/e2e/users_spec/user_manage.cy.ts
+++ b/cypress/e2e/users_spec/user_manage.cy.ts
@@ -10,8 +10,10 @@ describe("Manage User", () => {
   const usernametolinkfacilitydoc1 = "dummydoctor4";
   const usernametolinkfacilitydoc2 = "dummydoctor5";
   const usernametolinkfacilitydoc3 = "dummydoctor6";
+  const usernametolinkskill = "devdistrictadmin";
   const usernamerealname = "Dummy Doctor";
   const facilitytolinkusername = "Dummy Shifting Center";
+  const workinghour = "23";
 
   before(() => {
     loginPage.loginAsDisctrictAdmin();
@@ -21,6 +23,22 @@ describe("Manage User", () => {
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.awaitUrl("/users");
+  });
+
+  it("add working hour for a user and verify its reflection in card and user profile", () => {
+    // verify mandatory field error and select working hour for a user
+    userPage.typeInSearchInput(usernametolinkskill);
+    userPage.checkUsernameText(usernametolinkskill);
+    manageUserPage.clicksetaveragehourbutton();
+    manageUserPage.clearweeklyhourfield();
+    manageUserPage.clickSubmit();
+    manageUserPage.verifyErrorText("Value should be between 0 and 168");
+    // verify the data is reflected in user card and profile page
+    manageUserPage.typeInWeeklyWorkingHours(workinghour);
+    manageUserPage.clickSubmit();
+    manageUserPage.verifyWorkingHours(workinghour);
+    manageUserPage.navigateToProfile();
+    manageUserPage.verifyProfileWorkingHours(workinghour);
   });
 
   it("linking and unlinking facility for multiple users, and confirm reflection in user cards and doctor connect", () => {

--- a/cypress/pageobject/Users/ManageUserPage.ts
+++ b/cypress/pageobject/Users/ManageUserPage.ts
@@ -56,6 +56,37 @@ export class ManageUserPage {
     cy.get("#submit").click();
   }
 
+  clicksetaveragehourbutton() {
+    cy.get("#avg-workinghour").click();
+  }
+
+  clearweeklyhourfield() {
+    cy.get("#weekly_working_hours").click().clear();
+  }
+
+  verifyErrorText(expectedError: string) {
+    cy.get(".error-text").should("contain", expectedError).and("be.visible");
+  }
+
+  typeInWeeklyWorkingHours(hours: string) {
+    cy.get("#weekly_working_hours").click().type(hours);
+  }
+
+  navigateToProfile() {
+    cy.get("#profilenamelink").click();
+  }
+
+  verifyWorkingHours(expectedHours: string) {
+    cy.get("#working-hours").should("contain", `${expectedHours} hours`);
+  }
+
+  verifyProfileWorkingHours(expectedHours: string) {
+    cy.get("#averageworkinghour-profile-details").should(
+      "contain",
+      expectedHours
+    );
+  }
+
   navigateToFacility() {
     cy.visit("/facility");
   }

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -442,7 +442,7 @@ export default function ManageUsers() {
                   ) && (
                     <div className="flex-col md:flex-row">
                       <ButtonV2
-                        id="skills"
+                        id="avg-workinghour"
                         className="flex w-full items-center md:w-full"
                         onClick={() => {
                           setExpandWorkingHours(true);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6668671</samp>

Added a Cypress test case and page object methods to verify the working hours feature for users. Modified the `id` attribute of a button in `ManageUsers.tsx` to match the feature and the test case.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6668671</samp>

* Change the `id` attribute of the `ButtonV2` component from `skills` to `avg-workinghour` in `ManageUsers.tsx` to reflect the functionality of showing the average working hours of a user ([link](https://github.com/coronasafe/care_fe/pull/6566/files?diff=unified&w=0#diff-a6a7ab3af39c9e2846bc2d69312a095aa77957d33c31ea4c0a70c034dfdfa121L445-R445))
* Add new methods to the `ManageUserPage` class in `ManageUserPage.ts` to interact and verify the elements related to the working hour feature, such as the `avg-workinghour` button, the `workinghour` input field, and the `workinghour` badge ([link](https://github.com/coronasafe/care_fe/pull/6566/files?diff=unified&w=0#diff-6f5fc8a8e198279f426615195b23f2cc356307e1b39c2baa06f33af167d39c5fR59-R89))
  - Logout from the application ([link](https://github.com/coronasafe/care_fe/pull/6566/files?diff=unified&w=0#diff-01a6f60229b907af33145f82ce02b748944b5b0055250e3ffb808fef068a6adbL13-R16), [link](https://github.com/coronasafe/care_fe/pull/6566/files?diff=unified&w=0#diff-01a6f60229b907af33145f82ce02b748944b5b0055250e3ffb808fef068a6adbR28-R43))
