### PR TITLE
Remove Copilot for PR tags

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,6 @@
-### WHAT
-copilot:summary
-
 ## Proposed Changes
 
-- Fixes #issue?
+- Fixes #issue_number
 - Change 1
 - Change 2
 - More?
@@ -18,6 +15,3 @@ copilot:summary
 - [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
 - [ ] Request for Peer Reviews
 - [ ] Completion of QA
-
-### HOW
-copilot:walkthrough


### PR DESCRIPTION
See https://githubnext.com/copilot-for-prs-sunset

These tags are now deprecated as we see in recent PRs

<img width="994" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/626ffaa1-562c-4eb2-97a4-0be52bbd8ca6">
