### PR TITLE
Fix asset qr scan

### DIFF
--- a/src/Components/Assets/AssetsList.tsx
+++ b/src/Components/Assets/AssetsList.tsx
@@ -125,7 +125,7 @@ const AssetsList = () => {
 
   const checkValidAssetId = async (assetId: string) => {
     const { data: assetData } = await request(routes.getAsset, {
-      pathParams: { id: assetId },
+      pathParams: { external_id: assetId },
     });
     try {
       if (assetData) {


### PR DESCRIPTION
Fixes: https://github.com/coronasafe/care_fe/issues/7571

This pull request fixes the asset QR scan functionality by updating the path parameter in the `checkValidAssetId` function from `id` to `external_id` to match the API endpoint.