### PR TITLE
Update Content-Security-Policy script-src directive to allow 'blob' as a source

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,7 +26,7 @@ status = 200
     X-Content-Type-Options = "nosniff"
     Content-Security-Policy = '''
       default-src 'self';
-      script-src 'self' 'nonce-f51b9742' https://plausible.10bedicu.in;
+      script-src 'self' blob: 'nonce-f51b9742' https://plausible.10bedicu.in;
       style-src 'self' 'unsafe-inline';
       connect-src *;
       img-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;

--- a/src/Components/ABDM/LinkABHANumberModal.tsx
+++ b/src/Components/ABDM/LinkABHANumberModal.tsx
@@ -13,7 +13,7 @@ import TextFormField from "../Form/FormFields/TextFormField";
 import { classNames } from "../../Utils/utils";
 import request from "../../Utils/request/request";
 import routes from "../../Redux/api";
-import { ABDMError } from "./models";
+import { ABDMError, ABHAQRContent } from "./models";
 
 export const validateRule = (
   condition: boolean,
@@ -188,9 +188,20 @@ const ScanABHAQRSection = ({
           setIsLoading(true);
 
           try {
-            const abha = JSON.parse(value);
+            const abha = JSON.parse(value) as ABHAQRContent;
+
             const { res, data } = await request(routes.abha.linkViaQR, {
-              body: { ...abha, patientId },
+              body: {
+                patientId,
+                hidn: abha?.hidn,
+                phr: abha?.hid,
+                name: abha?.name,
+                gender: abha?.gender,
+                dob: abha?.dob.replace(/\//g, "-"),
+                address: abha?.address,
+                "dist name": abha?.district_name,
+                "state name": abha?.["state name"],
+              },
             });
 
             if (res?.status === 200 || res?.status === 202) {

--- a/src/Components/ABDM/models.ts
+++ b/src/Components/ABDM/models.ts
@@ -107,3 +107,29 @@ export interface IcreateHealthFacilityTBody {
 export interface IpartialUpdateHealthFacilityTBody {
   hf_id: string;
 }
+
+export interface ILinkViaQRBody {
+  hidn: string;
+  phr: string;
+  name: string;
+  gender: "M" | "F" | "O";
+  dob: string;
+  address?: string;
+  "dist name"?: string;
+  "state name"?: string;
+  patientId?: string;
+}
+
+export interface ABHAQRContent {
+  address: string;
+  distlgd: string;
+  district_name: string;
+  dob: string;
+  gender: "M";
+  hid: string;
+  hidn: string;
+  mobile: string;
+  name: string;
+  "state name": string;
+  statelgd: string;
+}

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -14,6 +14,7 @@ import {
   IHealthId,
   IinitiateAbdmAuthenticationTBody,
   ILinkABHANumber,
+  ILinkViaQRBody,
   IpartialUpdateHealthFacilityTBody,
   ISearchByHealthIdTBody,
   IVerifyAadhaarOtpTBody,
@@ -1188,7 +1189,7 @@ const routes = {
       path: "/api/v1/abdm/healthid/link_via_qr/",
       method: "POST",
       TRes: Type<ILinkABHANumber>(),
-      TBody: Type<ISearchByHealthIdTBody>(),
+      TBody: Type<ILinkViaQRBody>(),
     },
 
     linkCareContext: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,7 +101,7 @@ export default defineConfig({
   preview: {
     headers: {
       "Content-Security-Policy": `default-src 'self';\
-      script-src 'self' 'nonce-f51b9742' https://plausible.10bedicu.in;\
+      script-src 'self' blob: 'nonce-f51b9742' https://plausible.10bedicu.in;\
       style-src 'self' 'unsafe-inline';\
       connect-src *;\
       img-src 'self' blob: data: https://cdn.coronasafe.network ${cdnUrls};\


### PR DESCRIPTION
Fixes #7104 

This pull request updates the Content-Security-Policy script-src directive to allow 'blob' as a source. This change ensures that scripts from blob URLs are allowed to execute, which is necessary for certain functionalities in the application.