### PR TITLE
Fix filters cache restoration logic + cleaner URL query params and filters cache + fixes state management of facility, lsg body and district in patient filters

### DIFF
--- a/src/Common/hooks/useFilters.tsx
+++ b/src/Common/hooks/useFilters.tsx
@@ -5,14 +5,14 @@ import GenericFilterBadge from "../../CAREUI/display/FilterBadge";
 import PaginationComponent from "../../Components/Common/Pagination";
 import useConfig from "./useConfig";
 import { classNames } from "../../Utils/utils";
+import FiltersCache from "../../Utils/FiltersCache";
 
 export type FilterState = Record<string, unknown>;
-export type FilterParamKeys = string | string[];
 
 interface FilterBadgeProps {
   name: string;
   value?: string;
-  paramKey: FilterParamKeys;
+  paramKey: string | string[];
 }
 
 /**
@@ -32,18 +32,18 @@ export default function useFilters({
   const [showFilters, setShowFilters] = useState(false);
   const [qParams, _setQueryParams] = useQueryParams();
 
+  const updateCache = (query: QueryParam) => {
+    const blacklist = FILTERS_CACHE_BLACKLIST.concat(cacheBlacklist);
+    FiltersCache.set(query, blacklist);
+  };
+
   const setQueryParams = (
     query: QueryParam,
     options?: setQueryParamsOptions
   ) => {
-    const updatedQParams = { ...query };
-
-    for (const param of cacheBlacklist) {
-      delete updatedQParams[param];
-    }
-
+    query = FiltersCache.utils.clean(query);
     _setQueryParams(query, options);
-    updateFiltersCache(updatedQParams);
+    updateCache(query);
   };
 
   const updateQuery = (filter: FilterState) => {
@@ -61,15 +61,22 @@ export default function useFilters({
   const removeFilter = (param: string) => removeFilters([param]);
 
   useEffect(() => {
-    const cache = getFiltersCache();
     const qParamKeys = Object.keys(qParams);
-    const canSkip = Object.keys(cache).every(
-      (key) => qParamKeys.includes(key) && qParams[key] === cache[key]
-    );
-    if (canSkip) return;
-    if (Object.keys(cache).length) {
-      setQueryParams(cache);
+
+    // If we navigate to a path that has query params set on mount,
+    // skip restoring the cache, instead update the cache with new filters.
+    if (qParamKeys.length) {
+      updateCache(qParams);
+      return;
     }
+
+    const cache = FiltersCache.get();
+    if (!cache) {
+      return;
+    }
+
+    // Restore cache
+    setQueryParams(cache);
   }, []);
 
   const FilterBadge = ({ name, value, paramKey }: FilterBadgeProps) => {
@@ -99,7 +106,7 @@ export default function useFilters({
   };
 
   const badgeUtils = {
-    badge(name: string, paramKey: FilterParamKeys) {
+    badge(name: string, paramKey: FilterBadgeProps["paramKey"]) {
       return { name, paramKey };
     },
     ordering(name = "Sort by", paramKey = "ordering") {
@@ -109,7 +116,7 @@ export default function useFilters({
         value: qParams[paramKey] && t("SortOptions." + qParams[paramKey]),
       };
     },
-    value(name: string, paramKey: FilterParamKeys, value: string) {
+    value(name: string, paramKey: FilterBadgeProps["paramKey"], value: string) {
       return { name, value, paramKey };
     },
     phoneNumber(name = "Phone Number", paramKey = "phone_number") {
@@ -278,15 +285,3 @@ const removeFromQuery = (query: Record<string, unknown>, params: string[]) => {
 };
 
 const FILTERS_CACHE_BLACKLIST = ["page", "limit", "offset"];
-
-const getFiltersCacheKey = () => `filters--${window.location.pathname}`;
-const getFiltersCache = () => {
-  return JSON.parse(localStorage.getItem(getFiltersCacheKey()) || "{}");
-};
-const updateFiltersCache = (cache: Record<string, unknown>) => {
-  const result = { ...cache };
-  for (const param of FILTERS_CACHE_BLACKLIST) {
-    delete result[param];
-  }
-  localStorage.setItem(getFiltersCacheKey(), JSON.stringify(result));
-};

--- a/src/Components/Auth/Login.tsx
+++ b/src/Components/Auth/Login.tsx
@@ -11,8 +11,8 @@ import useConfig from "../../Common/hooks/useConfig";
 import CircularProgress from "../Common/components/CircularProgress";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
-import { invalidateFiltersCache } from "../../Utils/utils";
 import { useAuthContext } from "../../Common/hooks/useAuthUser";
+import FiltersCache from "../../Utils/FiltersCache";
 
 export const Login = (props: { forgot?: boolean }) => {
   const { signIn } = useAuthContext();
@@ -93,7 +93,7 @@ export const Login = (props: { forgot?: boolean }) => {
   const handleSubmit = async (e: any) => {
     e.preventDefault();
     setLoading(true);
-    invalidateFiltersCache();
+    FiltersCache.invaldiateAll();
     const validated = validateData();
     if (!validated) {
       setLoading(false);

--- a/src/Components/Common/FacilitySelect.tsx
+++ b/src/Components/Common/FacilitySelect.tsx
@@ -16,7 +16,7 @@ interface FacilitySelectProps {
   showAll?: boolean;
   showNOptions?: number;
   freeText?: boolean;
-  selected: FacilityModel | FacilityModel[] | null;
+  selected?: FacilityModel | FacilityModel[] | null;
   setSelected: (selected: FacilityModel | FacilityModel[] | null) => void;
 }
 

--- a/src/Components/Facility/FacilityFilter/DistrictSelect.tsx
+++ b/src/Components/Facility/FacilityFilter/DistrictSelect.tsx
@@ -8,7 +8,7 @@ interface DistrictSelectProps {
   errors: string;
   className?: string;
   multiple?: boolean;
-  selected: string;
+  selected?: string;
   setSelected: (selected: string) => void;
 }
 

--- a/src/Redux/actions.tsx
+++ b/src/Redux/actions.tsx
@@ -132,9 +132,6 @@ export const getWardByLocalBody = (pathParam: object) => {
 export const getLocalBody = (pathParam: object) => {
   return fireRequest("getLocalBody", [], {}, pathParam);
 };
-export const getAllLocalBody = (params: object) => {
-  return fireRequest("getAllLocalBody", [], params);
-};
 
 // Sample Test
 export const getSampleTestList = (params: object, pathParam: object) => {

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -761,6 +761,8 @@ const routes = {
   },
   getAllLocalBody: {
     path: "/api/v1/local_body/",
+    method: "GET",
+    TRes: Type<PaginatedResponse<LocalBodyModel>>(),
   },
   getLocalbodyByName: {
     path: "/api/v1/local_body/",

--- a/src/Utils/FiltersCache.tsx
+++ b/src/Utils/FiltersCache.tsx
@@ -1,0 +1,77 @@
+type Filters = Record<string, unknown>;
+
+/**
+ * @returns The filters cache key associated to the current window URL
+ */
+const getKey = () => {
+  return `filters--${window.location.pathname}`;
+};
+
+/**
+ * Returns a sanitized filter object that ignores filters with no value or
+ * filters that are part of the blacklist.
+ *
+ * @param filters Input filters to be sanitized
+ * @param blacklist Optional array of filter keys that are to be ignored.
+ */
+const clean = (filters: Filters, blacklist?: string[]) => {
+  const reducer = (cleaned: Filters, key: string) => {
+    const valueAllowed = (filters[key] ?? "") != "";
+    if (valueAllowed && !blacklist?.includes(key)) {
+      cleaned[key] = filters[key];
+    }
+    return cleaned;
+  };
+
+  return Object.keys(filters).reduce(reducer, {});
+};
+
+/**
+ * Retrieves the cached filters
+ */
+const get = (key?: string) => {
+  const content = localStorage.getItem(key ?? getKey());
+  return content ? (JSON.parse(content) as Filters) : null;
+};
+
+/**
+ * Sets the filters cache with the specified filters.
+ */
+const set = (filters: Filters, blacklist?: string[], key?: string) => {
+  key ??= getKey();
+  filters = clean(filters, blacklist);
+
+  if (Object.keys(filters).length) {
+    localStorage.setItem(key, JSON.stringify(filters));
+  } else {
+    invalidate(key);
+  }
+};
+
+/**
+ * Removes the filters cache for the specified key or current URL.
+ */
+const invalidate = (key?: string) => {
+  localStorage.removeItem(key ?? getKey());
+};
+
+/**
+ * Removes all filters cache in the platform.
+ */
+const invaldiateAll = () => {
+  for (const key in localStorage) {
+    if (key.startsWith("filters--")) {
+      invalidate(key);
+    }
+  }
+};
+
+export default {
+  get,
+  set,
+  invalidate,
+  invaldiateAll,
+  utils: {
+    clean,
+  },
+};

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -449,14 +449,6 @@ export const showUserDelete = (authUser: UserModel, targetUser: UserModel) => {
   return false;
 };
 
-export const invalidateFiltersCache = () => {
-  for (const key in localStorage) {
-    if (key.startsWith("filters--")) {
-      localStorage.removeItem(key);
-    }
-  }
-};
-
 export const compareBy = <T extends object>(key: keyof T) => {
   return (a: T, b: T) => {
     return a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0;


### PR DESCRIPTION
## Proposed Changes

- Fixes #7151
- Fixes #7166
- Restore cache on mount only if qParams does not exist already and cache is present.
- URL Query Params will now contain filters that are applied only instead of all filters.
- Filters cache will now contain filters that are applied only instead of all filters.

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/c34e59fb-cb0f-4895-a185-50e43f6e15ba">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
