### PR TITLE
feat:Inline view of selected options of Multiselect

### DIFF
--- a/src/Components/Form/MultiSelectMenuV2.tsx
+++ b/src/Components/Form/MultiSelectMenuV2.tsx
@@ -61,9 +61,6 @@ const MultiSelectMenuV2 = <T, V>(props: Props<T, V>) => {
     if (selectedOptions.length === 0) return placeholder;
     if (props.renderSelectedOptions)
       return props.renderSelectedOptions(selectedOptions.map((o) => o.option));
-    return (
-      <span className="text-gray-800">{`${selectedOptions.length} item(s) selected`}</span>
-    );
   };
 
   return (
@@ -89,17 +86,30 @@ const MultiSelectMenuV2 = <T, V>(props: Props<T, V>) => {
                       <p className="ml-2.5 text-sm font-normal text-gray-600">
                         <Placeholder />
                       </p>
+
+                      {selectedOptions.length !== 0 && (
+                        <div className="flex flex-wrap gap-2 p-2">
+                          {selectedOptions.map((option) => (
+                            <MultiSelectOptionChip
+                              key={option.value}
+                              label={option.selectedLabel}
+                              onRemove={() => {
+                                const updatedOptions = selectedOptions.filter(
+                                  (selectedOption) =>
+                                    selectedOption.value !== option.value
+                                );
+                                props.onChange(
+                                  updatedOptions.map((o) => o.value) as any
+                                );
+                              }}
+                            />
+                          ))}
+                        </div>
+                      )}
                     </div>
                     <CareIcon className="care-l-angle-down -mb-0.5 text-lg text-gray-900" />
                   </div>
                 </Listbox.Button>
-                {selectedOptions.length !== 0 && (
-                  <div className="flex flex-wrap gap-2 p-2">
-                    {selectedOptions.map((option) => (
-                      <MultiSelectOptionChip label={option.selectedLabel} />
-                    ))}
-                  </div>
-                )}
               </div>
               <DropdownTransition show={open}>
                 <Listbox.Options className="cui-dropdown-base absolute top-12">


### PR DESCRIPTION
## Proposed Changes
Implement showing the selected options within the input itself. Overflowing chips could be wrapped in a new line within the input itself or be horizontally scrollable in one line. Additionally, each chip could optionally have a remove button to the right of it.

- Fixes #7278 

![image](https://github.com/coronasafe/care_fe/assets/72148636/49754041-f18c-474e-abfe-86ab7b3bcb7f)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
