### PR TITLE
Sort wards by ward number in filters + adds utility method: `compareBy`

### DIFF
--- a/src/Components/Diagnosis/LegacyDiagnosesList.tsx
+++ b/src/Components/Diagnosis/LegacyDiagnosesList.tsx
@@ -6,6 +6,7 @@ import {
 } from "./types";
 import { useTranslation } from "react-i18next";
 import CareIcon from "../../CAREUI/icons/CareIcon";
+import { compareByKey } from "../../Utils/utils";
 
 interface Props {
   diagnoses: ConsultationDiagnosis[];
@@ -22,7 +23,7 @@ function groupDiagnoses(diagnoses: ConsultationDiagnosis[]) {
   for (const status of ActiveConditionVerificationStatuses) {
     groupedDiagnoses[status] = diagnoses
       .filter((d) => d.verification_status === status)
-      .sort((a, b) => Number(b.is_principal) - Number(a.is_principal));
+      .sort(compareByKey("is_principal"));
   }
 
   return groupedDiagnoses;

--- a/src/Components/Diagnosis/LegacyDiagnosesList.tsx
+++ b/src/Components/Diagnosis/LegacyDiagnosesList.tsx
@@ -6,7 +6,7 @@ import {
 } from "./types";
 import { useTranslation } from "react-i18next";
 import CareIcon from "../../CAREUI/icons/CareIcon";
-import { compareByKey } from "../../Utils/utils";
+import { compareBy } from "../../Utils/utils";
 
 interface Props {
   diagnoses: ConsultationDiagnosis[];
@@ -23,7 +23,7 @@ function groupDiagnoses(diagnoses: ConsultationDiagnosis[]) {
   for (const status of ActiveConditionVerificationStatuses) {
     groupedDiagnoses[status] = diagnoses
       .filter((d) => d.verification_status === status)
-      .sort(compareByKey("is_principal"));
+      .sort(compareBy("is_principal"));
   }
 
   return groupedDiagnoses;

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -6,7 +6,7 @@ import TextFormField from "../Form/FormFields/TextFormField";
 import { MultiSelectFormField } from "../Form/FormFields/SelectFormField";
 import DateRangeFormField from "../Form/FormFields/DateRangeFormField";
 import dayjs from "dayjs";
-import { dateQueryString, compareByKey } from "../../Utils/utils";
+import { dateQueryString, compareBy } from "../../Utils/utils";
 import useAuthUser from "../../Common/hooks/useAuthUser";
 import useQuery from "../../Utils/request/useQuery";
 import routes from "../../Redux/api";
@@ -68,8 +68,8 @@ export default function ListFilter(props: any) {
           });
         }
 
-        allWards.sort(compareByKey("number"));
-        allLsgs.sort(compareByKey("name"));
+        allWards.sort(compareBy("number"));
+        allLsgs.sort(compareBy("name"));
 
         setWardList(allWards);
         setLsgList(allLsgs);

--- a/src/Components/ExternalResult/ListFilter.tsx
+++ b/src/Components/ExternalResult/ListFilter.tsx
@@ -6,11 +6,12 @@ import TextFormField from "../Form/FormFields/TextFormField";
 import { MultiSelectFormField } from "../Form/FormFields/SelectFormField";
 import DateRangeFormField from "../Form/FormFields/DateRangeFormField";
 import dayjs from "dayjs";
-import { dateQueryString } from "../../Utils/utils";
+import { dateQueryString, compareByKey } from "../../Utils/utils";
 import useAuthUser from "../../Common/hooks/useAuthUser";
 import useQuery from "../../Utils/request/useQuery";
 import routes from "../../Redux/api";
 import Loading from "../Common/Loading";
+import { LocalBodyModel, WardModel } from "../Facility/models";
 
 const clearFilterState = {
   created_date_before: "",
@@ -27,10 +28,10 @@ const getDate = (value: any) =>
 
 export default function ListFilter(props: any) {
   const { filter, onChange, closeFilter, dataList, removeFilters } = props;
-  const [wardList, setWardList] = useState<any[]>([]);
-  const [lsgList, setLsgList] = useState<any[]>([]);
-  const [wards, setWards] = useState<any[]>([]);
-  const [selectedLsgs, setSelectedLsgs] = useState<any[]>([]);
+  const [wardList, setWardList] = useState<WardModel[]>([]);
+  const [lsgList, setLsgList] = useState<LocalBodyModel[]>([]);
+  const [wards, setWards] = useState<WardModel[]>([]);
+  const [selectedLsgs, setSelectedLsgs] = useState<LocalBodyModel[]>([]);
   const authUser = useAuthUser();
   const [filterState, setFilterState] = useMergeState({
     created_date_before: filter.created_date_before || null,
@@ -47,32 +48,32 @@ export default function ListFilter(props: any) {
     pathParams: { id: String(authUser.district) },
     onResponse: ({ res, data }) => {
       if (res && data) {
-        let allWards: any[] = [];
-        let allLsgs: any[] = [];
+        const allWards: any[] = [];
+        const allLsgs: any[] = [];
+
         if (res && data) {
           data.forEach((local: any) => {
-            allLsgs = [...allLsgs, { id: local.id, name: local.name }];
+            allLsgs.push({ id: local.id, name: local.name });
             if (local.wards) {
               local.wards.forEach((ward: any) => {
-                allWards = [
-                  ...allWards,
-                  {
-                    id: ward.id,
-                    name: ward.number + ": " + ward.name,
-                    panchayath: local.name,
-                    number: ward.number,
-                    local_body_id: local.id,
-                  },
-                ];
+                allWards.push({
+                  id: ward.id,
+                  name: ward.number + ": " + ward.name,
+                  panchayath: local.name,
+                  number: ward.number,
+                  local_body_id: local.id,
+                });
               });
             }
           });
         }
 
-        sortByName(allWards);
-        sortByName(allLsgs);
-        setWardList(allWards || []);
-        setLsgList(allLsgs || []);
+        allWards.sort(compareByKey("number"));
+        allLsgs.sort(compareByKey("name"));
+
+        setWardList(allWards);
+        setLsgList(allLsgs);
+
         const filteredWard = filter?.wards?.split(",").map(Number);
         const selectedWards: any =
           filteredWard && allWards
@@ -104,13 +105,6 @@ export default function ListFilter(props: any) {
     filterData[endDateId] = e.value.end?.toString();
 
     setFilterState(filterData);
-  };
-
-  const handleWardChange = (value: any) => {
-    setWards(value);
-  };
-  const handleLsgChange = (value: any) => {
-    setSelectedLsgs(value);
   };
 
   const field = (name: string) => ({
@@ -161,12 +155,6 @@ export default function ListFilter(props: any) {
     dataList(selectedLsgs, wards);
   };
 
-  const sortByName = (items: any) => {
-    items.sort(function (a: any, b: any) {
-      return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
-    });
-  };
-
   const filterWards = () => {
     const selectedLsgIds: any = selectedLsgs.map((e) => {
       return e.id;
@@ -205,29 +193,27 @@ export default function ListFilter(props: any) {
         closeFilter();
       }}
     >
-      <div>
-        <MultiSelectFormField
-          name="local_bodies"
-          options={lsgList}
-          label={t("Local Body")}
-          placeholder={t("select_local_body")}
-          value={selectedLsgs}
-          optionLabel={(option: any) => option.name}
-          onChange={(e: any) => handleLsgChange(e.value)}
-        />
-      </div>
+      <MultiSelectFormField
+        name="local_bodies"
+        options={lsgList}
+        label={t("Local Body")}
+        placeholder={t("select_local_body")}
+        value={selectedLsgs}
+        optionLabel={(option) => option.name}
+        optionDescription={(option) => option.localbody_code}
+        onChange={({ value }) => setSelectedLsgs(value)}
+      />
 
-      <div>
-        <MultiSelectFormField
-          name="wards"
-          options={filterWards()}
-          label={t("Ward")}
-          placeholder={t("select_wards")}
-          value={wards}
-          optionLabel={(option: any) => option.name}
-          onChange={(e: any) => handleWardChange(e.value)}
-        />
-      </div>
+      <MultiSelectFormField
+        name="wards"
+        options={filterWards() as WardModel[]}
+        label={t("Ward")}
+        placeholder={t("select_wards")}
+        value={wards}
+        optionLabel={(option) => option.name}
+        optionDescription={(option) => option.panchayath}
+        onChange={({ value }) => setWards(value)}
+      />
       <DateRangeFormField
         name="created_date"
         id="created_date"

--- a/src/Components/ExternalResult/ResultUpdate.tsx
+++ b/src/Components/ExternalResult/ResultUpdate.tsx
@@ -11,7 +11,7 @@ import Page from "../Common/components/Page.js";
 import useQuery from "../../Utils/request/useQuery.js";
 import routes from "../../Redux/api.js";
 import request from "../../Utils/request/request.js";
-import { compareByKey } from "../../Utils/utils.js";
+import { compareBy } from "../../Utils/utils.js";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -266,7 +266,7 @@ export default function UpdateResult(props: any) {
                     name="ward"
                     label="Ward/Division of respective LSGI"
                     required
-                    options={ward.sort(compareByKey("number")).map((e) => {
+                    options={ward.sort(compareBy("number")).map((e) => {
                       return { id: e.id, name: e.number + ": " + e.name };
                     })}
                     value={state.form.ward}

--- a/src/Components/ExternalResult/ResultUpdate.tsx
+++ b/src/Components/ExternalResult/ResultUpdate.tsx
@@ -11,6 +11,7 @@ import Page from "../Common/components/Page.js";
 import useQuery from "../../Utils/request/useQuery.js";
 import routes from "../../Redux/api.js";
 import request from "../../Utils/request/request.js";
+import { compareByKey } from "../../Utils/utils.js";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -265,11 +266,9 @@ export default function UpdateResult(props: any) {
                     name="ward"
                     label="Ward/Division of respective LSGI"
                     required
-                    options={ward
-                      .sort((a, b) => a.number - b.number)
-                      .map((e) => {
-                        return { id: e.id, name: e.number + ": " + e.name };
-                      })}
+                    options={ward.sort(compareByKey("number")).map((e) => {
+                      return { id: e.id, name: e.number + ": " + e.name };
+                    })}
                     value={state.form.ward}
                     optionLabel={(ward) => ward.name}
                     optionValue={(ward) => ward.id}

--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -1,7 +1,14 @@
 import * as Notification from "../../Utils/Notifications.js";
 
 import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
-import { CapacityModal, DoctorModal } from "./models";
+import {
+  CapacityModal,
+  DistrictModel,
+  DoctorModal,
+  LocalBodyModel,
+  StateModel,
+  WardModel,
+} from "./models";
 import { DraftSection, useAutoSaveReducer } from "../../Utils/AutoSave.js";
 import {
   FACILITY_FEATURE_TYPES,
@@ -30,6 +37,7 @@ import {
   getPincodeDetails,
   includesIgnoreCase,
   parsePhoneNumber,
+  compareByKey,
 } from "../../Utils/utils";
 import {
   phonePreg,
@@ -65,15 +73,6 @@ const Loading = lazy(() => import("../Common/Loading"));
 
 interface FacilityProps {
   facilityId?: string;
-}
-
-interface StateObj {
-  id: number;
-  name: string;
-}
-
-interface WardObj extends StateObj {
-  number: number;
 }
 
 type FacilityForm = {
@@ -162,10 +161,10 @@ export const FacilityCreate = (props: FacilityProps) => {
   const [isDistrictLoading, setIsDistrictLoading] = useState(false);
   const [isLocalbodyLoading, setIsLocalbodyLoading] = useState(false);
   const [isWardLoading, setIsWardLoading] = useState(false);
-  const [states, setStates] = useState<StateObj[]>([]);
-  const [districts, setDistricts] = useState<StateObj[]>([]);
-  const [localBodies, setLocalBodies] = useState<StateObj[]>([]);
-  const [ward, setWard] = useState<WardObj[]>([]);
+  const [states, setStates] = useState<StateModel[]>([]);
+  const [districts, setDistricts] = useState<DistrictModel[]>([]);
+  const [localBodies, setLocalBodies] = useState<LocalBodyModel[]>([]);
+  const [ward, setWard] = useState<WardModel[]>([]);
   const [currentStep, setCurrentStep] = useState(1);
   const [createdFacilityId, setCreatedFacilityId] = useState("");
   const [showAutoFilledPincode, setShowAutoFilledPincode] = useState(false);
@@ -855,14 +854,12 @@ export const FacilityCreate = (props: FacilityProps) => {
                     className={isWardLoading ? "animate-pulse" : ""}
                     disabled={isWardLoading}
                     placeholder="Choose Ward"
-                    options={ward
-                      .sort((a, b) => a.number - b.number)
-                      .map((e) => {
-                        return {
-                          id: e.id,
-                          name: e.number + ": " + e.name,
-                        };
-                      })}
+                    options={ward.sort(compareByKey("number")).map((e) => {
+                      return {
+                        id: e.id,
+                        name: e.number + ": " + e.name,
+                      };
+                    })}
                     optionLabel={(o) => o.name}
                     optionValue={(o) => o.id}
                   />

--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -37,7 +37,7 @@ import {
   getPincodeDetails,
   includesIgnoreCase,
   parsePhoneNumber,
-  compareByKey,
+  compareBy,
 } from "../../Utils/utils";
 import {
   phonePreg,
@@ -854,7 +854,7 @@ export const FacilityCreate = (props: FacilityProps) => {
                     className={isWardLoading ? "animate-pulse" : ""}
                     disabled={isWardLoading}
                     placeholder="Choose Ward"
-                    options={ward.sort(compareByKey("number")).map((e) => {
+                    options={ward.sort(compareBy("number")).map((e) => {
                       return {
                         id: e.id,
                         name: e.number + ": " + e.name,

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -29,7 +29,8 @@ export interface WardModel {
   id: number;
   name: string;
   number: number;
-  local_body: number;
+  panchayath: string;
+  local_body_id: LocalBodyModel["id"];
 }
 
 export interface FacilityModel {

--- a/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
+++ b/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import AutocompleteFormField from "./Autocomplete";
 import { FormFieldBaseProps } from "./Utils";
-import { classNames, compareByKey } from "../../../Utils/utils";
+import { classNames, compareBy } from "../../../Utils/utils";
 import ButtonV2 from "../../Common/components/ButtonV2";
 
 interface Threshold {
@@ -23,8 +23,7 @@ type Props = FormFieldBaseProps<number> & {
 
 export default function RangeAutocompleteFormField(props: Props) {
   const options = useMemo(() => {
-    const sortedThresholds =
-      props.thresholds?.sort(compareByKey("value")) || [];
+    const sortedThresholds = props.thresholds?.sort(compareBy("value")) || [];
 
     const getThreshold = (value: number) => {
       const threshold = sortedThresholds.findLast(

--- a/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
+++ b/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import AutocompleteFormField from "./Autocomplete";
 import { FormFieldBaseProps } from "./Utils";
-import { classNames } from "../../../Utils/utils";
+import { classNames, compareByKey } from "../../../Utils/utils";
 import ButtonV2 from "../../Common/components/ButtonV2";
 
 interface Threshold {
@@ -24,7 +24,7 @@ type Props = FormFieldBaseProps<number> & {
 export default function RangeAutocompleteFormField(props: Props) {
   const options = useMemo(() => {
     const sortedThresholds =
-      props.thresholds?.sort((a, b) => a.value - b.value) || [];
+      props.thresholds?.sort(compareByKey("value")) || [];
 
     const getThreshold = (value: number) => {
       const threshold = sortedThresholds.findLast(

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -27,7 +27,7 @@ import {
   includesIgnoreCase,
   parsePhoneNumber,
   scrollTo,
-  compareByKey,
+  compareBy,
 } from "../../Utils/utils";
 import { navigate, useQueryParams } from "raviger";
 import { statusType, useAbortableEffect } from "../../Common/utils";
@@ -1508,7 +1508,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                     {...field("ward")}
                                     label="Ward"
                                     options={ward
-                                      .sort(compareByKey("number"))
+                                      .sort(compareBy("number"))
                                       .map((e) => {
                                         return {
                                           id: e.id,

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -27,6 +27,7 @@ import {
   includesIgnoreCase,
   parsePhoneNumber,
   scrollTo,
+  compareByKey,
 } from "../../Utils/utils";
 import { navigate, useQueryParams } from "raviger";
 import { statusType, useAbortableEffect } from "../../Common/utils";
@@ -1507,7 +1508,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                     {...field("ward")}
                                     label="Ward"
                                     options={ward
-                                      .sort((a, b) => a.number - b.number)
+                                      .sort(compareByKey("number"))
                                       .map((e) => {
                                         return {
                                           id: e.id,

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -467,3 +467,9 @@ export const invalidateFiltersCache = () => {
     }
   }
 };
+
+export const compareByKey = <T extends object>(key: keyof T) => {
+  return (a: T, b: T) => {
+    return a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0;
+  };
+};

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -468,7 +468,7 @@ export const invalidateFiltersCache = () => {
   }
 };
 
-export const compareByKey = <T extends object>(key: keyof T) => {
+export const compareBy = <T extends object>(key: keyof T) => {
   return (a: T, b: T) => {
     return a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0;
   };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b9637f3</samp>

The pull request refactors and improves the code for sorting and displaying data related to diagnoses, external results, facilities, and patients. It uses consistent and imported types, and a common utility function `compareByKey` for sorting arrays of objects by a given key. It affects the files `LegacyDiagnosesList.tsx`, `ListFilter.tsx`, `ResultUpdate.tsx`, `FacilityCreate.tsx`, `RangeAutocompleteFormField.tsx`, `PatientRegister.tsx`, `models.tsx`, and `utils.ts`.

## Proposed Changes

- Fixes #6847
- Adds utility method: `compareBy` that returns a comparator function that operates on the value of an object specified by the key

```jsx
const sortedItems = items.toSorted(compareBy("quantity"));
// equivalent to:
const sortedItems = items.toSorted((a, b) => a["quantity"] < b["quantity"] ? -1 : a["quantity"] > b["quantity"] ? 1 : 0);


items.sort(compareBy("quantity"));
// equivalent to:
items.sort((a, b) => a["quantity"] < b["quantity"] ? -1 : a["quantity"] > b["quantity"] ? 1 : 0);
```

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b9637f3</samp>

*  Import and use `compareByKey` function for sorting arrays of objects by a given key in various components ([link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-add62844edebd51724c76bec6b204ec9e7397a4cbfbf4269c1351c24d3027975R9), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-add62844edebd51724c76bec6b204ec9e7397a4cbfbf4269c1351c24d3027975L25-R26),  [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL72-R76), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-1770267d993718929f1d0c3c41ee09ea8361ff033c24497cc98f7af4f6b3b923R14), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-1770267d993718929f1d0c3c41ee09ea8361ff033c24497cc98f7af4f6b3b923L268-R271), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-c1bd2754f233548fd1a6217ebe45fe603c71864f10c26f6350596f85b39e000cR40), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-c1bd2754f233548fd1a6217ebe45fe603c71864f10c26f6350596f85b39e000cL858-R862), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-85f062be60c76d24dca7abdf69ffcc7b576dd7bd4819adcdd66e253ae9804378L4-R4), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-85f062be60c76d24dca7abdf69ffcc7b576dd7bd4819adcdd66e253ae9804378L27-R27), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775R30), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-09e14a8b77195fb6628b716eb09a71a996a55f559ddc5c3ef19d3c54948a4775L1510-R1511))
*  Refactor and type `wardList`, `lsgList`, `wards`, and `selectedLsgs` state variables and props in `ListFilter.tsx` using `WardModel` and `LocalBodyModel` types ([link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL9-R14), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL30-R34), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL50-R65))
*  Simplify and enhance `MultiSelectFormField` components for `local_bodies` and `wards` in `ListFilter.tsx` by using `optionDescription` prop and removing unnecessary wrappers and functions ([link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL109-L115), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL164-L169), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-3da4ca70e78caf804ba3032b1a4fd1a93b0063da72163a1e54d3ebda68db071fL208-R216))
*  Modify `WardModel` interface in `models.tsx` to include `panchayath` and `local_body_id` fields and use `LocalBodyModel["id"]` type ([link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfL32-R33))
*  Type `states`, `districts`, `localBodies`, and `ward` state variables and props in `FacilityCreate.tsx` using `StateModel`, `DistrictModel`, `LocalBodyModel`, and `WardModel` types and remove unused interfaces ([link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-c1bd2754f233548fd1a6217ebe45fe603c71864f10c26f6350596f85b39e000cL4-R11), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-c1bd2754f233548fd1a6217ebe45fe603c71864f10c26f6350596f85b39e000cL70-L78), [link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-c1bd2754f233548fd1a6217ebe45fe603c71864f10c26f6350596f85b39e000cL165-R167))
*  Add `compareByKey` function to `utils.ts` as a utility function for sorting arrays of objects by a given key ([link](https://github.com/coronasafe/care_fe/pull/6852/files?diff=unified&w=0#diff-5903b23c9778624d9c178b9779024a4265e5fc365714fed34d49225ee6b8dc73R470-R475))
