### PR TITLE
Fix scroll overlay. 

### DIFF
--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -97,48 +97,51 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
           )
         }
       />
-
-      <ScrollOverlay
-        className="rounded-lg border shadow"
-        overlay={
-          <div className="flex items-center gap-2 pb-2">
-            <span className="text-sm">Scroll to view more prescriptions</span>
-            <CareIcon icon="l-arrow-down" className="animate-bounce text-2xl" />
-          </div>
-        }
-        disableOverlay={
-          loading || !prescriptions?.length || !(prescriptions?.length > 1)
-        }
-      >
-        {loading && <Loading />}
-        {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
-
-        {!!prescriptions?.length && (
-          <MedicineAdministrationTable
-            prescriptions={prescriptions}
-            pagination={pagination}
-            onRefetch={() => {
-              refetch();
-              discontinuedPrescriptions.refetch();
-            }}
-          />
-        )}
-      </ScrollOverlay>
-      {!showDiscontinued && !!discontinuedCount && (
-        <ButtonV2
-          variant="secondary"
-          className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
-          onClick={() => setShowDiscontinued(true)}
+      <div className="rounded-lg border shadow">
+        <ScrollOverlay
+          overlay={
+            <div className="flex items-center gap-2 pb-2">
+              <span className="text-sm">Scroll to view more prescriptions</span>
+              <CareIcon
+                icon="l-arrow-down"
+                className="animate-bounce text-2xl"
+              />
+            </div>
+          }
+          disableOverlay={
+            loading || !prescriptions?.length || !(prescriptions?.length > 1)
+          }
         >
-          <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
-            <CareIcon icon="l-eye" className="text-lg" />
-            <span>
-              Show <strong>{discontinuedCount}</strong> discontinued
-              prescription(s)
+          {loading && <Loading />}
+          {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
+
+          {!!prescriptions?.length && (
+            <MedicineAdministrationTable
+              prescriptions={prescriptions}
+              pagination={pagination}
+              onRefetch={() => {
+                refetch();
+                discontinuedPrescriptions.refetch();
+              }}
+            />
+          )}
+        </ScrollOverlay>
+        {!showDiscontinued && !!discontinuedCount && (
+          <ButtonV2
+            variant="secondary"
+            className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
+            onClick={() => setShowDiscontinued(true)}
+          >
+            <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
+              <CareIcon icon="l-eye" className="text-lg" />
+              <span>
+                Show <strong>{discontinuedCount}</strong> discontinued
+                prescription(s)
+              </span>
             </span>
-          </span>
-        </ButtonV2>
-      )}
+          </ButtonV2>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -106,7 +106,9 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
             <CareIcon icon="l-arrow-down" className="animate-bounce text-2xl" />
           </div>
         }
-        disableOverlay={loading || !prescriptions?.length}
+        disableOverlay={
+          loading || !prescriptions?.length || !(prescriptions?.length > 1)
+        }
       >
         {loading && <Loading />}
         {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
@@ -121,23 +123,22 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
             }}
           />
         )}
-
-        {!showDiscontinued && !!discontinuedCount && (
-          <ButtonV2
-            variant="secondary"
-            className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
-            onClick={() => setShowDiscontinued(true)}
-          >
-            <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
-              <CareIcon icon="l-eye" className="text-lg" />
-              <span>
-                Show <strong>{discontinuedCount}</strong> discontinued
-                prescription(s)
-              </span>
-            </span>
-          </ButtonV2>
-        )}
       </ScrollOverlay>
+      {!showDiscontinued && !!discontinuedCount && (
+        <ButtonV2
+          variant="secondary"
+          className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
+          onClick={() => setShowDiscontinued(true)}
+        >
+          <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
+            <CareIcon icon="l-eye" className="text-lg" />
+            <span>
+              Show <strong>{discontinuedCount}</strong> discontinued
+              prescription(s)
+            </span>
+          </span>
+        </ButtonV2>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2817c98</samp>

Improved UI and UX of `MedicineAdministrationSheet` component. Removed unnecessary overlay and repositioned discontinued prescriptions button.

## Proposed Changes

- Fixes #6590 
- Change scroll overlay 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2817c98</samp>

* Disable the overlay of the medicine administration sheet component when there is only one prescription to view, in addition to the existing conditions of loading or no prescriptions. This prevents the user from accidentally closing the sheet by clicking on the overlay. ([link](https://github.com/coronasafe/care_fe/pull/6598/files?diff=unified&w=0#diff-db20bc68269b5cb3e2695b4ab0ce9d97f1736a9179445b635bc28053b74125e2L109-R111))
