### PR TITLE
Add security headers

### DIFF
--- a/cypress/e2e/death_report_spec/death_report.cy.ts
+++ b/cypress/e2e/death_report_spec/death_report.cy.ts
@@ -12,9 +12,8 @@ describe("Death Report", () => {
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.clearLocalStorage(/filters--.+/);
-    cy.awaitUrl("/");
+    cy.awaitUrl("/patients");
     cy.intercept("**/api/v1/patient/**").as("getPatients");
-    cy.get("#facility-patients").contains("Patients").click({ force: true });
     cy.url().should("include", "/patients");
     cy.wait("@getPatients").get("a[data-cy=patient]").first().click();
     cy.url().then((url) => {

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,6 @@ status = 200
 [[headers]]
   for = "/*"
   [headers.values]
-  cache-control = '''
-  max-age=0,
-  no-store'''
+    cache-control = "max-age=0, no-store"
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"


### PR DESCRIPTION
This pull request adds security headers to the server response. Specifically, it sets the `cache-control` header to `max-age=0, no-store`, and adds the `X-Frame-Options` and `X-Content-Type-Options` headers to enhance security.