### PR TITLE
Rename encounter date field labels

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1213,9 +1213,9 @@ export const ConsultationForm = (props: any) => {
                           A: "Date & Time of Admission to the Facility",
                           DC: "Date & Time of Domiciliary Care commencement",
                           OP: "Date & Time of Out-patient visit",
-                          DD: "Date & Time of Encounter",
-                          HI: "Date & Time of Encounter",
-                          R: "Date & Time of Encounter",
+                          DD: "Date & Time of Consultation",
+                          HI: "Date & Time of Consultation",
+                          R: "Date & Time of Consultation",
                         }[state.form.suggestion]
                       }
                       type="datetime-local"


### PR DESCRIPTION
## Proposed Changes

- Rename encounter date field labels to "Date and Time of Consutation" for referred to, home isolation and declare death.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
