### PR TITLE
Show correct error message for interval server errors

### DIFF
--- a/src/Redux/fireRequest.tsx
+++ b/src/Redux/fireRequest.tsx
@@ -170,9 +170,15 @@ export const fireRequest = (
 
           // 5xx Errors
           if (error.response.status >= 500 && error.response.status <= 599) {
-            Notification.Error({
-              msg: "Something went wrong...!",
-            });
+            if (error.response.data && error.response.data.detail) {
+              Notification.Error({
+                msg: error.response.data.detail,
+              });
+            } else {
+              Notification.Error({
+                msg: "Something went wrong...!",
+              });
+            }
             return;
           }
         } else {
@@ -282,9 +288,15 @@ export const fireRequestV2 = (
 
         // 5xx Errors
         if (error.response.status >= 500 && error.response.status <= 599) {
-          Notification.Error({
-            msg: "Something went wrong...!",
-          });
+          if (error.response.data && error.response.data.detail) {
+            Notification.Error({
+              msg: error.response.data.detail,
+            });
+          } else {
+            Notification.Error({
+              msg: "Something went wrong...!",
+            });
+          }
           return;
         }
       }
@@ -391,9 +403,15 @@ export const fireRequestForFiles = (
 
           // 5xx Errors
           if (error.response.status >= 500 && error.response.status <= 599) {
-            Notification.Error({
-              msg: "Something went wrong...!",
-            });
+            if (error.response.data && error.response.data.detail) {
+              Notification.Error({
+                msg: error.response.data.detail,
+              });
+            } else {
+              Notification.Error({
+                msg: "Something went wrong...!",
+              });
+            }
             return;
           }
         }

--- a/src/Utils/request/handleResponse.ts
+++ b/src/Utils/request/handleResponse.ts
@@ -15,7 +15,7 @@ export default function handleResponse(
   // 5xx errors
   if (res.status >= 500 && res.status < 600) {
     console.error("Server error", res);
-    notify?.Error({ msg: "Something went wrong...!" });
+    notify?.Error({ msg: error?.detail || "Something went wrong...!" });
     return;
   }
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #6815
- Checked the error response returned when the error code was between 500 and 599, and notifying the correct error message if the response is JSON, and has data and data.detail properties. 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA