### PR TITLE
Add consciousness level options for normal daily round type

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -300,6 +300,19 @@ export const DISCHARGE_REASONS = [
   { id: "LAMA", text: "LAMA" },
 ];
 
+export const CONSCIOUSNESS_LEVEL = [
+  { id: "UNRESPONSIVE", text: "Unresponsive" },
+  { id: "RESPONDS_TO_PAIN", text: "Responds to Pain" },
+  { id: "RESPONDS_TO_VOICE", text: "Responds to Voice" },
+  { id: "ALERT", text: "Alert" },
+  { id: "AGITATED_OR_CONFUSED", text: "Agitated or Confused" },
+  {
+    id: "Onset of Agitation and Confusion",
+    text: "Onset of Agitation and Confusion",
+  },
+  { id: "UNKNOWN", text: "Unknown" },
+];
+
 export const LINES_CATHETER_CHOICES: Array<OptionsType> = [
   { id: 1, text: "CVP catheter " },
   { id: 2, text: "Arterial Line" },

--- a/src/Components/Form/FormFields/RadioFormField.tsx
+++ b/src/Components/Form/FormFields/RadioFormField.tsx
@@ -5,13 +5,14 @@ type Props<T> = FormFieldBaseProps<string> & {
   options: T[];
   optionDisplay: (option: T) => React.ReactNode;
   optionValue: (option: T) => string;
+  containerClassName?: string;
 };
 
 const RadioFormField = <T,>(props: Props<T>) => {
   const field = useFormFieldPropsResolver(props);
   return (
     <FormField field={field}>
-      <div className="flex gap-4 p-4">
+      <div className={props.containerClassName || "flex gap-4 p-4"}>
         {props.options.map((option, idx) => {
           const value = props.optionValue(option);
           const optionId = `${props.name}-${idx}`;

--- a/src/Components/Patient/DailyRoundListDetails.tsx
+++ b/src/Components/Patient/DailyRoundListDetails.tsx
@@ -1,6 +1,10 @@
 import { lazy, useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
-import { CURRENT_HEALTH_CHANGE, SYMPTOM_CHOICES } from "../../Common/constants";
+import {
+  CONSCIOUSNESS_LEVEL,
+  CURRENT_HEALTH_CHANGE,
+  SYMPTOM_CHOICES,
+} from "../../Common/constants";
 import { statusType, useAbortableEffect } from "../../Common/utils";
 import { getConsultationDailyRoundsDetails } from "../../Redux/actions";
 import { DailyRoundsModel } from "./models";
@@ -182,6 +186,16 @@ export const DailyRoundListDetails = (props: any) => {
               Rhythm Description:{" "}
             </span>
             {dailyRoundListDetailsData.rhythm_detail ?? "-"}
+          </div>
+          <div className="md:col-span-2">
+            <span className="font-semibold leading-relaxed">
+              Level Of Consciousness:{" "}
+            </span>
+            {dailyRoundListDetailsData.consciousness_level
+              ? CONSCIOUSNESS_LEVEL.find(
+                  (i) => i.id === dailyRoundListDetailsData.consciousness_level
+                )?.text
+              : "-"}
           </div>
           <div>
             <span className="font-semibold leading-relaxed">

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -4,6 +4,7 @@ import dayjs from "dayjs";
 import { lazy, useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import {
+  CONSCIOUSNESS_LEVEL,
   PATIENT_CATEGORIES,
   REVIEW_AT_CHOICES,
   RHYTHM_CHOICES,
@@ -35,6 +36,7 @@ import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
 import TextFormField from "../Form/FormFields/TextFormField";
 import { FieldChangeEvent } from "../Form/FormFields/Utils";
 import PatientCategorySelect from "./PatientCategorySelect";
+import RadioFormField from "../Form/FormFields/RadioFormField";
 const Loading = lazy(() => import("../Common/Loading"));
 
 const initForm: any = {
@@ -59,6 +61,7 @@ const initForm: any = {
   rhythm: "0",
   rhythm_detail: "",
   ventilator_spo2: null,
+  consciousness_level: "Unknown",
   // bed: null,
 };
 
@@ -129,6 +132,7 @@ export const DailyRounds = (props: any) => {
     "ventilator_spo2",
     "rhythm",
     "rhythm_detail",
+    "consciousness_level",
   ];
 
   useEffect(() => {
@@ -312,6 +316,7 @@ export const DailyRounds = (props: any) => {
             rhythm: Number(state.form.rhythm) || 0,
             rhythm_detail: state.form.rhythm_detail,
             ventilator_spo2: state.form.ventilator_spo2,
+            consciousness_level: state.form.consciousness_level,
           };
         }
       } else {
@@ -637,9 +642,21 @@ export const DailyRounds = (props: any) => {
 
                 <TextAreaFormField
                   {...field("rhythm_detail")}
-                  className="md:col-span-2"
+                  className="md:col-span-1"
                   label="Rhythm Description"
-                  rows={5}
+                  rows={7}
+                />
+
+                <RadioFormField
+                  label="Level Of Consciousness"
+                  {...field("consciousness_level")}
+                  options={CONSCIOUSNESS_LEVEL.map((level) => ({
+                    label: level.text,
+                    value: level.id,
+                  }))}
+                  optionDisplay={(option) => option.label}
+                  optionValue={(option) => option.value}
+                  containerClassName="grid gap-1 grid-cols-1"
                 />
               </>
             )}


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/6839

This pull request adds the option to select the level of consciousness for the normal daily round type. It includes changes to the constants file, form fields, and the daily rounds component.

![image](https://github.com/coronasafe/care_fe/assets/3626859/90dbd7a5-d9f1-4c8c-807f-e17c3ce68205)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers