### PR TITLE
Filter out push notif and Fix empty daily rounds design

### DIFF
--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -31,7 +31,7 @@ export const DailyRoundsList = (props: any) => {
         <div className="-mt-2 flex w-full flex-col gap-4">
           <div className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto overflow-x-hidden px-3">
             <PaginatedList.WhenEmpty className="flex w-full justify-center border-b border-gray-200 bg-white p-5 text-center text-2xl font-bold text-gray-500">
-              <span className="flex justify-center rounded-lg bg-white p-3 text-gray-700 shadow">
+              <span className="flex justify-center rounded-lg bg-white p-3 text-gray-700">
                 {t("no_consultation_updates")}
               </span>
             </PaginatedList.WhenEmpty>

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -30,7 +30,7 @@ export const DailyRoundsList = (props: any) => {
       {(_) => (
         <div className="-mt-2 flex w-full flex-col gap-4">
           <div className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto overflow-x-hidden px-3">
-            <PaginatedList.WhenEmpty className="flex w-full justify-center border-b border-gray-200 bg-white p-5 text-center text-2xl font-bold text-gray-500">
+            <PaginatedList.WhenEmpty className="flex w-full justify-center rounded-md border-b border-gray-200 bg-white px-5 py-1 text-center text-2xl font-bold text-gray-500">
               <span className="flex justify-center rounded-lg bg-white p-3 text-gray-700">
                 {t("no_consultation_updates")}
               </span>

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -358,6 +358,7 @@ export default function NotificationsList({
     manageResults = (
       <>
         {data
+          .filter((notification: any) => notification.event != "PUSH_MESSAGE")
           .filter((notification: any) =>
             showUnread ? notification.read_at === null : true
           )

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -358,7 +358,6 @@ export default function NotificationsList({
     manageResults = (
       <>
         {data
-          .filter((notification: any) => notification.event != "PUSH_MESSAGE")
           .filter((notification: any) =>
             showUnread ? notification.read_at === null : true
           )


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1fe5b48</samp>

Filter out `PUSH_MESSAGE` notifications from the notifications list component. This prevents showing duplicate notifications for the same push message that is also shown in the toast component.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1fe5b48</samp>

*  Filter out notifications with event type "PUSH_MESSAGE" from the notifications list to avoid duplicates ([link](https://github.com/coronasafe/care_fe/pull/6710/files?diff=unified&w=0#diff-75a5f730c112dc5dbfb5da454ea076adc2632003c0372b04ddc9be5752c4e586R361))
