### PR TITLE
HideAssetType

### DIFF
--- a/src/Components/Assets/AssetFilter.tsx
+++ b/src/Components/Assets/AssetFilter.tsx
@@ -21,9 +21,6 @@ const getDate = (value: any) =>
 function AssetFilter(props: any) {
   const { filter, onChange, closeFilter } = props;
   const [facility, setFacility] = useState<FacilityModel>({ name: "" });
-  const [asset_type, setAssetType] = useState<string>(
-    filter.asset_type ? filter.asset_type : ""
-  );
   const [asset_status, setAssetStatus] = useState<string>(filter.status || "");
   const [asset_class, setAssetClass] = useState<string>(
     filter.asset_class || ""
@@ -55,7 +52,6 @@ function AssetFilter(props: any) {
 
   const clearFilter = useCallback(() => {
     setFacility({ name: "" });
-    setAssetType("");
     setAssetStatus("");
     setAssetClass("");
     setFacilityId("");
@@ -69,7 +65,6 @@ function AssetFilter(props: any) {
   const applyFilter = () => {
     const data = {
       facility: facilityId,
-      asset_type: asset_type ?? "",
       asset_class: asset_class ?? "",
       status: asset_status ?? "",
       location: locationId ?? "",
@@ -132,18 +127,6 @@ function AssetFilter(props: any) {
           />
         </div>
       )}
-
-      <SelectFormField
-        label="Asset Type"
-        errorClassName="hidden"
-        id="asset-type"
-        name="asset_type"
-        options={["EXTERNAL", "INTERNAL"]}
-        optionLabel={(o) => o}
-        optionValue={(o) => o}
-        value={asset_type}
-        onChange={({ value }) => setAssetType(value)}
-      />
 
       <SelectFormField
         id="asset-status"

--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -365,11 +365,6 @@ const AssetManage = (props: AssetManageProps) => {
                   {asset?.description}
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {asset?.asset_type === "INTERNAL" ? (
-                    <Chip text="Internal" startIcon="l-building" />
-                  ) : (
-                    <Chip text="External" startIcon="l-globe" />
-                  )}
                   {asset?.status === "ACTIVE" ? (
                     <Chip text="Active" startIcon="l-check" />
                   ) : (

--- a/src/Components/Facility/AssetCreate.tsx
+++ b/src/Components/Facility/AssetCreate.tsx
@@ -107,12 +107,10 @@ const AssetCreate = (props: AssetProps) => {
   const { goBack } = useAppHistory();
   const { facilityId, assetId } = props;
 
-  let assetTypeInitial: AssetType;
   let assetClassInitial: AssetClass;
 
   const [state, dispatch] = useReducer(asset_create_reducer, initialState);
   const [name, setName] = useState("");
-  const [asset_type, setAssetType] = useState<AssetType>();
   const [asset_class, setAssetClass] = useState<AssetClass>();
   const [not_working_reason, setNotWorkingReason] = useState("");
   const [description, setDescription] = useState("");
@@ -199,7 +197,6 @@ const AssetCreate = (props: AssetProps) => {
       setName(asset.name);
       setDescription(asset.description);
       setLocation(asset.location_object.id);
-      setAssetType(asset.asset_type);
       setAssetClass(asset.asset_class);
       setIsWorking(String(asset.is_working));
       setNotWorkingReason(asset.not_working_reason);
@@ -238,12 +235,6 @@ const AssetCreate = (props: AssetProps) => {
         case "location":
           if (!location || location === "0" || location === "") {
             errors[field] = "Select a location";
-            invalidForm = true;
-          }
-          return;
-        case "asset_type":
-          if (!asset_type || asset_type == "NONE") {
-            errors[field] = "Select an asset type";
             invalidForm = true;
           }
           return;
@@ -304,7 +295,6 @@ const AssetCreate = (props: AssetProps) => {
     setName("");
     setDescription("");
     setLocation("");
-    setAssetType(assetTypeInitial);
     setAssetClass(assetClassInitial);
     setIsWorking(undefined);
     setNotWorkingReason("");
@@ -329,7 +319,7 @@ const AssetCreate = (props: AssetProps) => {
       setIsLoading(true);
       const data: any = {
         name: name,
-        asset_type: asset_type,
+        asset_type: AssetType.INTERNAL,
         asset_class: asset_class || "",
         description: description,
         is_working: is_working,
@@ -567,40 +557,7 @@ const AssetCreate = (props: AssetProps) => {
                         errors={state.errors.location}
                       />
                     </div>
-                    {/* Asset Type */}
                     <div className="col-span-6 flex flex-col gap-x-12 transition-all lg:flex-row xl:gap-x-16">
-                      <div
-                        ref={fieldRef["asset_type"]}
-                        className="flex-1"
-                        data-testid="asset-type-input"
-                      >
-                        <SelectFormField
-                          label={t("asset_type")}
-                          name="asset_type"
-                          required
-                          options={[
-                            {
-                              title: "Internal",
-                              description:
-                                "Asset is inside the facility premises.",
-                              value: AssetType.INTERNAL,
-                            },
-                            {
-                              title: "External",
-                              description:
-                                "Asset is outside the facility premises.",
-                              value: AssetType.EXTERNAL,
-                            },
-                          ]}
-                          value={asset_type}
-                          optionLabel={({ title }) => title}
-                          optionDescription={({ description }) => description}
-                          optionValue={({ value }) => value}
-                          onChange={({ value }) => setAssetType(value)}
-                          error={state.errors.asset_type}
-                        />
-                      </div>
-
                       {/* Asset Class */}
                       <div
                         ref={fieldRef["asset_class"]}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1341137</samp>

This pull request removes the asset type feature from the frontend components and logic related to asset management. The asset type is no longer a relevant or useful criterion for filtering, creating, or displaying assets. The changes affect the files `AssetFilter.tsx`, `AssetCreate.tsx`, and `AssetManage.tsx`.

## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/6789
 

- [ ] Removed "Asset Type" select input from asset create/edit form.

 

- [ ] Upon creating an asset, it is always created with asset type as "Internal" (default)

 

- [ ] Removed Asset Type label from the asset details page.

 

- [ ] Removed Asset Type filter from Advanced Filters also.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1341137</samp>

*  Remove the asset type filter option from the `AssetFilter` component ([link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L24-L26), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L58), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L72), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-eb665fb95a27de8a5d89f3f2525843abb2e62ce596832617cd03fa5e49bdeb96L137-L148))
*  Remove the asset type display from the `AssetManage` component ([link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-d3677127a55934962254fa660ba9b01a59fdb23bee06c9160832527f36c8bf20L368-L372))
*  Remove the asset type input option from the `AssetCreate` component and set all assets to internal by default ([link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L110-R113), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L202), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L244-L249), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L307), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L332-R322), [link](https://github.com/coronasafe/care_fe/pull/6834/files?diff=unified&w=0#diff-d7d19aab87f2678510fa29d56b44e2a94098c956b954df68110c117f7f366073L570-R560))
