### PR TITLE
Keep doctor notes popup opened when initially clicked

### DIFF
--- a/src/Components/Facility/PatientNotesSlideover.tsx
+++ b/src/Components/Facility/PatientNotesSlideover.tsx
@@ -18,7 +18,7 @@ interface PatientNotesProps {
 }
 
 export default function PatientNotesSlideover(props: PatientNotesProps) {
-  const [show, setShow] = useState(false);
+  const [show, setShow] = useState(true);
   const [patientActive, setPatientActive] = useState(true);
   const [noteField, setNoteField] = useState("");
   const [reload, setReload] = useState(false);


### PR DESCRIPTION
component

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 83da2a9</samp>

Changed the default visibility of the patient notes slideover component in `PatientNotesSlideover.tsx` to enhance user experience and accessibility.

## Proposed Changes

- Fixes #6700 


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 83da2a9</samp>

*  Make the patient notes slideover component visible by default to improve user experience and accessibility ([link](https://github.com/coronasafe/care_fe/pull/6702/files?diff=unified&w=0#diff-fd87ec7a0afcd3a38d84fab3a83e84def86072332dae665314e6da3f8661e145L21-R21))
