### PR TITLE
hide location filter if facility is not selected

### DIFF
--- a/src/Components/Common/LocationSelect.tsx
+++ b/src/Components/Common/LocationSelect.tsx
@@ -7,7 +7,7 @@ interface LocationSelectProps {
   name: string;
   disabled?: boolean;
   margin?: string;
-  errors: string;
+  errors?: string;
   className?: string;
   searchAll?: boolean;
   multiple?: boolean;

--- a/src/Components/Form/FormFields/FormField.tsx
+++ b/src/Components/Form/FormFields/FormField.tsx
@@ -1,6 +1,6 @@
+import { classNames } from "../../../Utils/utils";
 import { FieldError } from "../FieldValidators";
 import { FormFieldBaseProps } from "./Utils";
-import { classNames } from "../../../Utils/utils";
 
 type LabelProps = {
   id?: string | undefined;
@@ -71,7 +71,12 @@ const FormField = ({
         )}
       </div>
       <div className={field?.className}>{children}</div>
-      <FieldErrorText error={field?.error} className={field?.errorClassName} />
+      {field?.error && (
+        <FieldErrorText
+          error={field?.error}
+          className={field?.errorClassName}
+        />
+      )}
     </div>
   );
 };

--- a/src/Components/Form/FormFields/FormField.tsx
+++ b/src/Components/Form/FormFields/FormField.tsx
@@ -71,12 +71,7 @@ const FormField = ({
         )}
       </div>
       <div className={field?.className}>{children}</div>
