### PR TITLE
Fix patient name in transfer success notification

### DIFF
--- a/src/Components/Facility/TransferPatientDialog.tsx
+++ b/src/Components/Facility/TransferPatientDialog.tsx
@@ -125,8 +125,11 @@ const TransferPatientDialog = (props: Props) => {
       if (res && res.data && res.status === 200) {
         dispatch({ type: "set_form", form: initForm });
         handleOk();
+
+        const patientName =
+          patientOptions.find((p) => p.id === state.form.patient)?.text || "";
         Notification.Success({
-          msg: `Patient ${res.data.patient} transferred successfully`,
+          msg: `Patient ${patientName} transferred successfully`,
         });
         const newFacilityId =
           res.data && res.data.facility_object && res.data.facility_object.id;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0016206</samp>

This pull request enhances the user experience and readability of the consultation page URL and the transfer patient dialog. It uses the patient name instead of the id in the URL and shows the patient name when transferring.

## Proposed Changes

- Fixes #6811 
![image](https://github.com/coronasafe/care_fe/assets/57055998/7a1021f6-9192-4e46-a56b-9a360738dcf6)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0016206</samp>

* Add a variable `patientName` to store the patient name from the form state ([link](https://github.com/coronasafe/care_fe/pull/6829/files?diff=unified&w=0#diff-12a212ab8b86af3a4ce6dd25b6a304909a46ad8156446f1c065f88ee92de0242R128-R130))
* Use `patientName` instead of patient id in the URL when navigating to the consultation page after transferring the patient ([link](https://github.com/coronasafe/care_fe/pull/6829/files?diff=unified&w=0#diff-12a212ab8b86af3a4ce6dd25b6a304909a46ad8156446f1c065f88ee92de0242L135-R138))
