### PR TITLE
add concurrency to deploy workflow to cancel-in-progress runs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: care_fe
   AWS_DEFAULT_REGION: ap-south-1


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7da81a6</samp>

This pull request adds a concurrency policy to the `deploy` workflow to prevent concurrent deployments and cancel previous ones. This improves the reliability and efficiency of the deployment process.


when multiple push happen on a branch each commit runs the whole test and build process again and 
the gke staging deployments require a review to deploy, so that keeps the workflow active even if a new workflow has been triggered

this change will cancel the in progress workfows and only keep the latest run on a particular branch

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7da81a6</samp>

* Add a concurrency policy to the deploy workflow to prevent concurrent deployments and cancel previous instances ([link](https://github.com/coronasafe/care_fe/pull/6683/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R14-R17))
