### PR TITLE
Adds support for voluntarily opting into caching in `useQuery` and opt-in ICD-11 retrieve by ID API to be cached.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,22 +8,24 @@ import {
 import ThemedFavicon from "./CAREUI/misc/ThemedFavicon";
 import Intergrations from "./Integrations";
 import Loading from "./Components/Common/Loading";
+import QueryCacheProvider from "./Utils/request/QueryCacheProvider";
 
 const App = () => {
   return (
     <Suspense fallback={<Loading />}>
       <ThemedFavicon />
-      <HistoryAPIProvider>
-        <AppConfigProvider>
-          <AuthUserProvider unauthorized={<Routers.SessionRouter />}>
-            <Routers.AppRouter />
-          </AuthUserProvider>
-
-          {/* Integrations */}
-          <Intergrations.Sentry disabled={!import.meta.env.PROD} />
-          <Intergrations.Plausible />
-        </AppConfigProvider>
-      </HistoryAPIProvider>
+      <QueryCacheProvider>
+        <HistoryAPIProvider>
+          <AppConfigProvider>
+            <AuthUserProvider unauthorized={<Routers.SessionRouter />}>
+              <Routers.AppRouter />
+            </AuthUserProvider>
+            {/* Integrations */}
+            <Intergrations.Sentry disabled={!import.meta.env.PROD} />
+            <Intergrations.Plausible />
+          </AppConfigProvider>
+        </HistoryAPIProvider>
+      </QueryCacheProvider>
     </Suspense>
   );
 };

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -82,6 +82,7 @@ import {
   InvestigationGroup,
   InvestigationType,
 } from "../Components/Facility/Investigations";
+import { ICD11DiagnosisModel } from "../Components/Diagnosis/types";
 
 /**
  * A fake function that returns an empty object casted to type T
@@ -975,6 +976,12 @@ const routes = {
   // ICD11
   listICD11Diagnosis: {
     path: "/api/v1/icd/",
+    TRes: Type<ICD11DiagnosisModel[]>(),
+  },
+  getICD11Diagnosis: {
+    path: "/api/v1/icd/{id}/",
+    TRes: Type<ICD11DiagnosisModel>(),
+    enableExperimentalCache: true,
   },
   // Medibase
   listMedibaseMedicines: {

--- a/src/Utils/request/QueryCacheProvider.tsx
+++ b/src/Utils/request/QueryCacheProvider.tsx
@@ -1,0 +1,31 @@
+import { ReactNode, createContext, useContext, useRef } from "react";
+
+type QueryCacheAPI = {
+  get: (key: string) => unknown;
+  set: (key: string, value: unknown) => void;
+};
+
+const queryCacheContext = createContext<QueryCacheAPI | undefined>(undefined);
+
+export default function QueryCacheProvider(props: { children: ReactNode }) {
+  const cacheRef = useRef<Record<string, unknown>>({});
+
+  return (
+    <queryCacheContext.Provider
+      value={{
+        get: (key) => cacheRef.current[key],
+        set: (key, value) => (cacheRef.current[key] = value),
+      }}
+    >
+      {props.children}
+    </queryCacheContext.Provider>
+  );
+}
+
+export const useQueryCache = () => {
+  const queryCache = useContext(queryCacheContext);
+  if (queryCache === undefined) {
+    throw "useQueryCache should be used inside QueryCacheProvider";
+  }
+  return queryCache;
+};

--- a/src/Utils/request/types.ts
+++ b/src/Utils/request/types.ts
@@ -10,6 +10,7 @@ interface RouteBase<TData> {
 
 export interface QueryRoute<TData> extends RouteBase<TData> {
   method?: "GET";
+  enableExperimentalCache?: boolean;
 }
 
 export interface MutationRoute<TData, TBody> extends RouteBase<TData> {

--- a/src/Utils/request/utils.ts
+++ b/src/Utils/request/utils.ts
@@ -5,11 +5,11 @@ import { QueryParams, RequestOptions } from "./types";
 export function makeUrl(
   path: string,
   query?: QueryParams,
-  pathParams?: Record<string, string>
+  pathParams?: Record<string, string | number>
 ) {
   if (pathParams) {
     path = Object.entries(pathParams).reduce(
-      (acc, [key, value]) => acc.replace(`{${key}}`, value),
+      (acc, [key, value]) => acc.replace(`{${key}}`, `${value}`),
       path
     );
   }


### PR DESCRIPTION
## Proposed Changes

- Fixes #7063
- Opt-in ICD-11 retrieve by ID API to be cached

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
