### PR TITLE
Fix pincode district name comparison

### DIFF
--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -707,7 +707,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
     if (!fetchedDistricts) return;
 
     const matchedDistrict = fetchedDistricts.find((district) => {
-      return includesIgnoreCase(district.name, pincodeDetails.district);
+      return includesIgnoreCase(district.name, pincodeDetails.districtname);
     });
     if (!matchedDistrict) return;
 


### PR DESCRIPTION
This pull request fixes the pincode district name comparison in the PatientRegister component. Previously, the comparison was using the wrong property name, resulting in incorrect matching. This PR updates the code to use the correct property name, ensuring accurate district matching.