### PR TITLE
Fix Content-type header in Scribe.tsx

### DIFF
--- a/src/Components/Scribe/Scribe.tsx
+++ b/src/Components/Scribe/Scribe.tsx
@@ -91,7 +91,7 @@ export const Scribe: React.FC<ScribeProps> = ({ fields, onFormUpdate }) => {
       const newFile = new File([f], `${internal_name}`, { type: f.type });
       const config = {
         headers: {
-          "Content-type": newFile?.type,
+          "Content-type": newFile?.type?.split(";")?.[0],
           "Content-disposition": "inline",
         },
       };
@@ -120,7 +120,7 @@ export const Scribe: React.FC<ScribeProps> = ({ fields, onFormUpdate }) => {
           name: filename,
           associating_id: associatingId,
           file_category: category,
-          mime_type: audioBlob?.type.split(";")[0],
+          mime_type: audioBlob?.type?.split(";")?.[0],
         },
       })
         .then((response) => {


### PR DESCRIPTION
This pull request fixes the issue with the Content-type header in the Scribe.tsx file. It ensures that the Content-type is correctly set by splitting the type string and taking the first part.