### PR TITLE
Hide nav menu item "Dashboard" if not configured in config

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,4 @@
 {
-    "dashboard_url": "https://dashboard.coronasafe.in",
     "github_url": "https://github.com/coronasafe",
     "coronasafe_url": "https://coronasafe.network?ref=care",
     "site_url": "care.coronasafe.in",

--- a/src/Common/hooks/useConfig.ts
+++ b/src/Common/hooks/useConfig.ts
@@ -8,7 +8,7 @@ interface ILogo {
 }
 
 export interface IConfig {
-  dashboard_url: string;
+  dashboard_url?: string;
   github_url: string;
   coronasafe_url: string;
   site_url: string;

--- a/src/Components/Common/Sidebar/Sidebar.tsx
+++ b/src/Components/Common/Sidebar/Sidebar.tsx
@@ -147,13 +147,15 @@ const StatelessSidebar = ({
             handleOverflow={handleOverflow}
             onClickCB={() => onItemClick && onItemClick(false)}
           />
-          <Item
-            text="Dashboard"
-            to={dashboard_url}
-            icon={<CareIcon className="care-l-dashboard text-lg" />}
-            external
-            handleOverflow={handleOverflow}
-          />
+          {dashboard_url && (
+            <Item
+              text="Dashboard"
+              to={dashboard_url}
+              icon={<CareIcon className="care-l-dashboard text-lg" />}
+              external
+              handleOverflow={handleOverflow}
+            />
+          )}
         </div>
         <div className="hidden md:block md:flex-1" />
 


### PR DESCRIPTION
## Proposed Changes

- Hide dashboard nav menu item if not configured

## Required `config` changes
- https://github.com/coronasafe/care_deploy_configs/pull/20

Requested by @khavinshankar as per beagal security audit

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
