### PR TITLE
Add Patient transfer validations

### DIFF
--- a/src/Components/Facility/TransferPatientDialog.tsx
+++ b/src/Components/Facility/TransferPatientDialog.tsx
@@ -105,6 +105,14 @@ const TransferPatientDialog = (props: Props) => {
             },
           });
           return;
+        } else {
+          dispatch({
+            type: "set_error",
+            errors: {
+              ...state.errors,
+              last_consultation_discharge_date: "",
+            },
+          });
         }
       }
     }

--- a/src/Components/Facility/models.tsx
+++ b/src/Components/Facility/models.tsx
@@ -597,6 +597,7 @@ export type InventoryLogResponse = InventorySummaryResponse & {
 export type PatientTransferRequest = {
   facility: string;
   year_of_birth: string;
+  last_consultation_discharge_date: string;
 };
 
 export type PatientTransferResponse = {


### PR DESCRIPTION
Fixes #7662
Backend: https://github.com/coronasafe/care/pull/2110
This pull request adds a new field called `last_consultation_discharge_date` to the `TransferPatientDialog` component. This field allows the user to specify the date and time of discharge for an existing encounter. The field is required and has validation logic to ensure that it is greater than the existing encounter date if applicable.