### PR TITLE
"Fix issue #7361: Block users from entering date out of range"

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -159,6 +159,22 @@ const DateInputV2: React.FC<Props> = ({
     return true;
   };
 
+  const isDateWithinLimits = (parsedDate: dayjs.Dayjs): boolean => {
+    if (parsedDate?.isValid()) {
+      if (
+        (max && parsedDate.toDate() > max) ||
+        (min && parsedDate.toDate() < min)
+      ) {
+        Notification.Error({
+          msg: outOfLimitsErrorMessage ?? "Cannot select date out of range",
+        });
+        return false;
+      }
+      return true;
+    }
+    return false;
+  };
+
   const isSelectedMonth = (month: number) =>
     month === datePickerHeaderDate.getMonth();
 
@@ -261,7 +277,7 @@ const DateInputV2: React.FC<Props> = ({
                       onChange={(e) => {
                         setDisplayValue(e.target.value.replaceAll("/", ""));
                         const value = dayjs(e.target.value, "DD/MM/YYYY", true);
-                        if (value.isValid()) {
+                        if (isDateWithinLimits(value)) {
                           onChange(value.toDate());
                           close();
                           setIsOpen?.(false);


### PR DESCRIPTION
## Proposed Changes

- Fixes #7361 
- "now we blocked user to add facility triage with a future date."
- also now each date like enter dob for example issue #7360 user will not be allowed to type date input not valid "notification error will pop up"

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
![Screenshot (140)](https://github.com/coronasafe/care_fe/assets/103316419/a12959a6-140b-4c97-8f29-daa9015ce0b2)


## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
