### PR TITLE
Add mime_type to upload request for sample results

### DIFF
--- a/src/Components/Patient/UpdateStatusDialog.tsx
+++ b/src/Components/Patient/UpdateStatusDialog.tsx
@@ -161,6 +161,7 @@ const UpdateStatusDialog = (props: Props) => {
       name: `${sample.patient_name} Sample Report`,
       associating_id: sample.id,
       file_category: category,
+      mime_type: contentType,
     };
     redux_dispatch(createUpload(requestData))
       .then(uploadfile)


### PR DESCRIPTION
This pull request adds the `mime_type` field to the upload request for sample results. This allows for more accurate categorization and handling of the uploaded files.