### PR TITLE
Add blob: data: for media-src CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -30,6 +30,6 @@ status = 200
       style-src 'self' 'unsafe-inline';
       connect-src *;
       img-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
-      media-src *;
+      media-src * blob: data:;
       object-src 'self' blob: https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
       '''

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,10 +102,10 @@ export default defineConfig({
     headers: {
       "Content-Security-Policy": `default-src 'self';\
       script-src 'self' 'nonce-f51b9742' https://plausible.10bedicu.in;\
-      style-src 'self' 'nonce-7e14cf80';\
-      connect-src 'self' ws: wss: https://sentry.io https://plausible.10bedicu.in https://api.data.gov.in ${cdnUrls};\
+      style-src 'self' 'unsafe-inline';\
+      connect-src *;\
       img-src 'self' blob: data: https://cdn.coronasafe.network ${cdnUrls};\
-      media-src 'self' blob: data: https://cdn.coronasafe.network ${cdnUrls};\
+      media-src * blob: data:;\
       object-src 'self' blob: ${cdnUrls};`,
     },
     port: 4000,


### PR DESCRIPTION
This pull request adds the `blob: data:` value to the `media-src` directive in the Content Security Policy (CSP) configuration. This allows the use of blob URLs and data URLs for media resources.

Tested on iPhone:
![image](https://github.com/coronasafe/care_fe/assets/3626859/8ea641eb-9587-4493-ae4f-153446ba0dd1)

Tested on Chrome/Windows:
![image](https://github.com/coronasafe/care_fe/assets/3626859/28aa0e4e-2f06-4bd7-8946-907f8be86179)
