### PR TITLE
refresh administrations upon archive

### DIFF
--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationEventCell.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationEventCell.tsx
@@ -11,12 +11,14 @@ interface Props {
   administrations: MedicineAdministrationRecord[];
   interval: { start: Date; end: Date };
   prescription: Prescription;
+  refetch: () => void;
 }
 
 export default function AdministrationEventCell({
   administrations,
   interval: { start, end },
   prescription,
+  refetch,
 }: Props) {
   const [showTimeline, setShowTimeline] = useState(false);
   // Check if cell belongs to an administered prescription
@@ -55,6 +57,7 @@ export default function AdministrationEventCell({
             interval={{ start, end }}
             prescription={prescription}
             showPrescriptionDetails
+            onRefetch={refetch}
           />
         </DialogModal>
         <button

--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
@@ -33,22 +33,25 @@ export default function MedicineAdministrationTableRow({
   const [showAdminister, setShowAdminister] = useState(false);
   const [showDiscontinue, setShowDiscontinue] = useState(false);
 
-  const { data, loading } = useQuery(MedicineRoutes.listAdministrations, {
-    pathParams: { consultation },
-    query: {
-      prescription: prescription.id,
-      administered_date_after: formatDateTime(
-        props.intervals[0].start,
-        "YYYY-MM-DD"
-      ),
-      administered_date_before: formatDateTime(
-        props.intervals[props.intervals.length - 1].end,
-        "YYYY-MM-DD"
-      ),
-      archived: false,
-    },
-    key: `${prescription.last_administered_on}`,
-  });
+  const { data, loading, refetch } = useQuery(
+    MedicineRoutes.listAdministrations,
+    {
+      pathParams: { consultation },
+      query: {
+        prescription: prescription.id,
+        administered_date_after: formatDateTime(
+          props.intervals[0].start,
+          "YYYY-MM-DD"
+        ),
+        administered_date_before: formatDateTime(
+          props.intervals[props.intervals.length - 1].end,
+          "YYYY-MM-DD"
+        ),
+        archived: false,
+      },
+      key: `${prescription.last_administered_on}`,
+    }
+  );
 
   return (
     <tr
@@ -220,6 +223,7 @@ export default function MedicineAdministrationTableRow({
                 administrations={data.results}
                 interval={{ start, end }}
                 prescription={prescription}
+                refetch={refetch}
               />
             )}
           </td>

--- a/src/Components/Medicine/PrescrpitionTimeline.tsx
+++ b/src/Components/Medicine/PrescrpitionTimeline.tsx
@@ -28,11 +28,13 @@ interface Props {
   interval: { start: Date; end: Date };
   prescription: Prescription;
   showPrescriptionDetails?: boolean;
+  onRefetch?: () => void;
 }
 
 export default function PrescrpitionTimeline({
   prescription,
   interval,
+  onRefetch,
 }: Props) {
   const consultation = useSlug("consultation");
   const { data, refetch, loading } = useQuery(
@@ -82,7 +84,10 @@ export default function PrescrpitionTimeline({
               <MedicineAdministeredNode
                 key={`activity-${event.type}-${prescription.id}`}
                 event={event}
-                onArchived={refetch}
+                onArchived={() => {
+                  onRefetch?.();
+                  refetch();
+                }}
                 isLastNode={index === events.length - 1}
                 hideArchive={prescription.discontinued}
               />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0a888b</samp>

Added a new feature to archive medicine administration events in the `PrescriptionTimeline` component and refetch the data in the parent and child components. This improves the data consistency and user experience of the medicine administration sheet. Modified the files `AdministrationEventCell.tsx`, `AdministrationTableRow.tsx`, and `PrescrpitionTimeline.tsx` to implement this feature.

## Proposed Changes

- Fixes #6585 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0a888b</samp>

*  Add `refetch` prop to `AdministrationEventCell` component to allow refetching data from parent component ([link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-bb2ad27e44ce21e7b7e8e3cf916b18fd517231239a173ef72dc78bdbc550928fR14), [link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-bb2ad27e44ce21e7b7e8e3cf916b18fd517231239a173ef72dc78bdbc550928fR21), [link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-bb2ad27e44ce21e7b7e8e3cf916b18fd517231239a173ef72dc78bdbc550928fR60))
*  Pass `refetch` function from `useQuery` hook to `AdministrationEventCell` component in `AdministrationTableRow` component ([link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-c388c3a7e8b9c259248167f310faff48a7cffa944d22308fee3b0bf16a90b461L36-R54), [link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-c388c3a7e8b9c259248167f310faff48a7cffa944d22308fee3b0bf16a90b461R226))
*  Add optional `onRefetch` prop to `PrescriptionTimeline` component to trigger refetching data from parent component ([link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-9fec7a75164a6b1f4d65f6daacdb9aa72c4c34205b35683a00ecac955b540691R31), [link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-9fec7a75164a6b1f4d65f6daacdb9aa72c4c34205b35683a00ecac955b540691R37))
*  Call both `onRefetch` and `refetch` functions in `onArchived` prop of `PrescriptionTimelineEvent` component to update data when an event is archived ([link](https://github.com/coronasafe/care_fe/pull/6586/files?diff=unified&w=0#diff-9fec7a75164a6b1f4d65f6daacdb9aa72c4c34205b35683a00ecac955b540691L85-R90))
