### PR TITLE
Disable multiple buttons for discharged patients

### DIFF
--- a/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
@@ -49,6 +49,7 @@ const DefaultLogUpdateCard = ({ round, ...props }: Props) => {
         </ButtonV2>
         <ButtonV2
           variant="secondary"
+          disabled={props.consultationData?.discharge_date ? true : false}
           border
           ghost
           size="small"

--- a/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/DefaultLogUpdateCard.tsx
@@ -49,7 +49,7 @@ const DefaultLogUpdateCard = ({ round, ...props }: Props) => {
         </ButtonV2>
         <ButtonV2
           variant="secondary"
-          disabled={props.consultationData?.discharge_date ? true : false}
+          disabled={!!props.consultationData?.discharge_date}
           border
           ghost
           size="small"

--- a/src/Components/Facility/Investigations/InvestigationTable.tsx
+++ b/src/Components/Facility/Investigations/InvestigationTable.tsx
@@ -64,6 +64,7 @@ const TestRow = ({ data, i, onChange, showForm, value, isChanged }: any) => {
 export const InvestigationTable = ({
   title,
   data,
+  isDischargedPatient,
   handleValueChange,
   changedFields,
   handleUpdateCancel,
@@ -94,6 +95,7 @@ export const InvestigationTable = ({
             Print Report
           </ButtonV2>
           <ButtonV2
+            disabled={isDischargedPatient}
             variant="primary"
             className="my-2 mr-2"
             onClick={() => {

--- a/src/Components/Facility/Investigations/ShowInvestigation.tsx
+++ b/src/Components/Facility/Investigations/ShowInvestigation.tsx
@@ -80,6 +80,11 @@ export default function ShowInvestigation(props: any) {
     },
   );
 
+  const { data: consultation } = useQuery(routes.getConsultation, {
+    pathParams: { id: consultationId },
+    prefetch: !!consultationId,
+  });
+
   const handleValueChange = (value: any, name: string) => {
     const changedFields = { ...state.changedFields };
     set(changedFields, name, value);
@@ -151,6 +156,7 @@ export default function ShowInvestigation(props: any) {
       <InvestigationTable
         title={`ID: ${sessionId}`}
         data={state.initialValues}
+        isDischargedPatient={consultation?.discharge_date ? true : false}
         changedFields={state.changedFields}
         handleValueChange={handleValueChange}
         handleUpdateCancel={handleUpdateCancel}

--- a/src/Components/Facility/Investigations/ShowInvestigation.tsx
+++ b/src/Components/Facility/Investigations/ShowInvestigation.tsx
@@ -156,7 +156,7 @@ export default function ShowInvestigation(props: any) {
       <InvestigationTable
         title={`ID: ${sessionId}`}
         data={state.initialValues}
-        isDischargedPatient={consultation?.discharge_date ? true : false}
+        isDischargedPatient={!!consultation?.discharge_date}
         changedFields={state.changedFields}
         handleValueChange={handleValueChange}
         handleUpdateCancel={handleUpdateCancel}

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -13,7 +13,7 @@ import { VoiceRecorder } from "../../Utils/VoiceRecorder";
 import Pagination from "../Common/Pagination";
 import { RESULTS_PER_PAGE_LIMIT } from "../../Common/constants";
 import imageCompression from "browser-image-compression";
-import { formatDateTime } from "../../Utils/utils";
+import { classNames, formatDateTime } from "../../Utils/utils";
 import { useTranslation } from "react-i18next";
 import HeadedTabs from "../Common/HeadedTabs";
 import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
@@ -1531,7 +1531,7 @@ export const FileUpload = (props: FileUploadProps) => {
                     )}
                     <div className="flex flex-col items-center gap-4 md:flex-row md:flex-wrap lg:flex-nowrap">
                       <VoiceRecorder
-                        isDisabled={consultation?.discharge_date ? true : false}
+                        isDisabled={!!consultation?.discharge_date}
                         createAudioBlob={createAudioBlob}
                         confirmAudioBlobExists={confirmAudioBlobExists}
                         reset={resetRecording}
@@ -1593,7 +1593,12 @@ export const FileUpload = (props: FileUploadProps) => {
                         {({ isAuthorized }) =>
                           isAuthorized ? (
                             <label
-                              className={`button-size-default button-shape-square inline-flex h-min w-full items-center justify-center gap-2 whitespace-pre font-medium outline-offset-1 ${consultation?.discharge_date ? "cursor-not-allowed bg-gray-200 text-gray-500" : "button-primary-default cursor-pointer transition-all duration-200 ease-in-out"}`}
+                              className={classNames(
+                                consultation?.discharge_date
+                                  ? "cursor-not-allowed bg-gray-200 text-gray-500"
+                                  : "button-primary-default cursor-pointer transition-all duration-200 ease-in-out",
+                                "button-size-default button-shape-square inline-flex h-min w-full items-center justify-center gap-2 whitespace-pre font-medium outline-offset-1",
+                              )}
                             >
                               <CareIcon
                                 icon="l-file-upload-alt"
@@ -1607,9 +1612,7 @@ export const FileUpload = (props: FileUploadProps) => {
                                 type="file"
                                 accept="image/*,video/*,audio/*,text/plain,text/csv,application/rtf,application/msword,application/vnd.oasis.opendocument.text,application/pdf,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet,application/pdf"
                                 hidden
-                                disabled={
-                                  consultation?.discharge_date ? true : false
-                                }
+                                disabled={!!consultation?.discharge_date}
                               />
                             </label>
                           ) : (
@@ -1618,7 +1621,7 @@ export const FileUpload = (props: FileUploadProps) => {
                         }
                       </AuthorizedChild>
                       <ButtonV2
-                        disabled={consultation?.discharge_date ? true : false}
+                        disabled={!!consultation?.discharge_date}
                         onClick={() => setModalOpenForCamera(true)}
                         className="w-full"
                       >

--- a/src/Components/Patient/FileUpload.tsx
+++ b/src/Components/Patient/FileUpload.tsx
@@ -258,6 +258,11 @@ export const FileUpload = (props: FileUploadProps) => {
     prefetch: !!patientId,
   });
 
+  const { data: consultation } = useQuery(routes.getConsultation, {
+    pathParams: { id: consultationId },
+    prefetch: !!consultationId,
+  });
+
   const captureImage = () => {
     setPreviewImage(webRef.current.getScreenshot());
     const canvas = webRef.current.getCanvas();
@@ -1526,6 +1531,7 @@ export const FileUpload = (props: FileUploadProps) => {
                     )}
                     <div className="flex flex-col items-center gap-4 md:flex-row md:flex-wrap lg:flex-nowrap">
                       <VoiceRecorder
+                        isDisabled={consultation?.discharge_date ? true : false}
                         createAudioBlob={createAudioBlob}
                         confirmAudioBlobExists={confirmAudioBlobExists}
                         reset={resetRecording}
@@ -1586,7 +1592,9 @@ export const FileUpload = (props: FileUploadProps) => {
                       <AuthorizedChild authorizeFor={NonReadOnlyUsers}>
                         {({ isAuthorized }) =>
                           isAuthorized ? (
-                            <label className="button-size-default button-shape-square button-primary-default inline-flex h-min w-full cursor-pointer items-center justify-center gap-2 whitespace-pre font-medium outline-offset-1 transition-all duration-200 ease-in-out disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500">
+                            <label
+                              className={`button-size-default button-shape-square inline-flex h-min w-full items-center justify-center gap-2 whitespace-pre font-medium outline-offset-1 ${consultation?.discharge_date ? "cursor-not-allowed bg-gray-200 text-gray-500" : "button-primary-default cursor-pointer transition-all duration-200 ease-in-out"}`}
+                            >
                               <CareIcon
                                 icon="l-file-upload-alt"
                                 className="text-lg"
@@ -1599,6 +1607,9 @@ export const FileUpload = (props: FileUploadProps) => {
                                 type="file"
                                 accept="image/*,video/*,audio/*,text/plain,text/csv,application/rtf,application/msword,application/vnd.oasis.opendocument.text,application/pdf,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet,application/pdf"
                                 hidden
+                                disabled={
+                                  consultation?.discharge_date ? true : false
+                                }
                               />
                             </label>
                           ) : (
@@ -1607,6 +1618,7 @@ export const FileUpload = (props: FileUploadProps) => {
                         }
                       </AuthorizedChild>
                       <ButtonV2
+                        disabled={consultation?.discharge_date ? true : false}
                         onClick={() => setModalOpenForCamera(true)}
                         className="w-full"
                       >

--- a/src/Utils/VoiceRecorder.tsx
+++ b/src/Utils/VoiceRecorder.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 export const VoiceRecorder = (props: any) => {
   const { t } = useTranslation();
   const {
+    isDisabled,
     createAudioBlob,
     confirmAudioBlobExists,
     reset,
@@ -75,6 +76,7 @@ export const VoiceRecorder = (props: any) => {
             {!audioURL && (
               <ButtonV2
                 id="record-audio"
+                disabled={isDisabled}
                 onClick={startRecording}
                 authorizeFor={NonReadOnlyUsers}
                 className="w-full md:w-fit"


### PR DESCRIPTION
## Proposed Changes

- Fixes #7722
- Disabled multiple buttons based on the consultation discharge date for patients
![image](https://github.com/coronasafe/care_fe/assets/22475370/c2fc2cb7-2151-49f9-bd31-5d2a09a7e4bc)
![image](https://github.com/coronasafe/care_fe/assets/22475370/fa1041fd-d1be-41d9-a8c3-02930a7953f5)
![image](https://github.com/coronasafe/care_fe/assets/22475370/34e2e131-a8c5-4f2b-a130-7664bf093430)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
