### PR TITLE
Fixes additional scroll in shifting and resource tab

### DIFF
--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -37,7 +37,7 @@ export default function BoardView() {
   };
 
   return (
-    <div className="flex h-screen flex-col px-2 pb-2">
+    <div className="flex flex-col px-2 pb-2">
       <div className="flex w-full flex-col items-center justify-between lg:flex-row">
         <div className="w-1/3 lg:w-1/4">
           <PageTitle

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -58,7 +58,7 @@ export default function BoardView() {
   const { t } = useTranslation();
 
   return (
-    <div className="flex h-screen flex-col px-2 pb-2">
+    <div className="flex  flex-col px-2 pb-2">
       <div className="flex w-full flex-col items-center justify-between lg:flex-row">
         <div className="w-1/3 lg:w-1/4">
           <PageTitle


### PR DESCRIPTION
## Proposed Changes

- temporary fix for  #6636 
- Before
![image](https://github.com/coronasafe/care_fe/assets/101407963/e73fa418-1ca5-440a-9087-1c90cbc5bc0a)
![image](https://github.com/coronasafe/care_fe/assets/101407963/413c1d02-bd27-4b9e-b902-2c35fb32b592)

- After
![image](https://github.com/coronasafe/care_fe/assets/101407963/bff11091-3cd2-4be4-9560-61d14b38dc20)
![image](https://github.com/coronasafe/care_fe/assets/101407963/0899c38a-4ebb-4f3e-91ba-b40f5b7c5792)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
