### PR TITLE
Update tooltip position in ConfigureHealthFacility

### DIFF
--- a/src/Components/ABDM/ConfigureHealthFacility.tsx
+++ b/src/Components/ABDM/ConfigureHealthFacility.tsx
@@ -178,7 +178,7 @@ export const ConfigureHealthFacility = (props: any) => {
                 >
                   {state.form.health_facility?.registered ? (
                     <>
-                      <div className="tooltip-text tooltip-top -left-48 flex flex-col gap-4">
+                      <div className="tooltip-text -ml-20 -mt-36 flex w-48 flex-col gap-4 whitespace-break-spaces">
                         <span className="text-gray-100">
                           The ABDM health facility is successfully linked with
                           care{" "}
@@ -192,7 +192,7 @@ export const ConfigureHealthFacility = (props: any) => {
                     </>
                   ) : (
                     <>
-                      <div className="tooltip-text -ml-20 -mt-12 flex w-48 flex-col gap-4 whitespace-break-spaces">
+                      <div className="tooltip-text -ml-20 -mt-44 flex w-48 flex-col gap-4 whitespace-break-spaces">
                         <span className="text-gray-100">
                           The ABDM health facility is successfully linked with
                           care{" "}

--- a/src/Components/ABDM/ConfigureHealthFacility.tsx
+++ b/src/Components/ABDM/ConfigureHealthFacility.tsx
@@ -192,7 +192,7 @@ export const ConfigureHealthFacility = (props: any) => {
                     </>
                   ) : (
                     <>
-                      <div className="tooltip-text tooltip-top -left-48 flex flex-col gap-4">
+                      <div className="tooltip-text -ml-20 -mt-12 flex w-48 flex-col gap-4 whitespace-break-spaces">
                         <span className="text-gray-100">
                           The ABDM health facility is successfully linked with
                           care{" "}


### PR DESCRIPTION
component

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 76e8b4f</samp>

Improved the UI of the tooltip for the success icon in the `ConfigureHealthFacility` component. Adjusted the CSS properties of the `div` element that wraps the tooltip text in `src/Components/ABDM/ConfigureHealthFacility.tsx`.

## Proposed Changes

- Fixes #6763

![image](https://github.com/coronasafe/care_fe/assets/3626859/4f8f10fd-9d7c-429a-87b7-b1bca516065f)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 76e8b4f</samp>

*  Adjust the tooltip text style for the success icon in the health facility configuration form ([link](https://github.com/coronasafe/care_fe/pull/6764/files?diff=unified&w=0#diff-82ab3a1b124e696b6416145151d2a8c2e3883275674526de3a812d431ce801f3L195-R195))
