### PR TITLE
New Cypress Test | Verify Facility CSV Export | Facility Tab

### DIFF
--- a/cypress/e2e/facility_spec/facility_homepage.cy.ts
+++ b/cypress/e2e/facility_spec/facility_homepage.cy.ts
@@ -1,0 +1,54 @@
+// FacilityCreation
+import { cy, describe, before, beforeEach, it, afterEach } from "local-cypress";
+import LoginPage from "../../pageobject/Login/LoginPage";
+import FacilityHome from "../../pageobject/Facility/FacilityHome";
+
+describe("Facility Creation", () => {
+  const loginPage = new LoginPage();
+  const facilityHome = new FacilityHome();
+  const facilitiesAlias = "downloadFacilitiesCSV";
+  const capacitiesAlias = "downloadCapacitiesCSV";
+  const doctorsAlias = "downloadDoctorsCSV";
+  const triagesAlias = "downloadTriagesCSV";
+
+  before(() => {
+    loginPage.loginAsDisctrictAdmin();
+    cy.saveLocalStorage();
+  });
+
+  beforeEach(() => {
+    cy.viewport(1280, 720);
+    cy.restoreLocalStorage();
+    cy.awaitUrl("/facility");
+  });
+
+  it("Verify Facility Export Functionality", () => {
+    // Download the Facilities CSV
+    facilityHome.csvDownloadIntercept(facilitiesAlias, "");
+    facilityHome.clickExportButton();
+    facilityHome.clickMenuItem("Facilities");
+    facilityHome.verifyDownload(facilitiesAlias);
+    facilityHome.clickSearchButton(); // to avoid flaky test, as sometimes, the test is unable to focus on the object
+    // Download the Capacities CSV
+    facilityHome.csvDownloadIntercept(capacitiesAlias, "&capacity");
+    facilityHome.clickExportButton();
+    facilityHome.clickMenuItem("Capacities");
+    facilityHome.verifyDownload(capacitiesAlias);
+    facilityHome.clickSearchButton();
+    // Download the Doctors CSV
+    facilityHome.csvDownloadIntercept(doctorsAlias, "&doctors");
+    facilityHome.clickExportButton();
+    facilityHome.clickMenuItem("Doctors");
+    facilityHome.verifyDownload(doctorsAlias);
+    facilityHome.clickSearchButton();
+    // Download the Triages CSV
+    facilityHome.csvDownloadIntercept(triagesAlias, "&triage");
+    facilityHome.clickExportButton();
+    facilityHome.clickMenuItem("Triages");
+    facilityHome.verifyDownload(triagesAlias);
+    facilityHome.clickSearchButton();
+  });
+  afterEach(() => {
+    cy.saveLocalStorage();
+  });
+});

--- a/cypress/pageobject/Facility/FacilityHome.ts
+++ b/cypress/pageobject/Facility/FacilityHome.ts
@@ -1,0 +1,31 @@
+// cypress/support/pageObjects/FacilityHome.ts
+
+class FacilityHome {
+  // Selectors
+  exportButton = "#export-button";
+  searchButton = "#search";
+  menuItem = "[role='menuitem']";
+
+  // Operations
+  clickExportButton() {
+    cy.get(this.exportButton).click();
+  }
+
+  clickSearchButton() {
+    cy.get(this.searchButton).click();
+  }
+
+  clickMenuItem(itemName: string) {
+    cy.get(this.menuItem).contains(itemName).click();
+  }
+
+  csvDownloadIntercept(alias: string, queryParam: string) {
+    cy.intercept("GET", `**/api/v1/facility/?csv${queryParam}`).as(alias);
+  }
+
+  verifyDownload(alias: string) {
+    cy.wait(`@${alias}`).its("response.statusCode").should("eq", 200);
+  }
+}
+
+export default FacilityHome;

--- a/src/Components/Common/Export.tsx
+++ b/src/Components/Common/Export.tsx
@@ -40,7 +40,7 @@ export const ExportMenu = ({
   const { isExporting, exportFile } = useExport();
 
   return (
-    <div key="export-menu">
+    <div key="export-menu" id="export-button">
       <DropdownMenu
         disabled={isExporting || disabled}
         title={isExporting ? "Exporting..." : label}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8010592</samp>

This pull request adds a new end-to-end test suite for the facility creation feature using Cypress. It also adds a new page object class for the facility home page and a minor modification to the `Export.tsx` component.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8010592</samp>

*  Add a test suite for the facility creation feature ([link](https://github.com/coronasafe/care_fe/pull/6730/files?diff=unified&w=0#diff-274258dc54c7eb7e1917e3e958543df207b3498ecb5cd6bb09ca160284270765R1-R54))
* Add a page object class for the facility home page ([link](https://github.com/coronasafe/care_fe/pull/6730/files?diff=unified&w=0#diff-2c6573c06a874087a6f559c553ec1f95e49bbf03f21a6371366176129f6773b6R1-R31))
* Add an id attribute to the export button element in `Export.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6730/files?diff=unified&w=0#diff-376ad6d16f7f4cef25791aafc63205b7dda4e3d85102c6b23e4f6fd88d731d56L43-R43))
