### PR TITLE
Convert the unit from grams to kg in inventory form.

### DIFF
--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -146,7 +146,7 @@ export const AddInventoryForm = (props: any) => {
     if (unitName === "Dozen") {
       return Number(unitData.quantity) * 12;
     }
-    if (unitName === "Gram") {
+    if (unitName === "gram") {
       return Number(unitData.quantity) / 1000;
     }
     return Number(unitData.quantity);
@@ -238,6 +238,11 @@ export const AddInventoryForm = (props: any) => {
     };
     // if user has selected "Add stock" or "stockValidation" function is true
     if (data.is_incoming || stockValidation(data)) {
+      // if user has selected grams as unit then convert it to kg
+      if (data.unit === 5) {
+        data.quantity = data.quantity / 1000;
+        data.unit = 6;
+      }
       const res = await dispatchAction(postInventory(data, { facilityId }));
       setIsLoading(false);
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 617a4e2</samp>

Fixed a bug in the inventory form for gram-based items. Converted the unit and quantity to `kilogram` before sending to the API.

## Proposed Changes

- Fixes #6615 
- The bug for adding rice in grams in inventory form is resolved.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 617a4e2</samp>

*  Lowercase the unit name for gram to match the backend API and the form options ([link](https://github.com/coronasafe/care_fe/pull/6750/files?diff=unified&w=0#diff-0cbcee446c25081b9cc3657703cc28e1aadc287f7d948423827bcff814f803b9L149-R149))
