### PR TITLE
Fix tooltip styling in the patient's dashboard.

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -154,12 +154,7 @@ export default function PatientInfoCard(props: {
             >
               {consultation?.current_bed &&
               consultation?.discharge_date === null ? (
-                <div
-                  className="flex h-full flex-col items-center justify-center"
-                  title={`
-                ${consultation?.current_bed?.bed_object?.location_object?.name}\n${consultation?.current_bed?.bed_object.name}
-              `}
-                >
+                <div className="tooltip flex h-full flex-col items-center justify-center">
                   <p className="w-full truncate px-2 text-center text-sm text-gray-900">
                     {
                       consultation?.current_bed?.bed_object?.location_object
@@ -169,6 +164,15 @@ export default function PatientInfoCard(props: {
                   <p className="w-full truncate px-2 text-center text-base font-bold">
                     {consultation?.current_bed?.bed_object.name}
                   </p>
+                  <div className="tooltip-text tooltip-right flex -translate-x-1/3 translate-y-1/2 flex-col items-center justify-center text-sm ">
+                    <span>
+                      {
+                        consultation?.current_bed?.bed_object?.location_object
+                          ?.name
+                      }
+                    </span>
+                    <span>{consultation?.current_bed?.bed_object.name}</span>
+                  </div>
                 </div>
               ) : (
                 <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e94892</samp>

Added a custom tooltip component to show patient bed and location. This improves the patient info card UI in `PatientInfoCard.tsx`.

## Proposed Changes

- Fixes #6838 
- Changed the tooltip styling to make it uniform. 


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e94892</samp>

*  Replace native `title` attribute with custom tooltip component for displaying patient's bed and location (`[link](https://github.com/coronasafe/care_fe/pull/6842/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948L157-R157)`, `[link](https://github.com/coronasafe/care_fe/pull/6842/files?diff=unified&w=0#diff-474c76838170cd340f215b026249385e32a2d8263bd30a568c2b02b38d272948R167-R175)` in `PatientInfoCard.tsx`)
