### PR TITLE
Fix cypress for doctor notes

### DIFF
--- a/cypress/pageobject/Patient/PatientConsultation.ts
+++ b/cypress/pageobject/Patient/PatientConsultation.ts
@@ -203,12 +203,13 @@ export class PatientConsultationPage {
   }
 
   addDoctorsNotes(notes: string) {
+    cy.get("#expand_doctor_notes").click();
     cy.get("#doctor_notes_textarea").type(notes);
   }
 
   postDoctorNotes() {
     cy.intercept("POST", "**/api/v1/patient/*/notes").as("postDoctorNotes");
-    cy.get("#submit").contains("Post Your Note").click();
+    cy.get("#add_doctor_note_button").click();
     cy.wait("@postDoctorNotes").its("response.statusCode").should("eq", 201);
   }
 

--- a/src/Components/Facility/PatientNotesSlideover.tsx
+++ b/src/Components/Facility/PatientNotesSlideover.tsx
@@ -79,6 +79,7 @@ export default function PatientNotesSlideover(props: PatientNotesProps) {
         </Link>
       )}
       <div
+        id="expand_doctor_notes"
         className={classNames(
           "flex h-8 w-8 cursor-pointer items-center justify-center rounded bg-primary-800 text-gray-100 text-opacity-70 hover:bg-primary-700 hover:text-opacity-100",
           show && "rotate-180"
@@ -129,6 +130,7 @@ export default function PatientNotesSlideover(props: PatientNotesProps) {
           />
           <div className="relative mx-4 flex items-center">
             <TextFormField
+              id="doctor_notes_textarea"
               name="note"
               value={noteField}
               onChange={(e) => setNoteField(e.value)}
@@ -139,6 +141,7 @@ export default function PatientNotesSlideover(props: PatientNotesProps) {
               disabled={!patientActive}
             />
             <ButtonV2
+              id="add_doctor_note_button"
               onClick={onAddNote}
               border={false}
               className="absolute right-2"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4925c8f</samp>

This pull request improves the cypress test for the patient consultation page and adds id attributes to the `PatientNotesSlideover` component. The test is updated to reflect the new UI for the doctor notes section and the id attributes are added to make the elements easier to locate by cypress.

## Proposed Changes

- Fixes #6699 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4925c8f</samp>

*  Add id attributes to the elements in the patient notes slideover component to facilitate cypress testing ([link](https://github.com/coronasafe/care_fe/pull/6703/files?diff=unified&w=0#diff-fd87ec7a0afcd3a38d84fab3a83e84def86072332dae665314e6da3f8661e145R82), [link](https://github.com/coronasafe/care_fe/pull/6703/files?diff=unified&w=0#diff-fd87ec7a0afcd3a38d84fab3a83e84def86072332dae665314e6da3f8661e145R133), [link](https://github.com/coronasafe/care_fe/pull/6703/files?diff=unified&w=0#diff-fd87ec7a0afcd3a38d84fab3a83e84def86072332dae665314e6da3f8661e145R144)) in `src/Components/Facility/PatientNotesSlideover.tsx`
