### PR TITLE
Add Restriction to redirect to facility page if user can't Create Fac…

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -18,7 +18,7 @@ import {
   SelectFormField,
 } from "../Form/FormFields/SelectFormField";
 import { Popover, Transition } from "@headlessui/react";
-import { Fragment, lazy, useState } from "react";
+import { Fragment, lazy, useEffect, useState } from "react";
 import Steps, { Step } from "../Common/Steps";
 import {
   getPincodeDetails,
@@ -57,6 +57,7 @@ import request from "../../Utils/request/request.js";
 import routes from "../../Redux/api.js";
 import useQuery from "../../Utils/request/useQuery.js";
 import { RequestResult } from "../../Utils/request/types.js";
+import useAuthUser from "../../Common/hooks/useAuthUser";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -158,6 +159,21 @@ export const FacilityCreate = (props: FacilityProps) => {
   const { goBack } = useAppHistory();
   const headerText = !facilityId ? "Create Facility" : "Update Facility";
   const buttonText = !facilityId ? "Save Facility" : "Update Facility";
+
+  const authUser = useAuthUser();
+  useEffect(() => {
+    if (
+      authUser &&
+      authUser.user_type !== "StateAdmin" &&
+      authUser.user_type !== "DistrictAdmin" &&
+      authUser.user_type !== "DistrictLabAdmin"
+    ) {
+      navigate("/facility");
+      Notification.Error({
+        msg: "You don't have permission to perform this action. Contact the admin",
+      });
+    }
+  }, [authUser]);
 
   const {
     data: districtData,


### PR DESCRIPTION
## Proposed Changes

- Fixes #7597 
Redirect from the Create Facility page to the Facility home page if the user isn't allowed to create the facility.
Only allow `DistrictAdmin`, `StateAdmin`, and `DistrictLabAdmin` to perform the action
![image](https://github.com/coronasafe/care_fe/assets/70687348/96ba94f8-7e30-4691-a01e-b2f49beb2e7d)

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
