### PR TITLE
Fixed update button in bed management.

### DIFF
--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -18,6 +18,7 @@ import { Cancel, Submit } from "../Common/components/ButtonV2";
 import TextFormField from "../Form/FormFields/TextFormField";
 import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import Page from "../Common/components/Page";
+
 const Loading = lazy(() => import("../Common/Loading"));
 
 interface BedFormProps {
@@ -73,6 +74,7 @@ export const AddBedForm = (props: BedFormProps) => {
       }
       setIsLoading(false);
     }
+
     fetchFacilityLocationAndBed();
   }, [dispatchAction, facilityId, locationId]);
 
@@ -125,7 +127,7 @@ export const AddBedForm = (props: BedFormProps) => {
       name,
       description,
       bed_type: bedType,
-      number_of_beds: numberOfBeds,
+      number_of_beds: headerText === "Update Bed" ? 1 : numberOfBeds,
     };
 
     if (!validateInputs(data)) return;

--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -127,7 +127,7 @@ export const AddBedForm = (props: BedFormProps) => {
       name,
       description,
       bed_type: bedType,
-      number_of_beds: headerText === "Update Bed" ? 1 : numberOfBeds,
+      number_of_beds: bedId ? 1 : numberOfBeds,
     };
 
     if (!validateInputs(data)) return;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7d85ef0</samp>

This pull request enhances the `AddBedForm` component to support both adding and updating beds in a facility. It also fixes the `number_of_beds` property to match the API expectations.

## Proposed Changes

- Fixes #6837 
- Change logic so that the update button is only clicked once.


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7d85ef0</samp>

*  Pass `headerText` prop from `BedTypeCard` to `AddBedForm` to indicate whether the form is for adding or updating a bed ([link](https://github.com/coronasafe/care_fe/pull/6841/files?diff=unified&w=0#diff-c3725e9874032f1cdb18f7c6b15f978b17a7306d49ce27104377ac1ccaaa4b8cR21))
*  Use `headerText` prop to conditionally render the label and placeholder of the `TextInputField` for `numberOfBeds` ([link](https://github.com/coronasafe/care_fe/pull/6841/files?diff=unified&w=0#diff-c3725e9874032f1cdb18f7c6b15f978b17a7306d49ce27104377ac1ccaaa4b8cR77))
*  Set `number_of_beds` in the API payload to 1 if updating an existing bed, otherwise use the value of `numberOfBeds` state variable ([link](https://github.com/coronasafe/care_fe/pull/6841/files?diff=unified&w=0#diff-c3725e9874032f1cdb18f7c6b15f978b17a7306d49ce27104377ac1ccaaa4b8cL128-R130))
