### PR TITLE
Include start date for Prescription timeline cells

### DIFF
--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationEventCell.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationEventCell.tsx
@@ -21,10 +21,10 @@ export default function AdministrationEventCell({
   refetch,
 }: Props) {
   const [showTimeline, setShowTimeline] = useState(false);
-  // Check if cell belongs to an administered prescription
+  // Check if cell belongs to an administered prescription (including start and excluding end)
   const administered = administrations
     .filter((administration) =>
-      dayjs(administration.administered_date).isBetween(start, end)
+      dayjs(administration.administered_date).isBetween(start, end, null, "[)")
     )
     .sort(
       (a, b) =>


### PR DESCRIPTION
Fixes #7066
This pull request includes a change to the AdministrationEventCell component. It adds a check to determine if a cell belongs to an administered prescription, including the start date and excluding the end date. This change ensures that the correct cells are displayed in the Prescription timeline.