### PR TITLE
Fix: Disable add counsultations button when patient is discharged

### DIFF
--- a/src/Components/Facility/ConsultationCard.tsx
+++ b/src/Components/Facility/ConsultationCard.tsx
@@ -163,6 +163,7 @@ export const ConsultationCard = (props: ConsultationProps) => {
                 `/facility/${itemData.facility}/patient/${itemData.patient}/consultation/${itemData.id}/daily-rounds`
               )
             }
+            disabled={itemData.discharge_date}
             authorizeFor={NonReadOnlyUsers}
           >
             Add Consultation Updates


### PR DESCRIPTION
## Proposed Changes

- Fixes https://github.com/coronasafe/care_fe/issues/7131
- If there is a discharge date the button will be disabled

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

Screenshot of working example
![image](https://github.com/coronasafe/care_fe/assets/115069516/10551fdc-35fe-4ec9-8d55-9f5742fc9ce0)
