### PR TITLE
fix cypress: resource and sample test

### DIFF
--- a/src/Components/Resource/ListView.tsx
+++ b/src/Components/Resource/ListView.tsx
@@ -135,7 +135,7 @@ export default function ListView() {
             <div className="mt-2 flex">
               <button
                 data-testid="resource-details"
-                onClick={(_) => navigate(`/resource/${resource.external_id}`)}
+                onClick={(_) => navigate(`/resource/${resource.id}`)}
                 className="btn btn-default mr-2 w-full bg-white"
               >
                 <i className="fas fa-eye mr-2" /> All Details

--- a/src/Components/Resource/ResourceBoard.tsx
+++ b/src/Components/Resource/ResourceBoard.tsx
@@ -137,7 +137,7 @@ const ResourceCard = ({ resource }: any) => {
           <div className="mt-2 flex">
             <button
               data-testid="resource-details"
-              onClick={(_) => navigate(`/resource/${resource.external_id}`)}
+              onClick={(_) => navigate(`/resource/${resource.id}`)}
               className="btn btn-default mr-2 w-full bg-white"
             >
               <i className="fas fa-eye mr-2" /> All Details

--- a/src/Components/Resource/ResourceDetails.tsx
+++ b/src/Components/Resource/ResourceDetails.tsx
@@ -253,7 +253,7 @@ export default function ResourceDetails(props: { id: string }) {
               <ButtonV2
                 data-testid="update-status"
                 className="mt-4 w-full sm:mt-2"
-                href={`/resource/${data.external_id}/update`}
+                href={`/resource/${data.id}/update`}
               >
                 Update Status/Details
               </ButtonV2>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at edd2c04</samp>

Fixed a bug in resource list view that prevented accessing some resource details. Changed the button `onClick` handler to use `id` instead of `external_id` in `src/Components/Resource/ListView.tsx`.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at edd2c04</samp>

* Fix a bug where some resources could not be accessed from the list view by using the `id` property instead of the `external_id` property for the `onClick` handler of the button that navigates to the resource details page ([link](https://github.com/coronasafe/care_fe/pull/6569/files?diff=unified&w=0#diff-9b8688043522f05d85d852d6a8b0a6d4ee406f772f626d435136c5e357b91d00L138-R138))
