### PR TITLE
New Cypress Test | Facility Triage Functionality | Facility Tab

### DIFF
--- a/cypress/e2e/facility_spec/facility_creation.cy.ts
+++ b/cypress/e2e/facility_spec/facility_creation.cy.ts
@@ -30,7 +30,9 @@ describe("Facility Creation", () => {
   const doctorCapacity = "5";
   const totalDoctor = "10";
   const facilityName = "cypress facility";
+  const facilityName2 = "Dummy Request Approving Center";
   const facilityAddress = "cypress address";
+  const facilityUpdateAddress = "cypress updated address";
   const facilityNumber = "9898469865";
   const facilityErrorMessage = [
     "Required",
@@ -59,6 +61,35 @@ describe("Facility Creation", () => {
     cy.viewport(1280, 720);
     cy.restoreLocalStorage();
     cy.awaitUrl("/facility");
+  });
+
+  it("Update the existing facility", () => {
+    // update a existing dummy data facility
+    manageUserPage.typeFacilitySearch(facilityName2);
+    facilityPage.verifyFacilityBadgeContent(facilityName2);
+    manageUserPage.assertFacilityInCard(facilityName2);
+    facilityHome.verifyURLContains(facilityName2);
+    facilityPage.visitAlreadyCreatedFacility();
+    facilityPage.clickManageFacilityDropdown();
+    facilityPage.clickUpdateFacilityOption();
+    facilityPage.clickUpdateFacilityType("Govt Hospital");
+    facilityPage.fillAddress(facilityUpdateAddress);
+    facilityPage.fillOxygenCapacity(oxygenCapacity);
+    facilityPage.fillExpectedOxygenRequirement(oxygenExpected);
+    facilityPage.selectLocation("Kochi, Kerala");
+    facilityPage.submitForm();
+    cy.url().should("not.include", "/update");
+    // verify the updated data
+    facilityPage.getFacilityOxygenInfo().scrollIntoView();
+    facilityPage
+      .getFacilityOxygenInfo()
+      .contains(oxygenCapacity)
+      .should("be.visible");
+    facilityPage.getAddressDetailsView().scrollIntoView();
+    facilityPage
+      .getAddressDetailsView()
+      .contains(facilityUpdateAddress)
+      .should("be.visible");
   });
 
   it("Create a new facility with multiple bed and doctor capacity", () => {
@@ -207,20 +238,6 @@ describe("Facility Creation", () => {
       .getPhoneNumberView()
       .contains(facilityNumber)
       .should("be.visible");
-  });
-
-  it("Update the existing facility", () => {
-    facilityPage.visitUpdateFacilityPage(facilityUrl1);
-    facilityPage.clickManageFacilityDropdown();
-    facilityPage.clickUpdateFacilityOption();
-    facilityPage.clickUpdateFacilityType("Request Approving Center");
-    facilityPage.fillFacilityName("cypress facility updated");
-    facilityPage.fillAddress("Cypress Facility Updated Address");
-    facilityPage.fillOxygenCapacity("100");
-    facilityPage.fillExpectedOxygenRequirement("80");
-    facilityPage.selectLocation("Kochi, Kerala");
-    facilityPage.submitForm();
-    cy.url().should("not.include", "/update");
   });
 
   it("Configure the existing facility", () => {

--- a/cypress/e2e/facility_spec/facility_creation.cy.ts
+++ b/cypress/e2e/facility_spec/facility_creation.cy.ts
@@ -30,7 +30,6 @@ describe("Facility Creation", () => {
   const doctorCapacity = "5";
   const totalDoctor = "10";
   const facilityName = "cypress facility";
-  const facilityName2 = "Dummy Request Approving Center";
   const facilityAddress = "cypress address";
   const facilityUpdateAddress = "cypress updated address";
   const facilityNumber = "9898469865";
@@ -61,35 +60,6 @@ describe("Facility Creation", () => {
     cy.viewport(1280, 720);
     cy.restoreLocalStorage();
     cy.awaitUrl("/facility");
-  });
-
-  it("Update the existing facility", () => {
-    // update a existing dummy data facility
-    manageUserPage.typeFacilitySearch(facilityName2);
-    facilityPage.verifyFacilityBadgeContent(facilityName2);
-    manageUserPage.assertFacilityInCard(facilityName2);
-    facilityHome.verifyURLContains(facilityName2);
-    facilityPage.visitAlreadyCreatedFacility();
-    facilityPage.clickManageFacilityDropdown();
-    facilityPage.clickUpdateFacilityOption();
-    facilityPage.clickUpdateFacilityType("Govt Hospital");
-    facilityPage.fillAddress(facilityUpdateAddress);
-    facilityPage.fillOxygenCapacity(oxygenCapacity);
-    facilityPage.fillExpectedOxygenRequirement(oxygenExpected);
-    facilityPage.selectLocation("Kochi, Kerala");
-    facilityPage.submitForm();
-    cy.url().should("not.include", "/update");
-    // verify the updated data
-    facilityPage.getFacilityOxygenInfo().scrollIntoView();
-    facilityPage
-      .getFacilityOxygenInfo()
-      .contains(oxygenCapacity)
-      .should("be.visible");
-    facilityPage.getAddressDetailsView().scrollIntoView();
-    facilityPage
-      .getAddressDetailsView()
-      .contains(facilityUpdateAddress)
-      .should("be.visible");
   });
 
   it("Create a new facility with multiple bed and doctor capacity", () => {
@@ -237,6 +207,31 @@ describe("Facility Creation", () => {
     facilityPage
       .getPhoneNumberView()
       .contains(facilityNumber)
+      .should("be.visible");
+  });
+
+  it("Update the existing facility", () => {
+    // update a existing dummy data facility
+    facilityPage.visitUpdateFacilityPage(facilityUrl1);
+    facilityPage.clickManageFacilityDropdown();
+    facilityPage.clickUpdateFacilityOption();
+    facilityPage.clickUpdateFacilityType("Govt Hospital");
+    facilityPage.fillAddress(facilityUpdateAddress);
+    facilityPage.fillOxygenCapacity(oxygenCapacity);
+    facilityPage.fillExpectedOxygenRequirement(oxygenExpected);
+    facilityPage.selectLocation("Kochi, Kerala");
+    facilityPage.submitForm();
+    cy.url().should("not.include", "/update");
+    // verify the updated data
+    facilityPage.getFacilityOxygenInfo().scrollIntoView();
+    facilityPage
+      .getFacilityOxygenInfo()
+      .contains(oxygenCapacity)
+      .should("be.visible");
+    facilityPage.getAddressDetailsView().scrollIntoView();
+    facilityPage
+      .getAddressDetailsView()
+      .contains(facilityUpdateAddress)
       .should("be.visible");
   });
 

--- a/cypress/e2e/facility_spec/facility_creation.cy.ts
+++ b/cypress/e2e/facility_spec/facility_creation.cy.ts
@@ -30,9 +30,13 @@ describe("Facility Creation", () => {
   const doctorCapacity = "5";
   const totalDoctor = "10";
   const facilityName = "cypress facility";
+  const facilityName2 = "Dummy Facility 1";
   const facilityAddress = "cypress address";
   const facilityUpdateAddress = "cypress updated address";
   const facilityNumber = "9898469865";
+  const triageDate = "02122023";
+  const initialTriageValue = "60";
+  const modifiedTriageValue = "50";
   const facilityErrorMessage = [
     "Required",
     "Invalid Pincode",
@@ -50,6 +54,7 @@ describe("Facility Creation", () => {
     "Field is required",
   ];
   const doctorErrorMessage = ["Field is required", "Field is required"];
+  const triageErrorMessage = ["Field is required"];
 
   before(() => {
     loginPage.loginAsDisctrictAdmin();
@@ -60,6 +65,48 @@ describe("Facility Creation", () => {
     cy.viewport(1280, 720);
     cy.restoreLocalStorage();
     cy.awaitUrl("/facility");
+  });
+
+  it("Verify Facility Triage Function", () => {
+    // mandatory field error throw
+    manageUserPage.typeFacilitySearch(facilityName2);
+    facilityPage.verifyFacilityBadgeContent(facilityName2);
+    manageUserPage.assertFacilityInCard(facilityName2);
+    facilityHome.verifyURLContains(facilityName2);
+    facilityPage.visitAlreadyCreatedFacility();
+    facilityPage.scrollToFacilityTriage();
+    facilityPage.clickAddFacilityTriage();
+    manageUserPage.clickSubmit();
+    userCreationPage.verifyErrorMessages(triageErrorMessage);
+    // create a entry and verify reflection
+    facilityPage.fillEntryDate(triageDate);
+    facilityPage.fillTriageEntryFields(
+      initialTriageValue,
+      initialTriageValue,
+      initialTriageValue,
+      initialTriageValue,
+      initialTriageValue
+    );
+    manageUserPage.clickSubmit();
+    // edit the entry and verify reflection
+    facilityPage.scrollToFacilityTriage();
+    facilityPage.verifyTriageTableContains(initialTriageValue);
+    facilityPage.clickEditButton();
+    facilityPage.fillTriageEntryFields(
+      modifiedTriageValue,
+      modifiedTriageValue,
+      modifiedTriageValue,
+      modifiedTriageValue,
+      modifiedTriageValue
+    );
+    manageUserPage.clickSubmit();
+    facilityPage.scrollToFacilityTriage();
+    facilityPage.verifyTriageTableContains(modifiedTriageValue);
+    // validate error of filling data on same date already data exist and verify reflection
+    facilityPage.scrollToFacilityTriage();
+    facilityPage.clickAddFacilityTriage();
+    facilityPage.fillEntryDate(triageDate);
+    facilityPage.clickButtonsMultipleTimes("button#submit");
   });
 
   it("Create a new facility with multiple bed and doctor capacity", () => {

--- a/cypress/pageobject/Facility/FacilityCreation.ts
+++ b/cypress/pageobject/Facility/FacilityCreation.ts
@@ -217,6 +217,53 @@ class FacilityPage {
     cy.get("#delete-facility").contains("Delete Facility").click();
   }
 
+  scrollToFacilityTriage() {
+    cy.get("#add-facility-triage").scrollIntoView();
+  }
+
+  fillTriageEntryFields(
+    visited,
+    homeQuarantine,
+    isolation,
+    referred,
+    confirmedPositive
+  ) {
+    cy.get("#num_patients_visited").clear().click().type(visited);
+    cy.get("#num_patients_home_quarantine")
+      .clear()
+      .click()
+      .type(homeQuarantine);
+    cy.get("#num_patients_isolation").clear().click().type(isolation);
+    cy.get("#num_patient_referred").clear().click().type(referred);
+    cy.get("#num_patient_confirmed_positive")
+      .clear()
+      .click()
+      .type(confirmedPositive);
+  }
+
+  fillEntryDate(date) {
+    cy.get("#entry_date").click();
+    cy.get("#date-input").click().type(date);
+  }
+
+  clickEditButton() {
+    cy.get("#edit-button").click();
+  }
+
+  clickButtonsMultipleTimes(selector) {
+    cy.get(selector).each(($button) => {
+      cy.wrap($button).click();
+    });
+  }
+
+  verifyTriageTableContains(value) {
+    cy.get("#triage-table").contains(value);
+  }
+
+  clickAddFacilityTriage() {
+    cy.get("#add-facility-triage").click();
+  }
+
   clickfacilityfeatureoption() {
     cy.get("#features").click();
   }

--- a/src/Components/Facility/FacilityHomeTriage.tsx
+++ b/src/Components/Facility/FacilityHomeTriage.tsx
@@ -30,6 +30,7 @@ export const FacilityHomeTriage = (props: any) => {
     );
     temp.push(
       <ButtonV2
+        id="edit-button"
         variant="secondary"
         ghost
         border
@@ -52,6 +53,7 @@ export const FacilityHomeTriage = (props: any) => {
         <div className="justify-between md:flex md:pb-2">
           <div className="mb-2 text-xl font-bold">Corona Triage</div>
           <ButtonV2
+            id="add-facility-triage"
             className="w-full md:w-auto"
             onClick={() => navigate(`/facility/${props.facilityId}/triage`)}
             authorizeFor={props.NonReadOnlyUsers}
@@ -60,7 +62,10 @@ export const FacilityHomeTriage = (props: any) => {
             Add Triage
           </ButtonV2>
         </div>
-        <div className="mt-4 overflow-x-auto overflow-y-hidden">
+        <div
+          className="mt-4 overflow-x-auto overflow-y-hidden"
+          id="triage-table"
+        >
           <Table
             rows={stats}
             headings={[


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b0d8c26</samp>

The pull request adds and updates test cases for the facility triage and update functions using Cypress. It also adds id attributes to some elements in the facility triage component and new methods to the FacilityPage class in the page object model. These changes improve the test coverage and reliability of the facility features.

## Proposed Changes

- Fixes #issue?
- Change 1
- Change 2
- More?

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b0d8c26</samp>

*  Add and modify test cases for facility triage and update functions ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3L33-R39), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3R57), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3R70-R111), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3L213-R282))
  * Use new constants for input and output values ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3L33-R39), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3L213-R282))
  * Verify error message for missing triage entry date ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3R57))
  * Check triage table and edit button after adding and editing triage details ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3R70-R111))
  * Check facility home page after updating facility address and oxygen capacity ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-898a29c439f5f233c044c96296b5975aa93adec4319b7e32a62cdfd4685faac3L213-R282))
* Add new methods for facility triage actions and assertions in page object model ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-a4a17d53a337d155d03bd531b8473e60d3cabdd6dcb1514840799f46a5a2dd0bR220-R266))
  * Use `FacilityPage` class in `FacilityCreation.ts` file ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-a4a17d53a337d155d03bd531b8473e60d3cabdd6dcb1514840799f46a5a2dd0bR220-R266))
* Add id attributes to triage buttons and table elements in `FacilityHomeTriage.tsx` file ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-7022b6d18b94fd364a005a7c9331083e05433d563920220f6f1b6099fb390146R33), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-7022b6d18b94fd364a005a7c9331083e05433d563920220f6f1b6099fb390146R56), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-7022b6d18b94fd364a005a7c9331083e05433d563920220f6f1b6099fb390146L63-R68))
  * Use ids to locate elements in test cases ([link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-7022b6d18b94fd364a005a7c9331083e05433d563920220f6f1b6099fb390146R33), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-7022b6d18b94fd364a005a7c9331083e05433d563920220f6f1b6099fb390146R56), [link](https://github.com/coronasafe/care_fe/pull/6795/files?diff=unified&w=0#diff-7022b6d18b94fd364a005a7c9331083e05433d563920220f6f1b6099fb390146L63-R68))
