### PR TITLE
Fix layout issue in DailyRoundsList component

### DIFF
--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -28,7 +28,7 @@ export const DailyRoundsList = (props: any) => {
       }}
     >
       {(_) => (
-        <div className="flex w-full flex-col gap-4">
+        <div className="-mt-2 flex w-full flex-col gap-4">
           <div className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto overflow-x-hidden px-3">
             <PaginatedList.WhenEmpty className="flex w-full justify-center border-b border-gray-200 bg-white p-5 text-center text-2xl font-bold text-gray-500">
               <span className="flex justify-center rounded-lg bg-white p-3 text-gray-700 shadow">
@@ -42,7 +42,7 @@ export const DailyRoundsList = (props: any) => {
                 ))}
               </>
             </PaginatedList.WhenLoading>
-            <PaginatedList.Items<DailyRoundsModel> className="my-8 flex grow flex-col gap-3 lg:mx-8">
+            <PaginatedList.Items<DailyRoundsModel> className="flex grow flex-col gap-3">
               {(item, items) => {
                 if (item.rounds_type === "AUTOMATED") {
                   return (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bae3e2c</samp>

Improved the UI of the daily rounds list component for consultations. Refactored the code in `DailyRoundsList.tsx` to use better spacing and alignment.

## Proposed Changes

![image](https://github.com/coronasafe/care_fe/assets/3626859/3fe04f86-bd28-46ac-a16b-da03324fd8b8)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bae3e2c</samp>

* Reduce the top margin of the daily rounds list to remove extra space ([link](https://github.com/coronasafe/care_fe/pull/6709/files?diff=unified&w=0#diff-65429b4a69e72bfde74a8cb5766d1c36270bed52bbacc759c59f9f4a18fb82b6L31-R31))
* Remove the horizontal margin of the daily rounds list to make it span the full width on smaller devices ([link](https://github.com/coronasafe/care_fe/pull/6709/files?diff=unified&w=0#diff-65429b4a69e72bfde74a8cb5766d1c36270bed52bbacc759c59f9f4a18fb82b6L45-R45))
