### PR TITLE
Show error for invalid records of import external results page

### DIFF
--- a/src/Components/ExternalResult/ExternalResultUpload.tsx
+++ b/src/Components/ExternalResult/ExternalResultUpload.tsx
@@ -11,6 +11,7 @@ import useAppHistory from "../../Common/hooks/useAppHistory";
 import request from "../../Utils/request/request";
 import routes from "../../Redux/api";
 import { IExternalResult } from "./models";
+import CareIcon from "../../CAREUI/icons/CareIcon";
 
 export default function ExternalResultUpload() {
   const { sample_format_external_result_import } = useConfig();
@@ -175,8 +176,9 @@ export default function ExternalResultUpload() {
                   </div>
                   <div>
                     {data.district !== user.district_object.name && (
-                      <p className="mt-2 flex items-center justify-center text-red-500">
-                        Different districts
+                      <p className="mt-2 flex items-center justify-center gap-1 text-red-500">
+                        <CareIcon icon="l-exclamation-triangle" /> Different
+                        districts
                       </p>
                     )}
                   </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c9677f</samp>

The pull request enhances the security and usability of the `ExternalResultUpload` component. It checks the district names in the CSV data against the user's district, and shows feedback on the upload status.

## Proposed Changes

- Fixes #6814
Display in front of each record whether it is valid or not
Also, give the option to upload only validated data from the front-end (filtering out the invalid data)

![image](https://github.com/coronasafe/care_fe/assets/70687348/713c5550-5775-4750-96d1-c21fe84d60f0)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c9677f</samp>

* Import `useEffect` hook and add states for `validationError` and `user` ([link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cL3-R3), [link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cL21-R46))
* Fetch the current user data on component mount and store it in `user` state ([link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cL21-R46))
* Validate the district name in each row against the user's district and update `validationError` state accordingly ([link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cL21-R46), [link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cR172-R178))
* Filter out the invalid rows from the CSV data before sending the API request to upload it ([link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cL47-R73))
* Display the total number of rows in the CSV data, if any ([link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cR150-R152))
* Disable the submit button if all the rows are invalid or show the number of valid records to be saved ([link](https://github.com/coronasafe/care_fe/pull/6832/files?diff=unified&w=0#diff-40181ebadedb37c4a654bf245c2286ce3cbf9cb836d5262fdb373cb9c5e5032cL152-R195))
