### PR TITLE
🪛 Fixed Non-uniform height of Asset List Tiles.

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -189,12 +189,12 @@ const AssetsList = () => {
           <Link
             key={asset.id}
             href={`/facility/${asset?.location_object.facility.id}/assets/${asset.id}`}
-            className="text-inherit"
+            className="h-full text-inherit"
             data-testid="created-asset-list"
           >
             <div
               key={asset.id}
-              className="border-1 w-full cursor-pointer items-center justify-center rounded-lg border border-transparent bg-white p-5 shadow hover:border-primary-500"
+              className="border-1 h-full w-full cursor-pointer items-center justify-center rounded-lg border border-transparent bg-white p-5 shadow hover:border-primary-500"
             >
               <div className="md:flex">
                 <p className="flex break-words text-xl font-medium capitalize">


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef18c68</samp>

Improved the UI of the assets list component by adjusting the link height. Modified the `className` attribute of the `Link` component in `src/Components/Assets/AssetsList.tsx`.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6550

### Changes

**Before:**

![Screenshot 2023-11-09 234731](https://github.com/coronasafe/care_fe/assets/106866225/388b08d5-2498-4087-9d26-110a06af8029)

**After:**

![Screenshot 2023-11-09 234741](https://github.com/coronasafe/care_fe/assets/106866225/dae389fe-906e-4721-beb2-3b59604964a4)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef18c68</samp>

*  Added `h-full` class to `Link` component to fill parent height ([link](https://github.com/coronasafe/care_fe/pull/6578/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49L192-R197))
