### PR TITLE
Allow occupancy indicator to resize when default font size changes.

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -160,7 +160,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                 <div className="flex w-full flex-wrap justify-between gap-2 py-2">
                   <div className="flex flex-wrap gap-2">
                     <div
-                      className={`tooltip ml-auto flex h-[38px] w-fit items-center justify-center rounded-md px-2 text-xl ${
+                      className={`tooltip button-size-default ml-auto flex w-fit items-center justify-center rounded-md px-2 ${
                         facility.patient_count / facility.bed_count > 0.85
                           ? "button-danger-border bg-red-500"
                           : "button-primary-border bg-primary-100"
@@ -178,7 +178,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                         )}
                       />{" "}
                       <dt
-                        className={`my-1 text-sm font-semibold ${
+                        className={`text-sm font-semibold ${
                           facility.patient_count / facility.bed_count > 0.85
                             ? "text-white"
                             : "text-gray-700"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 55d266f</samp>

Improved the UI of the facility card component by removing unnecessary CSS classes. This affects the file `src/Components/Facility/FacilityCard.tsx`.

## Proposed Changes

- Fixes #6805?
- Remove hardcoded height
- Use`.button-size-default` class
- Remove internal margin that caused occupancy to look bigger than buttons

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [ ] Completion of QA

<img width="1450" alt="Screenshot 2023-12-07 at 2 08 36 PM" src="https://github.com/coronasafe/care_fe/assets/56870381/0c7b53b9-a80c-4561-b9c4-97fc04eea69b">
<img width="1450" alt="Screenshot 2023-12-07 at 2 08 22 PM" src="https://github.com/coronasafe/care_fe/assets/56870381/ad59c600-0ba0-4d40-824b-52578696d1ff">
<img width="1450" alt="Screenshot 2023-12-07 at 2 07 38 PM" src="https://github.com/coronasafe/care_fe/assets/56870381/e5fbcadd-09ec-4e44-b667-56cd9680b9de">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 55d266f</samp>

*  Removed the `h-[38px]` and `my-1` classes from the div and dt elements that show the occupancy percentage of the facility, to improve the alignment and spacing of the button and the tooltip icon ([link](https://github.com/coronasafe/care_fe/pull/6806/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L163-R163), [link](https://github.com/coronasafe/care_fe/pull/6806/files?diff=unified&w=0#diff-2cc6bedfa390407b524789d1828633368f746e65564574ffa86b715c469c8098L181-R181))
