### PR TITLE
Limit the decimal points in the Facility GPS Location field upto 7.

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -252,8 +252,10 @@ export const FacilityCreate = (props: FacilityProps) => {
                 ? "+91" + data.phone_number
                 : data.phone_number
               : "",
-            latitude: data.latitude ? String(data.latitude) : "",
-            longitude: data.longitude ? String(data.longitude) : "",
+            latitude: data.latitude ? parseFloat(data.latitude).toFixed(7) : "",
+            longitude: data.longitude
+              ? parseFloat(data.longitude).toFixed(7)
+              : "",
             type_b_cylinders: data.type_b_cylinders,
             type_c_cylinders: data.type_c_cylinders,
             type_d_cylinders: data.type_d_cylinders,
@@ -292,8 +294,8 @@ export const FacilityCreate = (props: FacilityProps) => {
         type: "set_form",
         form: {
           ...state.form,
-          latitude: location.lat().toString(),
-          longitude: location.lng().toString(),
+          latitude: location.lat().toFixed(7),
+          longitude: location.lng().toFixed(7),
         },
       });
     }


### PR DESCRIPTION
## Proposed Changes

- Fixes #7135 
-Prior to this change GPS location picker limits the decimal point to 14. This PR updates the decimal points to 7.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
