### PR TITLE
Update weekly_working_hours to allow null value

### DIFF
--- a/src/Components/Users/UserProfile.tsx
+++ b/src/Components/Users/UserProfile.tsx
@@ -34,7 +34,7 @@ type EditForm = {
   doctor_qualification: string | undefined;
   doctor_experience_commenced_on: number | string | undefined;
   doctor_medical_council_registration: string | undefined;
-  weekly_working_hours: string | undefined;
+  weekly_working_hours: string | null;
 };
 type ErrorForm = {
   firstName: string;
@@ -253,13 +253,11 @@ export default function UserProfile() {
           }
           return;
         case "weekly_working_hours":
-          if (!states.form[field]) {
-            errors[field] = "This field is required";
-            invalidForm = true;
-          } else if (
-            Number(states.form[field]) < 0 ||
-            Number(states.form[field]) > 168 ||
-            !/^\d+$/.test(states.form[field] ?? "")
+          if (
+            states.form[field] &&
+            (Number(states.form[field]) < 0 ||
+              Number(states.form[field]) > 168 ||
+              !/^\d+$/.test(states.form[field] ?? ""))
           ) {
             errors[field] =
               "Average weekly working hours must be a number between 0 and 168";
@@ -331,7 +329,11 @@ export default function UserProfile() {
           states.form.user_type === "Doctor"
             ? states.form.doctor_medical_council_registration
             : undefined,
-        weekly_working_hours: states.form.weekly_working_hours,
+        weekly_working_hours:
+          states.form.weekly_working_hours &&
+          states.form.weekly_working_hours !== ""
+            ? states.form.weekly_working_hours
+            : null,
       };
       const { res } = await request(routes.partialUpdateUser, {
         pathParams: { username: authUser.username },
@@ -588,7 +590,7 @@ export default function UserProfile() {
                       Average weekly working hours
                     </dt>
                     <dd className="mt-1 text-sm leading-5 text-gray-900">
-                      {userData?.weekly_working_hours || "-"}
+                      {userData?.weekly_working_hours ?? "-"}
                     </dd>
                   </div>
                   <div
@@ -707,7 +709,6 @@ export default function UserProfile() {
                         )}
                         <TextFormField
                           {...fieldProps("weekly_working_hours")}
-                          required
                           label="Average weekly working hours"
                           className="col-span-6 sm:col-span-3"
                           type="number"

--- a/src/Components/Users/models.tsx
+++ b/src/Components/Users/models.tsx
@@ -43,7 +43,7 @@ export type UserModel = UserBareMinimum & {
   doctor_qualification?: string;
   doctor_experience_commenced_on?: string;
   doctor_medical_council_registration?: string;
-  weekly_working_hours?: string;
+  weekly_working_hours?: string | null;
 };
 
 export interface SkillObjectModel {


### PR DESCRIPTION
This pull request updates the `weekly_working_hours` field in the `UserProfile` component to allow a null value. Previously, the field was required and had to be a number between 0 and 168. Now, it can be left empty or set to null. This change ensures more flexibility when entering weekly working hours for a user.

![image](https://github.com/coronasafe/care_fe/assets/3626859/a9cf1317-12e8-4e9e-8722-850d1f94411c)
