### PR TITLE
Log update vital feature modified 

### DIFF
--- a/src/Components/CriticalCareRecording/Pain/CriticalCare__PainInputModal.res
+++ b/src/Components/CriticalCareRecording/Pain/CriticalCare__PainInputModal.res
@@ -55,13 +55,15 @@ let make = (
     }
   })
 
-  let getStatus = (min, minText, max, maxText, val) => {
-    switch (val >= min, val <= max) {
-    | (true, true) => ("Normal", "#059669")
-    | (true, false) => (maxText, "#DC2626")
-    | _ => (minText, "#DC2626")
-    }
+  let getLabel = (param: float) => {
+  let minText = "Low"
+  let maxText = "High"
+  switch param {
+  | 0.0 => (minText, "#059669")
+  | 5.0 => (maxText, "#DC2626")
+  | _ => ("", "")
   }
+}
 
   <div
     hidden={!show}
@@ -104,7 +106,7 @@ let make = (
                       | None => setState(prev => {...prev, scale: 0})
                       }
                     }}
-                    getLabel={getStatus(2.0, "Low", 4.0, "High")}
+                    getLabel={getLabel}
                     hasError={ValidationUtils.isInputInRangeInt(
                       0,
                       5,


### PR DESCRIPTION
## Proposed Changes
In Log updates (Critical round), Vitals section, there is a section to mark details of pain.
Against a region, user can mark scale of pain from 0-5.
Here the text "Low" , "Normal", "High" comes written next to the number.

Here is the Screenshot of the fix
![image](https://github.com/coronasafe/care_fe/assets/100074110/1df8722c-d81c-4f2f-a5c7-3d3a9e65ad79)


- Fixes #7290 
-  Here removed the text Normal for painscale 1-4


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x]  removed the appearance of "normal" against 1-4 painscale
