### PR TITLE
No close button once you open the discontinued prescriptions

### DIFF
--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -138,26 +138,20 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
           <ButtonV2
             variant="secondary"
             className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
-            onClick={() => !loading && setShowDiscontinued(!showDiscontinued)}
+            disabled={loading || discontinuedPrescriptions.loading}
+            onClick={() => setShowDiscontinued(!showDiscontinued)}
           >
-            {loading ? (
-              <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
-                <CareIcon icon="l-spinner-alt" className="text-lg" />
-                <span>Loading...</span>
+            <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
+              <CareIcon
+                icon={showDiscontinued ? "l-eye-slash" : "l-eye"}
+                className="text-lg"
+              />
+              <span>
+                {showDiscontinued ? "Hide" : "Show"}{" "}
+                <strong>{discontinuedCount}</strong> discontinued
+                prescription(s)
               </span>
-            ) : (
-              <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
-                <CareIcon
-                  icon={showDiscontinued ? "l-eye-slash" : "l-eye"}
-                  className="text-lg"
-                />
-                <span>
-                  {showDiscontinued ? "Hide" : "Show"}{" "}
-                  <strong>{discontinuedCount}</strong> discontinued
-                  prescription(s)
-                </span>
-              </span>
-            )}
+            </span>
           </ButtonV2>
         )}
       </div>

--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -97,48 +97,51 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
           )
         }
       />
-
-      <ScrollOverlay
-        className="rounded-lg border shadow"
-        overlay={
-          <div className="flex items-center gap-2 pb-2">
-            <span className="text-sm">Scroll to view more prescriptions</span>
-            <CareIcon icon="l-arrow-down" className="animate-bounce text-2xl" />
-          </div>
-        }
-        disableOverlay={
-          loading || !prescriptions?.length || !(prescriptions?.length > 1)
-        }
-      >
-        {loading && <Loading />}
-        {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
-
-        {!!prescriptions?.length && (
-          <MedicineAdministrationTable
-            prescriptions={prescriptions}
-            pagination={pagination}
-            onRefetch={() => {
-              refetch();
-              discontinuedPrescriptions.refetch();
-            }}
-          />
-        )}
-      </ScrollOverlay>
-      {!showDiscontinued && !!discontinuedCount && (
-        <ButtonV2
-          variant="secondary"
-          className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
-          onClick={() => setShowDiscontinued(true)}
+      <div className="rounded-lg border shadow">
+        <ScrollOverlay
+          overlay={
+            <div className="flex items-center gap-2 pb-2">
+              <span className="text-sm">Scroll to view more prescriptions</span>
+              <CareIcon
+                icon="l-arrow-down"
+                className="animate-bounce text-2xl"
+              />
+            </div>
+          }
+          disableOverlay={
+            loading || !prescriptions?.length || !(prescriptions?.length > 1)
+          }
         >
-          <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
-            <CareIcon icon="l-eye" className="text-lg" />
-            <span>
-              Show <strong>{discontinuedCount}</strong> discontinued
-              prescription(s)
+          {loading && <Loading />}
+          {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
+
+          {!!prescriptions?.length && (
+            <MedicineAdministrationTable
+              prescriptions={prescriptions}
+              pagination={pagination}
+              onRefetch={() => {
+                refetch();
+                discontinuedPrescriptions.refetch();
+              }}
+            />
+          )}
+        </ScrollOverlay>
+        {!showDiscontinued && !!discontinuedCount && (
+          <ButtonV2
+            variant="secondary"
+            className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
+            onClick={() => setShowDiscontinued(true)}
+          >
+            <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
+              <CareIcon icon="l-eye" className="text-lg" />
+              <span>
+                Show <strong>{discontinuedCount}</strong> discontinued
+                prescription(s)
+              </span>
             </span>
-          </span>
-        </ButtonV2>
-      )}
+          </ButtonV2>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -106,7 +106,9 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
             <CareIcon icon="l-arrow-down" className="animate-bounce text-2xl" />
           </div>
         }
-        disableOverlay={loading || !prescriptions?.length}
+        disableOverlay={
+          loading || !prescriptions?.length || !(prescriptions?.length > 1)
+        }
       >
         {loading && <Loading />}
         {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
@@ -121,23 +123,22 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
             }}
           />
         )}
-
-        {!showDiscontinued && !!discontinuedCount && (
-          <ButtonV2
-            variant="secondary"
-            className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
-            onClick={() => setShowDiscontinued(true)}
-          >
-            <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
-              <CareIcon icon="l-eye" className="text-lg" />
-              <span>
-                Show <strong>{discontinuedCount}</strong> discontinued
-                prescription(s)
-              </span>
-            </span>
-          </ButtonV2>
-        )}
       </ScrollOverlay>
+      {!showDiscontinued && !!discontinuedCount && (
+        <ButtonV2
+          variant="secondary"
+          className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
+          onClick={() => setShowDiscontinued(true)}
+        >
+          <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
+            <CareIcon icon="l-eye" className="text-lg" />
+            <span>
+              Show <strong>{discontinuedCount}</strong> discontinued
+              prescription(s)
+            </span>
+          </span>
+        </ButtonV2>
+      )}
     </div>
   );
 };

--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -39,7 +39,11 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
 
   const discontinuedPrescriptions = useQuery(MedicineRoutes.listPrescriptions, {
     pathParams: { consultation },
-    query: { ...filters, discontinued: true },
+    query: {
+      ...filters,
+      limit: showDiscontinued ? 100 : 1,
+      discontinued: true,
+    },
     prefetch: !showDiscontinued,
   });
 
@@ -112,33 +116,48 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
             loading || !prescriptions?.length || !(prescriptions?.length > 1)
           }
         >
-          {loading && <Loading />}
-          {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
-
-          {!!prescriptions?.length && (
-            <MedicineAdministrationTable
-              prescriptions={prescriptions}
-              pagination={pagination}
-              onRefetch={() => {
-                refetch();
-                discontinuedPrescriptions.refetch();
-              }}
-            />
+          {loading ? (
+            <Loading />
+          ) : (
+            <>
+              {prescriptions?.length === 0 && <NoPrescriptions prn={is_prn} />}
+              {!!prescriptions?.length && (
+                <MedicineAdministrationTable
+                  prescriptions={prescriptions}
+                  pagination={pagination}
+                  onRefetch={() => {
+                    refetch();
+                    discontinuedPrescriptions.refetch();
+                  }}
+                />
+              )}
+            </>
           )}
         </ScrollOverlay>
-        {!showDiscontinued && !!discontinuedCount && (
+        {!!discontinuedCount && (
           <ButtonV2
             variant="secondary"
             className="group sticky left-0 w-full rounded-b-lg rounded-t-none bg-gray-100"
-            onClick={() => setShowDiscontinued(true)}
+            onClick={() => !loading && setShowDiscontinued(!showDiscontinued)}
           >
-            <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
-              <CareIcon icon="l-eye" className="text-lg" />
-              <span>
-                Show <strong>{discontinuedCount}</strong> discontinued
-                prescription(s)
+            {loading ? (
+              <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
+                <CareIcon icon="l-spinner-alt" className="text-lg" />
+                <span>Loading...</span>
               </span>
-            </span>
+            ) : (
+              <span className="flex w-full items-center justify-start gap-1 text-xs transition-all duration-200 ease-in-out group-hover:gap-3 md:text-sm">
+                <CareIcon
+                  icon={showDiscontinued ? "l-eye-slash" : "l-eye"}
+                  className="text-lg"
+                />
+                <span>
+                  {showDiscontinued ? "Hide" : "Show"}{" "}
+                  <strong>{discontinuedCount}</strong> discontinued
+                  prescription(s)
+                </span>
+              </span>
+            )}
           </ButtonV2>
         )}
       </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1cdaf4</samp>

This pull request improves the performance and usability of the `MedicineAdministrationSheet` component, which displays the prescriptions and doses for a patient. It allows the user to filter the discontinued prescriptions and to fetch more data on demand. It also refines the appearance and behavior of the scroll and button components.

## Proposed Changes

- Fixes #6599 
- Add a close button to hide discontinued prescriptions. 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c1cdaf4</samp>

* Optimize data fetching for discontinued prescriptions by adding a limit parameter that depends on the showDiscontinued state ([link](https://github.com/coronasafe/care_fe/pull/6614/files?diff=unified&w=0#diff-db20bc68269b5cb3e2695b4ab0ce9d97f1736a9179445b635bc28053b74125e2L42-R46))
  - Wrapping the ScrollOverlay inside a styled div and moving the ButtonV2 outside it ([link](https://github.com/coronasafe/care_fe/pull/6614/files?diff=unified&w=0#diff-db20bc68269b5cb3e2695b4ab0ce9d97f1736a9179445b635bc28053b74125e2L100-R163))
  - Adding a loading state and a toggle logic for the ButtonV2 to control the showDiscontinued state ([link](https://github.com/coronasafe/care_fe/pull/6614/files?diff=unified&w=0#diff-db20bc68269b5cb3e2695b4ab0ce9d97f1736a9179445b635bc28053b74125e2L100-R163))
