### PR TITLE
edit padding in shifting board and resource board pages in mobile screen

### DIFF
--- a/src/Components/Resource/ResourceBoardView.tsx
+++ b/src/Components/Resource/ResourceBoardView.tsx
@@ -87,8 +87,8 @@ export default function BoardView() {
       </div>
 
       <BadgesList {...{ appliedFilters, FilterBadges }} />
-      <ScrollingComponent className="mt-4 flex flex-1 items-start overflow-x-scroll px-4 pb-2 @container">
-        <div className="mt-4 flex flex-1 items-start overflow-x-scroll px-4 pb-2">
+      <ScrollingComponent className="mt-4 flex flex-1 items-start overflow-x-scroll px-0 pb-2 @container">
+        <div className="mt-4 flex flex-1 items-start overflow-x-scroll px-0 pb-2">
           {isLoading ? (
             <Loading />
           ) : (

--- a/src/Components/Shifting/BoardView.tsx
+++ b/src/Components/Shifting/BoardView.tsx
@@ -113,7 +113,7 @@ export default function BoardView() {
       isIconEnable && (
         <div
           className={`relative z-20 self-center ${
-            direction === "right" ? "-left-12" : ""
+            direction === "right" ? "-left-5" : ""
           }`}
         >
           <CareIcon
@@ -184,7 +184,7 @@ export default function BoardView() {
             <>
               {renderArrowIcons("left")}
               <div
-                className="mx-11 flex max-h-[75vh] w-full flex-row overflow-y-auto overflow-x-hidden"
+                className="mx-0 flex max-h-[75vh] w-full flex-row overflow-y-auto overflow-x-hidden"
                 ref={containerRef}
               >
                 {boardFilter.map((board) => (


### PR DESCRIPTION
## Proposed Changes

- Fixes #7427 
- Change : Fixed padding in ScrollingComponent from px-4 to px-0 to enhance card visibility on mobile screens, particularly evident in pages like the shifting board page and resouce board page. 


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist
# screenshots

shifting board page

![image](https://github.com/coronasafe/care_fe/assets/104725768/f881ad4d-ed8c-4d30-b5eb-8e5f4ac193fd)

resource board page

![image](https://github.com/coronasafe/care_fe/assets/104725768/1ad12c1d-f607-4704-aa36-e12aaea81ca0)


## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

