### PR TITLE
Use resolved_middleware for overrides

### DIFF
--- a/src/Components/Assets/AssetType/HL7Monitor.tsx
+++ b/src/Components/Assets/AssetType/HL7Monitor.tsx
@@ -1,5 +1,5 @@
 import { SyntheticEvent, useEffect, useState } from "react";
-import { AssetData } from "../AssetTypes";
+import { AssetData, ResolvedMiddleware } from "../AssetTypes";
 import * as Notification from "../../../Utils/Notifications.js";
 import MonitorConfigure from "../configure/MonitorConfigure";
 import Loading from "../../Common/Loading";
@@ -13,7 +13,6 @@ import VentilatorPatientVitalsMonitor from "../../VitalsMonitor/VentilatorPatien
 import useAuthUser from "../../../Common/hooks/useAuthUser";
 import request from "../../../Utils/request/request";
 import routes from "../../../Redux/api";
-import useQuery from "../../../Utils/request/useQuery";
 
 interface HL7MonitorProps {
   assetId: string;
@@ -22,27 +21,20 @@ interface HL7MonitorProps {
 }
 
 const HL7Monitor = (props: HL7MonitorProps) => {
-  const { assetId, asset, facilityId } = props;
+  const { assetId, asset } = props;
   const [assetType, setAssetType] = useState("");
   const [middlewareHostname, setMiddlewareHostname] = useState("");
-  const [facilityMiddlewareHostname, setFacilityMiddlewareHostname] =
-    useState("");
+  const [resolvedMiddleware, setResolvedMiddleware] =
+    useState<ResolvedMiddleware>();
   const [isLoading, setIsLoading] = useState(true);
   const [localipAddress, setLocalIPAddress] = useState("");
   const [ipadrdress_error, setIpAddress_error] = useState("");
   const authUser = useAuthUser();
-  const { data: facility, loading } = useQuery(routes.getPermittedFacility, {
-    pathParams: { id: facilityId },
-    onResponse: ({ res, data }) => {
-      if (res?.status === 200 && data && data.middleware_address) {
-        setFacilityMiddlewareHostname(data.middleware_address);
-      }
-    },
-  });
 
   useEffect(() => {
     setAssetType(asset?.asset_class);
     setMiddlewareHostname(asset?.meta?.middleware_hostname);
+    setResolvedMiddleware(asset?.resolved_middleware);
     setLocalIPAddress(asset?.meta?.local_ip_address);
     setIsLoading(false);
   }, [asset]);
@@ -76,10 +68,7 @@ const HL7Monitor = (props: HL7MonitorProps) => {
     }
   };
 
-  const fallbackMiddleware =
-    asset?.location_object?.middleware_address || facilityMiddlewareHostname;
-
-  if (isLoading || loading || !facility) return <Loading />;
+  if (isLoading) return <Loading />;
   return (
     <div className="mx-auto flex w-full xl:mt-8">
       <div className="mx-auto flex flex-col gap-4 xl:flex-row-reverse">
@@ -94,23 +83,21 @@ const HL7Monitor = (props: HL7MonitorProps) => {
                     label={
                       <div className="flex flex-row gap-1">
                         <p>Middleware Hostname</p>
-                        {!middlewareHostname && (
+                        {resolvedMiddleware?.source != "asset" && (
                           <div className="tooltip">
                             <CareIcon
                               icon="l-info-circle"
                               className="tooltip text-indigo-500 hover:text-indigo-600"
                             />
                             <span className="tooltip-text w-56 whitespace-normal">
-                              Middleware hostname sourced from{" "}
-                              {asset?.location_object?.middleware_address
-                                ? "asset location"
-                                : "asset facility"}
+                              Middleware hostname sourced from asset{" "}
+                              {resolvedMiddleware?.source}
                             </span>
                           </div>
                         )}
                       </div>
                     }
-                    placeholder={fallbackMiddleware}
+                    placeholder={resolvedMiddleware?.hostname}
                     value={middlewareHostname}
                     onChange={(e) => setMiddlewareHostname(e.value)}
                     errorClassName="hidden"
@@ -140,16 +127,12 @@ const HL7Monitor = (props: HL7MonitorProps) => {
 
         {assetType === "HL7MONITOR" && (
           <HL7PatientVitalsMonitor
-            socketUrl={`wss://${
-              middlewareHostname || fallbackMiddleware
-            }/observations/${localipAddress}`}
+            socketUrl={`wss://${resolvedMiddleware?.hostname}/observations/${localipAddress}`}
           />
         )}
         {assetType === "VENTILATOR" && (
           <VentilatorPatientVitalsMonitor
-            socketUrl={`wss://${
-              middlewareHostname || fallbackMiddleware
-            }/observations/${localipAddress}`}
+            socketUrl={`wss://${resolvedMiddleware?.hostname}/observations/${localipAddress}`}
           />
         )}
       </div>

--- a/src/Components/Assets/AssetTypes.tsx
+++ b/src/Components/Assets/AssetTypes.tsx
@@ -20,7 +20,6 @@ export interface AssetLocationObject {
     id: string;
     name: string;
   };
-  middleware_address?: string;
 }
 
 export enum AssetType {
@@ -73,6 +72,11 @@ export interface AssetService {
   note: string;
 }
 
+export interface ResolvedMiddleware {
+  hostname: string;
+  source: "asset" | "location" | "facility";
+}
+
 export interface AssetData {
   id: string;
   name: string;
@@ -94,6 +98,7 @@ export interface AssetData {
   qr_code_id: string;
   manufacturer: string;
   warranty_amc_end_of_validity: string;
+  resolved_middleware?: ResolvedMiddleware;
   last_service: AssetService;
   meta?: {
     [key: string]: any;

--- a/src/Components/CameraFeed/CameraFeed.tsx
+++ b/src/Components/CameraFeed/CameraFeed.tsx
@@ -14,7 +14,6 @@ import Fullscreen from "../../CAREUI/misc/Fullscreen";
 interface Props {
   children?: React.ReactNode;
   asset: AssetData;
-  fallbackMiddleware: string; // TODO: remove this in favour of `asset.resolved_middleware.hostname` once https://github.com/coronasafe/care/pull/1741 is merged
   preset?: PTZPayload;
   silent?: boolean;
   className?: string;
@@ -29,7 +28,7 @@ interface Props {
 
 export default function CameraFeed(props: Props) {
   const playerRef = useRef<HTMLVideoElement | ReactPlayer | null>(null);
-  const streamUrl = getStreamUrl(props.asset, props.fallbackMiddleware);
+  const streamUrl = getStreamUrl(props.asset);
 
   const player = usePlayer(streamUrl, playerRef);
   const operate = useOperateCamera(props.asset.id, props.silent);

--- a/src/Components/CameraFeed/CameraFeedWithBedPresets.tsx
+++ b/src/Components/CameraFeed/CameraFeedWithBedPresets.tsx
@@ -5,7 +5,6 @@ import AssetBedSelect from "./AssetBedSelect";
 
 interface Props {
   asset: AssetData;
-  fallbackMiddleware?: string;
 }
 
 export default function LocationFeedTile(props: Props) {
@@ -14,7 +13,6 @@ export default function LocationFeedTile(props: Props) {
   return (
     <CameraFeed
       asset={props.asset}
-      fallbackMiddleware={props.fallbackMiddleware as string}
       silent
       preset={preset?.meta.position}
       shortcutsDisabled

--- a/src/Components/CameraFeed/CentralLiveMonitoring/index.tsx
+++ b/src/Components/CameraFeed/CentralLiveMonitoring/index.tsx
@@ -67,13 +67,7 @@ export default function CentralLiveMonitoring(props: { facilityId: string }) {
           <div className="mt-1 grid grid-cols-1 place-content-center gap-1 lg:grid-cols-2 3xl:grid-cols-3">
             {data.results.map((asset) => (
               <div className="text-clip" key={asset.id}>
-                <LocationFeedTile
-                  asset={asset}
-                  fallbackMiddleware={
-                    asset.location_object.middleware_address ||
-                    facilityQuery.data?.middleware_address
-                  }
-                />
+                <LocationFeedTile asset={asset} />
               </div>
             ))}
           </div>

--- a/src/Components/CameraFeed/utils.ts
+++ b/src/Components/CameraFeed/utils.ts
@@ -17,9 +17,9 @@ export const calculateVideoDelay = (
   return playedDuration - video.currentTime;
 };
 
-export const getStreamUrl = (asset: AssetData, fallbackMiddleware?: string) => {
+export const getStreamUrl = (asset: AssetData) => {
   const config = getCameraConfig(asset);
-  const host = config.middleware_hostname || fallbackMiddleware;
+  const host = asset.resolved_middleware?.hostname;
   const uuid = config.accessKey;
 
   return isIOS

--- a/src/Components/Common/FilePreviewDialog.tsx
+++ b/src/Components/Common/FilePreviewDialog.tsx
@@ -192,7 +192,7 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
                           />
                         ) : (
                           <iframe
-                            sandbox
+                            sandbox=""
                             title="Source Files"
                             src={fileUrl}
                             className="mx-auto h-5/6 w-5/6 border-2 border-black bg-white md:my-6 md:w-4/6"

--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -86,8 +86,7 @@ export default function CentralNursingStation({ facilityId }: Props) {
       setTotalCount(res.data.count);
       setData(
         entries.map(({ patient, asset, bed }) => {
-          const middleware =
-            asset.meta?.middleware_hostname || facilityObj?.middleware_address;
+          const middleware = asset.resolved_middleware?.hostname;
           const local_ip_address = asset.meta?.local_ip_address;
 
           return {

--- a/src/Components/Facility/Consultations/Feed.tsx
+++ b/src/Components/Facility/Consultations/Feed.tsx
@@ -27,6 +27,7 @@ import { triggerGoal } from "../../../Integrations/Plausible.js";
 import useAuthUser from "../../../Common/hooks/useAuthUser.js";
 import Spinner from "../../Common/Spinner.js";
 import useQuery from "../../../Utils/request/useQuery.js";
+import { ResolvedMiddleware } from "../../Assets/AssetTypes.js";
 
 interface IFeedProps {
   facilityId: string;
@@ -35,7 +36,7 @@ interface IFeedProps {
 
 const PATIENT_DEFAULT_PRESET = "Patient View".trim().toLowerCase();
 
-export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
+export const Feed: React.FC<IFeedProps> = ({ consultationId }) => {
   const dispatch: any = useDispatch();
 
   const videoWrapper = useRef<HTMLDivElement>(null);
@@ -55,24 +56,9 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
   const [isFullscreen, setFullscreen] = useFullscreen();
   const [videoStartTime, setVideoStartTime] = useState<Date | null>(null);
   const [statusReported, setStatusReported] = useState(false);
-  const [facilityMiddlewareHostname, setFacilityMiddlewareHostname] =
-    useState("");
+  const [resolvedMiddleware, setResolvedMiddleware] =
+    useState<ResolvedMiddleware>();
   const authUser = useAuthUser();
-
-  useQuery(routes.getPermittedFacility, {
-    pathParams: { id: facilityId || "" },
-    onResponse: ({ res, data }) => {
-      if (res && res.status === 200 && data && data.middleware_address) {
-        setFacilityMiddlewareHostname(data.middleware_address);
-      }
-    },
-  });
-
-  const fallbackMiddleware =
-    cameraAsset.location_middleware || facilityMiddlewareHostname;
-
-  const currentMiddleware =
-    cameraAsset.middleware_address || fallbackMiddleware;
 
   useEffect(() => {
     if (cameraState) {
@@ -136,6 +122,9 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
                   bedAssets.data.results[0].asset_object.location_object
                     ?.middleware_address,
               });
+              setResolvedMiddleware(
+                bedAssets.data.results[0].asset_object.resolved_middleware
+              );
               setCameraConfig(bedAssets.data.results[0].meta);
               setCameraState({
                 ...bedAssets.data.results[0].meta.position,
@@ -173,8 +162,8 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
   );
 
   const url = !isIOS
-    ? `wss://${currentMiddleware}/stream/${cameraAsset?.accessKey}/channel/0/mse?uuid=${cameraAsset?.accessKey}&channel=0`
-    : `https://${currentMiddleware}/stream/${cameraAsset?.accessKey}/channel/0/hls/live/index.m3u8?uuid=${cameraAsset?.accessKey}&channel=0`;
+    ? `wss://${resolvedMiddleware?.hostname}/stream/${cameraAsset?.accessKey}/channel/0/mse?uuid=${cameraAsset?.accessKey}&channel=0`
+    : `https://${resolvedMiddleware?.hostname}/stream/${cameraAsset?.accessKey}/channel/0/hls/live/index.m3u8?uuid=${cameraAsset?.accessKey}&channel=0`;
 
   const {
     startStream,
@@ -185,7 +174,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
     : // eslint-disable-next-line react-hooks/rules-of-hooks
       useMSEMediaPlayer({
         config: {
-          middlewareHostname: currentMiddleware,
+          middlewareHostname: resolvedMiddleware?.hostname ?? "",
           ...cameraAsset,
         },
         url,
@@ -254,7 +243,7 @@ export const Feed: React.FC<IFeedProps> = ({ consultationId, facilityId }) => {
       });
       getBedPresets(cameraAsset);
     }
-  }, [cameraAsset, currentMiddleware]);
+  }, [cameraAsset, resolvedMiddleware?.hostname]);
 
   useEffect(() => {
     let tId: any;


### PR DESCRIPTION
## Proposed Changes

- Fixes #6803
- Fixes #6523
This pull request refactors the usage of the middleware hostname in the CameraFeed components. It removes the fallbackMiddleware prop and replaces it with the resolved_middleware.hostname property from the asset object. This improves the code readability and simplifies the logic.

![image](https://github.com/coronasafe/care_fe/assets/3626859/5bc5794b-5b77-486a-805d-e32039bf36a7)
![image](https://github.com/coronasafe/care_fe/assets/3626859/c098218e-155f-4377-b85e-15762fa1e39c)
![image](https://github.com/coronasafe/care_fe/assets/3626859/b2282458-b653-41ab-9658-64fddaec0e6a)
![image](https://github.com/coronasafe/care_fe/assets/3626859/7486df1d-989b-42d1-b7bf-e0ae6e6f4d43)
![image](https://github.com/coronasafe/care_fe/assets/3626859/ca2978cf-49f4-4bc5-9c4c-891ce7198bab)
![image](https://github.com/coronasafe/care_fe/assets/3626859/0700223c-9d87-4d69-a312-26991ffc19c4)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

### HOW
copilot:walkthrough
