### PR TITLE
Add icu_admission_date field to ConsultationForm

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -724,6 +724,7 @@ export const ConsultationForm = (props: any) => {
             : undefined,
         consultation_notes: state.form.consultation_notes,
         is_telemedicine: state.form.is_telemedicine,
+        icu_admission_date: state.form.icu_admission_date,
         action: state.form.action,
         review_interval: state.form.review_interval,
         assigned_to:


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bc6459a</samp>

Add `icu_admission_date` field to consultation form. This change allows the user to record the date of ICU admission for a patient in the `ConsultationForm.tsx` component.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bc6459a</samp>

*  Add `icu_admission_date` field to the state object in `ConsultationForm` component ([link](https://github.com/coronasafe/care_fe/pull/6711/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR727))
