### PR TITLE
Fix styling issues in the patient details page

### DIFF
--- a/src/Components/Common/RelativeDateUserMention.tsx
+++ b/src/Components/Common/RelativeDateUserMention.tsx
@@ -8,7 +8,7 @@ function RelativeDateUserMention(props: {
   tooltipPosition?: "top" | "bottom" | "left" | "right";
 }) {
   return (
-    <div className="flex flex-row items-center">
+    <div className="flex flex-row flex-wrap items-center justify-center ">
       <div className="tooltip">
         <span
           className={`tooltip-text tooltip-${props.tooltipPosition || "top"}`}

--- a/src/Components/Facility/ConsultationCard.tsx
+++ b/src/Components/Facility/ConsultationCard.tsx
@@ -112,21 +112,25 @@ export const ConsultationCard = (props: ConsultationProps) => {
       <div className="mt-8 flex flex-col">
         {
           <div className="flex flex-col items-center text-sm text-gray-700 md:flex-row">
-            Created:{" "}
-            <RelativeDateUserMention
-              tooltipPosition="right"
-              actionDate={itemData.created_date}
-              user={itemData.created_by}
-            />
+            Created :{" "}
+            <div className=" ml-1 text-black">
+              <RelativeDateUserMention
+                tooltipPosition="right"
+                actionDate={itemData.created_date}
+                user={itemData.created_by}
+              />
+            </div>
           </div>
         }
         <div className="flex flex-col items-center text-sm text-gray-700 md:flex-row">
-          Last Modified:{" "}
-          <RelativeDateUserMention
-            tooltipPosition="right"
-            actionDate={itemData.modified_date}
-            user={itemData.last_edited_by}
-          />
+          Last Modified :{" "}
+          <div className=" ml-1 text-black">
+            <RelativeDateUserMention
+              tooltipPosition="right"
+              actionDate={itemData.modified_date}
+              user={itemData.last_edited_by}
+            />
+          </div>
         </div>
       </div>
       <div className="mt-4 flex w-full flex-col justify-between gap-1 md:flex-row">

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -457,7 +457,7 @@ export const PatientHome = (props: any) => {
             </div>
             <div className="mt-4 flex items-center">
               <ButtonV2
-                className="w-full"
+                className="mb-2 w-full"
                 disabled={!patientData.is_active}
                 onClick={() =>
                   navigate(
@@ -717,7 +717,7 @@ export const PatientHome = (props: any) => {
                   </div>
                 </div>
                 <div className="mt-2 flex justify-between rounded-sm bg-white p-2 px-4 text-center shadow">
-                  <div className="w-1/2 border-r-2 pb-1">
+                  <div className="w-1/2 border-r-2 pb-1 pr-2">
                     <div className="text-sm font-normal leading-5 text-gray-500">
                       Created
                     </div>
@@ -730,7 +730,7 @@ export const PatientHome = (props: any) => {
                       </div>
                     </div>
                   </div>
-                  <div className="w-1/2 pb-1">
+                  <div className="w-1/2 pb-1 pl-2">
                     <div className="text-sm font-normal leading-5 text-gray-500">
                       Last Edited
                     </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d71611</samp>

Improved the layout and responsiveness of some components on smaller screens. Modified the `PatientHome`, `RelativeDateUserMention`, and `ConsultationCard` components to use Tailwind CSS classes for spacing, alignment, and contrast.

## Proposed Changes

- Fixes #6632
- [x]  Added margin below the Create Consultation button
- [x] Center aligned The Created and Last Edited cards
- [x] Added styling to the key and value in the Created and Last Modified fields in Consultation History

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d71611</samp>

*  Improve the responsiveness and alignment of the tooltip and the user name in the `RelativeDateUserMention` component by using `flex-wrap` and `justify-center` classes ([link](https://github.com/coronasafe/care_fe/pull/6639/files?diff=unified&w=0#diff-2ede4b233e73dd96da58adafe316457a60954fbf31e8d91c530462c148908171L11-R11))
* Add some margin and contrast to the user name and the date in the `ConsultationCard` component by wrapping the `RelativeDateUserMention` component inside a `div` with `ml-1` and `text-black` classes ([link](https://github.com/coronasafe/care_fe/pull/6639/files?diff=unified&w=0#diff-e487f280661a7995b9602b6ded894fcd6612af833435ab16aeefdcd41268cab7L115-R133))
* Create some space between the button and the patient details card in the `PatientHome` component by adding a `mb-2` class to the `ButtonV2` component ([link](https://github.com/coronasafe/care_fe/pull/6639/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL460-R460))
* Create some padding between the border and the content in the patient details card in the `PatientHome` component by adding a `pr-2` class to the first `div` and a `pl-2` class to the second `div` inside the card ([link](https://github.com/coronasafe/care_fe/pull/6639/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL720-R720), [link](https://github.com/coronasafe/care_fe/pull/6639/files?diff=unified&w=0#diff-53fbb567d16de67259204bd83187f4916032665a0198c0f09fe3dd67a7541e6fL733-R733))
