### PR TITLE
Update HL7 and ventilator middleware override

### DIFF
--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -8,6 +8,7 @@ export interface AssetLocationObject {
   description: string;
   created_date?: string;
   modified_date?: string;
+  middleware_address?: string;
   facility: {
     id: string;
     name: string;

--- a/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
@@ -60,7 +60,10 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
       setMonitorBedData(monitorBedData);
       const assetDataForMonitor = monitorBedData?.asset_object;
       const hl7Meta = assetDataForMonitor?.meta;
-      const hl7Middleware = hl7Meta?.middleware_hostname || middleware_address;
+      const hl7Middleware =
+        hl7Meta?.middleware_hostname ||
+        assetDataForMonitor?.location_object?.middleware_address ||
+        middleware_address;
       if (hl7Middleware && hl7Meta?.local_ip_address) {
         setHL7SocketUrl(
           `wss://${hl7Middleware}/observations/${hl7Meta.local_ip_address}`
@@ -85,7 +88,9 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
       setVentilatorBedData(ventilatorBedData);
       const ventilatorMeta = ventilatorBedData?.asset_object?.meta;
       const ventilatorMiddleware =
-        ventilatorMeta?.middleware_hostname || middleware_address;
+        ventilatorMeta?.middleware_hostname ||
+        consultationBedVentilator?.location_object.middleware_address ||
+        middleware_address;
       if (ventilatorMiddleware && ventilatorMeta?.local_ip_address) {
         setVentilatorSocketUrl(
           `wss://${ventilatorMiddleware}/observations/${ventilatorMeta?.local_ip_address}`


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c1a1562</samp>

This pull request enhances the socket connection for the consultation updates tab by adding a fallback option for the middleware address. It also updates the `AssetLocationObject` interface to include the `middleware_address` property.

## Proposed Changes

- Fixes #issue?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c1a1562</samp>

*  Add `middleware_address` property to `AssetLocationObject` interface to store the middleware server address for assets ([link](https://github.com/coronasafe/care_fe/pull/6778/files?diff=unified&w=0#diff-b1df14c97376139c1e0b897e944b610f11afea110738c80cd6ae9c0fd448eb6dR11))
*  Use `middleware_address` as a fallback option for constructing HL7 socket URL for monitor bed data, in case `middleware_hostname` is not available in asset metadata ([link](https://github.com/coronasafe/care_fe/pull/6778/files?diff=unified&w=0#diff-a1ae41968a05e24ed2d94c91009fbb88f1319a60a3b965773b3395130d27658bL63-R66))
*  Use `middleware_address` as a fallback option for constructing ventilator socket URL for ventilator bed data, in case `middleware_hostname` is not available in asset metadata ([link](https://github.com/coronasafe/care_fe/pull/6778/files?diff=unified&w=0#diff-a1ae41968a05e24ed2d94c91009fbb88f1319a60a3b965773b3395130d27658bL88-R93))
