### PR TITLE
Fix stretching issue in comment section on shifting detail page

### DIFF
--- a/src/Components/Shifting/CommentsSection.tsx
+++ b/src/Components/Shifting/CommentsSection.tsx
@@ -9,10 +9,63 @@ import { IComment } from "../Resource/models";
 import PaginatedList from "../../CAREUI/misc/PaginatedList";
 import request from "../../Utils/request/request";
 
-interface CommentSectionProps {
+interface CommentProps {
   id: string;
+  comment: string;
+  created_by_object: any;
+  modified_date: string;
 }
-const CommentSection = (props: CommentSectionProps) => {
+
+const Comment = ({
+  id,
+  comment,
+  created_by_object,
+  modified_date,
+}: CommentProps) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
+
+  const truncatedComment = comment.split(" ").slice(0, 20).join(" ");
+  const remainingComment = comment.split(" ").slice(20).join(" ");
+
+  return (
+    <div
+      key={id}
+      className="mt-4 flex  flex-col rounded-lg border border-gray-500 bg-white p-4 text-gray-800"
+    >
+      <div className="flex  w-full ">
+        <p className="text-justify">
+          {expanded ? comment : truncatedComment}
+          {!expanded && remainingComment && (
+            <button onClick={toggleExpanded} className="ml-2 text-blue-500">
+              Read more
+            </button>
+          )}
+        </p>
+      </div>
+      <div className="mt-3">
+        <span className="text-xs text-gray-500">
+          {modified_date ? formatDateTime(modified_date) : "-"}
+        </span>
+      </div>
+      <div className=" mr-auto flex items-center rounded-md border bg-gray-100 py-1 pl-2 pr-3">
+        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-700 p-1 uppercase text-white">
+          {created_by_object?.first_name?.charAt(0) || t("unknown")}
+        </div>
+        <span className="pl-2 text-sm text-gray-700">
+          {created_by_object?.first_name || t("unknown")}{" "}
+          {created_by_object?.last_name}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const CommentSection = ({ id }: { id: string }) => {
   const [commentBox, setCommentBox] = useState("");
   const { t } = useTranslation();
 
@@ -27,21 +80,17 @@ const CommentSection = (props: CommentSectionProps) => {
       return;
     }
     const { res } = await request(routes.addShiftComments, {
-      pathParams: { id: props.id },
+      pathParams: { id: id },
       body: payload,
     });
     if (res?.ok) {
       Notification.Success({ msg: t("comment_added_successfully") });
-
       setCommentBox("");
     }
   };
 
   return (
-    <PaginatedList
-      route={routes.getShiftComments}
-      pathParams={{ id: props.id }}
-    >
+    <PaginatedList route={routes.getShiftComments} pathParams={{ id: id }}>
       {(_, query) => (
         <div className="flex w-full flex-col">
           <textarea
@@ -81,36 +130,3 @@ const CommentSection = (props: CommentSectionProps) => {
 };
 
 export default CommentSection;
-
-export const Comment = ({
-  id,
-  comment,
-  created_by_object,
-  modified_date,
-}: IComment) => {
-  const { t } = useTranslation();
-  return (
-    <div
-      key={id}
-      className="mt-4 flex w-full flex-col rounded-lg border border-gray-300 bg-white p-4 text-gray-800"
-    >
-      <div className="flex  w-full ">
-        <p className="text-justify">{comment}</p>
-      </div>
-      <div className="mt-3">
-        <span className="text-xs text-gray-500">
-          {modified_date ? formatDateTime(modified_date) : "-"}
-        </span>
-      </div>
-      <div className=" mr-auto flex items-center rounded-md border bg-gray-100 py-1 pl-2 pr-3">
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-700 p-1 uppercase text-white">
-          {created_by_object?.first_name?.charAt(0) || t("unknown")}
-        </div>
-        <span className="pl-2 text-sm text-gray-700">
-          {created_by_object?.first_name || t("unknown")}{" "}
-          {created_by_object?.last_name}
-        </span>
-      </div>
-    </div>
-  );
-};

--- a/src/Components/Shifting/CommentsSection.tsx
+++ b/src/Components/Shifting/CommentsSection.tsx
@@ -41,8 +41,13 @@ const Comment = ({
         <p className="text-justify">
           {expanded ? comment : truncatedComment}
           {!expanded && remainingComment && (
-            <button onClick={toggleExpanded} className="ml-2 text-blue-500">
-              Read more
+            <button onClick={toggleExpanded} className="ml-2 text-green-600">
+              ..... Read more
+            </button>
+          )}
+          {expanded && remainingComment && (
+            <button onClick={toggleExpanded} className="ml-2 text-green-600">
+              Read less
             </button>
           )}
         </p>

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -281,7 +281,7 @@ export default function ShiftDetails(props: { id: string }) {
 
   const showFacilityCard = (facilityData: any) => {
     return (
-      <div className="mt-2 h-full rounded-lg border bg-white p-4 text-black shadow">
+      <div className="mt-2 rounded-lg border bg-white p-4 text-black shadow lg:h-[25vh] lg:w-[30vw]">
         <div>
           <span className="mr-1 font-semibold leading-relaxed">
             {t("name")}:{" "}
@@ -796,10 +796,6 @@ export default function ShiftDetails(props: { id: string }) {
                 </h4>
                 {showPatientCard(data?.patient_object)}
               </div>
-              <div className="mb-10 mr-3 md:mr-8">
-                <h4 className="mt-8">{t("comments")}</h4>
-                <CommentSection id={props.id} />
-              </div>
             </div>
 
             <div className="col-span-2">
@@ -838,12 +834,12 @@ export default function ShiftDetails(props: { id: string }) {
 
                 {showFacilityCard(data?.origin_facility_object)}
               </div>
-              {!data?.assigned_facility_external && (
+              {/* {!data?.assigned_facility_external && (
                 <div>
                   <h4 className="mt-8">{t("details_of_assigned_facility")}</h4>
                   {showFacilityCard(data?.assigned_facility_object)}
                 </div>
-              )}
+              )} */}
               {wartime_shifting && (
                 <div>
                   <h4 className="mt-8">
@@ -852,6 +848,28 @@ export default function ShiftDetails(props: { id: string }) {
                   {showFacilityCard(data?.shifting_approving_facility_object)}
                 </div>
               )}
+            </div>
+            <div
+              className="Details of assigned facility flex w-full flex-col lg:flex-row
+
+"
+            >
+              <div className="Details of assigned facility">
+                {!data?.assigned_facility_external && (
+                  <div className=" w-full lg:w-[50vw]">
+                    <h4 className="mt-8">
+                      {t("details_of_assigned_facility")}
+                    </h4>
+                    {showFacilityCard(data?.assigned_facility_object)}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="">
+            <div className="mb-10 mr-3 md:mr-8">
+              <h4 className="mt-8">{t("comments")}</h4>
+              <CommentSection id={props.id} />
             </div>
           </div>
         </Page>


### PR DESCRIPTION
I have realigned the UI of the shift page and also added a "Read More" and "Read Less" option for comments with more than 30 words.

Closes #6637