### PR TITLE
Fixes issue preventing from administering down titration prescriptions

### DIFF
--- a/src/Components/Medicine/CreatePrescriptionForm.tsx
+++ b/src/Components/Medicine/CreatePrescriptionForm.tsx
@@ -92,7 +92,7 @@ export default function CreatePrescriptionForm(props: {
               optionValue={(key) => key}
             />
             {field("dosage_type").value === "TITRATED" ? (
-              <div className="flex w-full gap-4">
+              <div className="flex w-full flex-[2] gap-4">
                 <DosageFormField
                   className="flex-1"
                   label={t("start_dosage")}

--- a/src/Components/Medicine/EditPrescriptionForm.tsx
+++ b/src/Components/Medicine/EditPrescriptionForm.tsx
@@ -120,7 +120,7 @@ export default function EditPrescriptionForm(props: Props) {
               optionValue={(key) => key}
             />
             {field("dosage_type").value === "TITRATED" ? (
-              <div className="flex w-full gap-4">
+              <div className="flex w-full flex-[2] gap-4">
                 <DosageFormField
                   className="flex-1"
                   label={t("start_dosage")}

--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
@@ -153,7 +153,7 @@ export default function MedicineAdministrationTableRow({
               <span>{t("edit_caution_note")}</span>
             </div>
           }
-          className="w-full max-w-3xl lg:min-w-[600px]"
+          className="w-full max-w-4xl lg:min-w-[768px]"
         >
           <EditPrescriptionForm
             initial={prescription}

--- a/src/Components/Medicine/PrescriptionBuilder.tsx
+++ b/src/Components/Medicine/PrescriptionBuilder.tsx
@@ -102,7 +102,7 @@ export default function PrescriptionBuilder({
               <span>{t("modification_caution_note")}</span>
             </div>
           }
-          className="w-full max-w-3xl lg:min-w-[600px]"
+          className="w-full max-w-4xl lg:min-w-[768px]"
         >
           <CreatePrescriptionForm
             prescription={

--- a/src/Components/Medicine/validators.ts
+++ b/src/Components/Medicine/validators.ts
@@ -42,6 +42,7 @@ const PRESCRIPTION_COMPARE_FIELDS: (keyof Prescription)[] = [
   "medicine",
   "days",
   "discontinued",
+  "target_dosage",
   "base_dosage",
   "frequency",
   "indicator",
@@ -77,11 +78,12 @@ export const AdministrationDosageValidator = (
     if (value?.split(" ")[1] !== base_dosage?.split(" ")[1])
       return "Unit must be the same as start and target dosage's unit";
 
-    if (
-      baseDosage &&
-      targetDosage &&
-      (valueDosage < baseDosage || valueDosage > targetDosage)
-    )
-      return "Dosage should be between start and target dosage";
+    if (baseDosage && targetDosage) {
+      const [min, max] = [baseDosage, targetDosage].sort((a, b) => a - b);
+
+      if (!(min <= valueDosage && valueDosage <= max)) {
+        return "Dosage should be between start and target dosage";
+      }
+    }
   };
 };


### PR DESCRIPTION
## Proposed Changes

- Fixes #7742
- Improve the responsiveness of Create and Edit prescription forms.
- Fixes issue with validation that prevented administration for down titration prescriptions.
- Fixes issue with edit prescription showing error "No changes present" when only target dosage is changed for titrated prescriptions

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
