### PR TITLE
Add min_encounter_date validation

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -22,5 +22,6 @@
     "sample_format_asset_import": "https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=11JaEhNHdyCHth4YQs_44YaRlP77Rrqe81VSEfg1glko&exportFormat=xlsx",
     "sample_format_external_result_import": "/External-Results-Template.csv",
     "enable_abdm": true,
-    "enable_hcx": false
+    "enable_hcx": false,
+    "min_encounter_date": "2020-01-01"
 }

--- a/src/Common/hooks/useConfig.ts
+++ b/src/Common/hooks/useConfig.ts
@@ -69,6 +69,11 @@ export interface IConfig {
    */
   wartime_shifting: boolean;
   jwt_token_refresh_interval?: number;
+
+  /*
+   * Minimum date for a possible consultation encounter.
+   */
+  min_encounter_date: string;
 }
 
 const useConfig = () => {

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -507,6 +507,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
             invalidForm = true;
           }
           if (
+            min_encounter_date &&
             dayjs(state.form.encounter_date).isBefore(dayjs(min_encounter_date))
           ) {
             errors[

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -263,6 +263,8 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
   const [bedStatusVisible, bedStatusRef] = useVisibility(-300);
   const [disabledFields, setDisabledFields] = useState<string[]>([]);
 
+  const { min_encounter_date } = useConfig();
+
   const sections = {
     "Consultation Details": {
       iconClass: "care-l-medkit",
@@ -504,8 +506,12 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
             errors[field] = "Field is required";
             invalidForm = true;
           }
-          if (dayjs(state.form.encounter_date).isBefore(dayjs("2000-01-01"))) {
-            errors[field] = "Admission date cannot be before 01/01/2000";
+          if (
+            dayjs(state.form.encounter_date).isBefore(dayjs(min_encounter_date))
+          ) {
+            errors[
+              field
+            ] = `Admission date cannot be before ${min_encounter_date}`;
             invalidForm = true;
           }
           return;
@@ -1238,6 +1244,11 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                         "YYYY-MM-DDTHH:mm"
                       )}
                       max={dayjs().format("YYYY-MM-DDTHH:mm")}
+                      min={
+                        min_encounter_date
+                          ? dayjs(min_encounter_date).format("YYYY-MM-DDTHH:mm")
+                          : undefined
+                      }
                     />
                   </div>
 


### PR DESCRIPTION
This pull request adds validation for the minimum encounter date in the consultation form. It ensures that the admission date cannot be before the specified minimum encounter date.