### PR TITLE
Fix conditional logic in PatientInfoCard

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -490,6 +490,7 @@ export default function PatientInfoCard(props: {
                           key={i}
                           className="dropdown-item-primary pointer-events-auto m-2 flex cursor-pointer items-center justify-start gap-2 rounded border-0 p-2 text-sm font-normal transition-all duration-200 ease-in-out"
                           href={
+                            action[1] !== "Treatment Summary" &&
                             consultation?.admitted &&
                             !consultation?.current_bed &&
                             i === 1
@@ -498,6 +499,7 @@ export default function PatientInfoCard(props: {
                           }
                           onClick={() => {
                             if (
+                              action[1] !== "Treatment Summary" &&
                               consultation?.admitted &&
                               !consultation?.current_bed &&
                               i === 1


### PR DESCRIPTION
This pull request fixes the conditional logic in the PatientInfoCard component. The issue was that the logic was not correctly checking for the "Treatment Summary" action and the consultation's admission and current bed status. This caused unexpected behavior when clicking on certain dropdown items. The fix ensures that the correct conditions are checked before executing the corresponding actions.