### PR TITLE
Replaced useDispatch with useQuerry on DailyRoundListDetails

### DIFF
--- a/src/Components/Patient/DailyRoundListDetails.tsx
+++ b/src/Components/Patient/DailyRoundListDetails.tsx
@@ -18,34 +18,36 @@ export const DailyRoundListDetails = (props: any) => {
       id,
     },
   });
-  const fetchpatient = async () => {
-    if (res && data) {
-      const currentHealth = currentHealthChoices.find(
-        (i) => i.text === data?.current_health
-      );
-
-      const Data: DailyRoundsModel = {
-        ...data,
-        temperature: Number(data?.temperature) ? data.temperature : "",
-        additional_symptoms_text: "",
-        medication_given:
-          Object.keys(data.medication_given ?? {}).length === 0
-            ? []
-            : data.medication_given,
-        current_health: currentHealth
-          ? currentHealth.desc
-          : data.current_health,
-      };
-      if (data.additional_symptoms?.length) {
-        const symptoms = data.additional_symptoms.map((symptom: number) => {
-          const option = symptomChoices.find((i) => i.id === symptom);
-          return option ? option.text.toLowerCase() : symptom;
-        });
-        Data.additional_symptoms_text = symptoms.join(", ");
+  let currentHealth:
+    | {
+        id: number;
+        text: string;
+        desc: string;
       }
-    }
+    | undefined;
+  if (res && data) {
+    currentHealth = currentHealthChoices.find(
+      (i) => i.text === data?.current_health
+    );
+  }
+
+  const Data: DailyRoundsModel = {
+    ...data,
+    temperature: Number(data?.temperature) ? data?.temperature : "",
+    additional_symptoms_text: "",
+    medication_given:
+      Object.keys(data?.medication_given ?? {}).length === 0
+        ? []
+        : data?.medication_given,
+    current_health: currentHealth ? currentHealth.desc : data?.current_health,
   };
-  fetchpatient();
+  if (data?.additional_symptoms?.length) {
+    const symptoms = data.additional_symptoms.map((symptom: number) => {
+      const option = symptomChoices.find((i) => i.id === symptom);
+      return option ? option.text.toLowerCase() : symptom;
+    });
+    data.additional_symptoms_text = symptoms.join(", ");
+  }
   if (loading) {
     return <Loading />;
   }
@@ -61,7 +63,7 @@ export const DailyRoundListDetails = (props: any) => {
               <span className="font-semibold leading-relaxed">
                 Patient Category:{" "}
               </span>
-              {data?.patient_category ?? "-"}
+              {Data.patient_category ?? "-"}
             </div>
           </div>
 
@@ -79,49 +81,49 @@ export const DailyRoundListDetails = (props: any) => {
         <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
           <div>
             <span className="font-semibold leading-relaxed">Temperature: </span>
-            {data?.temperature ?? "-"}
+            {Data.temperature ?? "-"}
           </div>
           <div>
             <span className="font-semibold leading-relaxed">Taken at: </span>
-            {data?.taken_at ? formatDateTime(data?.taken_at) : "-"}
+            {Data.taken_at ? formatDateTime(data?.taken_at) : "-"}
           </div>
           <div>
             <span className="font-semibold leading-relaxed">SpO2: </span>
-            {data?.ventilator_spo2 ?? "-"}
+            {Data.ventilator_spo2 ?? "-"}
           </div>
           <div className="capitalize md:col-span-2">
             <span className="font-semibold leading-relaxed">
               Additional Symptoms:{" "}
             </span>
-            {data?.additional_symptoms_text ?? "-"}
+            {Data.additional_symptoms_text ?? "-"}
           </div>
           <div className="capitalize md:col-span-2">
             <span className="font-semibold leading-relaxed">
               Admitted To *:{" "}
             </span>
-            {data?.admitted_to ?? "-"}
+            {Data.admitted_to ?? "-"}
           </div>
           <div className="md:col-span-2">
             <span className="font-semibold leading-relaxed">
               Physical Examination Info:{" "}
             </span>
-            {data?.physical_examination_info ?? "-"}
+            {Data.physical_examination_info ?? "-"}
           </div>
           <div className="md:col-span-2">
             <span className="font-semibold leading-relaxed">
               Other Symptoms:{" "}
             </span>
-            {data?.other_symptoms ?? "-"}
+            {Data.other_symptoms ?? "-"}
           </div>
           <div className="md:col-span-2">
             <span className="font-semibold leading-relaxed">
               Other Details:{" "}
             </span>
-            {data?.other_details ?? "-"}
+            {Data.other_details ?? "-"}
           </div>
           <div className="md:col-span-2">
             <span className="font-semibold leading-relaxed">Pulse(bpm): </span>
-            {data?.pulse ?? "-"}
+            {Data.pulse ?? "-"}
           </div>
           <div className="md:col-span-2 ">
             <span className="font-semibold leading-relaxed">BP</span>
@@ -130,14 +132,14 @@ export const DailyRoundListDetails = (props: any) => {
                 <span className="font-semibold leading-relaxed">
                   Systolic:{" "}
                 </span>
-                {data?.bp?.systolic ?? "-"}
+                {Data.bp?.systolic ?? "-"}
               </div>
               <div className="flex">
                 {" "}
                 <span className="font-semibold leading-relaxed">
                   Diastolic:
                 </span>
-                {data?.bp?.diastolic ?? "-"}
+                {Data.bp?.diastolic ?? "-"}
               </div>
             </div>
           </div>
@@ -147,23 +149,23 @@ export const DailyRoundListDetails = (props: any) => {
               Respiratory Rate (bpm):
             </span>
 
-            {data?.resp ?? "-"}
+            {Data.resp ?? "-"}
           </div>
           <div className="md:col-span-2">
             <span className="font-semibold leading-relaxed">Rhythm: </span>
-            {data?.rhythm ?? "-"}
+            {Data.rhythm ?? "-"}
           </div>
           <div className="md:col-span-2">
             <span className="font-semibold leading-relaxed">
               Rhythm Description:{" "}
             </span>
-            {data?.rhythm_detail ?? "-"}
+            {Data.rhythm_detail ?? "-"}
           </div>
           <div>
             <span className="font-semibold leading-relaxed">
               Recommend Discharge:{" "}
             </span>
-            {data?.recommend_discharge ? (
+            {Data.recommend_discharge ? (
               <span className="badge badge-pill badge-warning">Yes</span>
             ) : (
               <span className="badge badge-pill badge-secondary">No</span>

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -46,7 +46,7 @@ import { Prescription } from "../Components/Medicine/models";
 
 import { UserModel } from "../Components/Users/models";
 import { PaginatedResponse } from "../Utils/request/types";
-import { PatientModel } from "../Components/Patient/models";
+import { PatientModel, DailyRoundsModel } from "../Components/Patient/models";
 import { IComment, IResource } from "../Components/Resource/models";
 
 /**
@@ -441,6 +441,8 @@ const routes = {
 
   getDailyReport: {
     path: "/api/v1/consultation/{consultationId}/daily_rounds/{id}/",
+    method: "GET",
+    TRes: Type<DailyRoundsModel>(),
   },
   dailyRoundsAnalyse: {
     path: "/api/v1/consultation/{consultationId}/daily_rounds/analyse/",


### PR DESCRIPTION
### WHAT
copilot: 

## Proposed Changes

- Part of #6546
- Change 1
- Change 2
- Removed the useDispatch and its related actions, and replaced it with a custom hook which calls useQuery() to fetch data in DailyRoundListDetails file

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b3fea0a</samp>

*  Replace `dispatch` and `getConsultationDailyRoundsDetails` actions with custom hook `useConsultationQuery` that uses `useQuery` and `routes.getDailyReport` to fetch daily round details in `DailyRoundListDetails.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-053735ce31a3f4f61ee63c4e404e0ca2f5d09e64911b6201bee883eb44fe0e42L2-R5), [link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-053735ce31a3f4f61ee63c4e404e0ca2f5d09e64911b6201bee883eb44fe0e42L14-R36), [link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-053735ce31a3f4f61ee63c4e404e0ca2f5d09e64911b6201bee883eb44fe0e42L61-R67), [link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-053735ce31a3f4f61ee63c4e404e0ca2f5d09e64911b6201bee883eb44fe0e42L67-R73))
* Add optional chaining operators (`?.`) to access `current_health` and `medication_given` properties of `res.data` object in `DailyRoundListDetails.tsx` to prevent errors when they are null or undefined ([link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-053735ce31a3f4f61ee63c4e404e0ca2f5d09e64911b6201bee883eb44fe0e42L14-R36), [link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-053735ce31a3f4f61ee63c4e404e0ca2f5d09e64911b6201bee883eb44fe0e42L40-R46))
* Import `DailyRoundsModel` type from `models` module and use it to define response type of `routes.getDailyReport` object in `api.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cL49-R49), [link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR444-R445))
* Add `method` property to `routes.getDailyReport` object in `api.tsx` to specify GET request ([link](https://github.com/coronasafe/care_fe/pull/6696/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cR444-R445))
