### PR TITLE
Made Covid Detail section by default collapsed in patient advance filters

### DIFF
--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -671,7 +671,7 @@ export default function PatientFilter(props: any) {
             COVID Details based
           </h1>
         }
-        expanded={true}
+        expanded={false}
         className="w-full rounded-md"
       >
         <div className="grid w-full grid-cols-1 gap-4">


### PR DESCRIPTION
…ters #6651

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 81839f1</samp>

Changed the default state of the filter panel on the patient list page to collapsed. This improves the user experience and reduces the clutter on the page.

## Proposed Changes

- Fixes #6651 
- Change 1
- Make Covid Detail section by default collapsed in patient advance filters
- [https://github.com/coronasafe/care_fe/issues/6651](url)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
before
![before](https://github.com/coronasafe/care_fe/assets/117653570/ed08ba20-ec3e-4832-b174-f32829faeff3)

after
![after](https://github.com/coronasafe/care_fe/assets/117653570/8d46d6b7-e879-449c-a324-bd4bffc69d6f)



## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 81839f1</samp>

*  Collapse the filter panel by default on the patient list page to improve the user experience and reduce the clutter (`[link](https://github.com/coronasafe/care_fe/pull/6654/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL674-R674)` in `PatientFilter.tsx`)
