### PR TITLE
Remove scroll bar when header text overflows in patient details. 

### DIFF
--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -311,20 +311,18 @@ export const PatientHome = (props: any) => {
     patientData.medical_history.length
   ) {
     const medHis = patientData.medical_history;
-    patientMedHis = medHis.map((item: any, idx: number) => (
-      <>
-        {item?.disease !== "NO" && (
-          <div className="sm:col-span-1" key={`med_his_${idx}`}>
-            <div className="break-words text-sm font-semibold leading-5 text-zinc-400">
-              {item.disease}
-            </div>
-            <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
-              {item.details}
-            </div>
+    patientMedHis = medHis
+      .filter((item) => item.disease !== "NO")
+      .map((item, idx) => (
+        <div className="sm:col-span-1" key={`med_his_${idx}`}>
+          <div className="break-words text-sm font-semibold leading-5 text-zinc-400">
+            {item.disease}
           </div>
-        )}
-      </>
-    ));
+          <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
+            {item.details}
+          </div>
+        </div>
+      ));
   }
 
   let consultationList, sampleList;

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -312,18 +312,18 @@ export const PatientHome = (props: any) => {
   ) {
     const medHis = patientData.medical_history;
     patientMedHis = medHis.map((item: any, idx: number) => (
-      <div className="sm:col-span-1" key={`med_his_${idx}`}>
+      <>
         {item?.disease !== "NO" && (
-          <>
-            <div className="overflow-x-scroll text-sm font-semibold leading-5 text-zinc-400">
+          <div className="sm:col-span-1" key={`med_his_${idx}`}>
+            <div className="break-words text-sm font-semibold leading-5 text-zinc-400">
               {item.disease}
             </div>
-            <div className="mt-1 overflow-x-scroll whitespace-normal break-words text-sm font-medium leading-5">
+            <div className="mt-1 whitespace-normal break-words text-sm font-medium leading-5">
               {item.details}
             </div>
-          </>
+          </div>
         )}
-      </div>
+      </>
     ));
   }
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #6902 
- Removed overflow-x and added break-words class
- Also remove space when No is selected in diseases 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
