### PR TITLE
[#7648] Add Specialization to Treating Physician Card

### DIFF
--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -63,6 +63,9 @@ export default function PatientInfoCard(props: {
 
   const patient = props.patient;
   const consultation = props.consultation;
+  console.log(consultation);
+  console.log(consultation?.treating_physician_object);
+
   const activeShiftingData = props.activeShiftingData;
 
   const [medicoLegalCase, setMedicoLegalCase] = useState(
@@ -456,6 +459,11 @@ export default function PatientInfoCard(props: {
                     {consultation?.treating_physician_object
                       ? `${consultation?.treating_physician_object.first_name} ${consultation?.treating_physician_object.last_name}`
                       : consultation?.deprecated_verified_by}
+                    {consultation?.treating_physician_object && (
+                      <span className="ml-2 text-xs font-semibold text-gray-500">
+                        ({consultation.treating_physician_object.user_type})
+                      </span>
+                    )}
                     <CareIcon
                       icon="l-check"
                       className="ml-2 fill-current text-xl text-green-500"

--- a/src/Components/Patient/PatientInfoCard.tsx
+++ b/src/Components/Patient/PatientInfoCard.tsx
@@ -63,8 +63,6 @@ export default function PatientInfoCard(props: {
 
   const patient = props.patient;
   const consultation = props.consultation;
-  console.log(consultation);
-  console.log(consultation?.treating_physician_object);
 
   const activeShiftingData = props.activeShiftingData;
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #7648 
- Added `{consultation?.treating_physician_object && ( {consultation.treating_physician_object.user_type} ) }` to display the physician's specialization.
- Updated the JSX code in `PatientInfoCard.tsx`.
- user_type is a attribute which tells the type of physician he is of treating_physician_object object that contains information about the physician.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Screenshots
![image](https://github.com/coronasafe/care_fe/assets/77767837/3b437060-cc68-41ab-a013-5f4bd9fa0ce8)

## Additional Notes
- This change improves user experience by providing more context about the treating physician.
- Specialization is only displayed if treating physician object is available.