### PR TITLE
Invalidate filters cache upon login attempt

### DIFF
--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -12,7 +12,7 @@ import CircularProgress from "../Common/components/CircularProgress";
 import { LocalStorageKeys } from "../../Common/constants";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
-import { handleRedirection } from "../../Utils/utils";
+import { handleRedirection, invalidateFiltersCache } from "../../Utils/utils";
 
 export const Login = (props: { forgot?: boolean }) => {
   const {
@@ -91,6 +91,7 @@ export const Login = (props: { forgot?: boolean }) => {
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
+    invalidateFiltersCache();
     const valid = validateData();
     if (valid) {
       // replaces button with spinner

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -459,3 +459,11 @@ export const scrollTo = (id: string | boolean) => {
   const element = document.querySelector(`#${id}`);
   element?.scrollIntoView({ behavior: "smooth", block: "center" });
 };
+
+export const invalidateFiltersCache = () => {
+  for (const key in localStorage) {
+    if (key.startsWith("filters--")) {
+      localStorage.removeItem(key);
+    }
+  }
+};


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f09fee7</samp>

The pull request adds a feature to clear the cached filters from the local storage when the user logs in. This is done by defining and calling the `invalidateFiltersCache` function in `src/Utils/utils.ts` and `src/Components/Auth/Login.tsx`.

## Proposed Changes

- Fixes #6822

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f09fee7</samp>

*  Invalidate filters cache on user login to show latest data without stale filters ([link](https://github.com/coronasafe/care_fe/pull/6823/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304L15-R15), [link](https://github.com/coronasafe/care_fe/pull/6823/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304R94), [link](https://github.com/coronasafe/care_fe/pull/6823/files?diff=unified&w=0#diff-5903b23c9778624d9c178b9779024a4265e5fc365714fed34d49225ee6b8dc73R462-R469))
  - Import `invalidateFiltersCache` function from `src/Utils/utils.ts` in `Login` component ([link](https://github.com/coronasafe/care_fe/pull/6823/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304L15-R15))
  - Call `invalidateFiltersCache` function inside `useEffect` hook of `Login` component ([link](https://github.com/coronasafe/care_fe/pull/6823/files?diff=unified&w=0#diff-4c2858c07a7b7999725237900da3d8bc7f685382ae64b974f06a7b06d3c82304R94))
  - Define `invalidateFiltersCache` function in `src/Utils/utils.ts` to remove local storage keys that start with `filters--` ([link](https://github.com/coronasafe/care_fe/pull/6823/files?diff=unified&w=0#diff-5903b23c9778624d9c178b9779024a4265e5fc365714fed34d49225ee6b8dc73R462-R469))
