### PR TITLE
fix: hide the diagonses card if it's empty

### DIFF
--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -401,7 +401,7 @@ export const ConsultationDetails = (props: any) => {
             </div>
           </div>
         </div>
-        {consultationData.diagnoses?.length && (
+        {!!consultationData.diagnoses?.length && (
           <div className="col-span-1 mt-2 overflow-hidden rounded-lg bg-white shadow">
             <div className="px-4 py-2">
               <DiagnosesListAccordion

--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -401,16 +401,15 @@ export const ConsultationDetails = (props: any) => {
             </div>
           </div>
         </div>
-        {consultationData.diagnoses &&
-          consultationData.diagnoses.length > 0 && (
-            <div className="col-span-1 mt-2 overflow-hidden rounded-lg bg-white shadow">
-              <div className="px-4 py-2">
-                <DiagnosesListAccordion
-                  diagnoses={consultationData.diagnoses ?? []}
-                />
-              </div>
+        {consultationData.diagnoses?.length && (
+          <div className="col-span-1 mt-2 overflow-hidden rounded-lg bg-white shadow">
+            <div className="px-4 py-2">
+              <DiagnosesListAccordion
+                diagnoses={consultationData.diagnoses ?? []}
+              />
             </div>
-          )}
+          </div>
+        )}
         <div className="mt-4 w-full border-b-2 border-gray-200">
           <div className="overflow-x-auto sm:flex sm:items-baseline">
             <div className="mt-4 sm:mt-0">

--- a/src/Components/Facility/ConsultationDetails/index.tsx
+++ b/src/Components/Facility/ConsultationDetails/index.tsx
@@ -401,13 +401,16 @@ export const ConsultationDetails = (props: any) => {
             </div>
           </div>
         </div>
-        <div className="col-span-1 mt-2 overflow-hidden rounded-lg bg-white shadow">
-          <div className="px-4 py-2">
-            <DiagnosesListAccordion
-              diagnoses={consultationData.diagnoses ?? []}
-            />
-          </div>
-        </div>
+        {consultationData.diagnoses &&
+          consultationData.diagnoses.length > 0 && (
+            <div className="col-span-1 mt-2 overflow-hidden rounded-lg bg-white shadow">
+              <div className="px-4 py-2">
+                <DiagnosesListAccordion
+                  diagnoses={consultationData.diagnoses ?? []}
+                />
+              </div>
+            </div>
+          )}
         <div className="mt-4 w-full border-b-2 border-gray-200">
           <div className="overflow-x-auto sm:flex sm:items-baseline">
             <div className="mt-4 sm:mt-0">


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- [x] Fixes #7187

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Screenshot

- Current staging:
![image](https://github.com/coronasafe/care_fe/assets/77210185/8e90d229-79c8-4ae1-87b2-83a06b75251e)

- Fix:
![image](https://github.com/coronasafe/care_fe/assets/77210185/f993de4d-db10-413f-b55a-673a722a58bb)


## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
