### PR TITLE
fixes missing warranty validity filters

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -63,6 +63,10 @@ const AssetsList = () => {
     asset_class: qParams.asset_class || "",
     location: qParams.facility ? qParams.location || "" : "",
     status: qParams.status || "",
+    warranty_amc_end_of_validity_before:
+      qParams.warranty_amc_end_of_validity_before || "",
+    warranty_amc_end_of_validity_after:
+      qParams.warranty_amc_end_of_validity_after || "",
   };
 
   const { loading } = useQuery(routes.listAssets, {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5b0251d</samp>

Added warranty and AMC filters to `AssetsList` component. The component now accepts two query parameters from the URL to filter the assets by their warranty or AMC end date.

## Proposed Changes

- Fixes #6697 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5b0251d</samp>

* Add warranty and AMC filters to the assets list component ([link](https://github.com/coronasafe/care_fe/pull/6698/files?diff=unified&w=0#diff-d61b507f07891c695d44e81effbf8f1da3a8667b0379dcfbd98c5761aa124f49R66-R69))