-      {field?.error && (
-        <FieldErrorText
-          error={field?.error}
-          className={field?.errorClassName}
-        />
-      )}
+      <FieldErrorText error={field?.error} className={field?.errorClassName} />
     </div>
   );
 };

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -600,22 +600,23 @@ export default function PatientFilter(props: any) {
               setSelected={(obj) => setFacility(obj, "facility")}
             />
           </div>
-          <div>
-            <FieldLabel className="text-sm">Location</FieldLabel>
-            <LocationSelect
-              disabled={!filterState.facility}
-              name="facility"
-              selected={filterState.last_consultation_current_bed__location}
-              multiple={false}
-              facilityId={filterState.facility}
-              setSelected={(selected) =>
-                setFilterState({
-                  ...filterState,
-                  last_consultation_current_bed__location: selected,
-                })
-              }
-            />
-          </div>
+          {filterState.facility && (
+            <div>
+              <FieldLabel className="text-sm">Location</FieldLabel>
+              <LocationSelect
+                name="facility"
+                selected={filterState.last_consultation_current_bed__location}
+                multiple={false}
+                facilityId={filterState.facility}
+                setSelected={(selected) =>
+                  setFilterState({
+                    ...filterState,
+                    last_consultation_current_bed__location: selected,
+                  })
+                }
+              />
+            </div>
+          )}
           <div>
             <FieldLabel className="text-sm">Facility type</FieldLabel>
             <SelectMenuV2

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -1,40 +1,40 @@
-import { useEffect, useCallback } from "react";
-import { FacilitySelect } from "../Common/FacilitySelect";
-import AutoCompleteAsync from "../Form/AutoCompleteAsync";
+import dayjs from "dayjs";
+import { navigate } from "raviger";
+import { useCallback, useEffect } from "react";
+import { useDispatch } from "react-redux";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
 import {
-  GENDER_TYPES,
-  FACILITY_TYPES,
-  DISEASE_STATUS,
-  PATIENT_FILTER_CATEGORIES,
   ADMITTED_TO,
   DISCHARGE_REASONS,
+  DISEASE_STATUS,
+  FACILITY_TYPES,
+  GENDER_TYPES,
+  PATIENT_FILTER_CATEGORIES,
 } from "../../Common/constants";
+import useConfig from "../../Common/hooks/useConfig";
+import useMergeState from "../../Common/hooks/useMergeState";
 import {
   getAllLocalBody,
   getAnyFacility,
   getDistrict,
 } from "../../Redux/actions";
-import { useDispatch } from "react-redux";
-import { navigate } from "raviger";
+import { dateQueryString } from "../../Utils/utils";
+import { DateRange } from "../Common/DateRangeInputV2";
+import { FacilitySelect } from "../Common/FacilitySelect";
+import { LocationSelect } from "../Common/LocationSelect";
+import AccordionV2 from "../Common/components/AccordionV2";
 import DistrictSelect from "../Facility/FacilityFilter/DistrictSelect";
-import SelectMenuV2 from "../Form/SelectMenuV2";
+import AutoCompleteAsync from "../Form/AutoCompleteAsync";
+import DateRangeFormField from "../Form/FormFields/DateRangeFormField";
+import { FieldLabel } from "../Form/FormFields/FormField";
 import TextFormField from "../Form/FormFields/TextFormField";
 import {
   FieldChangeEvent,
   FieldChangeEventHandler,
 } from "../Form/FormFields/Utils";
-import { FieldLabel } from "../Form/FormFields/FormField";
 import MultiSelectMenuV2 from "../Form/MultiSelectMenuV2";
-import DateRangeFormField from "../Form/FormFields/DateRangeFormField";
-import { DateRange } from "../Common/DateRangeInputV2";
-import CareIcon from "../../CAREUI/icons/CareIcon";
-import useMergeState from "../../Common/hooks/useMergeState";
-import useConfig from "../../Common/hooks/useConfig";
-import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
-import AccordionV2 from "../Common/components/AccordionV2";
-import { dateQueryString } from "../../Utils/utils";
-import dayjs from "dayjs";
-import { LocationSelect } from "../Common/LocationSelect";
+import SelectMenuV2 from "../Form/SelectMenuV2";
 
 const getDate = (value: any) =>
   value && dayjs(value).isValid() && dayjs(value).toDate();
@@ -587,10 +587,10 @@ export default function PatientFilter(props: any) {
           </h1>
         }
         expanded={true}
-        className="w-full rounded-md"
+        className="rounded-md"
       >
-        <div className="grid w-full grid-cols-1 gap-4">
-          <div className="w-full flex-none">
+        <div className="space-y-4">
+          <div>
             <FieldLabel className="text-sm">Facility</FieldLabel>
             <FacilitySelect
               multiple={false}
@@ -600,14 +600,13 @@ export default function PatientFilter(props: any) {
               setSelected={(obj) => setFacility(obj, "facility")}
             />
           </div>
-          <div className="w-full flex-none">
+          <div>
             <FieldLabel className="text-sm">Location</FieldLabel>
             <LocationSelect
               disabled={!filterState.facility}
               name="facility"
               selected={filterState.last_consultation_current_bed__location}
               multiple={false}
-              errors=""
               facilityId={filterState.facility}
               setSelected={(selected) =>
                 setFilterState({
@@ -617,7 +616,7 @@ export default function PatientFilter(props: any) {
               }
             />
           </div>
-          <div className="-mt-6 w-full flex-none">
+          <div>
             <FieldLabel className="text-sm">Facility type</FieldLabel>
             <SelectMenuV2
               placeholder="Show all"
@@ -633,7 +632,7 @@ export default function PatientFilter(props: any) {
               )}
             />
           </div>
-          <div className="w-full flex-none">
+          <div>
             <FieldLabel className="text-sm">LSG Body</FieldLabel>
             <div className="">
               <AutoCompleteAsync
@@ -653,7 +652,7 @@ export default function PatientFilter(props: any) {
             </div>
           </div>
 
-          <div className="w-full flex-none">
+          <div>
             <FieldLabel className="text-sm">District</FieldLabel>
             <DistrictSelect
               multiple={false}

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -605,6 +605,7 @@ export default function PatientFilter(props: any) {
               <FieldLabel className="text-sm">Location</FieldLabel>
               <LocationSelect
                 name="facility"
+                errorClassName="hidden"
                 selected={filterState.last_consultation_current_bed__location}
                 multiple={false}
                 facilityId={filterState.facility}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c3bb44d</samp>

This pull request introduces some improvements and new features for the form and filter components in the frontend. It adds a `LocationSelect` component and a `SelectMenuV2` component, which allow users to select locations and other options more easily. It also fixes some issues with error handling and code style in `FormField.tsx` and `PatientFilter.tsx`.

## Proposed Changes

- Fixes #6671
- 50080e67a7703dbf5ae9c636d899beca0af853a2 Make the error field in `LocationSelect` optional instead of required and make the error component in `FormField` render only if an error is present. This now makes sure that we don't have an empty span taking up space on the screen even if there is no error. This was causing extra space below the location filter and negative margin was being used to fix that earlier.
- 431cf7b490a7eb88f8011e759e7e21b8fde8f878 Remove unnecessary tailwind classes and negative margin mentioned above as the extra space issue is now fixed by not rendering the error span. No reason to use grid/flex properties for a simple top-down form.
- c3bb44d2be49b74435585eb824be36b470c4401b Render the location filter only if a facility is selected

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c3bb44d</samp>

*  Make `errors` prop optional in `LocationSelectProps` interface ([link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-9d60bc53c3485cac0e686868653412071302d60323e05e0337df49fbad4f4fabL10-R10))
*  Reorder and group import statements in `LocationSelect.tsx` and `PatientFilter.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-85bba5418d27d8aaf29bfddc378f96a3e0f7356cb337160cd5bc4960179860fbL1-R3), [link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL1-R16), [link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL17-R30), [link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL26-R37))
*  Conditionally render `FieldErrorText` component in `FormField` component ([link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-85bba5418d27d8aaf29bfddc378f96a3e0f7356cb337160cd5bc4960179860fbL74-R79))
*  Change `className` prop of `AccordionV2` component to `rounded-md` and use `space-y-4` for accordion content in `PatientFilter.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL590-R593))
*  Conditionally render `LocationSelect` component in `PatientFilter.tsx` and remove unnecessary props ([link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL603-R620))
*  Remove unused `className` props from `div` elements containing `FieldLabel` components in `PatientFilter.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL636-R636), [link](https://github.com/coronasafe/care_fe/pull/6688/files?diff=unified&w=0#diff-c2cb85d3cdc89692ee11a2f37a159ecb45eec9e1148bb2e9a779d2bcf7cd7c8aL656-R656))
