### PR TITLE
Sort by "Measured At" in daily rounds

### DIFF
--- a/src/CAREUI/misc/PaginatedList.tsx
+++ b/src/CAREUI/misc/PaginatedList.tsx
@@ -33,6 +33,7 @@ function useContextualized<TItem>() {
 interface Props<TItem> extends QueryOptions<PaginatedResponse<TItem>> {
   route: QueryRoute<PaginatedResponse<TItem>>;
   perPage?: number;
+  sortFunc?: (item1: any, item2: any) => number;
   children: (
     ctx: PaginatedListContext<TItem>,
     query: ReturnType<typeof useQuery<PaginatedResponse<TItem>>>
@@ -42,6 +43,7 @@ interface Props<TItem> extends QueryOptions<PaginatedResponse<TItem>> {
 export default function PaginatedList<TItem extends object>({
   children,
   route,
+  sortFunc,
   perPage = DEFAULT_PER_PAGE_LIMIT,
   ...queryOptions
 }: Props<TItem>) {
@@ -55,7 +57,11 @@ export default function PaginatedList<TItem extends object>({
     },
   });
 
-  const items = query.data?.results ?? [];
+  const items = query.data?.results
+    ? sortFunc
+      ? query.data?.results.sort(sortFunc)
+      : query.data?.results
+    : [];
 
   return (
     <context.Provider

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -26,6 +26,11 @@ export const DailyRoundsList = (props: any) => {
       query={{
         rounds_type: showAutomatedRounds ? "" : "NORMAL,VENTILATOR,ICU",
       }}
+      sortFunc={(item1, item2) => {
+        const takenAt1 = item1.taken_at;
+        const takenAt2 = item2.taken_at;
+        return Number(new Date(takenAt2)) - Number(new Date(takenAt1));
+      }}
     >
       {(_) => (
         <div className="-mt-2 flex w-full flex-col gap-4">
@@ -52,6 +57,7 @@ export const DailyRoundsList = (props: any) => {
                     />
                   );
                 }
+                console.log(items);
                 return (
                   <DefaultLogUpdateCard
                     round={item}

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -57,7 +57,6 @@ export const DailyRoundsList = (props: any) => {
                     />
                   );
                 }
-                console.log(items);
                 return (
                   <DefaultLogUpdateCard
                     round={item}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at adac57c</samp>

This pull request enhances the `PaginatedList` component to accept a custom sorting function and applies it to the `DailyRoundsList` component to sort the daily rounds by date. This improves the user experience and data presentation in the facility consultations page.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6693

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at adac57c</samp>

*  Add optional `sortFunc` prop to `PaginatedList` component to allow custom sorting of items ([link](https://github.com/coronasafe/care_fe/pull/6714/files?diff=unified&w=0#diff-d5a0491d201afa07e9229b4529d76bf770f7bab2f577a2e0c542414347199fb7R36))
*  Pass `sortFunc` prop to `useQuery` hook as part of query key to trigger refetching when sorting function changes ([link](https://github.com/coronasafe/care_fe/pull/6714/files?diff=unified&w=0#diff-d5a0491d201afa07e9229b4529d76bf770f7bab2f577a2e0c542414347199fb7R46))
*  Apply `sortFunc` to `query.data?.results` array if defined, or leave it as is otherwise, to assign sorted items to `items` variable ([link](https://github.com/coronasafe/care_fe/pull/6714/files?diff=unified&w=0#diff-d5a0491d201afa07e9229b4529d76bf770f7bab2f577a2e0c542414347199fb7L58-R64))
*  Pass `sortFunc` prop to `PaginatedList` component in `DailyRoundsList` component to sort daily rounds by descending `taken_at` date ([link](https://github.com/coronasafe/care_fe/pull/6714/files?diff=unified&w=0#diff-65429b4a69e72bfde74a8cb5766d1c36270bed52bbacc759c59f9f4a18fb82b6R29-R33))
