### PR TITLE
Switch to report only for CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,12 +24,12 @@ status = 200
     cache-control = "max-age=0, no-store"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
-    Content-Security-Policy = '''
+    Content-Security-Policy-Report-Only = '''
       default-src 'self';
-      script-src 'self' blob: 'nonce-f51b9742' https://plausible.10bedicu.in;
+      script-src 'self' 'nonce-f51b9742' https://plausible.10bedicu.in;
       style-src 'self' 'unsafe-inline';
-      connect-src *;
-      img-src 'self' blob: data: https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
-      media-src * blob: data:;
-      object-src 'self' blob: https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
+      connect-src 'self' https://plausible.10bedicu.in;
+      img-src 'self' https://cdn.coronasafe.network https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
+      object-src 'self' https://egov-s3-facility-10bedicu.s3.amazonaws.com https://egov-s3-patient-data-10bedicu.s3.amazonaws.com;
+      report-uri https://csp-logger.ohc.network/
       '''

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,13 +100,12 @@ export default defineConfig({
   },
   preview: {
     headers: {
-      "Content-Security-Policy": `default-src 'self';\
+      "Content-Security-Policy-Report-Only": `default-src 'self';\
       script-src 'self' blob: 'nonce-f51b9742' https://plausible.10bedicu.in;\
       style-src 'self' 'unsafe-inline';\
-      connect-src *;\
-      img-src 'self' blob: data: https://cdn.coronasafe.network ${cdnUrls};\
-      media-src * blob: data:;\
-      object-src 'self' blob: ${cdnUrls};`,
+      connect-src 'self' https://plausible.10bedicu.in;\
+      img-src 'self' https://cdn.coronasafe.network ${cdnUrls};\
+      object-src 'self' ${cdnUrls};`,
     },
     port: 4000,
     proxy: {


### PR DESCRIPTION
This pull request switches the Content-Security-Policy header to Content-Security-Policy-Report-Only in order to report violations without blocking any content.