### PR TITLE
Show asset down on assets manage page

### DIFF
--- a/src/Components/Assets/AssetManage.tsx
+++ b/src/Components/Assets/AssetManage.tsx
@@ -387,6 +387,13 @@ const AssetManage = (props: AssetManageProps) => {
                   {warrantyAmcValidityChip(
                     asset?.warranty_amc_end_of_validity as string
                   )}
+                  {asset?.latest_status === "Down" && (
+                    <Chip
+                      variant="danger"
+                      startIcon="l-link-broken"
+                      text={asset?.latest_status}
+                    />
+                  )}
                 </div>
               </div>
               <div className="mt-3 hidden text-gray-700 sm:block">


### PR DESCRIPTION
## Proposed Changes

- Fixes #7442 
Display the Asset Down Chip on the Asset Manage page
![image](https://github.com/coronasafe/care_fe/assets/70687348/47d9179d-1d13-4a48-abc2-3d78898f0adb)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
