### PR TITLE
Fix blood pressure being negative values when field is cleared

### DIFF
--- a/src/Components/Common/BloodPressureFormField.tsx
+++ b/src/Components/Common/BloodPressureFormField.tsx
@@ -1,3 +1,4 @@
+import { FieldValidator } from "../Form/FieldValidators";
 import FormField from "../Form/FormFields/FormField";
 import RangeAutocompleteFormField from "../Form/FormFields/RangeAutocompleteFormField";
 import {
@@ -5,40 +6,36 @@ import {
   FormFieldBaseProps,
   useFormFieldPropsResolver,
 } from "../Form/FormFields/Utils";
+import { DailyRoundsModel } from "../Patient/models";
 
-export interface BloodPressure {
-  systolic: number;
-  diastolic: number;
-}
+type BloodPressure = NonNullable<DailyRoundsModel["bp"]>;
 
-type Props = FormFieldBaseProps<Partial<BloodPressure>>;
+type Props = FormFieldBaseProps<BloodPressure>;
 
 export default function BloodPressureFormField(props: Props) {
   const field = useFormFieldPropsResolver(props as any);
 
   const handleChange = (event: FieldChangeEvent<number>) => {
-    field.onChange({
-      name: field.name,
-      value: {
-        ...field.value,
-        [event.name]: event.value ?? -1,
-      },
-    });
+    const value: BloodPressure = {
+      ...field.value,
+      [event.name]: event.value,
+    };
+    value.mean = meanArterialPressure(value);
+    field.onChange({ name: field.name, value });
   };
 
   const map =
     !!props.value?.diastolic &&
     !!props.value.systolic &&
-    meanArterialPressure(props.value as BloodPressure);
+    meanArterialPressure(props.value);
 
   return (
     <FormField
       field={{
         ...field,
-        labelSuffix:
-          map && map !== -1 ? (
-            <span className="font-medium">MAP: {map.toFixed(1)}</span>
-          ) : undefined,
+        labelSuffix: map ? (
+          <span className="font-medium">MAP: {map.toFixed(1)}</span>
+        ) : undefined,
       }}
     >
       <div className="flex flex-row items-center">
@@ -108,5 +105,19 @@ export const meanArterialPressure = ({
   diastolic,
   systolic,
 }: BloodPressure) => {
-  return (2 * diastolic + systolic) / 3;
+  if (diastolic != null && systolic != null) {
+    return (2 * diastolic + systolic) / 3;
+  }
+};
+
+export const BPValidator: FieldValidator<BloodPressure> = (bp) => {
+  if (Object.values(bp).every((v) => v == null)) {
+    return;
+  }
+  if (bp.diastolic == null) {
+    return "Diastolic is missing. Either specify both or clear both.";
+  }
+  if (bp.systolic == null) {
+    return "Systolic is missing. Either specify both or clear both.";
+  }
 };

--- a/src/Components/Common/BloodPressureFormField.tsx
+++ b/src/Components/Common/BloodPressureFormField.tsx
@@ -110,7 +110,7 @@ export const meanArterialPressure = ({
   }
 };
 
-export const BPValidator: FieldValidator<BloodPressure> = (bp) => {
+export const BloodPressureValidator: FieldValidator<BloodPressure> = (bp) => {
   if (Object.values(bp).every((v) => v == null)) {
     return;
   }

--- a/src/Components/Facility/Consultations/Mews.tsx
+++ b/src/Components/Facility/Consultations/Mews.tsx
@@ -26,7 +26,6 @@ const getHeartRateScore = (value?: number) => {
 
 const getSystolicBPScore = (value?: number) => {
   if (typeof value !== "number") return;
-  if (value === -1) return;
 
   if (value <= 70) return 3;
   if (value <= 80) return 2;
@@ -38,7 +37,6 @@ const getSystolicBPScore = (value?: number) => {
 };
 
 const getTempRange = (value?: number) => {
-  console.log(value);
   if (typeof value !== "number") return;
 
   if (value < 95) return 2;

--- a/src/Components/Patient/DailyRoundListDetails.tsx
+++ b/src/Components/Patient/DailyRoundListDetails.tsx
@@ -158,20 +158,14 @@ export const DailyRoundListDetails = (props: any) => {
                 <span className="font-semibold leading-relaxed">
                   Systolic:{" "}
                 </span>
-                {dailyRoundListDetailsData.bp?.systolic &&
-                dailyRoundListDetailsData.bp?.systolic !== -1
-                  ? dailyRoundListDetailsData.bp?.systolic
-                  : "-"}
+                {dailyRoundListDetailsData.bp?.systolic ?? "-"}
               </div>
               <div className="flex">
                 {" "}
                 <span className="font-semibold leading-relaxed">
                   Diastolic:
                 </span>
-                {dailyRoundListDetailsData.bp?.diastolic &&
-                dailyRoundListDetailsData.bp?.diastolic !== -1
-                  ? dailyRoundListDetailsData.bp?.diastolic
-                  : "-"}
+                {dailyRoundListDetailsData.bp?.diastolic ?? "-"}
               </div>
             </div>
           </div>

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -140,8 +140,6 @@ export const DailyRounds = (props: any) => {
     "consciousness_level",
   ];
 
-  console.log(state.form.bp);
-
   const fetchRoundDetails = useCallback(
     async (status: statusType) => {
       setIsLoading(true);

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -23,7 +23,7 @@ import { DraftSection, useAutoSaveReducer } from "../../Utils/AutoSave";
 import * as Notification from "../../Utils/Notifications";
 import { formatDateTime } from "../../Utils/utils";
 import BloodPressureFormField, {
-  BPValidator,
+  BloodPressureValidator,
 } from "../Common/BloodPressureFormField";
 import { SymptomsSelect } from "../Common/SymptomsSelect";
 import TemperatureFormField from "../Common/TemperatureFormField";
@@ -250,7 +250,7 @@ export const DailyRounds = (props: any) => {
           }
           return;
         case "bp": {
-          const error = BPValidator(state.form.bp);
+          const error = BloodPressureValidator(state.form.bp);
           if (error) {
             errors.bp = error;
             invalidForm = true;

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -23,7 +23,7 @@ import { DraftSection, useAutoSaveReducer } from "../../Utils/AutoSave";
 import * as Notification from "../../Utils/Notifications";
 import { formatDateTime } from "../../Utils/utils";
 import BloodPressureFormField, {
-  meanArterialPressure,
+  BPValidator,
 } from "../Common/BloodPressureFormField";
 import { SymptomsSelect } from "../Common/SymptomsSelect";
 import TemperatureFormField from "../Common/TemperatureFormField";
@@ -63,9 +63,9 @@ const initForm: any = {
   ventilator_spo2: null,
   consciousness_level: "UNKNOWN",
   bp: {
-    systolic: -1,
-    diastolic: -1,
-    mean: -1,
+    systolic: undefined,
+    diastolic: undefined,
+    mean: undefined,
   },
   // bed: null,
 };
@@ -139,6 +139,8 @@ export const DailyRounds = (props: any) => {
     "rhythm_detail",
     "consciousness_level",
   ];
+
+  console.log(state.form.bp);
 
   const fetchRoundDetails = useCallback(
     async (status: statusType) => {
@@ -247,18 +249,14 @@ export const DailyRounds = (props: any) => {
             invalidForm = true;
           }
           return;
-        case "bp":
-          if (
-            (state.form.bp?.systolic &&
-              state.form.bp?.diastolic &&
-              state.form.bp.systolic !== -1 &&
-              state.form.bp.diastolic === -1) ||
-            (state.form.bp.systolic === -1 && state.form.bp.diastolic !== -1)
-          ) {
-            errors.bp = "Please enter both systolic and diastolic values";
+        case "bp": {
+          const error = BPValidator(state.form.bp);
+          if (error) {
+            errors.bp = error;
             invalidForm = true;
           }
           return;
+        }
         default:
           return;
       }
@@ -303,27 +301,7 @@ export const DailyRounds = (props: any) => {
         if (["NORMAL", "TELEMEDICINE"].includes(state.form.rounds_type)) {
           data = {
             ...data,
-            bp:
-              state.form.bp?.systolic !== -1 && state.form.bp?.diastolic !== -1
-                ? {
-                    systolic: state.form.bp?.systolic
-                      ? Number(state.form.bp?.systolic)
-                      : -1,
-                    diastolic: state.form.bp?.diastolic
-                      ? Number(state.form.bp?.diastolic)
-                      : -1,
-                    mean:
-                      state.form.bp?.systolic && state.form.bp?.diastolic
-                        ? parseFloat(
-                            meanArterialPressure(state.form.bp).toFixed(2)
-                          )
-                        : -1,
-                  }
-                : {
-                    systolic: -1,
-                    diastolic: -1,
-                    mean: -1,
-                  },
+            bp: state.form.bp ?? {},
             pulse: state.form.pulse ?? null,
             resp: state.form.resp ?? null,
             temperature: state.form.temperature ?? null,

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -282,9 +282,9 @@ export interface DailyRoundsModel {
   rhythm?: string;
   rhythm_detail?: string;
   bp?: {
-    diastolic: number;
-    mean: number;
-    systolic: number;
+    diastolic?: number;
+    mean?: number;
+    systolic?: number;
   };
   pulse?: number;
   resp?: number;
@@ -297,7 +297,7 @@ export interface DailyRoundsModel {
   medication_given?: Array<any>;
   additional_symptoms_text?: string;
   current_health?: string;
-  id: string;
+  id?: string;
   other_symptoms?: string;
   admitted_to?: string;
   patient_category?: PatientCategory;
@@ -314,7 +314,7 @@ export interface DailyRoundsModel {
     | "AGITATED_OR_CONFUSED"
     | "ONSET_OF_AGITATION_AND_CONFUSION"
     | "UNKNOWN";
-  rounds_type: (typeof DailyRoundTypes)[number];
+  rounds_type?: (typeof DailyRoundTypes)[number];
   last_updated_by_telemedicine?: boolean;
   created_by_telemedicine?: boolean;
   created_by?: {


### PR DESCRIPTION
## Proposed Changes

- Partial Fix #6984 
- Adds validator: BPValidator
- `BloodPressureFormField` now directly calculates the mean arterial pressure for you.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
