### PR TITLE
Don't allow negative values for quantity in Manage Inventory and Minimum Quantity Required page

### DIFF
--- a/src/Components/Facility/AddInventoryForm.tsx
+++ b/src/Components/Facility/AddInventoryForm.tsx
@@ -160,6 +160,9 @@ export const AddInventoryForm = (props: any) => {
           if (!state.form[field]?.length) {
             errors[field] = "Please select a quantity";
             invalidForm = true;
+          } else if (state.form[field] <= 0) {
+            errors[field] = "Quantity must be more than 0";
+            invalidForm = true;
           }
           return;
         case "unit":

--- a/src/Components/Facility/SetInventoryForm.tsx
+++ b/src/Components/Facility/SetInventoryForm.tsx
@@ -16,8 +16,13 @@ const initForm = {
   id: "",
   quantity: "",
 };
+const initError = Object.assign(
+  {},
+  ...Object.keys(initForm).map((k) => ({ [k]: "" }))
+);
 const initialState = {
   form: { ...initForm },
+  errors: { ...initError },
 };
 
 const inventoryFormReducer = (state = initialState, action: any) => {
@@ -99,8 +104,32 @@ export const SetInventoryForm = (props: any) => {
     }
   }, [state.form.id]);
 
+  const validateForm = () => {
+    const errors = { ...initError };
+    let invalidForm = false;
+
+    Object.keys(state.form).forEach((field) => {
+      switch (field) {
+        case "quantity":
+          if (!state.form[field]?.length) {
+            errors[field] = "Please select a quantity";
+            invalidForm = true;
+          } else if (state.form[field] < 0) {
+            errors[field] = "Quantity can't be negative";
+            invalidForm = true;
+          }
+          return;
+      }
+    });
+
+    dispatch({ type: "set_error", errors });
+    return !invalidForm;
+  };
+
   const handleSubmit = async (e: any) => {
     e.preventDefault();
+    const validated = validateForm();
+    if (!validated) return;
     await request(routes.setMinQuantity, {
       pathParams: { facilityId },
       body: {
@@ -159,6 +188,7 @@ export const SetInventoryForm = (props: any) => {
               type="number"
               value={state.form.quantity}
               onChange={handleChange}
+              error={state.errors.quantity}
             />
 
             <TextFormField


### PR DESCRIPTION
## Proposed Changes

- Fixes #7454 
Show error and don't allow the form to be submitted for invalid values
![image](https://github.com/coronasafe/care_fe/assets/70687348/e56e50e4-3946-4382-97af-96f869400438)

- Show error for negative value for Minimum Quantity Required in Inventory
![image](https://github.com/coronasafe/care_fe/assets/70687348/5874f4b8-f06a-4f3e-8bdc-5479f7c41dbd)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
