### PR TITLE
fix responsiveness on patients page

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -589,10 +589,10 @@ export const PatientManager = () => {
               )}
             </div>
             <div className="flex w-full flex-col gap-2 pl-2 md:block md:flex-row">
-              <div className="flex w-full justify-between gap-2">
-                <div className="flex flex-wrap font-semibold">
+              <div className="flex w-full items-center justify-between gap-2">
+                <div className="flex flex-wrap gap-2 font-semibold">
                   <span className="text-xl capitalize">{patient.name}</span>
-                  <span className="ml-4 text-gray-800">
+                  <span className="text-gray-800">
                     {formatAge(patient.age, patient.date_of_birth, true)}
                   </span>
                 </div>

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -590,7 +590,7 @@ export const PatientManager = () => {
             </div>
             <div className="flex w-full flex-col gap-2 pl-2 md:block md:flex-row">
               <div className="flex w-full justify-between gap-2">
-                <div className="font-semibold">
+                <div className="flex flex-wrap font-semibold">
                   <span className="text-xl capitalize">{patient.name}</span>
                   <span className="ml-4 text-gray-800">
                     {formatAge(patient.age, patient.date_of_birth, true)}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9083467</samp>

Improved the responsiveness and layout of the patient manager component by adding flex classes to the patient name and age `div` in `ManagePatients.tsx`.

## Proposed Changes

- Fixes #6722 
Fix patient age responsiveness view
![image](https://github.com/coronasafe/care_fe/assets/70687348/32d0763c-4b13-405f-96ca-78a217ab9f2a)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9083467</samp>

*  Prevent patient name and age from overflowing to the next line on smaller screens by adding `flex flex-wrap` classes to the `div` element with the `font-semibold` class ([link](https://github.com/coronasafe/care_fe/pull/6759/files?diff=unified&w=0#diff-6a60fce2df893cf91c0457f6445b903c1d6667b6a86fc21c38a9e8fc385c7575L593-R593))
