### PR TITLE
Add auto-scroll function to error in add triage form

### DIFF
--- a/src/Components/Facility/TriageForm.tsx
+++ b/src/Components/Facility/TriageForm.tsx
@@ -21,7 +21,7 @@ import { FieldChangeEvent } from "../Form/FormFields/Utils";
 const Loading = lazy(() => import("../Common/Loading"));
 import Page from "../Common/components/Page";
 import dayjs from "dayjs";
-import { dateQueryString } from "../../Utils/utils";
+import { dateQueryString, scrollTo } from "../../Utils/utils";
 
 interface triageFormProps extends PatientStatsModel {
   facilityId: number;
@@ -59,11 +59,6 @@ const triageFormReducer = (state = initialState, action: any) => {
     default:
       return state;
   }
-};
-
-const scrollTo = (id: string | boolean) => {
-  const element = document.querySelector(`#${id}`);
-  element?.scrollIntoView({ behavior: "smooth", block: "center" });
 };
 
 export const TriageForm = (props: triageFormProps) => {

--- a/src/Components/Facility/TriageForm.tsx
+++ b/src/Components/Facility/TriageForm.tsx
@@ -61,6 +61,11 @@ const triageFormReducer = (state = initialState, action: any) => {
   }
 };
 
+const scrollTo = (id: string | boolean) => {
+  const element = document.querySelector(`#${id}`);
+  element?.scrollIntoView({ behavior: "smooth", block: "center" });
+};
+
 export const TriageForm = (props: triageFormProps) => {
   const { goBack } = useAppHistory();
   const dispatchTriageData: any = useDispatch();
@@ -172,6 +177,10 @@ export const TriageForm = (props: triageFormProps) => {
     });
     if (invalidForm) {
       dispatch({ type: "set_error", errors });
+      const firstError = Object.keys(errors).find((e) => errors[e]);
+      if (firstError) {
+        scrollTo(firstError);
+      }
       return false;
     }
     dispatch({ type: "set_error", errors });

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -26,6 +26,7 @@ import {
   getPincodeDetails,
   includesIgnoreCase,
   parsePhoneNumber,
+  scrollTo,
 } from "../../Utils/utils";
 import { navigate, useQueryParams } from "raviger";
 import { statusType, useAbortableEffect } from "../../Common/utils";
@@ -175,11 +176,6 @@ const patientFormReducer = (state = initialState, action: any) => {
     default:
       return state;
   }
-};
-
-const scrollTo = (id: string | boolean) => {
-  const element = document.querySelector(`#${id}`);
-  element?.scrollIntoView({ behavior: "smooth", block: "center" });
 };
 
 export const PatientRegister = (props: PatientRegisterProps) => {

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -437,3 +437,8 @@ export const formatAge = (
   }
   return `${age} ${yearSuffix}`;
 };
+
+export const scrollTo = (id: string | boolean) => {
+  const element = document.querySelector(`#${id}`);
+  element?.scrollIntoView({ behavior: "smooth", block: "center" });
+};


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb4b9a2</samp>

This pull request improves the user experience of the `TriageForm` component by scrolling to the first error when the form is submitted. It also adds a `scrollTo` helper function to `src/Components/Facility/TriageForm.tsx` for smooth scrolling.

## Proposed Changes
In the mobile view, when the triage form throw mandatory field error, it is now auto scrolled to the error.

- Fixes #6622 ?
- Add auto-scroll function to error in add triage form.


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb4b9a2</samp>

*  Define a helper function `scrollTo` to scroll to a given element id or the top of the page ([link](https://github.com/coronasafe/care_fe/pull/6645/files?diff=unified&w=0#diff-f93cec80e3e6d3ceaf340ad221fdba7c079b646a2c55e832a660ef267568d7e7R64-R68))
*  Add logic to `TriageForm` component to check for errors after validation and scroll to the first error using `scrollTo` ([link](https://github.com/coronasafe/care_fe/pull/6645/files?diff=unified&w=0#diff-f93cec80e3e6d3ceaf340ad221fdba7c079b646a2c55e832a660ef267568d7e7R180-R183))
*  Improve the user experience of the triage form by highlighting the first error and bringing it into view ([link](https://github.com/coronasafe/care_fe/pull/6645/files?diff=unified&w=0#diff-f93cec80e3e6d3ceaf340ad221fdba7c079b646a2c55e832a660ef267568d7e7R180-R183))
