### PR TITLE
Add break-all class to SelectMenuV2 component

### DIFF
--- a/src/Components/Form/SelectMenuV2.tsx
+++ b/src/Components/Form/SelectMenuV2.tsx
@@ -101,7 +101,7 @@ const SelectMenuV2 = <T, V>(props: SelectMenuProps<T, V>) => {
                         {value.icon}
                       </div>
                     )}
-                    <p className="ml-2.5 text-sm font-medium">
+                    <p className="ml-2.5 break-all text-sm font-medium">
                       {value.selectedLabel}
                     </p>
                   </div>

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -86,11 +86,14 @@ export default function PrescriptionDetailCard({
           <Detail className="col-span-9 md:col-span-5" label={t("medicine")}>
             {prescription.medicine_object?.name ?? prescription.medicine_old}
           </Detail>
-          <Detail className="col-span-5 md:col-span-2" label={t("route")}>
+          <Detail
+            className="col-span-5 break-all md:col-span-3"
+            label={t("route")}
+          >
             {prescription.route &&
               t("PRESCRIPTION_ROUTE_" + prescription.route)}
           </Detail>
-          <Detail className="col-span-4 md:col-span-2" label={t("dosage")}>
+          <Detail className="col-span-4 md:col-span-1" label={t("dosage")}>
             {prescription.dosage}
           </Detail>
 

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -87,13 +87,13 @@ export default function PrescriptionDetailCard({
             {prescription.medicine_object?.name ?? prescription.medicine_old}
           </Detail>
           <Detail
-            className="col-span-5 break-all md:col-span-3"
+            className="col-span-5 break-all md:col-span-2"
             label={t("route")}
           >
             {prescription.route &&
               t("PRESCRIPTION_ROUTE_" + prescription.route)}
           </Detail>
-          <Detail className="col-span-4 md:col-span-1" label={t("dosage")}>
+          <Detail className="col-span-4 md:col-span-2" label={t("dosage")}>
             {prescription.dosage}
           </Detail>
 


### PR DESCRIPTION
This pull request adds the "break-all" class to the SelectMenuV2 component in the Form directory. This class allows the text within the component to break at any character, preventing it from overflowing its container.