### PR TITLE
fix resp. rate from being 0 instead of null when unset

### DIFF
--- a/src/CAREUI/display/RecordMeta.tsx
+++ b/src/CAREUI/display/RecordMeta.tsx
@@ -1,7 +1,8 @@
 import CareIcon from "../icons/CareIcon";
 import {
-  formatDateTime,
+  formatDate,
   formatName,
+  formatTime,
   isUserOnline,
   relativeTime,
 } from "../../Utils/utils";
@@ -37,8 +38,9 @@ const RecordMeta = ({
   let child = (
     <div className="tooltip">
       <span className="underline">{relativeTime(time)}</span>
-      <span className="tooltip-text tooltip-left flex gap-1 text-xs font-medium tracking-wider">
-        {formatDateTime(time)}
+      <span className="tooltip-text tooltip-bottom flex -translate-x-1/2 gap-1 text-xs font-medium tracking-wider">
+        {formatTime(time)} <br />
+        {formatDate(time)}
         {user && !inlineUser && (
           <span className="flex items-center gap-1">
             by

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -296,9 +296,9 @@ export const DailyRounds = (props: any) => {
                   }
                 : undefined,
             pulse: state.form.pulse,
-            resp: Number(state.form.resp),
+            resp: state.form.resp,
             temperature: state.form.temperature,
-            rhythm: Number(state.form.rhythm) || 0,
+            rhythm: state.form.rhythm || 0,
             rhythm_detail: state.form.rhythm_detail,
             ventilator_spo2: state.form.ventilator_spo2,
             consciousness_level: state.form.consciousness_level,


### PR DESCRIPTION
## Proposed Changes

- fix resp. rate from being 0 instead of null when unset

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
