### PR TITLE
Make Update Log buttons responsive

### DIFF
--- a/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
@@ -126,7 +126,11 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
         )}
       <div className="flex flex-col xl:flex-row">
         <div className="w-full xl:w-2/3">
-          <PageTitle title="Info" hideBack={true} breadcrumbs={false} />
+          <PageTitle
+            title="Basic Information"
+            hideBack={true}
+            breadcrumbs={false}
+          />
           <div className="mt-4 grid gap-4 lg:grid-cols-2">
             {!props.consultationData.discharge_date &&
               ((hl7SocketUrl && !ventilatorSocketUrl) ||

--- a/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
@@ -32,7 +32,7 @@ const DefaultLogUpdateCard = ({ round, ...props }: Props) => {
         attributeKey="other_details"
         attributeValue={round.other_details}
       />
-      <div className="mt-2 flex w-full flex-col items-center gap-2 md:w-auto md:flex-row">
+      <div className="mt-2 flex w-full flex-col items-center gap-2 md:w-auto 2xl:flex-row">
         <ButtonV2
           variant="secondary"
           border


### PR DESCRIPTION
This pull request updates the Update Log buttons to be responsive. It includes changes to the ConsultationUpdatesTab.tsx and DefaultLogUpdateCard.tsx files.

Fixes #7181

![image](https://github.com/coronasafe/care_fe/assets/3626859/b9ceff3a-8198-4cf4-bef3-b934b05b6e3c)
