### PR TITLE
Fixes profile page not able to retrieve details for superusers

### DIFF
--- a/src/Components/Users/UserProfile.tsx
+++ b/src/Components/Users/UserProfile.tsx
@@ -144,8 +144,7 @@ export default function UserProfile() {
     data: userData,
     loading: isUserLoading,
     refetch: refetchUserData,
-  } = useQuery(routes.getUserDetails, {
-    pathParams: { username: authUser.username },
+  } = useQuery(routes.currentUser, {
     onResponse: (result) => {
       if (!result || !result.res || !result.data) return;
       const formData: EditForm = {


### PR DESCRIPTION
## Proposed Changes

- Fixes #7650

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/46d25ff7-57f1-44b0-a64d-31b42361f415">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
