### PR TITLE
Hide delete facility option for users who dont have access

### DIFF
--- a/cypress/e2e/patient_spec/patient_crud.cy.ts
+++ b/cypress/e2e/patient_spec/patient_crud.cy.ts
@@ -8,7 +8,7 @@ import {
   emergency_phone_number,
   phone_number,
 } from "../../pageobject/constants";
-const yearOfBirth = "2023";
+const yearOfBirth = "2001";
 
 const calculateAge = () => {
   const currentYear = new Date().getFullYear();

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -99,6 +99,10 @@ export const FacilityHome = (props: any) => {
     USER_TYPES.findIndex((type) => type == authUser.user_type) >=
       StaffUserTypeIndex;
 
+  const hasPermissionToDeleteFacility =
+    authUser.user_type === "DistrictAdmin" ||
+    authUser.user_type === "StateAdmin";
+
   const editCoverImageTooltip = hasPermissionToEditCoverImage && (
     <div className="absolute right-0 top-0 z-10 flex h-full w-full flex-col items-center justify-center bg-black text-sm text-gray-300 opacity-0 transition-[opacity] hover:opacity-60 md:h-[88px]">
       <i className="fa-solid fa-pen" />
@@ -372,16 +376,18 @@ export const FacilityHome = (props: any) => {
                 >
                   View Users
                 </DropdownItem>
-                <DropdownItem
-                  id="delete-facility"
-                  variant="danger"
-                  onClick={() => setOpenDeleteDialog(true)}
-                  className="flex items-center gap-3"
-                  icon={<CareIcon className="care-l-trash-alt text-lg" />}
-                  authorizeFor={AuthorizeFor(["DistrictAdmin", "StateAdmin"])}
-                >
-                  Delete Facility
-                </DropdownItem>
+                {hasPermissionToDeleteFacility && (
+                  <DropdownItem
+                    id="delete-facility"
+                    variant="danger"
+                    onClick={() => setOpenDeleteDialog(true)}
+                    className="flex items-center gap-3"
+                    icon={<CareIcon className="care-l-trash-alt text-lg" />}
+                    authorizeFor={AuthorizeFor(["DistrictAdmin", "StateAdmin"])}
+                  >
+                    Delete Facility
+                  </DropdownItem>
+                )}
               </DropdownMenu>
             </div>
             <div className="flex flex-col justify-end">

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -1,6 +1,6 @@
 import * as Notification from "../../Utils/Notifications.js";
 
-import AuthorizeFor, { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
+import { NonReadOnlyUsers } from "../../Utils/AuthorizeFor";
 import { FacilityModel } from "./models";
 import { FACILITY_FEATURE_TYPES, USER_TYPES } from "../../Common/constants";
 import DropdownMenu, { DropdownItem } from "../Common/components/Menu";

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -383,7 +383,6 @@ export const FacilityHome = (props: any) => {
                     onClick={() => setOpenDeleteDialog(true)}
                     className="flex items-center gap-3"
                     icon={<CareIcon className="care-l-trash-alt text-lg" />}
-                    authorizeFor={AuthorizeFor(["DistrictAdmin", "StateAdmin"])}
                   >
                     Delete Facility
                   </DropdownItem>


### PR DESCRIPTION
## Proposed Changes

- Fixes #6608 
Hide delete facility option for users who don't have access

Admin View:
![image](https://github.com/coronasafe/care_fe/assets/70687348/b7dcbf98-a473-46e9-961f-9d6517796059)

Non admin view:
![image](https://github.com/coronasafe/care_fe/assets/70687348/32f398f1-d598-467c-a65a-1df6ab1bc762)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
