### PR TITLE
Add validation for admission_date in consultation form.

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -491,6 +491,10 @@ export const ConsultationForm = (props: any) => {
             errors[field] = "Field is required";
             invalidForm = true;
           }
+          if (dayjs(state.form.admission_date).isBefore(dayjs("2000-01-01"))) {
+            errors[field] = "Admission date cannot be before 01/01/2000";
+            invalidForm = true;
+          }
           return;
         case "cause_of_death":
           if (state.form.suggestion === "DD" && !state.form[field]) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dff93a1</samp>

Added admission date validation to consultation form. This prevents submitting consultations with invalid or unrealistic dates in the `admission_date` field of `ConsultationForm.tsx`.

## Proposed Changes

- Fixes #6657 ?
-  Added minimum date validation for the admission date as year 2000 in consultation form.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dff93a1</samp>

* Add a validation check for admission date in consultation form ([link](https://github.com/coronasafe/care_fe/pull/6746/files?diff=unified&w=0#diff-0815d428acd0061366098da333b4ad3a1df84c9f05d55a82b23790c22bdc5f2fR494-R497))
