### PR TITLE
Add Telemedicine as a rounds type option

### DIFF
--- a/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
@@ -54,6 +54,10 @@ const DefaultLogUpdateCard = ({ round, ...props }: Props) => {
           />
         )}
         <LogUpdateCardAttribute
+          attributeKey={"Round Type" as any}
+          attributeValue={t(round.rounds_type)}
+        />
+        <LogUpdateCardAttribute
           attributeKey="patient_category"
           attributeValue={round.patient_category}
         />

--- a/src/Components/Facility/Consultations/DailyRoundsList.tsx
+++ b/src/Components/Facility/Consultations/DailyRoundsList.tsx
@@ -62,10 +62,11 @@ export default function DailyRoundsList({ consultation }: Props) {
                     );
                   }
 
-                  const itemUrl =
-                    item.rounds_type === "NORMAL"
-                      ? `${consultationUrl}/daily-rounds/${item.id}`
-                      : `${consultationUrl}/daily_rounds/${item.id}`;
+                  const itemUrl = ["NORMAL", "TELEMEDICINE"].includes(
+                    item.rounds_type
+                  )
+                    ? `${consultationUrl}/daily-rounds/${item.id}`
+                    : `${consultationUrl}/daily_rounds/${item.id}`;
 
                   return (
                     <DefaultLogUpdateCard

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -230,7 +230,7 @@ export const DailyRounds = (props: any) => {
         case "resp":
           if (
             state.form.resp === null &&
-            state.form.rounds_type === "NORMAL" &&
+            ["NORMAL", "TELEMEDICINE"].includes(state.form.rounds_type) &&
             state.form.clone_last !== true
           ) {
             errors[field] = "Please enter a respiratory rate";
@@ -278,7 +278,7 @@ export const DailyRounds = (props: any) => {
           action: prevAction,
           review_interval: Number(prevReviewInterval),
         };
-        if (state.form.rounds_type === "NORMAL") {
+        if (["NORMAL", "TELEMEDICINE"].includes(state.form.rounds_type)) {
           data = {
             ...data,
             bp:
@@ -320,7 +320,7 @@ export const DailyRounds = (props: any) => {
           Notification.Success({
             msg: "Consultation Updates details updated successfully",
           });
-          if (state.form.rounds_type === "NORMAL") {
+          if (["NORMAL", "TELEMEDICINE"].includes(state.form.rounds_type)) {
             navigate(
               `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}`
             );
@@ -333,7 +333,7 @@ export const DailyRounds = (props: any) => {
           Notification.Success({
             msg: "Consultation Updates details created successfully",
           });
-          if (state.form.rounds_type === "NORMAL") {
+          if (["NORMAL", "TELEMEDICINE"].includes(state.form.rounds_type)) {
             if (data.clone_last) {
               navigate(
                 `/facility/${facilityId}/patient/${patientId}/consultation/${consultationId}/daily-rounds/${res.data.external_id}/update`

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -105,6 +105,7 @@ export const DailyRounds = (props: any) => {
   const [isLoading, setIsLoading] = useState(false);
   const [facilityName, setFacilityName] = useState("");
   const [patientName, setPatientName] = useState("");
+  const [consultationSuggestion, setConsultationSuggestion] = useState<any>("");
   const [prevReviewInterval, setPreviousReviewInterval] = useState(-1);
   const [prevAction, setPreviousAction] = useState("NO_ACTION");
   const [hasPreviousLog, setHasPreviousLog] = useState(false);
@@ -118,6 +119,7 @@ export const DailyRounds = (props: any) => {
         if (res.data) {
           setPatientName(res.data.name);
           setFacilityName(res.data.facility_object.name);
+          setConsultationSuggestion(res.data.last_consultation?.suggestion);
           setPreviousReviewInterval(
             Number(res.data.last_consultation.review_interval)
           );
@@ -434,8 +436,13 @@ export const DailyRounds = (props: any) => {
               className="w-full"
               label="Round Type"
               options={[
-                { id: "NORMAL", text: "Normal" },
-                { id: "VENTILATOR", text: "Critical Care" },
+                ...[
+                  { id: "NORMAL", text: "Normal" },
+                  { id: "VENTILATOR", text: "Critical Care" },
+                ],
+                ...(consultationSuggestion == "DC"
+                  ? [{ id: "TELEMEDICINE", text: "Telemedicine" }]
+                  : []),
               ]}
               optionLabel={(option) => option.text}
               optionValue={(option) => option.id}
@@ -513,7 +520,7 @@ export const DailyRounds = (props: any) => {
               }}
             />
 
-            {state.form.rounds_type === "NORMAL" && (
+            {["NORMAL", "TELEMEDICINE"].includes(state.form.rounds_type) && (
               <>
                 <h3 className="mb-6 md:col-span-2">Vitals</h3>
 

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -252,22 +252,6 @@ export const DailyRounds = (props: any) => {
             invalidForm = true;
           }
           return;
-        case "clone_last":
-          if (state.form.clone_last === null) {
-            errors[field] = "Please choose a value";
-            invalidForm = true;
-          }
-          return;
-        case "resp":
-          if (
-            state.form.resp === null &&
-            ["NORMAL", "TELEMEDICINE"].includes(state.form.rounds_type) &&
-            state.form.clone_last !== true
-          ) {
-            errors[field] = "Please enter a respiratory rate";
-            invalidForm = true;
-          }
-          return;
         default:
           return;
       }

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -269,7 +269,12 @@ export interface DailyRoundsOutput {
   quantity: number;
 }
 
-export const DailyRoundTypes = ["NORMAL", "VENTILATOR", "AUTOMATED"] as const;
+export const DailyRoundTypes = [
+  "NORMAL",
+  "VENTILATOR",
+  "AUTOMATED",
+  "TELEMEDICINE",
+] as const;
 
 export interface DailyRoundsModel {
   ventilator_spo2?: number;

--- a/src/Locale/en/Consultation.json
+++ b/src/Locale/en/Consultation.json
@@ -15,5 +15,6 @@
   "generated_summary_caution": "This is a computer generated summary using the information captured in the CARE system.",
   "NORMAL": "Normal",
   "VENTILATOR": "Critical Care",
-  "AUTOMATED": "Automated"
+  "AUTOMATED": "Automated",
+  "TELEMEDICINE": "Telemedicine"
 }


### PR DESCRIPTION
Backend PR: https://github.com/coronasafe/care/pull/1760
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dbbe0a6</samp>

This pull request adds a feature to record telemedicine follow-ups for discharged patients in the `DailyRounds` component. It also adds the round type to the `DefaultLogUpdateCard` component and updates the `models.tsx` and `Consultation.json` files accordingly.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6676

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dbbe0a6</samp>

*  Add `TELEMEDICINE` option for `rounds_type` field in `DailyRounds` component ([link](https://github.com/coronasafe/care_fe/pull/6831/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L437-R445), [link](https://github.com/coronasafe/care_fe/pull/6831/files?diff=unified&w=0#diff-d9b29c5d9c92cf894c097a6c8d38ca2ff4c598fdbc68e91a33324654e54eed81L272-R277), [link](https://github.com/coronasafe/care_fe/pull/6831/files?diff=unified&w=0#diff-8215187c0f8fbf725abf64ef064d516931dec5f66b524f6a151812ee04877b28L18-R19))
*  Display round type in `DefaultLogUpdateCard` component using `t` function ([link](https://github.com/coronasafe/care_fe/pull/6831/files?diff=unified&w=0#diff-dd6193fcd7f9bfeb6ed50d55385f1ccd2b8f7c73bdd54955a7bf1afe9f852c4bR57-R60))
*  Fetch and store `consultationSuggestion` from last consultation in `DailyRounds` component ([link](https://github.com/coronasafe/care_fe/pull/6831/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612R108), [link](https://github.com/coronasafe/care_fe/pull/6831/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612R122))
*  Render vitals section for `TELEMEDICINE` round type in `DailyRounds` component ([link](https://github.com/coronasafe/care_fe/pull/6831/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L516-R523))
