### PR TITLE
Add Facility Notify button for District/State Admins

### DIFF
--- a/src/Components/Facility/FacilityCard.tsx
+++ b/src/Components/Facility/FacilityCard.tsx
@@ -225,7 +225,7 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                     </DialogModal>
                   </div>
                   <div className="flex flex-wrap gap-2">
-                    {userType !== "Staff" ? (
+                    {["DistrictAdmin", "StateAdmin"].includes(userType) && (
                       <ButtonV2
                         id="facility-notify"
                         ghost
@@ -236,8 +236,6 @@ export const FacilityCard = (props: { facility: any; userType: any }) => {
                         <CareIcon className="care-l-megaphone text-lg" />
                         <span className="hidden md:block">Notify</span>
                       </ButtonV2>
-                    ) : (
-                      <></>
                     )}
                     <ButtonV2
                       href={`/facility/${facility.id}`}


### PR DESCRIPTION
This pull request adds a new feature to the FacilityCard component. The FacilityCard now includes a "Notify" button that is only visible to District and State Admin users. This button allows these users to send notifications related to the facility.