### PR TITLE
Fix invalid page title while rendering consent form

### DIFF
--- a/cypress/e2e/patient_spec/patient_consultation.cy.ts
+++ b/cypress/e2e/patient_spec/patient_consultation.cy.ts
@@ -193,6 +193,7 @@ describe("Patient Consultation in multiple combination", () => {
     cy.verifyNotification(
       "Create Diagnoses - Atleast one diagnosis is required"
     );
+    cy.closeNotification();
     patientConsultationPage.selectPatientDiagnosis(
       diagnosis4,
       "add-icd11-diagnosis-as-confirmed"

--- a/cypress/e2e/patient_spec/patient_logupdate.cy.ts
+++ b/cypress/e2e/patient_spec/patient_logupdate.cy.ts
@@ -42,6 +42,7 @@ describe("Patient Log Update in Normal, Critical and TeleIcu", () => {
     patientConsultationPage.selectPatientSuggestion("Domiciliary Care");
     cy.submitButton("Update Consultation");
     cy.verifyNotification("Consultation updated successfully");
+    cy.closeNotification();
     patientLogupdate.clickLogupdate();
     patientLogupdate.typePhysicalExamination(physicalExamination);
     patientLogupdate.typeOtherDetails(otherExamination);
@@ -79,6 +80,7 @@ describe("Patient Log Update in Normal, Critical and TeleIcu", () => {
     patientConsultationPage.selectPatientSuggestion("Domiciliary Care");
     cy.submitButton("Update Consultation");
     cy.verifyNotification("Consultation updated successfully");
+    cy.closeNotification();
     patientLogupdate.clickLogupdate();
     patientLogupdate.typePhysicalExamination(physicalExamination);
     patientLogupdate.typeOtherDetails(otherExamination);

--- a/cypress/e2e/patient_spec/patient_logupdate.cy.ts
+++ b/cypress/e2e/patient_spec/patient_logupdate.cy.ts
@@ -97,6 +97,7 @@ describe("Patient Log Update in Normal, Critical and TeleIcu", () => {
     cy.get("#consciousness_level-2").click();
     cy.submitButton("Save");
     cy.verifyNotification("Consultation Updates details created successfully");
+    cy.closeNotification();
     // edit the card and verify the data.
     patientLogupdate.clickLogupdateCard("#dailyround-entry", patientCategory);
     cy.verifyContentPresence("#consultation-preview", [

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -78,8 +78,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add("verifyNotification", (text) => {
-  cy.get(".pnotify-container").should("exist").contains(text);
-  return cy.get(".pnotify-container").contains(text).click({ force: true });
+  return cy.get(".pnotify-container").should("exist").contains(text);
 });
 
 Cypress.on("uncaught:exception", () => {

--- a/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
@@ -703,6 +703,7 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
                             } )`}
                         </div>
                         <FileUpload
+                          changePageMetadata={false}
                           type="CONSENT_RECORD"
                           hideBack
                           unspecified


### PR DESCRIPTION
This pull request fixes an issue where the page title was invalid when rendering the consent form. The change ensures that the page title is correct and displays the appropriate information.