### PR TITLE
Redesign location card UI

### DIFF
--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -20,7 +20,6 @@ export interface AssetLocationObject {
     id: string;
     name: string;
   };
-  middleware_address?: string;
 }
 
 export enum AssetType {

--- a/src/Components/Facility/LocationManagement.tsx
+++ b/src/Components/Facility/LocationManagement.tsx
@@ -6,6 +6,7 @@ import Page from "../Common/components/Page";
 import routes from "../../Redux/api";
 import PaginatedList from "../../CAREUI/misc/PaginatedList";
 import { LocationModel } from "./models";
+import RecordMeta from "../../CAREUI/display/RecordMeta";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -118,12 +119,8 @@ const Location = ({
     </ButtonV2>
 
     <div className="mt-3 flex items-center justify-between gap-4 text-sm font-medium text-gray-700">
-      <p>
-        <strong>Created:</strong> {created_date?.slice(0, 10)}
-      </p>
-      <p>
-        <strong>Modified:</strong> {modified_date?.slice(0, 10)}
-      </p>
+      <RecordMeta time={created_date} prefix="Created:" />
+      <RecordMeta time={modified_date} prefix="Modified:" />
     </div>
   </div>
 );

--- a/src/Components/Facility/LocationManagement.tsx
+++ b/src/Components/Facility/LocationManagement.tsx
@@ -51,10 +51,11 @@ export default function LocationManagement({ facilityId }: Props) {
           <PaginatedList.WhenLoading>
             <Loading />
           </PaginatedList.WhenLoading>
-
-          <PaginatedList.Items<LocationModel> className="my-8 flex grow flex-col gap-3 lg:mx-8">
-            {(item) => <Location {...item} />}
-          </PaginatedList.Items>
+          <div className="w-full @container">
+            <PaginatedList.Items<LocationModel> className="my-8 grid gap-3 @4xl:grid-cols-2 @6xl:grid-cols-3 @[100rem]:grid-cols-4 lg:mx-8">
+              {(item) => <Location {...item} />}
+            </PaginatedList.Items>
+          </div>
 
           <div className="flex w-full items-center justify-center">
             <PaginatedList.Paginator hideIfSinglePage />
@@ -69,43 +70,60 @@ const Location = ({
   name,
   description,
   middleware_address,
+  location_type,
+  created_date,
+  modified_date,
   id,
 }: LocationModel) => (
-  <div className="w-full items-center justify-between rounded border border-gray-300 bg-white p-6 shadow-sm transition-all duration-200 ease-in-out hover:border-primary-400 lg:flex">
-    <div className="lg:w-3/4">
-      <div className="w-full items-baseline gap-4 lg:flex lg:items-center">
-        <p className="break-words text-xl lg:mr-4 lg:w-3/4">
-          {name}
-          <p className="break-all text-sm text-gray-700">
-            {description || "-"}
-          </p>
-        </p>
-        <p className="break-all text-sm lg:mr-4 lg:w-3/4">
-          {middleware_address}
-        </p>
+  <div className="flex h-full w-full flex-col rounded border border-gray-300 bg-white p-6 shadow-sm transition-all duration-200 ease-in-out hover:border-primary-400">
+    <div className="flex-1">
+      <div className="flex w-full items-center justify-between gap-2">
+        <div className="flex items-center gap-3">
+          <p className="break-words text-xl font-medium">{name}</p>
+          <div className="h-fit rounded-full border-2 border-primary-500 bg-primary-100 px-3 py-[3px]">
+            <p className="text-xs font-bold text-primary-500">
+              {location_type}
+            </p>
+          </div>
+        </div>
+        <ButtonV2
+          variant="secondary"
+          border
+          href={`location/${id}/update`}
+          authorizeFor={NonReadOnlyUsers}
+        >
+          <CareIcon className="care-l-pen text-lg" />
+          Edit
+        </ButtonV2>
       </div>
+      <p className="mt-3 break-all text-sm font-medium text-gray-700">
+        {description || "-"}
+      </p>
+      <p className="mt-3 text-sm font-semibold text-gray-700">
+        Middleware Address:
+      </p>
+      <p className="mt-1 break-all font-mono text-sm font-bold text-gray-700">
+        {middleware_address || "-"}
+      </p>
     </div>
 
-    <div className="mt-4 flex flex-col gap-2 lg:mt-0 lg:flex-row">
-      <ButtonV2
-        variant="secondary"
-        border
-        className="w-full lg:w-auto"
-        href={`location/${id}/update`}
-        authorizeFor={NonReadOnlyUsers}
-      >
-        <CareIcon className="care-l-pen text-lg" />
-        Edit
-      </ButtonV2>
-      <ButtonV2
-        variant="secondary"
-        border
-        className="w-full lg:w-auto"
-        href={`location/${id}/beds`}
-      >
-        <CareIcon className="care-l-bed text-lg" />
-        Manage Beds
-      </ButtonV2>
+    <ButtonV2
+      variant="secondary"
+      border
+      className="mt-3 w-full"
+      href={`location/${id}/beds`}
+    >
+      <CareIcon className="care-l-bed text-lg" />
+      Manage Beds
+    </ButtonV2>
+
+    <div className="mt-3 flex items-center justify-between gap-4 text-sm font-medium text-gray-700">
+      <p>
+        <strong>Created:</strong> {created_date?.slice(0, 10)}
+      </p>
+      <p>
+        <strong>Modified:</strong> {modified_date?.slice(0, 10)}
+      </p>
     </div>
   </div>
 );

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -1,7 +1,7 @@
 import { AssignedToObjectModel } from "../Patient/models";
 import { ProcedureType } from "../Common/prescription-builder/ProcedureBuilder";
 import { NormalPrescription, PRNPrescription } from "../Medicine/models";
-import { AssetData } from "../Assets/AssetTypes";
+import { AssetData, AssetLocationType } from "../Assets/AssetTypes";
 import { UserBareMinimum } from "../Users/models";
 import { RouteToFacility } from "../Common/RouteToFacilitySelect";
 import { ConsultationDiagnosis, CreateDiagnosis } from "../Diagnosis/types";
@@ -204,7 +204,7 @@ export interface LocationModel {
   name?: string;
   description?: string;
   middleware_address?: string;
-  location_type?: string;
+  location_type?: AssetLocationType;
   facility?: {
     name: string;
   };

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -204,9 +204,12 @@ export interface LocationModel {
   name?: string;
   description?: string;
   middleware_address?: string;
+  location_type?: string;
   facility?: {
     name: string;
   };
+  created_date?: string;
+  modified_date?: string;
 }
 
 export interface BedModel {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47c1b4b</samp>

This pull request enhances the location management feature of the facility module by adding a responsive grid layout, showing more location details, and updating the `LocationModel` interface to match the backend API. The changes affect the `LocationManagement.tsx` and `models.tsx` files.

## Proposed Changes

- Fixes #6843

## Screenshot
<img width="486" alt="image" src="https://github.com/coronasafe/care_fe/assets/40627011/3167c443-2108-4a1f-99fb-f2d116415d89">

 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47c1b4b</samp>

*  Redesign the `Location` component to show more information and use a grid layout ([link](https://github.com/coronasafe/care_fe/pull/6853/files?diff=unified&w=0#diff-042c54113f687e89c2429ff1d97fe7dfcccfa3818279170a82ea1286684a53cdL54-R59), [link](https://github.com/coronasafe/care_fe/pull/6853/files?diff=unified&w=0#diff-042c54113f687e89c2429ff1d97fe7dfcccfa3818279170a82ea1286684a53cdL72-R126), [link](https://github.com/coronasafe/care_fe/pull/6853/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfL207-R212))
  - Add the `location_type`, `created_date`, and `modified_date` properties to the `LocationModel` interface in `models.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6853/files?diff=unified&w=0#diff-e2841f01e53119db63c01994d866100758f06ecc85d11914eecc7cdfe8a2f4dfL207-R212))
  - Display the `location_type` as a badge next to the name, the `middleware_address` as a separate section, and the dates at the bottom of the `Location` component in `LocationManagement.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6853/files?diff=unified&w=0#diff-042c54113f687e89c2429ff1d97fe7dfcccfa3818279170a82ea1286684a53cdL72-R126))
  - Reposition and style the `Edit` and `Manage Beds` buttons in the `Location` component ([link](https://github.com/coronasafe/care_fe/pull/6853/files?diff=unified&w=0#diff-042c54113f687e89c2429ff1d97fe7dfcccfa3818279170a82ea1286684a53cdL72-R126))
  - Use a `grid` layout with responsive columns for the `PaginatedList.Items` component and wrap it in a `div` with a `w-full @container` class in `LocationManagement.tsx` ([link](https://github.com/coronasafe/care_fe/pull/6853/files?diff=unified&w=0#diff-042c54113f687e89c2429ff1d97fe7dfcccfa3818279170a82ea1286684a53cdL54-R59))
