### PR TITLE
Add consultation_filed filter to Patients list

### DIFF
--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -110,6 +110,7 @@ export const PatientManager = () => {
   const [districtName, setDistrictName] = useState("");
   const [localbodyName, setLocalbodyName] = useState("");
   const [facilityBadgeName, setFacilityBadge] = useState("");
+  const [consultationFiledBadgeName, setConsultationFiledBadge] = useState("");
   const [locationBadgeName, setLocationBadge] = useState("");
   const [phone_number, setPhoneNumber] = useState("");
   const [phoneNumberError, setPhoneNumberError] = useState("");
@@ -194,6 +195,7 @@ export const PatientManager = () => {
     date_of_result_after: qParams.date_of_result_after || undefined,
     last_consultation_medico_legal_case:
       qParams.last_consultation_medico_legal_case || undefined,
+    consultation_filed: qParams.consultation_filed || undefined,
     last_consultation_encounter_date_before:
       qParams.last_consultation_encounter_date_before || undefined,
     last_consultation_encounter_date_after:
@@ -386,9 +388,20 @@ export const PatientManager = () => {
     qParams.last_vaccinated_date_before,
     qParams.last_vaccinated_date_after,
     qParams.last_consultation_is_telemedicine,
+    qParams.consultation_filed,
     qParams.is_antenatal,
     qParams.ventilator_interface,
   ]);
+
+  useEffect(() => {
+    if (qParams.consultation_filed != null) {
+      setConsultationFiledBadge(
+        qParams.consultation_filed === "true" ? "Filed" : "Not Filed"
+      );
+    } else {
+      setConsultationFiledBadge("");
+    }
+  }, [qParams.consultation_filed]);
 
   const getTheCategoryFromId = () => {
     let category_name;
@@ -977,6 +990,11 @@ export const PatientManager = () => {
             badge(
               "Is Medico-Legal Case",
               "last_consultation_medico_legal_case"
+            ),
+            value(
+              "Consultation Status",
+              "consultation_filed",
+              consultationFiledBadgeName
             ),
             value("Facility", "facility", facilityBadgeName),
             value(

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -96,6 +96,7 @@ export default function PatientFilter(props: any) {
     last_vaccinated_date_after: filter.last_vaccinated_date_after || null,
     last_consultation_is_telemedicine:
       filter.last_consultation_is_telemedicine || null,
+    consultation_filed: filter.consultation_filed || null,
     is_antenatal: filter.is_antenatal || null,
     ventilator_interface: filter.ventilator_interface || null,
   });
@@ -131,6 +132,7 @@ export default function PatientFilter(props: any) {
     last_consultation_discharge_date_after: "",
     last_consultation_admitted_to_list: [],
     last_consultation_current_bed__location: "",
+    consultation_filed: null,
     srf_id: "",
     number_of_doses: null,
     covin_id: "",
@@ -253,6 +255,7 @@ export default function PatientFilter(props: any) {
       last_vaccinated_date_before,
       last_vaccinated_date_after,
       last_consultation_is_telemedicine,
+      consultation_filed,
       is_antenatal,
       ventilator_interface,
     } = filterState;
@@ -315,6 +318,7 @@ export default function PatientFilter(props: any) {
       last_vaccinated_date_after: dateQueryString(last_vaccinated_date_after),
       last_consultation_is_telemedicine:
         last_consultation_is_telemedicine || "",
+      consultation_filed: consultation_filed || "",
       is_antenatal: is_antenatal || "",
       ventilator_interface: ventilator_interface || "",
     };
@@ -497,6 +501,23 @@ export default function PatientFilter(props: any) {
                 setFilterState({
                   ...filterState,
                   last_consultation_medico_legal_case: v,
+                })
+              }
+            />
+          </div>
+          <div className="w-full flex-none">
+            <FieldLabel className="text-sm">Consultation Status</FieldLabel>
+            <SelectMenuV2
+              placeholder="Show all"
+              options={["true", "false"]}
+              optionLabel={(o) =>
+                o === "true" ? "Consultation Filed" : "No Consultation Filed"
+              }
+              value={filterState.consultation_filed}
+              onChange={(v) =>
+                setFilterState({
+                  ...filterState,
+                  consultation_filed: v,
                 })
               }
             />


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/6921

Backend: https://github.com/coronasafe/care/pull/1789

This pull request adds a new filter option, consultation_filed, to the Patients list. This filter allows users to search for patients based on whether their consultation has been filed or not.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers