### PR TITLE
Disable submit button in round type normal if no value selected

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -50,7 +50,7 @@ const initForm: any = {
   admitted_to: "",
   taken_at: null,
   rounds_type: "NORMAL",
-  clone_last: null,
+  clone_last: true,
   systolic: null,
   diastolic: null,
   pulse: null,
@@ -666,7 +666,8 @@ export const DailyRounds = (props: any) => {
                 (field: string) => state.form[field] == initialData[field]
               ) &&
               (state.form.temperature == initialData.temperature ||
-                isNaN(state.form.temperature))
+                isNaN(state.form.temperature)) &&
+              state.form.rounds_type !== "VENTILATOR"
             }
             onClick={(e) => handleSubmit(e)}
             label={buttonText}

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -108,6 +108,7 @@ export const DailyRounds = (props: any) => {
   const [prevReviewInterval, setPreviousReviewInterval] = useState(-1);
   const [prevAction, setPreviousAction] = useState("NO_ACTION");
   const [hasPreviousLog, setHasPreviousLog] = useState(false);
+  // const [disabled, setDisabled] = useState(true);
   const headerText = !id ? "Add Consultation Update" : "Info";
   const buttonText = !id ? "Save" : "Continue";
 
@@ -365,6 +366,21 @@ export const DailyRounds = (props: any) => {
       form: { ...state.form, [event.name]: event.value },
     });
   };
+
+  const formFields = [
+    "physical_examination_info",
+    "other_details",
+    "symptoms",
+    "action",
+    "review_interval",
+    "bp",
+    "pulse",
+    "temperature",
+    "resp",
+    "ventilator_spo2",
+    "rhythm",
+    "rhythm_detail",
+  ];
 
   const field = (name: string) => {
     return {
@@ -627,7 +643,27 @@ export const DailyRounds = (props: any) => {
 
         <div className="mt-4 flex flex-col-reverse justify-end gap-2 md:flex-row">
           <Cancel onClick={() => goBack()} />
-          <Submit onClick={(e) => handleSubmit(e)} label={buttonText} />
+          <Submit
+            disabled={
+              formFields.every((field: string, index: number) => {
+                console.log(
+                  index.toString() + " " + field + " " + state.form[field]
+                );
+                return (
+                  state.form[field]?.length === 0 ||
+                  state.form[field] === null ||
+                  state.form[field] === undefined ||
+                  state.form[field] === "" ||
+                  typeof state.form[field] === undefined ||
+                  isNaN(state.form[field])
+                );
+              }) &&
+              state.form.rounds_type === "NORMAL" &&
+              !state.form.clone_last
+            }
+            onClick={(e) => handleSubmit(e)}
+            label={buttonText}
+          />
         </div>
       </form>
     </Page>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f3c1ec2</samp>

Enable different rounds types and form validation for daily rounds. Refactor `Submit` component in `DailyRounds.tsx`.

## Proposed Changes

- Fixes #6787 
Disable submit button in round type normal if no value is modified in the form for at least any 1 field
![image](https://github.com/coronasafe/care_fe/assets/70687348/a9f2b6c3-415d-4907-9347-f1f34c2fb508)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f3c1ec2</samp>

*  Add a `disabled` state to control the submit button for daily rounds form ([link](https://github.com/coronasafe/care_fe/pull/6793/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612R111))
*  Enable the submit button when the rounds type is not "NORMAL" ([link](https://github.com/coronasafe/care_fe/pull/6793/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612R364))
*  Pass the `disabled` state and the `rounds_type` value to the `Submit` component as props ([link](https://github.com/coronasafe/care_fe/pull/6793/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L630-R636))
*  Disable the submit button in the `Submit` component when the rounds type is "NORMAL" and the form is not filled ([link](https://github.com/coronasafe/care_fe/pull/6793/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L630-R636))
*  Fix the indentation of the code in `DailyRounds.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6793/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L630-R636))
