### PR TITLE
Add facility name to ReportTable component

### DIFF
--- a/src/Components/Facility/Investigations/Reports/ReportTable.tsx
+++ b/src/Components/Facility/Investigations/Reports/ReportTable.tsx
@@ -5,12 +5,17 @@ import { InvestigationResponse } from "./types";
 import { formatAge, formatDateTime } from "../../../../Utils/utils";
 import { FC } from "react";
 
-const ReportRow = ({ data, name, min, max }: any) => {
+const ReportRow = ({ data, name, min, max, facilityName }: any) => {
   return (
     <tr className="bg-white even:bg-gray-50">
       <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
         {name}
       </td>
+      {facilityName && (
+        <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+          {facilityName}
+        </td>
+      )}
       {data.map((d: any) => {
         const color = getColorIndex({
           min: d?.min,
@@ -57,6 +62,7 @@ interface ReportTableProps {
     hospitalName: string;
   };
   investigationData: InvestigationResponse;
+  showFacilityName?: boolean;
   hidePrint?: boolean;
 }
 
@@ -64,6 +70,7 @@ const ReportTable: FC<ReportTableProps> = ({
   title,
   investigationData,
   patientDetails,
+  showFacilityName = false,
   hidePrint = false,
 }) => {
   const { data, sessions } = transformData(investigationData);
@@ -120,6 +127,14 @@ const ReportTable: FC<ReportTableProps> = ({
                 >
                   Name
                 </th>
+                {showFacilityName && (
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-800"
+                  >
+                    Facility
+                  </th>
+                )}
                 {sessions.map((session) => (
                   <th
                     scope="col"
@@ -153,6 +168,11 @@ const ReportTable: FC<ReportTableProps> = ({
                       min={t.investigation_object.min_value}
                       max={t.investigation_object.max_value}
                       name={t.investigation_object.name}
+                      facilityName={
+                        showFacilityName
+                          ? t.consultation_object.facility_name
+                          : null
+                      }
                     />
                   );
                 })

--- a/src/Components/Facility/Investigations/Reports/ReportTable.tsx
+++ b/src/Components/Facility/Investigations/Reports/ReportTable.tsx
@@ -5,17 +5,12 @@ import { InvestigationResponse } from "./types";
 import { formatAge, formatDateTime } from "../../../../Utils/utils";
 import { FC } from "react";
 
-const ReportRow = ({ data, name, min, max, facilityName }: any) => {
+const ReportRow = ({ data, name, min, max }: any) => {
   return (
     <tr className="bg-white even:bg-gray-50">
       <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
         {name}
       </td>
-      {facilityName && (
-        <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
-          {facilityName}
-        </td>
-      )}
       {data.map((d: any) => {
         const color = getColorIndex({
           min: d?.min,
@@ -62,7 +57,6 @@ interface ReportTableProps {
     hospitalName: string;
   };
   investigationData: InvestigationResponse;
-  showFacilityName?: boolean;
   hidePrint?: boolean;
 }
 
@@ -70,7 +64,6 @@ const ReportTable: FC<ReportTableProps> = ({
   title,
   investigationData,
   patientDetails,
-  showFacilityName = false,
   hidePrint = false,
 }) => {
   const { data, sessions } = transformData(investigationData);
@@ -127,21 +120,21 @@ const ReportTable: FC<ReportTableProps> = ({
                 >
                   Name
                 </th>
-                {showFacilityName && (
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-800"
-                  >
-                    Facility
-                  </th>
-                )}
                 {sessions.map((session) => (
                   <th
                     scope="col"
                     key={session.session_external_id}
-                    className="bg-[#4B5563] px-6 py-3 text-center text-xs font-semibold uppercase  tracking-wider text-[#F9FAFB]"
+                    className="bg-[#4B5563] px-6 py-3 text-center text-xs  font-semibold tracking-wider text-[#F9FAFB]"
                   >
-                    {formatDateTime(session.session_created_date)}
+                    <div className="flex flex-col items-center justify-center gap-1">
+                      {formatDateTime(session.session_created_date)}
+                      <a
+                        className="max-w-fit font-semibold text-white hover:underline"
+                        href={`/facility/${session.facility_id}/`}
+                      >
+                        {session.facility_name}
+                      </a>
+                    </div>
                   </th>
                 ))}
                 <th
@@ -168,11 +161,6 @@ const ReportTable: FC<ReportTableProps> = ({
                       min={t.investigation_object.min_value}
                       max={t.investigation_object.max_value}
                       name={t.investigation_object.name}
-                      facilityName={
-                        showFacilityName
-                          ? t.consultation_object.facility_name
-                          : null
-                      }
                     />
                   );
                 })

--- a/src/Components/Facility/Investigations/Reports/index.tsx
+++ b/src/Components/Facility/Investigations/Reports/index.tsx
@@ -421,6 +421,7 @@ const InvestigationReports = ({ id }: any) => {
                   investigationData={investigationTableData}
                   title="Report"
                   patientDetails={patientDetails}
+                  showFacilityName={true}
                 />
 
                 {!loadMoreDisabled && (

--- a/src/Components/Facility/Investigations/Reports/index.tsx
+++ b/src/Components/Facility/Investigations/Reports/index.tsx
@@ -421,7 +421,6 @@ const InvestigationReports = ({ id }: any) => {
                   investigationData={investigationTableData}
                   title="Report"
                   patientDetails={patientDetails}
-                  showFacilityName={true}
                 />
 
                 {!loadMoreDisabled && (

--- a/src/Components/Facility/Investigations/Reports/types.ts
+++ b/src/Components/Facility/Investigations/Reports/types.ts
@@ -1,8 +1,10 @@
 import { InvestigationValueType } from "..";
+import { ConsultationModel } from "../../models";
 
 export interface Investigation {
   id: string;
   group_object: any;
+  consultation_object: ConsultationModel;
   investigation_object: {
     external_id: string;
     name: string;
@@ -21,7 +23,6 @@ export interface Investigation {
   notes: any;
   investigation: number;
   group: any;
-  consultation: number;
   session: number;
 }
 

--- a/src/Components/Facility/Investigations/Reports/types.ts
+++ b/src/Components/Facility/Investigations/Reports/types.ts
@@ -18,6 +18,8 @@ export interface Investigation {
   session_object: {
     session_external_id: string;
     session_created_date: string;
+    facility_name: string;
+    facility_id: string;
   };
   value: number | null;
   notes: any;

--- a/src/Components/Facility/Investigations/Reports/utils.tsx
+++ b/src/Components/Facility/Investigations/Reports/utils.tsx
@@ -28,7 +28,7 @@ export const transformData = _.memoize((data: InvestigationResponse) => {
       }
     });
     const {
-      consultation,
+      consultation_object,
       group,
       group_object,
       id,
@@ -40,7 +40,7 @@ export const transformData = _.memoize((data: InvestigationResponse) => {
     } = value[0];
 
     return {
-      consultation,
+      consultation_object,
       group,
       group_object,
       id,

--- a/src/Components/Facility/Investigations/Reports/utils.tsx
+++ b/src/Components/Facility/Investigations/Reports/utils.tsx
@@ -3,7 +3,13 @@ import { InvestigationResponse } from "./types";
 
 export const transformData = _.memoize((data: InvestigationResponse) => {
   const sessions = _.chain(data)
-    .map((value) => value.session_object)
+    .map((value) => {
+      return {
+        ...value.session_object,
+        facility_name: value.consultation_object?.facility_name,
+        facility_id: value.consultation_object?.facility,
+      };
+    })
     .uniqBy("session_external_id")
     .orderBy("session_created_date", "desc")
     .value();
@@ -28,7 +34,6 @@ export const transformData = _.memoize((data: InvestigationResponse) => {
       }
     });
     const {
-      consultation_object,
       group,
       group_object,
       id,
@@ -40,7 +45,6 @@ export const transformData = _.memoize((data: InvestigationResponse) => {
     } = value[0];
 
     return {
-      consultation_object,
       group,
       group_object,
       id,

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -411,7 +411,7 @@ export default function PatientInfoCard(props: {
                             Principal Diagnosis:
                           </div>
                           <div className="flex gap-2 text-sm">
-                            {principal_diagnosis.diagnosis_object.label}{" "}
+                            {principal_diagnosis.diagnosis_object?.label ?? "-"}{" "}
                             <span className="flex items-center rounded border border-primary-500 pl-1 pr-2 text-xs font-medium text-primary-500">
                               <CareIcon icon="l-check" className="text-base" />
                               <p className="capitalize">


### PR DESCRIPTION
Fixes #7150
Waiting for backend: https://github.com/coronasafe/care/pull/1876
This pull request adds the facility name to the ReportTable component in order to display it in the table.

![image](https://github.com/coronasafe/care_fe/assets/3626859/db142bd0-f2a9-4f84-930b-6c33253a2902)
