### PR TITLE
✔️ Fixed reloading issue while Opening Investigations or Treatment Summary in Consultation Dashboard.

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -441,14 +441,14 @@ export default function PatientInfoCard(props: {
                   (action: any, i) =>
                     action[3] && (
                       <div key={i}>
-                        <a
+                        <Link
                           key={i}
                           className="dropdown-item-primary pointer-events-auto m-2 flex cursor-pointer items-center justify-start gap-2 rounded border-0 p-2 text-sm font-normal transition-all duration-200 ease-in-out"
                           href={
                             consultation?.admitted &&
                             !consultation?.current_bed &&
                             i === 1
-                              ? undefined
+                              ? ""
                               : `${action[0]}`
                           }
                           onClick={() => {
@@ -473,7 +473,7 @@ export default function PatientInfoCard(props: {
                             className={`care-l-${action[2]} text-lg text-primary-500`}
                           />
                           <span>{action[1]}</span>
-                        </a>
+                        </Link>
                         {action?.[4]?.[0] && (
                           <>
                             <p className="mt-1 text-xs text-red-500">


### PR DESCRIPTION
…ry in Consultation Dashboard.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a4e250</samp>

Improved patient info card UI and navigation. Used `Link` components for better routing and handled edge cases for undefined values in `PatientInfoCard.tsx`.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6554

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a4e250</samp>

*  Replace `a` tags with `Link` components to enable client-side routing and avoid page reloads ([link](https://github.com/coronasafe/care_fe/pull/6576/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L444-R444), [link](https://github.com/coronasafe/care_fe/pull/6576/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L451-R451), [link](https://github.com/coronasafe/care_fe/pull/6576/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L476-R476)) in `PatientInfoCard.tsx`
