### PR TITLE
Fix feed in patient consultation

### DIFF
--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -55,15 +55,15 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
   const [isFullscreen, setFullscreen] = useFullscreen();
   const [videoStartTime, setVideoStartTime] = useState<Date | null>(null);
   const [statusReported, setStatusReported] = useState(false);
+  const [facilityMiddlewareHostname, setFacilityMiddlewareHostname] =
+    useState("");
   const authUser = useAuthUser();
-
-  let facilityMiddlewareHostname = "";
 
   useQuery(routes.getPermittedFacility, {
     pathParams: { id: facilityId || "" },
     onResponse: ({ res, data }) => {
       if (res && res.status === 200 && data && data.middleware_address) {
-        facilityMiddlewareHostname = data.middleware_address;
+        setFacilityMiddlewareHostname(data.middleware_address);
       }
     },
   });


### PR DESCRIPTION
### WHAT
The Feed in the patient consultation was not working when there was no hostname present in asset and had to fallback to the facility's middleware hostname.

This was happening because the state was not updated properly in the frontend after the data was fetched.

## Proposed Changes

- Fixes #6752 
- make facilityMiddlewareHostname as a react state as it was not updated properly. 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d5bf7c7</samp>

* Change the `facilityMiddlewareHostname` variable to a state variable and add a setter function ([link](https://github.com/coronasafe/care_fe/pull/6753/files?diff=unified&w=0#diff-5720f1345a51b321a7409e05b9acc257c75783e165427270755ecc0626e59cb2L58-R66)). This allows the component to re-render when the middleware address changes and to pass it as a prop to the `ConsultationCard` component.
