### PR TITLE
fixed usages of font sizes to respect browser's

### DIFF
--- a/src/Components/CameraFeed/NoFeedAvailable.tsx
+++ b/src/Components/CameraFeed/NoFeedAvailable.tsx
@@ -28,7 +28,7 @@ export default function NoFeedAvailable(props: Props) {
     >
       <CareIcon icon={props.icon} className="text-2xl" />
       <span className="text-xs font-bold">{props.message}</span>
-      <span className="hidden px-10 font-mono text-[10px] text-gray-500 md:block">
+      <span className="hidden px-10 font-mono text-xs text-gray-500 md:block">
         {redactedURL}
       </span>
       <div className="mt-4 flex items-center gap-2">

--- a/src/Components/Common/Sidebar/SidebarItem.tsx
+++ b/src/Components/Common/Sidebar/SidebarItem.tsx
@@ -74,7 +74,7 @@ const SidebarItemBase = forwardRef(
           <span
             className={`absolute flex items-center justify-center bg-primary-500 font-semibold text-white ${
               shrinked
-                ? "right-3 top-0.5 h-4 w-5 rounded-md text-[9px]"
+                ? "right-3 top-0.5 h-4 w-5 rounded-md text-xs"
                 : "inset-y-0 right-4 my-auto h-6 rounded-md px-2 text-xs"
             } z-10 animate-pulse transition-all duration-200 ease-in-out`}
           >

--- a/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
@@ -724,7 +724,7 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
             tab2={
               <div className="flex items-center justify-center gap-1 text-sm">
                 Events
-                <span className="rounded-lg bg-warning-400 p-px px-1 text-[10px] text-white">
+                <span className="rounded-lg bg-warning-400 p-px px-1 text-xs text-white">
                   beta
                 </span>
               </div>

--- a/src/Components/Patient/Waveform.tsx
+++ b/src/Components/Patient/Waveform.tsx
@@ -126,7 +126,7 @@ export default function Waveform(props: {
       />
       <div className="absolute bottom-0 right-5 w-full md:w-[70%]">
         {props.metrics && (
-          <div className="flex flex-row flex-wrap justify-end gap-2 text-[10px] text-gray-400">
+          <div className="flex flex-row flex-wrap justify-end gap-2 text-xs text-gray-400">
             <div>Lowest: {Math.min(...queueData.slice(0, viewable))}</div>
             <div>Highest: {Math.max(...queueData.slice(0, viewable))}</div>
             <div>Stream Length: {data.length}</div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #7753
- Fixed all text size that are in `px` replace them with `rem`


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
