### PR TITLE
Remove blood group, weight and height badges on the top of patient info card

### DIFF
--- a/src/Common/utils.tsx
+++ b/src/Common/utils.tsx
@@ -44,16 +44,6 @@ export const parseOptionId: (
   return textArray.join(", ");
 };
 
-export const getDimensionOrDash = (
-  value: number | string | null | undefined,
-  unit: string
-) => {
-  if (value === undefined || value === null || value === 0 || value === "0") {
-    return "-";
-  }
-  return value + unit;
-};
-
 export const deepEqual = (x: any, y: any): boolean => {
   if (x === y) return true;
 

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -14,7 +14,6 @@ import { Link } from "raviger";
 import { useState } from "react";
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import useConfig from "../../Common/hooks/useConfig";
-import { getDimensionOrDash } from "../../Common/utils";
 import dayjs from "../../Utils/dayjs";
 import { classNames, formatDate, formatDateTime } from "../../Utils/utils.js";
 import ABHAProfileModal from "../ABDM/ABHAProfileModal";
@@ -247,17 +246,6 @@ export default function PatientInfoCard(props: {
             </div>
             <div className="flex flex-col items-center gap-2 text-sm sm:flex-row lg:mt-4">
               {[
-                ["Blood Group", patient.blood_group, patient.blood_group],
-                [
-                  "Weight",
-                  getDimensionOrDash(consultation?.weight, " kg"),
-                  true,
-                ],
-                [
-                  "Height",
-                  getDimensionOrDash(consultation?.height, "cm"),
-                  true,
-                ],
                 [
                   "Respiratory Support",
                   RESPIRATORY_SUPPORT.find(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 978a436</samp>

Removed unused code and fields related to patient weight and height. Simplified the patient info card component in `src/Components/Patient/PatientInfoCard.tsx` and deleted the `getDimensionOrDash` function from `src/Common/utils.tsx`.

## Proposed Changes

- Fixes #6631 ?
- Patient body details are shown twice on the patient consultation page. Removed blood group, weight and height badges on the top of patient info card.


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 978a436</samp>

*  Remove unused `getDimensionOrDash` function from `src/Common/utils.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6712/files?diff=unified&w=0#diff-f1b9b06c04dce5b6de1b9d6697e14b969d718382fd56c2649714883940a2f8d7L47-L56))
*  Delete import of `getDimensionOrDash` from `src/Components/Patient/PatientInfoCard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6712/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L17))
*  Simplify patient info card component by removing blood group, weight and height fields and reordering respiratory support field in `src/Components/Patient/PatientInfoCard.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6712/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L250-R249))
