### PR TITLE
Add api.data.gov.in to CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,7 +28,7 @@ status = 200
       default-src 'self';
       script-src 'self' 'nonce-f51b9742' https://plausible.10bedicu.in;
       style-src 'self' 'nonce-7e14cf80';
-      connect-src 'self' ws: wss: https://sentry.io https://plausible.10bedicu.in https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
+      connect-src 'self' ws: wss: https://sentry.io https://plausible.10bedicu.in https://api.data.gov.in https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
       img-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
       media-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
       object-src 'self' blob: https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,7 +103,7 @@ export default defineConfig({
       "Content-Security-Policy": `default-src 'self';\
       script-src 'self' 'nonce-f51b9742' https://plausible.10bedicu.in;\
       style-src 'self' 'nonce-7e14cf80';\
-      connect-src 'self' ws: wss: https://sentry.io https://plausible.10bedicu.in ${cdnUrls};\
+      connect-src 'self' ws: wss: https://sentry.io https://plausible.10bedicu.in https://api.data.gov.in ${cdnUrls};\
       img-src 'self' blob: data: https://cdn.coronasafe.network ${cdnUrls};\
       media-src 'self' blob: data: https://cdn.coronasafe.network ${cdnUrls};\
       object-src 'self' blob: ${cdnUrls};`,


### PR DESCRIPTION
Fixes #7088

This pull request adds the `api.data.gov.in` domain to the Content Security Policy (CSP) connect-src directive in both `netlify.toml` and `vite.config.ts` files. This allows the application to make requests to the `api.data.gov.in` domain for autofilling the state and the district from pincode. 