### PR TITLE
Add Frontend validation in the add multiple bed function

### DIFF
--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -229,6 +229,11 @@ export const AddBedForm = (props: BedFormProps) => {
                   min={1}
                   max={100}
                   onChange={(e) => setNumberOfBeds(Number(e.value))}
+                  error={
+                    numberOfBeds > 100
+                      ? "Number of beds cannot be greater than 100"
+                      : undefined
+                  }
                 />
               </>
             )}

--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -239,7 +239,11 @@ export const AddBedForm = (props: BedFormProps) => {
             )}
             <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <Cancel onClick={handleCancel} />
-              <Submit onClick={handleSubmit} label={buttonText} />
+              <Submit
+                onClick={handleSubmit}
+                label={buttonText}
+                disabled={numberOfBeds > 100}
+              />
             </div>
           </form>
         </Card>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd101fe</samp>

Added validation error message for `numberOfBeds` field in `AddBedForm` component. This improves the user experience and data quality when creating or updating beds in a facility.

## Proposed Changes
Add Frontend validation in the add multiple bed function. If there are more than 100 beds given into the input, ""Number of beds cannot be greater than 100" is given as error.

- Fixes #6624 ?
- Add Frontend validation for number of beds in AddBedForm.tsx


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd101fe</samp>

* Add a validation error message to the number of beds field ([link](https://github.com/coronasafe/care_fe/pull/6643/files?diff=unified&w=0#diff-c3725e9874032f1cdb18f7c6b15f978b17a7306d49ce27104377ac1ccaaa4b8cR232-R236))
