### PR TITLE
fix resend otp in abdm aadhar signup

### DIFF
--- a/src/Components/ABDM/LinkABHANumberModal.tsx
+++ b/src/Components/ABDM/LinkABHANumberModal.tsx
@@ -423,7 +423,7 @@ const VerifyAadhaarSection = ({
     if (!validateAadhaar() || !txnId) return;
 
     setIsSendingOtp(true);
-    const { res, data } = await request(routes.abha.generateAadhaarOtp, {
+    const { res, data } = await request(routes.abha.resendAadhaarOtp, {
       body: {
         txnId: txnId,
       },

--- a/src/Components/ABDM/LinkABHANumberModal.tsx
+++ b/src/Components/ABDM/LinkABHANumberModal.tsx
@@ -13,6 +13,7 @@ import TextFormField from "../Form/FormFields/TextFormField";
 import { classNames } from "../../Utils/utils";
 import request from "../../Utils/request/request";
 import routes from "../../Redux/api";
+import { ABDMError } from "./models";
 
 export const validateRule = (
   condition: boolean,
@@ -427,6 +428,7 @@ const VerifyAadhaarSection = ({
       body: {
         txnId: txnId,
       },
+      silent: true,
     });
     setIsSendingOtp(false);
 
@@ -436,7 +438,15 @@ const VerifyAadhaarSection = ({
         msg: "OTP has been resent to the mobile number registered with the Aadhar number.",
       });
     } else {
-      Notify.Error({ msg: JSON.stringify(data) });
+      Notify.Error({
+        msg:
+          (data as unknown as ABDMError).details
+            ?.map((detail) => detail.message)
+            .join(", ")
+            .trim() ||
+          (data as unknown as ABDMError).message ||
+          "OTP resend failed",
+      });
     }
   };
 

--- a/src/Components/ABDM/models.ts
+++ b/src/Components/ABDM/models.ts
@@ -48,6 +48,15 @@ export interface IHealthId {
   authMethods?: string[];
 }
 
+export interface ABDMError {
+  code: string;
+  details?: {
+    code: string;
+    message: string;
+  }[];
+  message: string;
+}
+
 export interface IAadhaarOtp {
   txnId: string;
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3348268</samp>

Fixed a bug in the `LinkABHANumberModal` component that prevented resending the Aadhaar OTP. Changed the API route for resending the OTP from `generateAadhaarOtp` to `resendAadhaarOtp`.

## Proposed Changes

- fix resend otp in abdm aadhar signup

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3348268</samp>

* Fix the OTP resend functionality in the `VerifyAadhaarSection` component by using the correct API route ([link](https://github.com/coronasafe/care_fe/pull/6867/files?diff=unified&w=0#diff-36ceb941bf1280680ee1b3afa1184ca349e7e1132cd1ba6cd45c8d4225862079L426-R426))
