### PR TITLE
Fixed dosage field malfunctioning.

### DIFF
--- a/src/Components/Form/FormFields/NumericWithUnitsFormField.tsx
+++ b/src/Components/Form/FormFields/NumericWithUnitsFormField.tsx
@@ -35,7 +35,9 @@ export default function NumericWithUnitsFormField(props: Props) {
           autoComplete={props.autoComplete}
           required={field.required}
           value={numValue}
-          onChange={(e) => field.handleChange(e.target.value + " " + unitValue)}
+          onChange={(e) =>
+            field.handleChange(Number(e.target.value) + " " + unitValue)
+          }
         />
         <div className="absolute inset-y-0 right-0 flex items-center">
           <select


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c69617</samp>

Fixed a bug in the `NumericWithUnitsFormField` component that caused incorrect values to be displayed and stored. Changed the `field.handleChange` function to use numeric values instead of strings.

## Proposed Changes

- Fixes #6625 
- Fixed a bug where the dosage limit accepts trailing zeros. 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c69617</samp>

* Fix a bug in the numeric with units form field component that caused incorrect values to be displayed and stored ([link](https://github.com/coronasafe/care_fe/pull/6626/files?diff=unified&w=0#diff-68c921c72ca740919481f0b7bb832b6fdb181affcaea8c0dbf7972522a091913L38-R40))
