### PR TITLE
show delete user button only for stateAdmin

### DIFF
--- a/src/Components/Facility/FacilityUsers.tsx
+++ b/src/Components/Facility/FacilityUsers.tsx
@@ -1,28 +1,28 @@
 import { lazy, useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
+import CountBlock from "../../CAREUI/display/Count";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import { RESULTS_PER_PAGE_LIMIT } from "../../Common/constants";
+import useAuthUser from "../../Common/hooks/useAuthUser";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import {
   addUserFacility,
-  deleteUserFacility,
-  getUserListFacility,
   deleteUser,
-  getFacilityUsers,
+  deleteUserFacility,
   getAnyFacility,
+  getFacilityUsers,
+  getUserListFacility,
 } from "../../Redux/actions";
-import Pagination from "../Common/Pagination";
-import { USER_TYPES, RESULTS_PER_PAGE_LIMIT } from "../../Common/constants";
-import { FacilityModel } from "../Facility/models";
-import LinkFacilityDialog from "../Users/LinkFacilityDialog";
-import UserDeleteDialog from "../Users/UserDeleteDialog";
 import * as Notification from "../../Utils/Notifications.js";
-import UserDetails from "../Common/UserDetails";
-import UnlinkFacilityDialog from "../Users/UnlinkFacilityDialog";
 import { classNames, isUserOnline, relativeTime } from "../../Utils/utils";
-import CountBlock from "../../CAREUI/display/Count";
-import CareIcon from "../../CAREUI/icons/CareIcon";
+import Pagination from "../Common/Pagination";
+import UserDetails from "../Common/UserDetails";
 import ButtonV2 from "../Common/components/ButtonV2";
 import Page from "../Common/components/Page";
-import useAuthUser from "../../Common/hooks/useAuthUser";
+import { FacilityModel } from "../Facility/models";
+import LinkFacilityDialog from "../Users/LinkFacilityDialog";
+import UnlinkFacilityDialog from "../Users/UnlinkFacilityDialog";
+import UserDeleteDialog from "../Users/UserDeleteDialog";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -273,26 +273,6 @@ export default function FacilityUsers(props: any) {
     loadFacilities(username);
   };
 
-  const showDelete = (user: any) => {
-    const STATE_ADMIN_LEVEL = USER_TYPES.indexOf("StateAdmin");
-    const STATE_READ_ONLY_ADMIN_LEVEL =
-      USER_TYPES.indexOf("StateReadOnlyAdmin");
-    const DISTRICT_ADMIN_LEVEL = USER_TYPES.indexOf("DistrictAdmin");
-    const level = USER_TYPES.indexOf(user.user_type);
-    const currentUserLevel = USER_TYPES.indexOf(authUser.user_type);
-    if (user.is_superuser) return true;
-
-    if (currentUserLevel >= STATE_ADMIN_LEVEL)
-      return user.state_object?.id === authUser.state;
-    if (
-      currentUserLevel < STATE_READ_ONLY_ADMIN_LEVEL &&
-      currentUserLevel >= DISTRICT_ADMIN_LEVEL &&
-      currentUserLevel > level
-    )
-      return facilityData?.district_object_id === authUser.district;
-    return false;
-  };
-
   let userList: any[] = [];
 
   users &&
@@ -340,7 +320,7 @@ export default function FacilityUsers(props: any) {
                       aria-label="Online"
                     ></i>
                   ) : null}
-                  {showDelete(user) && (
+                  {authUser.user_type === "StateAdmin" && (
                     <button
                       type="button"
                       className="focus:ring-blue m-3 w-20 self-end rounded-md border border-red-500 bg-white px-3 py-2 text-center text-sm font-medium leading-4 text-red-700 transition duration-150 ease-in-out hover:text-red-500 hover:shadow focus:border-red-300 focus:outline-none active:bg-gray-50 active:text-red-800"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8cb815e</samp>

Refactored and cleaned up `FacilityUsers.tsx` component. Removed unused code and improved delete button functionality.

## Proposed Changes

- Fixes #6660
- Delete `showDelete()` function
- Render delete button only if `authUser.user_type === "StateAdmin"`

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8cb815e</samp>

*  Remove unused `showDelete` function and simplify delete button logic for facility users ([link](https://github.com/coronasafe/care_fe/pull/6663/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL276-L295), [link](https://github.com/coronasafe/care_fe/pull/6663/files?diff=unified&w=0#diff-375be445736e1b9a46ec9bb639c703f54bdc93f0fbcbc6dca065cd108f4738cbL343-R323)) in `FacilityUsers.tsx`
