### PR TITLE
Fixed padding in "Reviewed before" chip in Consultation Dashboard

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -161,10 +161,10 @@ export default function PatientInfoCard(props: {
                 Number(consultation?.review_interval) > 0 && (
                   <div
                     className={
-                      "mb-2 inline-flex w-full items-center justify-center rounded-lg border border-gray-500 text-xs font-semibold leading-4 " +
+                      "mb-2 inline-flex w-full items-center justify-center rounded-lg border border-gray-500 p-1 text-xs font-semibold leading-4 " +
                       (dayjs().isBefore(patient.review_time)
-                        ? " bg-gray-100"
-                        : " bg-red-400 p-1 text-white")
+                        ? " bg-gray-100 "
+                        : " bg-red-400 text-white")
                     }
                   >
                     <i className="text-md fas fa-clock mr-2"></i>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 89a62b6</samp>

Refactored the padding of the patient info card component to fix a UI issue. Modified the `className` attribute in `src/Components/Patient/PatientInfoCard.tsx`.

## Proposed Changes

- Fixes #6646
- Added padding to the *Reviewed before* chip in Consultation Dashboard

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 89a62b6</samp>

* Move the `p-1` class to the common part of the className for the div that shows the patient review time indicator, to improve the alignment and appearance ([link](https://github.com/coronasafe/care_fe/pull/6647/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L164-R167))
