### PR TITLE
Fix tooltip in users

### DIFF
--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -105,7 +105,11 @@ export default ({ show, setShow, username }: IProps) => {
         <div>
           <div className="col-span-full sm:col-span-3 sm:col-start-2">
             {(!isLoading || !skillsLoading) && (
-              <div className="tooltip flex items-center gap-2">
+              <div
+                className={`${
+                  !authorizeForAddSkill && "tooltip"
+                } flex items-center gap-2`}
+              >
                 <SkillSelect
                   id="select-skill"
                   multiple={false}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 33ecec7</samp>

Fixed a bug in `SkillsSlideOver.tsx` that showed a misleading tooltip message. The `tooltip` class is now applied only when the user does not have permission to add new skills.

## Proposed Changes

- Fixes #6776 
- Clear selection tooltip will only show when mouse is hovered on the clear selection button.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 33ecec7</samp>

*  Conditionally apply `tooltip` class to `div` element based on `authorizeForAddSkill` value ([link](https://github.com/coronasafe/care_fe/pull/6827/files?diff=unified&w=0#diff-9f685588fbd4603da493b63e37915b3ba515b6df5f8969a239ad424b648cbca8L108-R112)). This prevents showing an unnecessary tooltip message to users who have permission to add new skills in the SkillsSlideOver component, which displays and edits the skills of a user in the `src/Components/Users/SkillsSlideOver.tsx` file.
