### PR TITLE
Allow route to facility to be edited if null

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -946,7 +946,7 @@ export const ConsultationForm = (props: any) => {
                       required
                       label="Route to Facility"
                       {...field("route_to_facility")}
-                      disabled={isUpdate}
+                      disabled={isUpdate && !!state.form.route_to_facility} // For backwards compatibility; Allow in edit form only if route_to_facility is not set previously
                     />
                   </div>
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9fd5cda</samp>

Prevent `route_to_facility` field from being overwritten in consultation update form. Allow editing the field only if it was not set before.

## Proposed Changes

- Fixes #6741

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9fd5cda</samp>

*  Prevent editing the `route_to_facility` field in the consultation update form if it was already set ([link](https://github.com/coronasafe/care_fe/pull/6742/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fL949-R949))
