### PR TITLE
Implemented Insurance Details Page

### DIFF
--- a/src/Components/HCX/models.ts
+++ b/src/Components/HCX/models.ts
@@ -26,8 +26,8 @@ export interface HCXPolicyModel {
   patient_object?: PatientModel;
   subscriber_id: string;
   policy_id: string;
-  insurer_id: string;
-  insurer_name: string;
+  insurer_id?: string;
+  insurer_name?: string;
   status?: HCXPolicyStatus;
   priority?: "Immediate" | "Normal" | "Deferred";
   purpose?: "Auth Requirements" | "Benefits" | "Discovery" | "Validation";

--- a/src/Components/Patient/InsuranceDetails.tsx
+++ b/src/Components/Patient/InsuranceDetails.tsx
@@ -5,6 +5,7 @@ import Page from "../Common/components/Page";
 import useQuery from "../../Utils/request/useQuery";
 import routes from "../../Redux/api";
 import { HCXPolicyModel } from "../HCX/models";
+import { InsuranceDetialsCard } from "./InsuranceDetailsCard";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -52,48 +53,7 @@ export const InsuranceDetails = (props: IProps) => {
           data-testid="patient-details"
         >
           {insuranceDetials?.results.map((data: HCXPolicyModel) => (
-            <div className="w-full" key={data.id}>
-              <div className="h-full space-y-2 rounded-lg bg-white p-7 shadow">
-                <div className="border-b border-dashed pb-2 text-xl font-bold text-gray-900">
-                  Policy Details
-                </div>
-
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-2">
-                  <div className=" ">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Member ID
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {data.subscriber_id || ""}
-                    </div>
-                  </div>
-                  <div className=" ">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Policy ID / Policy Name
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {data.policy_id || ""}
-                    </div>
-                  </div>
-                  <div className="sm:col-span-1">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Insurer ID
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {data.insurer_id || ""}
-                    </div>
-                  </div>
-                  <div className="sm:col-span-1">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Insurer Name
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {data.insurer_name || ""}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <InsuranceDetialsCard data={data} />
           ))}
         </section>
       )}

