### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('package-lock.json', 'Dockerfile') }}
@@ -87,7 +87,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('package-lock.json', 'Dockerfile') }}
@@ -149,7 +149,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('package-lock.json', 'Dockerfile') }}
@@ -188,6 +188,9 @@ jobs:
     needs: build-staging
     name: Deploy to staging GCP cluster
     runs-on: ubuntu-latest
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
     environment:
       name: Staging-GCP
       url: https://care-staging.ohc.network/
@@ -201,20 +204,20 @@ jobs:
           ref: main
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GKE_SA_KEY }}
           project_id: ${{ secrets.GKE_PROJECT }}
 
       # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      - uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: "v1.23.6"
         id: install
@@ -230,6 +233,9 @@ jobs:
     needs: build-production
     name: Deploy to GKE Manipur
     runs-on: ubuntu-latest
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
     environment:
       name: Production-Manipur
       url: https://care.mn.gov.in
@@ -243,20 +249,20 @@ jobs:
           ref: main
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GKE_SA_KEY }}
           project_id: ${{ secrets.GKE_PROJECT }}
 
       # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      - uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: "v1.23.6"
         id: install
@@ -272,6 +278,9 @@ jobs:
     needs: build-production
     name: Deploy to GKE Karnataka
     runs-on: ubuntu-latest
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
     environment:
       name: Production-Karnataka
       url: https://karnataka.care
@@ -285,20 +294,20 @@ jobs:
           ref: main
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GKE_SA_KEY }}
           project_id: ${{ secrets.GKE_PROJECT }}
 
       # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      - uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: "v1.23.6"
         id: install
@@ -314,6 +323,9 @@ jobs:
     needs: build-production
     name: Deploy to GKE Sikkim
     runs-on: ubuntu-latest
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
     environment:
       name: Production-Sikkim
       url: https://care.sikkim.gov.in
@@ -327,20 +339,20 @@ jobs:
           ref: main
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GKE_SA_KEY }}
           project_id: ${{ secrets.GKE_PROJECT }}
 
       # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      - uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: "v1.23.6"
         id: install
@@ -356,6 +368,9 @@ jobs:
     needs: build-production
     name: Deploy to GKE Assam
     runs-on: ubuntu-latest
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
     environment:
       name: Production-Assam
       url: https://care.assam.gov.in
@@ -369,20 +384,20 @@ jobs:
           ref: main
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GKE_SA_KEY }}
           project_id: ${{ secrets.GKE_PROJECT }}
 
       # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      - uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: "v1.23.6"
         id: install
@@ -398,6 +413,9 @@ jobs:
     needs: build-production
     name: Deploy to GKE Nagaland
     runs-on: ubuntu-latest
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
     environment:
       name: Production - Nagaland
       url: https://care.nagaland.gov.in
@@ -411,20 +429,20 @@ jobs:
           ref: main
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GKE_SA_KEY }}
           project_id: ${{ secrets.GKE_PROJECT }}
 
       # Get the GKE credentials, so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      - uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: "v1.23.6"
         id: install
@@ -440,6 +458,9 @@ jobs:
     needs: build-production
     name: Deploy to GKE Meghalaya
     runs-on: ubuntu-latest
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
     environment:
       name: Production-Meghalaya
       url: https://care.meghealth.gov.in
@@ -453,20 +474,20 @@ jobs:
           ref: main
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GKE_SA_KEY }}
           project_id: ${{ secrets.GKE_PROJECT }}
 
       # Get the GKE credentials, so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      - uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
       - name: install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: "v1.23.6"
         id: install

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: '20'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout your code repository to scan
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Run open source static analysis tools
       - name: Run OSSAR
-        uses: github/ossar-action@v1
+        uses: github/ossar-action@fae13e456b9973657a670eef6bccc3a4c2b5153d
         id: ossar
 
         # Upload results to the Security tab


### PR DESCRIPTION
Fixes #6798

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 597b824</samp>

The pull request updates the GitHub Actions workflows for deploying, linting, and analyzing the codebase. It uses the latest versions of the actions and Node.js, and ensures consistency across the workflows. It affects the files `.github/workflows/deploy.yaml`, `.github/workflows/linter.yml`, and `.github/workflows/ossar-analysis.yml`.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 597b824</samp>

*  Update cache action from v2 to v3 in all build and deploy steps to use the latest version and features ([link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L38-R38), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L90-R90), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L152-R152))
*  Add setup-node action to install Node.js version 20 in all build and deploy steps to match the node version used in the linter workflow ([link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R191-R193), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R236-R238), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R281-R283), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R326-R328), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R371-R373), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R416-R418), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R461-R463))
*  Update setup-gcloud, get-gke-credentials, and setup-kubectl actions from specific commit hashes or versions to v2 or v3 in all deploy steps to use the latest version and features ([link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L204-R207), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L210-R213), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L217-R220), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L246-R252), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L252-R258), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L259-R265), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L288-R297), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L294-R303), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L301-R310), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L330-R342), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L336-R348), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L343-R355), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L372-R387), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L378-R393), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L385-R400), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L414-R432), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L420-R438), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L427-R445), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L456-R477), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L462-R483), [link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L469-R490))
*  Update checkout action from v2 to v4 and setup-node action from v2 to v4 and change node-version from 18 to 20 in the linter workflow to use the latest versions and features and to match the node version used in the deploy workflow ([link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L20-R25))
*  Update checkout action from v2 to v4 in the ossar-analysis workflow to use the latest version and features ([link](https://github.com/coronasafe/care_fe/pull/6863/files?diff=unified&w=0#diff-7cd443f044c5f7c14e50eaae01ea2bd45db414503d1eb8a520260d6790c05a1cL20-R20))
