### PR TITLE
Disable Discontinue, Administer, Archive Administration & Edit prescription for discharged patients; disallow titrated prescriptions for discharge prescriptions; and more...

### DIFF
--- a/src/Components/Medicine/CreatePrescriptionForm.tsx
+++ b/src/Components/Medicine/CreatePrescriptionForm.tsx
@@ -61,26 +61,27 @@ export default function CreatePrescriptionForm(props: {
             {...field("medicine_object", RequiredFieldValidator())}
             required
           />
-          {props.prescription.dosage_type !== "PRN" && (
-            <CheckBoxFormField
-              label={t("titrate_dosage")}
-              name="Titrate Dosage"
-              value={field("dosage_type").value === "TITRATED"}
-              onChange={(e) => {
-                if (e.value) {
-                  field("dosage_type").onChange({
-                    name: "dosage_type",
-                    value: "TITRATED",
-                  });
-                } else {
-                  field("dosage_type").onChange({
-                    name: "dosage_type",
-                    value: "REGULAR",
-                  });
-                }
-              }}
-            />
-          )}
+          {props.prescription.dosage_type !== "PRN" &&
+            props.prescription.prescription_type !== "DISCHARGE" && (
+              <CheckBoxFormField
+                label={t("titrate_dosage")}
+                name="Titrate Dosage"
+                value={field("dosage_type").value === "TITRATED"}
+                onChange={(e) => {
+                  if (e.value) {
+                    field("dosage_type").onChange({
+                      name: "dosage_type",
+                      value: "TITRATED",
+                    });
+                  } else {
+                    field("dosage_type").onChange({
+                      name: "dosage_type",
+                      value: "REGULAR",
+                    });
+                  }
+                }}
+              />
+            )}
           <div className="flex flex-wrap items-center gap-x-4">
             <SelectFormField
               className="flex-1"

--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationEventCell.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationEventCell.tsx
@@ -12,6 +12,7 @@ interface Props {
   interval: { start: Date; end: Date };
   prescription: Prescription;
   refetch: () => void;
+  readonly?: boolean;
 }
 
 export default function AdministrationEventCell({
@@ -19,6 +20,7 @@ export default function AdministrationEventCell({
   interval: { start, end },
   prescription,
   refetch,
+  readonly,
 }: Props) {
   const [showTimeline, setShowTimeline] = useState(false);
   // Check if cell belongs to an administered prescription (including start and excluding end)
@@ -56,6 +58,7 @@ export default function AdministrationEventCell({
             prescription={prescription}
             showPrescriptionDetails
             onRefetch={refetch}
+            readonly={readonly}
           />
         </DialogModal>
         <button

--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTable.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTable.tsx
@@ -10,9 +10,11 @@ interface Props {
   prescriptions: Prescription[];
   pagination: ReturnType<typeof useRangePagination>;
   onRefetch: () => void;
+  readonly: boolean;
 }
 
 export default function MedicineAdministrationTable({
+  readonly,
   pagination,
   prescriptions,
   onRefetch,
@@ -101,6 +103,7 @@ export default function MedicineAdministrationTable({
               prescription={obj}
               intervals={pagination.slots!}
               refetch={onRefetch}
+              readonly={readonly}
             />
           ))}
         </tbody>

--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
@@ -19,6 +19,7 @@ interface Props {
   prescription: Prescription;
   intervals: { start: Date; end: Date }[];
   refetch: () => void;
+  readonly: boolean;
 }
 
 export default function MedicineAdministrationTableRow({
@@ -54,12 +55,7 @@ export default function MedicineAdministrationTableRow({
   );
 
   return (
-    <tr
-      className={classNames(
-        "group transition-all duration-200 ease-in-out",
-        loading ? "bg-gray-300" : "bg-white hover:bg-primary-100",
-      )}
-    >
+    <>
       {showDiscontinue && (
         <DiscontinuePrescription
           prescription={prescription}
@@ -96,42 +92,46 @@ export default function MedicineAdministrationTableRow({
                 onClick={() => setShowDetails(false)}
                 label={t("close")}
               />
-              <Submit
-                disabled={
-                  prescription.discontinued ||
-                  prescription.prescription_type === "DISCHARGE"
-                }
-                variant="danger"
-                onClick={() => setShowDiscontinue(true)}
-              >
-                <CareIcon icon="l-ban" className="text-lg" />
-                {t("discontinue")}
-              </Submit>
-              <Submit
-                disabled={
-                  prescription.discontinued ||
-                  prescription.prescription_type === "DISCHARGE"
-                }
-                variant="secondary"
-                border
-                onClick={() => {
-                  setShowDetails(false);
-                  setShowEdit(true);
-                }}
-              >
-                <CareIcon icon="l-pen" className="text-lg" />
-                {t("edit")}
-              </Submit>
-              <Submit
-                disabled={
-                  prescription.discontinued ||
-                  prescription.prescription_type === "DISCHARGE"
-                }
-                onClick={() => setShowAdminister(true)}
-              >
-                <CareIcon icon="l-syringe" className="text-lg" />
-                {t("administer")}
-              </Submit>
+              {!props.readonly && (
+                <>
+                  <Submit
+                    disabled={
+                      prescription.discontinued ||
+                      prescription.prescription_type === "DISCHARGE"
+                    }
+                    variant="danger"
+                    onClick={() => setShowDiscontinue(true)}
+                  >
+                    <CareIcon icon="l-ban" className="text-lg" />
+                    {t("discontinue")}
+                  </Submit>
+                  <Submit
+                    disabled={
+                      prescription.discontinued ||
+                      prescription.prescription_type === "DISCHARGE"
+                    }
+                    variant="secondary"
+                    border
+                    onClick={() => {
+                      setShowDetails(false);
+                      setShowEdit(true);
+                    }}
+                  >
+                    <CareIcon icon="l-pen" className="text-lg" />
+                    {t("edit")}
+                  </Submit>
+                  <Submit
+                    disabled={
+                      prescription.discontinued ||
+                      prescription.prescription_type === "DISCHARGE"
+                    }
+                    onClick={() => setShowAdminister(true)}
+                  >
+                    <CareIcon icon="l-syringe" className="text-lg" />
+                    {t("administer")}
+                  </Submit>
+                </>
+              )}
             </div>
           </div>
         </DialogModal>
@@ -166,93 +166,103 @@ export default function MedicineAdministrationTableRow({
           />
         </DialogModal>
       )}
-      <td
-        className="bg-gray-white sticky left-0 z-10 cursor-pointer bg-white py-3 pl-4 text-left transition-all duration-200 ease-in-out group-hover:bg-primary-100"
-        onClick={() => setShowDetails(true)}
+      <tr
+        className={classNames(
+          "group transition-all duration-200 ease-in-out",
+          loading ? "bg-gray-300" : "bg-white hover:bg-primary-100",
+        )}
       >
-        <div className="flex flex-col gap-1 lg:flex-row lg:justify-between lg:gap-2">
-          <div className="flex items-center gap-2">
-            <span
-              className={classNames(
-                "text-sm font-semibold",
-                prescription.discontinued ? "text-gray-700" : "text-gray-900",
-              )}
-            >
-              {prescription.medicine_object?.name ?? prescription.medicine_old}
-            </span>
-
-            {prescription.discontinued && (
-              <span className="hidden rounded-full border border-gray-500 bg-gray-200 px-1.5 text-xs font-medium text-gray-700 lg:block">
-                {t("discontinued")}
-              </span>
-            )}
-
-            {prescription.route && (
-              <span className="hidden rounded-full border border-blue-500 bg-blue-100 px-1.5 text-xs font-medium text-blue-700 lg:block">
-                {t(prescription.route)}
-              </span>
-            )}
-          </div>
-
-          <div className="flex gap-1 text-xs font-semibold text-gray-900 lg:flex-col lg:px-2 lg:text-center">
-            {prescription.dosage_type !== "TITRATED" ? (
-              <p>{prescription.base_dosage}</p>
-            ) : (
-              <p>
-                {prescription.base_dosage} - {prescription.target_dosage}
-              </p>
-            )}
-
-            <p>
-              {prescription.dosage_type !== "PRN"
-                ? t("PRESCRIPTION_FREQUENCY_" + prescription.frequency)
-                : prescription.indicator}
-            </p>
-          </div>
-        </div>
-      </td>
-
-      <td />
-
-      {/* Administration Cells */}
-      {props.intervals.map(({ start, end }, index) => (
-        <>
-          <td key={`event-seperator-${index}`}>
-            <AdministrationEventSeperator date={start} />
-          </td>
-
-          <td key={`event-socket-${index}`} className="text-center">
-            {!data?.results ? (
-              <CareIcon
-                icon="l-spinner"
-                className="animate-spin text-lg text-gray-500"
-              />
-            ) : (
-              <AdministrationEventCell
-                administrations={data.results}
-                interval={{ start, end }}
-                prescription={prescription}
-                refetch={refetch}
-              />
-            )}
-          </td>
-        </>
-      ))}
-      <td />
-
-      {/* Action Buttons */}
-      <td className="space-x-1 pr-2 text-right">
-        <ButtonV2
-          type="button"
-          size="small"
-          disabled={prescription.discontinued}
-          ghost
-          border
-          onClick={() => setShowAdminister(true)}
+        <td
+          className="bg-gray-white sticky left-0 z-10 cursor-pointer bg-white py-3 pl-4 text-left transition-all duration-200 ease-in-out group-hover:bg-primary-100"
+          onClick={() => setShowDetails(true)}
         >
-          {t("administer")}
-        </ButtonV2>
-      </td>
-    </tr>
+          <div className="flex flex-col gap-1 lg:flex-row lg:justify-between lg:gap-2">
+            <div className="flex items-center gap-2">
+              <span
+                className={classNames(
+                  "text-sm font-semibold",
+                  prescription.discontinued ? "text-gray-700" : "text-gray-900",
+                )}
+              >
+                {prescription.medicine_object?.name ??
+                  prescription.medicine_old}
+              </span>
+
+              {prescription.discontinued && (
+                <span className="hidden rounded-full border border-gray-500 bg-gray-200 px-1.5 text-xs font-medium text-gray-700 lg:block">
+                  {t("discontinued")}
+                </span>
+              )}
+
+              {prescription.route && (
+                <span className="hidden rounded-full border border-blue-500 bg-blue-100 px-1.5 text-xs font-medium text-blue-700 lg:block">
+                  {t(prescription.route)}
+                </span>
+              )}
+            </div>
+
+            <div className="flex gap-1 text-xs font-semibold text-gray-900 lg:flex-col lg:px-2 lg:text-center">
+              {prescription.dosage_type !== "TITRATED" ? (
+                <p>{prescription.base_dosage}</p>
+              ) : (
+                <p>
+                  {prescription.base_dosage} - {prescription.target_dosage}
+                </p>
+              )}
+
+              <p>
+                {prescription.dosage_type !== "PRN"
+                  ? t("PRESCRIPTION_FREQUENCY_" + prescription.frequency)
+                  : prescription.indicator}
+              </p>
+            </div>
+          </div>
+        </td>
+
+        <td />
+
+        {/* Administration Cells */}
+        {props.intervals.map(({ start, end }, index) => (
+          <>
+            <td key={`event-seperator-${index}`}>
+              <AdministrationEventSeperator date={start} />
+            </td>
+
+            <td key={`event-socket-${index}`} className="text-center">
+              {!data?.results ? (
+                <CareIcon
+                  icon="l-spinner"
+                  className="animate-spin text-lg text-gray-500"
+                />
+              ) : (
+                <AdministrationEventCell
+                  administrations={data.results}
+                  interval={{ start, end }}
+                  prescription={prescription}
+                  refetch={refetch}
+                />
+              )}
+            </td>
+          </>
+        ))}
+        <td />
+
+        {/* Action Buttons */}
+        <td className="space-x-1 pr-2 text-right">
+          {!props.readonly && (
+            <ButtonV2
+              type="button"
+              size="small"
+              disabled={prescription.discontinued}
+              ghost
+              border
+              onClick={() => setShowAdminister(true)}
+            >
+              {t("administer")}
+            </ButtonV2>
+          )}
+        </td>
+      </tr>
+    </>
   );
 }

--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
@@ -240,6 +240,7 @@ export default function MedicineAdministrationTableRow({
                   interval={{ start, end }}
                   prescription={prescription}
                   refetch={refetch}
+                  readonly={props.readonly}
                 />
               )}
             </td>

--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -140,6 +140,7 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
                     refetch();
                     discontinuedPrescriptions.refetch();
                   }}
+                  readonly={readonly || false}
                 />
               )}
             </>

--- a/src/Components/Medicine/PrescrpitionTimeline.tsx
+++ b/src/Components/Medicine/PrescrpitionTimeline.tsx
@@ -29,12 +29,14 @@ interface Props {
   prescription: Prescription;
   showPrescriptionDetails?: boolean;
   onRefetch?: () => void;
+  readonly?: boolean;
 }
 
 export default function PrescrpitionTimeline({
   prescription,
   interval,
   onRefetch,
+  readonly,
 }: Props) {
   const consultation = useSlug("consultation");
   const { data, refetch, loading } = useQuery(
@@ -89,7 +91,7 @@ export default function PrescrpitionTimeline({
                   refetch();
                 }}
                 isLastNode={index === events.length - 1}
-                hideArchive={prescription.discontinued}
+                hideArchive={prescription.discontinued || readonly}
               />
             );
         }

--- a/src/Locale/en/Medicine.json
+++ b/src/Locale/en/Medicine.json
@@ -2,6 +2,7 @@
   "medicine": "Medicine",
   "route": "Route",
   "dosage": "Dosage",
+  "base_dosage": "Dosage",
   "start_dosage": "Start Dosage",
   "target_dosage": "Target Dosage",
   "instruction_on_titration": "Instruction on titration",


### PR DESCRIPTION
## Proposed Changes

- Fixes #7672
- Corrects label for dosage field in discharged info prescriptions table.
- Prevent prescription row layout shift when any related modal is opened.
- Disable Discontinue, Administer, Archive Administration & Edit prescription buttons if discharged.
- Disable titrated prescriptions for discharge prescriptions.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
