### PR TITLE
Improve how time is shown in Administrations Timeline

### DIFF
--- a/src/Components/Medicine/PrescrpitionTimeline.tsx
+++ b/src/Components/Medicine/PrescrpitionTimeline.tsx
@@ -1,7 +1,7 @@
 import dayjs from "../../Utils/dayjs";
 import useSlug from "../../Common/hooks/useSlug";
 import useQuery from "../../Utils/request/useQuery";
-import { classNames, formatDateTime } from "../../Utils/utils";
+import { classNames, formatDateTime, formatTime } from "../../Utils/utils";
 import { MedicineAdministrationRecord, Prescription } from "./models";
 import MedicineRoutes from "./routes";
 import Timeline, {
@@ -120,7 +120,9 @@ const MedicineAdministeredNode = ({
         event={event}
         className={classNames(event.cancelled && "opacity-70")}
         // TODO: to add administered dosage when Titrated Prescriptions are implemented
-        // titleSuffix={`administered ${event.administration.dosage}.`}
+        titleSuffix={`administered the medicine at ${formatTime(
+          event.administration.administered_date
+        )}.`}
         actions={
           !event.cancelled &&
           !hideArchive && (
@@ -198,13 +200,14 @@ const compileEvents = (
   administrations
     .sort(
       (a, b) =>
-        new Date(a.created_date).getTime() - new Date(b.created_date).getTime()
+        new Date(a.administered_date!).getTime() -
+        new Date(b.administered_date!).getTime()
     )
     .forEach((administration) => {
       events.push({
         type: "administered",
         icon: "l-syringe",
-        timestamp: administration.created_date,
+        timestamp: administration.administered_date!,
         by: administration.administered_by,
         cancelled: !!administration.archived_on,
         administration,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 18f1f48</samp>

Improve medicine timeline accuracy and readability. Use `administered_date` and `formatTime` in `PrescrpitionTimeline.tsx`.

## Proposed Changes

- Fixes #6686
- Administration event text will now show absolute time information too
- Fix relative time from showing `created_date` instead of `administration_date`

<img width="988" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/b82cc173-82dd-42d2-a8a4-6d16d329ec26">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 18f1f48</samp>

* Import the `formatTime` function to format the time of medicine administration in the timeline ([link](https://github.com/coronasafe/care_fe/pull/6685/files?diff=unified&w=0#diff-9fec7a75164a6b1f4d65f6daacdb9aa72c4c34205b35683a00ecac955b540691L4-R4))
* Use the `formatTime` function to show the time of medicine administration in the `titleSuffix` prop of the `MedicineAdministeredNode` component ([link](https://github.com/coronasafe/care_fe/pull/6685/files?diff=unified&w=0#diff-9fec7a75164a6b1f4d65f6daacdb9aa72c4c34205b35683a00ecac955b540691L123-R125))
* Sort the medicine administration records by the `administered_date` field instead of the `created_date` field in the `compileEvents` function, as the former is more relevant for the timeline ([link](https://github.com/coronasafe/care_fe/pull/6685/files?diff=unified&w=0#diff-9fec7a75164a6b1f4d65f6daacdb9aa72c4c34205b35683a00ecac955b540691L201-R204))
* Use the `administered_date` field instead of the `created_date` field for the `timestamp` and `administered_date` fields of the medicine administration event object, as the former is more accurate for the timeline ([link](https://github.com/coronasafe/care_fe/pull/6685/files?diff=unified&w=0#diff-9fec7a75164a6b1f4d65f6daacdb9aa72c4c34205b35683a00ecac955b540691L207-R210))
