### PR TITLE
Relax CSP for styles and connect URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -30,6 +30,6 @@ status = 200
       style-src 'self' 'unsafe-inline';
       connect-src *;
       img-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
-      media-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
+      media-src *;
       object-src 'self' blob: https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
       '''

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,8 +27,8 @@ status = 200
     Content-Security-Policy = '''
       default-src 'self';
       script-src 'self' 'nonce-f51b9742' https://plausible.10bedicu.in;
-      style-src 'self' 'nonce-7e14cf80';
-      connect-src 'self' ws: wss: https://sentry.io https://plausible.10bedicu.in https://api.data.gov.in https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
+      style-src 'self' 'unsafe-inline';
+      connect-src *;
       img-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
       media-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
       object-src 'self' blob: https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;


### PR DESCRIPTION
This pull request relaxes the Content-Security-Policy (CSP) for styles and connect URLs. Specifically, it changes the style-src directive to allow 'unsafe-inline' styles and the connect-src directive to allow all URLs. This update is necessary to resolve issues with certain styles and connections being blocked by the CSP.