### PR TITLE
Fix inconsistent removal of facility filters

### DIFF
--- a/src/Components/Facility/HospitalList.tsx
+++ b/src/Components/Facility/HospitalList.tsx
@@ -4,7 +4,7 @@ import {
   downloadFacilityDoctors,
   downloadFacilityTriage,
 } from "../../Redux/actions";
-import { lazy } from "react";
+import { lazy, useEffect } from "react";
 import { AdvancedFilterButton } from "../../CAREUI/interactive/FiltersSlideover";
 import CountBlock from "../../CAREUI/display/Count";
 import ExportMenu from "../Common/Export";
@@ -35,6 +35,16 @@ export const HospitalList = () => {
   } = useFilters({
     limit: 14,
   });
+
+  useEffect(() => {
+    if (!qParams.state) {
+      advancedFilter.removeFilters(["district", "local_body"]);
+    }
+    if (!qParams.district) {
+      advancedFilter.removeFilters(["local_body"]);
+    }
+  }, [advancedFilter, qParams]);
+
   let manageFacilities: any = null;
   const { user_type } = useAuthUser();
   const { t } = useTranslation();


### PR DESCRIPTION
## Proposed Changes

- Fixes #7013
- When state is removed also remove district and local_body filters
- When district is removed also remove local_body filter

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

[facility-filter.webm](https://github.com/coronasafe/care_fe/assets/56870381/0136d465-5fa5-49f0-80fb-fbe5536c38c1)

