### PR TITLE
daily rounds, clone last default to null

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -50,7 +50,7 @@ const initForm: any = {
   admitted_to: "",
   taken_at: null,
   rounds_type: "NORMAL",
-  clone_last: true,
+  clone_last: null,
   systolic: null,
   diastolic: null,
   pulse: null,

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -644,6 +644,7 @@ export const DailyRounds = (props: any) => {
           <Cancel onClick={() => goBack()} />
           <Submit
             disabled={
+              buttonText === "Save" &&
               state.form.clone_last !== null &&
               !state.form.clone_last &&
               formFields.every(

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -50,7 +50,7 @@ const initForm: any = {
   admitted_to: "",
   taken_at: null,
   rounds_type: "NORMAL",
-  clone_last: null,
+  clone_last: false,
   systolic: null,
   diastolic: null,
   pulse: null,
@@ -223,7 +223,7 @@ export const DailyRounds = (props: any) => {
                 RHYTHM_CHOICES.find((i) => i.text === res.data.rhythm)?.id) ||
               "0",
             temperature: parseFloat(res.data.temperature),
-            clone_last: res.data.count > 0 ? true : false,
+            // clone_last: res.data.count > 0 ? true : false,
           },
         });
       }
@@ -250,12 +250,6 @@ export const DailyRounds = (props: any) => {
             invalidForm = true;
           }
           return;
-        case "clone_last":
-          if (state.form.clone_last === null) {
-            errors[field] = "Please choose a value";
-            invalidForm = true;
-          }
-          return;
 
         default:
           return;
@@ -271,7 +265,7 @@ export const DailyRounds = (props: any) => {
     if (validForm) {
       setIsLoading(true);
       const baseData = {
-        clone_last: state.form.clone_last,
+        clone_last: state.form.clone_last ?? false,
         rounds_type: state.form.rounds_type,
         patient_category: state.form.patient_category,
         taken_at: state.form.taken_at
@@ -479,7 +473,7 @@ export const DailyRounds = (props: any) => {
           />
         )}
 
-        {(state.form.clone_last === false || id) && (
+        {(!state.form.clone_last || id) && (
           <div className="grid grid-cols-1 gap-x-6 md:grid-cols-2">
             <TextAreaFormField
               {...field("physical_examination_info")}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a273d25</samp>

Fixed a bug in the daily rounds form where the `clone_last` option was always checked. Changed the initial value of `clone_last` to `null` and updated it based on user input in `DailyRounds.tsx`.

## Proposed Changes

- daily rounds, clone last default to null

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a273d25</samp>

*  Fixed a bug where the clone last option was always checked by default in the daily rounds form ([link](https://github.com/coronasafe/care_fe/pull/6872/files?diff=unified&w=0#diff-2b725d1dcc3aabbc0438aff687d8c29b79847cde3ea5e171e86ca113a4e6a612L53-R53))
