### PR TITLE
Fix: hide Monitors without a patient checkbox filter is not toggling

### DIFF
--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -48,7 +48,7 @@ export default function CentralNursingStation({ facilityId }: Props) {
       offset: (qParams.page ? qParams.page - 1 : 0) * PER_PAGE_LIMIT,
       asset_class: "HL7MONITOR",
       ordering: qParams.ordering || "bed__name",
-      bed_is_occupied: qParams.hide_monitors_without_patient ? true : false,
+      bed_is_occupied: qParams.hide_monitors_without_patient === "true",
     },
   });
 
@@ -190,7 +190,7 @@ export default function CentralNursingStation({ facilityId }: Props) {
         </div>
       }
     >
-      {data === undefined ? (
+      {data === undefined || query.loading ? (
         <Loading />
       ) : data.length === 0 ? (
         <div className="flex h-[80vh] w-full items-center justify-center text-center text-black">

--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -1,5 +1,5 @@
 import useFullscreen from "../../Common/hooks/useFullscreen";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import HL7PatientVitalsMonitor from "../VitalsMonitor/HL7PatientVitalsMonitor";
 import useFilters from "../../Common/hooks/useFilters";
 import Loading from "../Common/Loading";
@@ -39,6 +39,11 @@ export default function CentralNursingStation({ facilityId }: Props) {
   const { qParams, updateQuery, removeFilter, updatePage } = useFilters({
     limit: PER_PAGE_LIMIT,
   });
+  const [isBedOccupied, setIsBedOccupied] = useState<boolean>(
+    qParams.bed_is_occupied === undefined
+      ? true
+      : qParams.bed_is_occupied === "true"
+  );
   const query = useQuery(routes.listPatientAssetBeds, {
     pathParams: { facility_external_id: facilityId },
     query: {
@@ -151,16 +156,10 @@ export default function CentralNursingStation({ facilityId }: Props) {
                     <CheckBoxFormField
                       name="bed_is_occupied"
                       label="Hide Monitors without Patient"
-                      value={
-                        qParams.bed_is_occupied === "true" ||
-                        qParams.bed_is_occupied === undefined
-                      }
+                      value={isBedOccupied}
                       onChange={({ name, value }) => {
-                        if (value) {
-                          updateQuery({ [name]: value });
-                        } else {
-                          removeFilter(name);
-                        }
+                        updateQuery({ [name]: value });
+                        setIsBedOccupied(value);
                       }}
                       labelClassName="text-sm"
                       errorClassName="hidden"

--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -48,7 +48,7 @@ export default function CentralNursingStation({ facilityId }: Props) {
       offset: (qParams.page ? qParams.page - 1 : 0) * PER_PAGE_LIMIT,
       asset_class: "HL7MONITOR",
       ordering: qParams.ordering || "bed__name",
-      bed_is_occupied: qParams.bed_is_occupied ?? true,
+      bed_is_occupied: qParams.hide_monitors_without_patient ? true : false,
     },
   });
 
@@ -149,16 +149,12 @@ export default function CentralNursingStation({ facilityId }: Props) {
                       errorClassName="hidden"
                     />
                     <CheckBoxFormField
-                      name="bed_is_occupied"
+                      name="hide_monitors_without_patient"
                       label="Hide Monitors without Patient"
-                      value={
-                        qParams.bed_is_occupied === undefined
-                          ? true
-                          : qParams.bed_is_occupied === "true"
-                      }
-                      onChange={({ name, value }) => {
-                        updateQuery({ [name]: value });
-                      }}
+                      value={JSON.parse(
+                        qParams.hide_monitors_without_patient ?? true
+                      )}
+                      onChange={(e) => updateQuery({ [e.name]: e.value })}
                       labelClassName="text-sm"
                       errorClassName="hidden"
                     />

--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -1,5 +1,5 @@
 import useFullscreen from "../../Common/hooks/useFullscreen";
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 import HL7PatientVitalsMonitor from "../VitalsMonitor/HL7PatientVitalsMonitor";
 import useFilters from "../../Common/hooks/useFilters";
 import Loading from "../Common/Loading";
@@ -39,11 +39,6 @@ export default function CentralNursingStation({ facilityId }: Props) {
   const { qParams, updateQuery, removeFilter, updatePage } = useFilters({
     limit: PER_PAGE_LIMIT,
   });
-  const [isBedOccupied, setIsBedOccupied] = useState<boolean>(
-    qParams.bed_is_occupied === undefined
-      ? true
-      : qParams.bed_is_occupied === "true"
-  );
   const query = useQuery(routes.listPatientAssetBeds, {
     pathParams: { facility_external_id: facilityId },
     query: {
@@ -155,11 +150,14 @@ export default function CentralNursingStation({ facilityId }: Props) {
                     />
                     <CheckBoxFormField
                       name="bed_is_occupied"
-                      label="Hide Monitors without Patient"
-                      value={isBedOccupied}
+                      label="Hide Monitors without Patients"
+                      value={
+                        qParams.bed_is_occupied === undefined
+                          ? true
+                          : qParams.bed_is_occupied === "true"
+                      }
                       onChange={({ name, value }) => {
                         updateQuery({ [name]: value });
-                        setIsBedOccupied(value);
                       }}
                       labelClassName="text-sm"
                       errorClassName="hidden"

--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -150,7 +150,7 @@ export default function CentralNursingStation({ facilityId }: Props) {
                     />
                     <CheckBoxFormField
                       name="bed_is_occupied"
-                      label="Hide Monitors without Patients"
+                      label="Hide Monitors without Patient"
                       value={
                         qParams.bed_is_occupied === undefined
                           ? true

--- a/src/Components/Facility/CentralNursingStation.tsx
+++ b/src/Components/Facility/CentralNursingStation.tsx
@@ -48,7 +48,8 @@ export default function CentralNursingStation({ facilityId }: Props) {
       offset: (qParams.page ? qParams.page - 1 : 0) * PER_PAGE_LIMIT,
       asset_class: "HL7MONITOR",
       ordering: qParams.ordering || "bed__name",
-      bed_is_occupied: qParams.hide_monitors_without_patient === "true",
+      bed_is_occupied:
+        (qParams.hide_monitors_without_patient ?? "true") === "true",
     },
   });
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #6991 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
