### PR TITLE
Update API path for asset service records

### DIFF
--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -1057,7 +1057,7 @@ const routes = {
     method: "GET",
   },
   updateAssetService: {
-    path: "/api/v1/asset/{asset_external_id}/service_records/{external_id}",
+    path: "/api/v1/asset/{asset_external_id}/service_records/{external_id}/",
     method: "PUT",
     TRes: Type<AssetService>(),
     TBody: Type<AssetServiceUpdate>(),

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -955,7 +955,7 @@ const routes = {
     TBody: Type<Partial<IResource>>(),
   },
   updateResource: {
-    path: "/api/v1/resource/{id}",
+    path: "/api/v1/resource/{id}/",
     method: "PUT",
     TRes: Type<IResource>(),
     TBody: Type<Partial<IResource>>(),


### PR DESCRIPTION
Issue initially reported by @sainak 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 09d1d06</samp>

Fixed a bug in `updateAssetService` route by adding a trailing slash. Improved asset management functionality.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 09d1d06</samp>

* Fix asset service update bug by adding trailing slash to `updateAssetService` route ([link](https://github.com/coronasafe/care_fe/pull/6826/files?diff=unified&w=0#diff-21639e8b3b95469edd34a3d2641a85e6eb02393c442301e11d91665f10f1cf7cL1060-R1060))
