### PR TITLE
Fix clear button for CNS location filter

### DIFF
--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -168,11 +168,15 @@ export default function CentralNursingStation({ facilityId }: Props) {
                       <FieldLabel className="text-sm">
                         Filter by Location
                       </FieldLabel>
-                      <div className="flex w-full items-center gap-2">
+                      <div>
                         <LocationSelect
                           key={qParams.location}
                           name="Facilities"
-                          setSelected={(location) => updateQuery({ location })}
+                          setSelected={(location) => {
+                            location
+                              ? updateQuery({ location })
+                              : removeFilter("location");
+                          }}
                           selected={qParams.location}
                           showAll={false}
                           multiple={false}
@@ -180,16 +184,6 @@ export default function CentralNursingStation({ facilityId }: Props) {
                           errors=""
                           errorClassName="hidden"
                         />
-                        {qParams.location && (
-                          <ButtonV2
-                            variant="secondary"
-                            circle
-                            border
-                            onClick={() => removeFilter("location")}
-                          >
-                            Clear
-                          </ButtonV2>
-                        )}
                       </div>
                     </div>
                     <SelectFormField

--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -167,7 +167,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                             : "button-primary-border bg-primary-100"
                         }`}
                       >
-                        <span className="tooltip-text tooltip-bottom md:tooltip-right -translate-y-2">
+                        <span className="tooltip-text tooltip-top">
                           Live Patients / Total beds
                         </span>{" "}
                         <CareIcon

--- a/src/Components/Facility/LiveFeedScreen.tsx
+++ b/src/Components/Facility/LiveFeedScreen.tsx
@@ -137,11 +137,15 @@ export default function LiveFeedScreen({ facilityId }: Props) {
                       <FieldLabel className="text-sm">
                         Filter by Location
                       </FieldLabel>
-                      <div className="flex w-full items-center gap-2">
+                      <div>
                         <LocationSelect
                           key={qParams.location}
                           name="Facilities"
-                          setSelected={(location) => updateQuery({ location })}
+                          setSelected={(location) => {
+                            location
+                              ? updateQuery({ location })
+                              : removeFilter("location");
+                          }}
                           selected={qParams.location}
                           showAll={false}
                           multiple={false}
@@ -149,16 +153,6 @@ export default function LiveFeedScreen({ facilityId }: Props) {
                           errors=""
                           errorClassName="hidden"
                         />
-                        {qParams.location && (
-                          <ButtonV2
-                            variant="secondary"
-                            circle
-                            border
-                            onClick={() => removeFilter("location")}
-                          >
-                            Clear
-                          </ButtonV2>
-                        )}
                       </div>
                     </div>
                     <CheckBoxFormField


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7cfda46</samp>

Fixed a location filter bug and removed a redundant button in the central nursing station component. This improves the usability and performance of the `CentralNursingStation.tsx` file.

## Proposed Changes

- Fixes #6580

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7cfda46</samp>

* Fix location filter bug by calling `removeFilter` when location is cleared ([link](https://github.com/coronasafe/care_fe/pull/6581/files?diff=unified&w=0#diff-95b57b1137a563f4d92c994d950f87bc81e4a3eb129066d34a3c851d58c3609dL171-R179))
* Remove redundant `ButtonV2` component for clearing location filter ([link](https://github.com/coronasafe/care_fe/pull/6581/files?diff=unified&w=0#diff-95b57b1137a563f4d92c994d950f87bc81e4a3eb129066d34a3c851d58c3609dL183-L192))
