### PR TITLE
Show discharge reason for OP consultations

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -323,7 +323,11 @@ export default function PatientInfoCard(props: {
               </div>
               <div className="mt-1 text-xl font-semibold leading-5 text-gray-900">
                 {!consultation?.discharge_reason ? (
-                  <span className="text-gray-800">UNKNOWN</span>
+                  <span className="text-gray-800">
+                    {consultation.suggestion === "OP"
+                      ? "OP file closed"
+                      : "UNKNOWN"}
+                  </span>
                 ) : consultation?.discharge_reason === "EXP" ? (
                   <span className="text-red-600">EXPIRED</span>
                 ) : (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 023640f</samp>

Improve patient status display for outpatient consultations. Show `OP file closed` in `PatientInfoCard.tsx` when consultation suggestion is `OP` and discharge reason is not given.

## Proposed Changes

- Fixes #6679 

<img width="1495" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/505746ad-d6fe-43d2-b85a-e55396c998a0">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 023640f</samp>

*  Display "OP file closed" for outpatient consultations without discharge reason ([link](https://github.com/coronasafe/care_fe/pull/6724/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L326-R330))
