### PR TITLE
added toast messages on facility and skills dialog

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -639,6 +639,15 @@ function UserFacilities(props: { user: any }) {
       body: { home_facility: facility.id.toString() },
     });
     if (res && res.status === 200) user.home_facility_object = facility;
+    if (res?.status !== 200) {
+      Notification.Error({
+        msg: "Error while updating Home facility",
+      });
+    } else {
+      Notification.Success({
+        msg: "Home Facility updated successfully",
+      });
+    }
     await refetchUserFacilities();
     setIsLoading(false);
   };
@@ -650,11 +659,29 @@ function UserFacilities(props: { user: any }) {
         pathParams: { username },
       });
       if (res && res.status === 204) user.home_facility_object = null;
+      if (res?.status !== 204) {
+        Notification.Error({
+          msg: "Error while clearing home facility",
+        });
+      } else {
+        Notification.Success({
+          msg: "Home Facility cleared successfully",
+        });
+      }
     } else {
-      await request(routes.deleteUserFacility, {
+      const { res } = await request(routes.deleteUserFacility, {
         pathParams: { username },
         body: { facility: unlinkFacilityData?.facility?.id?.toString() },
       });
+      if (res?.status !== 204) {
+        Notification.Error({
+          msg: "Error while unlinking home facility",
+        });
+      } else {
+        Notification.Success({
+          msg: "Facility unlinked successfully",
+        });
+      }
     }
     await refetchUserFacilities();
     hideUnlinkFacilityModal();
@@ -667,9 +694,16 @@ function UserFacilities(props: { user: any }) {
       pathParams: { username },
       body: { facility: facility.id.toString() },
     });
+
+    console.log(res);
+
     if (res?.status !== 201) {
       Notification.Error({
         msg: "Error while linking facility",
+      });
+    } else {
+      Notification.Success({
+        msg: "Facility linked successfully",
       });
     }
     await refetchUserFacilities();

--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -638,12 +638,12 @@ function UserFacilities(props: { user: any }) {
       pathParams: { username },
       body: { home_facility: facility.id.toString() },
     });
-    if (res && res.status === 200) user.home_facility_object = facility;
-    if (res?.status !== 200) {
+    if (!res?.ok) {
       Notification.Error({
         msg: "Error while updating Home facility",
       });
     } else {
+      user.home_facility_object = facility;
       Notification.Success({
         msg: "Home Facility updated successfully",
       });
@@ -658,12 +658,13 @@ function UserFacilities(props: { user: any }) {
       const { res } = await request(routes.clearHomeFacility, {
         pathParams: { username },
       });
-      if (res && res.status === 204) user.home_facility_object = null;
-      if (res?.status !== 204) {
+
+      if (!res?.ok) {
         Notification.Error({
           msg: "Error while clearing home facility",
         });
       } else {
+        user.home_facility_object = null;
         Notification.Success({
           msg: "Home Facility cleared successfully",
         });
@@ -673,7 +674,7 @@ function UserFacilities(props: { user: any }) {
         pathParams: { username },
         body: { facility: unlinkFacilityData?.facility?.id?.toString() },
       });
-      if (res?.status !== 204) {
+      if (!res?.ok) {
         Notification.Error({
           msg: "Error while unlinking home facility",
         });
@@ -695,9 +696,7 @@ function UserFacilities(props: { user: any }) {
       body: { facility: facility.id.toString() },
     });
 
-    console.log(res);
-
-    if (res?.status !== 201) {
+    if (!res?.ok) {
       Notification.Error({
         msg: "Error while linking facility",
       });

--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -45,6 +45,9 @@ export default ({ show, setShow, username }: IProps) => {
         pathParams: { username },
         body: { skill: skill.id },
       });
+
+      console.log(res);
+
       if (!res?.ok) {
         Notification.Error({
           msg: "Error while adding skill",
@@ -69,6 +72,10 @@ export default ({ show, setShow, username }: IProps) => {
       if (res?.status !== 204) {
         Notification.Error({
           msg: "Error while unlinking skill",
+        });
+      } else {
+        Notification.Success({
+          msg: "Skill unlinked successfully",
         });
       }
       setDeleteSkill(null);

--- a/src/Components/Users/SkillsSlideOver.tsx
+++ b/src/Components/Users/SkillsSlideOver.tsx
@@ -46,8 +46,6 @@ export default ({ show, setShow, username }: IProps) => {
         body: { skill: skill.id },
       });
 
-      console.log(res);
-
       if (!res?.ok) {
         Notification.Error({
           msg: "Error while adding skill",


### PR DESCRIPTION
## Proposed Changes

- Fixes #7447 
I've implemented toast messages for success and error events in the linking/unlinking facility and skill section in the users page

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

## screenshots

https://github.com/coronasafe/care_fe/assets/104725768/1e6ba5ee-cfdd-4528-8d95-11e70a3181e2


