### PR TITLE
fixes #6766; Misaligned label in external results

### DIFF
--- a/src/Components/ExternalResult/ResultList.tsx
+++ b/src/Components/ExternalResult/ResultList.tsx
@@ -264,11 +264,11 @@ export default function ResultList() {
               value={qParams.name}
               placeholder="Search by name"
             />
-            <div className="my-2 text-sm font-medium">Search by number</div>
             <div className="w-full max-w-sm">
               <PhoneNumberFormField
+                label="Search by number"
                 name="mobile_number"
-                labelClassName="hidden"
+                labelClassName="my-2 text-sm font-medium"
                 value={phone_number}
                 onChange={(e) => setPhoneNum(e.value)}
                 error={phoneNumberError}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 04e726d</samp>

Simplify and improve accessibility of the label for the phone number input field in `ResultList.tsx`. Use the existing `PhoneNumberFormField` component with a `label` prop instead of a separate `div` element.

## Proposed Changes

- Fixes #6766
<img width="629" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/967cedc2-acf4-4ee3-9dcf-ee327c5dd89a">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 04e726d</samp>

*  Simplify the markup and improve the accessibility of the phone number search field by passing the label text as a prop to the `PhoneNumberFormField` component ([link](https://github.com/coronasafe/care_fe/pull/6769/files?diff=unified&w=0#diff-3ff48bac32004c8412fdd842f678d61ab738bbada999fa8d9fa1da73f760ea11L267-R271))