--- a/src/Components/Patient/InsuranceDetails.tsx
+++ b/src/Components/Patient/InsuranceDetails.tsx
@@ -1,0 +1,102 @@
+import { lazy } from "react";
+
+import Page from "../Common/components/Page";
+
+import useQuery from "../../Utils/request/useQuery";
+import routes from "../../Redux/api";
+import { HCXPolicyModel } from "../HCX/models";
+
+const Loading = lazy(() => import("../Common/Loading"));
+
+interface IProps {
+  facilityId: string;
+  id: string;
+}
+
+export const InsuranceDetails = (props: IProps) => {
+  const { facilityId, id } = props;
+
+  const { data: insuranceDetials, loading } = useQuery(routes.listHCXPolicies, {
+    query: {
+      patient: id,
+    },
+  });
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <Page
+      title="Insurance Details"
+      crumbsReplacements={{
+        [facilityId]: {
+          name: insuranceDetials?.results[0]?.patient_object?.facility_object
+            ?.name,
+        },
+        [id]: {
+          name: insuranceDetials?.results[0]?.patient_object?.name,
+        },
+      }}
+      className="w-full overflow-x-hidden"
+    >
+      {loading ? (
+        <Loading />
+      ) : insuranceDetials?.count === 0 ? (
+        <div className="mt-5 flex w-full items-center justify-center text-xl font-bold text-gray-500">
+          No Insurance Details Available
+        </div>
+      ) : (
+        <section
+          className="mt-5 grid grid-cols-1 gap-6 lg:grid-cols-3"
+          data-testid="patient-details"
+        >
+          {insuranceDetials?.results.map((data: HCXPolicyModel) => (
+            <div className="w-full" key={data.id}>
+              <div className="h-full space-y-2 rounded-lg bg-white p-7 shadow">
+                <div className="border-b border-dashed pb-2 text-xl font-bold text-gray-900">
+                  Policy Details
+                </div>
+
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-2">
+                  <div className=" ">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Member ID
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {data.subscriber_id || ""}
+                    </div>
+                  </div>
+                  <div className=" ">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Policy ID / Policy Name
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {data.policy_id || ""}
+                    </div>
+                  </div>
+                  <div className="sm:col-span-1">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Insurer ID
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {data.insurer_id || ""}
+                    </div>
+                  </div>
+                  <div className="sm:col-span-1">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Insurer Name
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {data.insurer_name || ""}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+    </Page>
+  );
+};

--- a/src/Components/Patient/InsuranceDetailsCard.tsx
+++ b/src/Components/Patient/InsuranceDetailsCard.tsx
@@ -1,0 +1,78 @@
+import ButtonV2 from "../Common/components/ButtonV2";
+import { HCXPolicyModel } from "../HCX/models";
+import { navigate } from "raviger";
+
+interface InsuranceDetails {
+  data?: HCXPolicyModel;
+  showViewAllDetails?: boolean;
+}
+
+export const InsuranceDetialsCard = (props: InsuranceDetails) => {
+  const { data, showViewAllDetails } = props;
+
+  return (
+    <div className="w-full">
+      <div className="h-full space-y-2 rounded-lg bg-white p-7 shadow">
+        <div className="border-b border-dashed pb-2 text-xl font-bold text-gray-900">
+          Policy Details
+        </div>
+        {data ? (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-2">
+            <div className=" ">
+              <div className="text-sm font-semibold leading-5 text-zinc-400">
+                Member ID
+              </div>
+              <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                {data.subscriber_id || ""}
+              </div>
+            </div>
+            <div className=" ">
+              <div className="text-sm font-semibold leading-5 text-zinc-400">
+                Policy ID / Policy Name
+              </div>
+              <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                {data.policy_id || ""}
+              </div>
+            </div>
+            <div className="sm:col-span-1">
+              <div className="text-sm font-semibold leading-5 text-zinc-400">
+                Insurer ID
+              </div>
+              <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                {data.insurer_id || ""}
+              </div>
+            </div>
+            <div className="sm:col-span-1">
+              <div className="text-sm font-semibold leading-5 text-zinc-400">
+                Insurer Name
+              </div>
+              <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                {data.insurer_name || ""}
+              </div>
+            </div>
+            {showViewAllDetails && (
+              <div className=" first-letter: sm:col-span-2  md:ml-auto md:mt-10 ">
+                <div className=" mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                  <ButtonV2
+                    onClick={() => {
+                      navigate(
+                        `/facility/${data.patient_object?.facility_object?.id}/patient/${data.patient_object?.id}/insurance`
+                      );
+                    }}
+                    className="h-auto whitespace-pre-wrap border border-gray-500 bg-white text-black hover:bg-gray-300"
+                  >
+                    View All Details
+                  </ButtonV2>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex w-full items-center justify-center text-xl font-bold text-gray-500">
+            No Insurance Details Available
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -34,6 +34,7 @@ import { triggerGoal } from "../../Integrations/Plausible";
 import useAuthUser from "../../Common/hooks/useAuthUser";
 import useQuery from "../../Utils/request/useQuery";
 import routes from "../../Redux/api";
+import { InsuranceDetialsCard } from "./InsuranceDetailsCard";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -93,14 +94,12 @@ export const PatientHome = (props: any) => {
     });
   };
 
-  const { data: insuranceDetials, loading: insuranceDetailsLoading } = useQuery(
-    routes.listHCXPolicies,
-    {
-      query: {
-        patient: id,
-      },
-    }
-  );
+  const { data: insuranceDetials } = useQuery(routes.listHCXPolicies, {
+    query: {
+      patient: id,
+      limit: 1,
+    },
+  });
 
   const handleAssignedVolunteer = () => {
     dispatch(
@@ -1121,71 +1120,14 @@ export const PatientHome = (props: any) => {
               </div>
             </div>
           </div>
-          <div className="w-full">
-            <div className="h-full space-y-2 rounded-lg bg-white p-7 shadow">
-              <div className="border-b border-dashed pb-2 text-xl font-bold text-gray-900">
-                Insurance Details
-              </div>
 
-              {insuranceDetials?.count == 0 || insuranceDetailsLoading ? (
-                <div className="flex w-full items-center justify-center text-xl font-bold text-gray-500">
-                  No Insurance Data Available
-                </div>
-              ) : (
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-2">
-                  <div className=" ">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Member ID
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {insuranceDetials?.results[0]?.subscriber_id || ""}
-                    </div>
-                  </div>
-                  <div className=" ">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Policy ID / Policy Name
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {insuranceDetials?.results[0]?.policy_id || ""}
-                    </div>
-                  </div>
-                  <div className="sm:col-span-1">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Insurer ID
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {insuranceDetials?.results[0]?.insurer_id || ""}
-                    </div>
-                  </div>
-                  <div className="sm:col-span-1">
-                    <div className="text-sm font-semibold leading-5 text-zinc-400">
-                      Insurer Name
-                    </div>
-                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                      {insuranceDetials?.results[0]?.insurer_name || ""}
-                    </div>
-                  </div>
-
-                  {insuranceDetials?.count && insuranceDetials?.count > 1 && (
-                    <div className=" first-letter: sm:col-span-2  md:ml-auto md:mt-10 ">
-                      <div className=" mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-                        <ButtonV2
-                          onClick={() => {
-                            navigate(
-                              `/facility/${patientData?.facility}/patient/${id}/insurance`
-                            );
-                          }}
-                          className="h-auto whitespace-pre-wrap border border-gray-500 bg-white text-black hover:bg-gray-300"
-                        >
-                          View All Details
-                        </ButtonV2>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
+          <InsuranceDetialsCard
+            data={insuranceDetials?.results[0]}
+            showViewAllDetails={
+              insuranceDetials?.count !== undefined &&
+              insuranceDetials?.count > 1
+            }
+          />
         </section>
         <section className="mt-4 space-y-2 md:flex">
           <div className="hidden lg:block">

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -32,6 +32,8 @@ import UserAutocompleteFormField from "../Common/UserAutocompleteFormField";
 import dayjs from "../../Utils/dayjs";
 import { triggerGoal } from "../../Integrations/Plausible";
 import useAuthUser from "../../Common/hooks/useAuthUser";
+import useQuery from "../../Utils/request/useQuery";
+import routes from "../../Redux/api";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -90,6 +92,15 @@ export const PatientHome = (props: any) => {
       );
     });
   };
+
+  const { data: insuranceDetials, loading: insuranceDetailsLoading } = useQuery(
+    routes.listHCXPolicies,
+    {
+      query: {
+        patient: id,
+      },
+    }
+  );
 
   const handleAssignedVolunteer = () => {
     dispatch(
@@ -975,7 +986,7 @@ export const PatientHome = (props: any) => {
         </section>
 
         <section
-          className="mt-5 grid grid-cols-1 gap-6 lg:grid-cols-2"
+          className="mt-5 grid grid-cols-1 gap-6 lg:grid-cols-3"
           data-testid="patient-details"
         >
           <div className="w-full">
@@ -1108,6 +1119,71 @@ export const PatientHome = (props: any) => {
                 )}
                 {patientMedHis}
               </div>
+            </div>
+          </div>
+          <div className="w-full">
+            <div className="h-full space-y-2 rounded-lg bg-white p-7 shadow">
+              <div className="border-b border-dashed pb-2 text-xl font-bold text-gray-900">
+                Insurance Details
+              </div>
+
+              {insuranceDetials?.count == 0 || insuranceDetailsLoading ? (
+                <div className="flex w-full items-center justify-center text-xl font-bold text-gray-500">
+                  No Insurance Data Available
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-2">
+                  <div className=" ">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Member ID
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {insuranceDetials?.results[0]?.subscriber_id || ""}
+                    </div>
+                  </div>
+                  <div className=" ">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Policy ID / Policy Name
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {insuranceDetials?.results[0]?.policy_id || ""}
+                    </div>
+                  </div>
+                  <div className="sm:col-span-1">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Insurer ID
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {insuranceDetials?.results[0]?.insurer_id || ""}
+                    </div>
+                  </div>
+                  <div className="sm:col-span-1">
+                    <div className="text-sm font-semibold leading-5 text-zinc-400">
+                      Insurer Name
+                    </div>
+                    <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                      {insuranceDetials?.results[0]?.insurer_name || ""}
+                    </div>
+                  </div>
+
+                  {insuranceDetials?.count && insuranceDetials?.count > 1 && (
+                    <div className=" first-letter: sm:col-span-2  md:ml-auto md:mt-10 ">
+                      <div className=" mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+                        <ButtonV2
+                          onClick={() => {
+                            navigate(
+                              `/facility/${patientData?.facility}/patient/${id}/insurance`
+                            );
+                          }}
+                          className="h-auto whitespace-pre-wrap border border-gray-500 bg-white text-black hover:bg-gray-300"
+                        >
+                          View All Details
+                        </ButtonV2>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </section>

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -52,6 +52,7 @@ import {
 import { PatientModel } from "../Components/Patient/models";
 import { IComment, IResource } from "../Components/Resource/models";
 import { IShift } from "../Components/Shifting/models";
+import { HCXPolicyModel } from "../Components/HCX/models";
 
 /**
  * A fake function that returns an empty object casted to type T
@@ -1163,6 +1164,7 @@ const routes = {
   listHCXPolicies: {
     path: "/api/v1/hcx/policy/",
     method: "GET",
+    TRes: Type<PaginatedResponse<HCXPolicyModel>>(),
   },
 
   createHCXPolicy: {

--- a/src/Routers/routes/PatientRoutes.tsx
+++ b/src/Routers/routes/PatientRoutes.tsx
@@ -6,6 +6,7 @@ import PatientNotes from "../../Components/Patient/PatientNotes";
 import { PatientRegister } from "../../Components/Patient/PatientRegister";
 import { DetailRoute } from "../types";
 import DeathReport from "../../Components/DeathReport/DeathReport";
+import { InsuranceDetails } from "../../Components/Patient/InsuranceDetails";
 
 export default {
   "/patients": () => <PatientManager />,
@@ -20,6 +21,9 @@ export default {
   ),
   "/facility/:facilityId/patient/:id": ({ facilityId, id }: any) => (
     <PatientHome facilityId={facilityId} id={id} />
+  ),
+  "/facility/:facilityId/patient/:id/insurance": ({ facilityId, id }: any) => (
+    <InsuranceDetails facilityId={facilityId} id={id} />
   ),
   "/facility/:facilityId/patient/:id/update": ({ facilityId, id }: any) => (
     <PatientRegister facilityId={facilityId} id={id} />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a288d64</samp>

Added a feature to show insurance details for patients in the frontend. Created a new `InsuranceDetails` component and a route to display the data in a separate page. Modified the `PatientHome` component to include a card with the insurance information. Added API support and updated the `HCXPolicyModel` interface to handle the data from the backend.

## Proposed Changes

- Fixes #6517 
- showing the view all details button only if the insurance details are more than one
 
![image](https://github.com/coronasafe/care_fe/assets/101407963/edb3239d-f689-4c0c-8f49-24b0e66b6808)
![image](https://github.com/coronasafe/care_fe/assets/101407963/27a86cf5-8eac-4819-94d9-d185b8fe6358)
![image](https://github.com/coronasafe/care_fe/assets/101407963/d9060b41-3f6f-42b6-9fc3-7e01c2e18f6a)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a288d64</samp>

* Create a new component `InsuranceDetails` to display the insurance details of a patient in a separate page ([link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-dce9e7af20d965d59cb39c4348e8e20d2b5a9ce5117c540caadfe0346feef620R1-R102))
* Import the `useQuery` hook and the `routes` object in the `PatientHome` component to fetch the insurance details of the patient from the `listHCXPolicies` route ([link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fR35-R36))
* Change the grid layout of the patient details section from two columns to three columns, and add a card to show the first policy of the patient or a message indicating no insurance data ([link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fR96-R104), [link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL978-R989), [link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fR1124-R1188))
* Add a button to the card that navigates to the insurance details page if the patient has more than one policy ([link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fR1124-R1188))
* Import the `HCXPolicyModel` interface in the `api.tsx` file and set the response type of the `listHCXPolicies` route to a paginated response of `HCXPolicyModel` objects ([link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR55), [link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR1167))
* Make the `insurer_id` and `insurer_name` fields optional in the `HCXPolicyModel` interface, as they may not be available for some policies ([link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-85ceca8e056645987380e5f45d62da65607c1d46e3772d96543077cc818a2457L29-R30))
* Add the insurance details page route to the `PatientRoutes.tsx` file, using the `facilityId` and `id` parameters to pass them as props to the `InsuranceDetails` component ([link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-a0f78905a49eb914c5b3b46efe7c2da3daf82dd17bf9ab1884644264b459baf1R9), [link](https://github.com/coronasafe/care_fe/pull/6595/files?diff=unified&w=0#diff-a0f78905a49eb914c5b3b46efe7c2da3daf82dd17bf9ab1884644264b459baf1R25-R27))
