### PR TITLE
Add delay before live feed reconnect

### DIFF
--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -230,8 +230,28 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
     }
   };
 
+  const startStreamFeed = () => {
+    startStream({
+      onSuccess: () => setStreamStatus(StreamStatus.Playing),
+      onError: () => {
+        setStreamStatus(StreamStatus.Offline);
+        if (!statusReported) {
+          triggerGoal("Camera Feed Viewed", {
+            consultationId,
+            userId: authUser.id,
+            result: "error",
+          });
+          setStatusReported(true);
+        }
+      },
+    });
+  };
+
   useEffect(() => {
     if (cameraAsset.id) {
+      setTimeout(() => {
+        startStreamFeed();
+      }, 1000);
       getPresets({
         onSuccess: (resp) => setPresets(resp),
         onError: (_) => {
@@ -251,20 +271,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
         setStreamStatus(StreamStatus.Loading);
       }
       tId = setTimeout(() => {
-        startStream({
-          onSuccess: () => setStreamStatus(StreamStatus.Playing),
-          onError: () => {
-            setStreamStatus(StreamStatus.Offline);
-            if (!statusReported) {
-              triggerGoal("Camera Feed Viewed", {
-                consultationId,
-                userId: authUser.id,
-                result: "error",
-              });
-              setStatusReported(true);
-            }
-          },
-        });
+        startStreamFeed();
       }, 5000);
     } else if (!statusReported) {
       triggerGoal("Camera Feed Viewed", {

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -265,7 +265,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
             }
           },
         });
-      }, 100);
+      }, 1000);
     } else if (!statusReported) {
       triggerGoal("Camera Feed Viewed", {
         consultationId,

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -265,7 +265,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
             }
           },
         });
-      }, 1000);
+      }, 5000);
     } else if (!statusReported) {
       triggerGoal("Camera Feed Viewed", {
         consultationId,

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -211,7 +211,7 @@ const LiveFeed = (props: any) => {
           onSuccess: () => setStreamStatus(StreamStatus.Playing),
           onError: () => setStreamStatus(StreamStatus.Offline),
         });
-      }, 1000);
+      }, 5000);
     }
 
     return () => {

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -211,7 +211,7 @@ const LiveFeed = (props: any) => {
           onSuccess: () => setStreamStatus(StreamStatus.Playing),
           onError: () => setStreamStatus(StreamStatus.Offline),
         });
-      }, 500);
+      }, 1000);
     }
 
     return () => {

--- a/src/Components/Facility/Consultations/LiveFeed.tsx
+++ b/src/Components/Facility/Consultations/LiveFeed.tsx
@@ -177,6 +177,9 @@ const LiveFeed = (props: any) => {
   useEffect(() => {
     if (cameraAsset?.hostname) {
       fetchCameraPresets();
+      setTimeout(() => {
+        startStreamFeed();
+      }, 1000);
     }
   }, []);
 
@@ -191,6 +194,13 @@ const LiveFeed = (props: any) => {
       absoluteMove(bedPresets[0]?.position, {});
     }
   }, [page.offset, cameraAsset.id, refreshPresetsHash]);
+
+  const startStreamFeed = () => {
+    startStream({
+      onSuccess: () => setStreamStatus(StreamStatus.Playing),
+      onError: () => setStreamStatus(StreamStatus.Offline),
+    });
+  };
 
   const viewOptions = (page: number) => {
     return presets
@@ -207,10 +217,7 @@ const LiveFeed = (props: any) => {
     if (streamStatus !== StreamStatus.Playing) {
       setStreamStatus(StreamStatus.Loading);
       tId = setTimeout(() => {
-        startStream({
-          onSuccess: () => setStreamStatus(StreamStatus.Playing),
-          onError: () => setStreamStatus(StreamStatus.Offline),
-        });
+        startStreamFeed();
       }, 5000);
     }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5bf116</samp>

The pull request changes the polling intervals of the `Feed` and `LiveFeed` components in `src/Components/Facility/Consultations` to reduce the number of API requests and potential errors.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5bf116</samp>

*  Increase the delay for polling the API for camera and live feed status to reduce unnecessary requests or errors ([link](https://github.com/coronasafe/care_fe/pull/6655/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L268-R268), [link](https://github.com/coronasafe/care_fe/pull/6655/files?diff=unified&w=0#diff-6352cfe4ad14fd5cf49cc8bca3a81880e50c91515c2c11bdff1b379a587c4983L214-R214))
