### PR TITLE
Disable critical care submit if only basic editor is filled

### DIFF
--- a/src/Components/CriticalCareRecording/Recording/CriticalCare__Recording.res
+++ b/src/Components/CriticalCareRecording/Recording/CriticalCare__Recording.res
@@ -237,7 +237,9 @@ let make = (~id, ~facilityId, ~patientId, ~consultationId, ~dailyRound) => {
             <button
               onClick={_ =>
                 Notifications.success({msg: "Critical care log updates are filed successfully"})}
-              className="btn btn-primary w-full mt-6">
+              className="btn btn-primary w-full mt-6"
+              disabled={Js.Array.length(state.updatedEditors) === 0}
+              >
               {str("Complete")}
             </button>
           </Link>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 99c20f7</samp>

Added a `disabled` attribute to the `button` element in `CriticalCare__Recording.res` to avoid filing empty changes. This improves the performance and usability of the critical care recording feature.

## Proposed Changes

- Fixes #6855 
Disable the `Complete` button on `Critical Care` log update if only the Basic Editor has been filled, thus prevent empty form submissions
![image](https://github.com/coronasafe/care_fe/assets/70687348/241c86a9-3bcd-4ea4-a5bc-381e2fb9d6e2)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 99c20f7</samp>

*  Add `disabled` attribute to `button` element to prevent filing unchanged data ([link](https://github.com/coronasafe/care_fe/pull/6860/files?diff=unified&w=0#diff-006414addec0db71c06df677a326f713cf862a97eb86e888f0cc5f3a5b10417dL240-R242))
