### PR TITLE
Fixed Facility Cover Image upload pop-up

### DIFF
--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -373,9 +373,6 @@ export const FacilityHome = (props: any) => {
           className={`group relative h-48 w-full text-clip rounded-t bg-gray-200 opacity-100 transition-all duration-200 ease-in-out md:h-0 md:opacity-0 ${
             hasPermissionToEditCoverImage && "cursor-pointer"
           }`}
-          onClick={() =>
-            hasPermissionToEditCoverImage && setEditCoverImage(true)
-          }
         >
           <CoverImage />
           {editCoverImageTooltip}

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -370,9 +370,9 @@ export const FacilityHome = (props: any) => {
       />
       {hasCoverImage ? (
         <div
-          className={`group relative h-48 w-full text-clip rounded-t bg-gray-200 opacity-100 transition-all duration-200 ease-in-out md:h-0 md:opacity-0 ${
-            hasPermissionToEditCoverImage && "cursor-pointer"
-          }`}
+          className={
+            "group relative h-48 w-full text-clip rounded-t bg-gray-200 opacity-100 transition-all duration-200 ease-in-out md:h-0 md:opacity-0"
+          }
         >
           <CoverImage />
           {editCoverImageTooltip}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2700c58</samp>

Refactor edit cover image functionality for facilities. Remove onClick handler from `FacilityHome.tsx` and use a separate component and button instead.

## Proposed Changes

- Fixes #6610 
- Removed extra unnessary onClick action
@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2700c58</samp>

* Remove the onClick handler for the facility cover image ([link](https://github.com/coronasafe/care_fe/pull/6616/files?diff=unified&w=0#diff-ad6af8429c47f2623c154aeb1256b603ed30a7b233d485bef095d3ddf7c4b97cL376-L378)) and replace it with a button that opens the edit cover image modal (                          
