### PR TITLE
Fixes text from overflowing in select menu dropdowns

### DIFF
--- a/src/Components/Form/SelectMenuV2.tsx
+++ b/src/Components/Form/SelectMenuV2.tsx
@@ -102,7 +102,7 @@ const SelectMenuV2 = <T, V>(props: SelectMenuProps<T, V>) => {
                         {value.icon}
                       </div>
                     )}
-                    <p className="ml-2.5 whitespace-nowrap break-all text-sm font-medium">
+                    <p className="ml-2.5 whitespace-pre-wrap text-start text-sm font-medium">
                       {value.selectedLabel}
                     </p>
                   </div>

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -29,7 +29,7 @@ import CollapseV2 from "../Common/components/CollapseV2";
 import ConfirmDialog from "../Common/ConfirmDialog";
 import DateFormField from "../Form/FormFields/DateFormField";
 import DialogModal from "../Common/Dialog";
-import { DupPatientModel } from "../Facility/models";
+import { DistrictModel, DupPatientModel, WardModel } from "../Facility/models";
 import DuplicatePatientDialog from "../Facility/DuplicatePatientDialog";
 import {
   FieldError,
@@ -64,6 +64,7 @@ import routes from "../../Redux/api.js";
 import request from "../../Utils/request/request.js";
 import SelectMenuV2 from "../Form/SelectMenuV2.js";
 import Checkbox from "../Common/components/CheckBox.js";
+import { ILocalBodies } from "../ExternalResult/models.js";
 
 const Loading = lazy(() => import("../Common/Loading"));
 const PageTitle = lazy(() => import("../Common/PageTitle"));
@@ -205,9 +206,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
   const [isDistrictLoading, setIsDistrictLoading] = useState(false);
   const [isLocalbodyLoading, setIsLocalbodyLoading] = useState(false);
   const [isWardLoading, setIsWardLoading] = useState(false);
-  const [districts, setDistricts] = useState<any[]>([]);
-  const [localBody, setLocalBody] = useState<any[]>([]);
-  const [ward, setWard] = useState<any[]>([]);
+  const [districts, setDistricts] = useState<DistrictModel[]>([]);
+  const [localBody, setLocalBody] = useState<ILocalBodies[]>([]);
+  const [ward, setWard] = useState<WardModel[]>([]);
   const [ageInputType, setAgeInputType] = useState<
     "date_of_birth" | "age" | "alert_for_age"
   >("date_of_birth");
@@ -1749,9 +1750,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                     }
                                     disabled={!field("district").value}
                                     options={localBody}
-                                    optionLabel={(o: any) => o.name}
-                                    optionValue={(o: any) => o.id}
-                                    onChange={(e: any) => {
+                                    optionLabel={(o) => o.name}
+                                    optionValue={(o) => o.id}
+                                    onChange={(e) => {
                                       field("local_body").onChange(e);
                                       field("ward").onChange({
                                         name: "ward",


### PR DESCRIPTION
## Proposed Changes

- Fixes #7790

### Before

<img width="429" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/499f2cdf-ba75-4855-8c83-d22c166a09a1">


### After

<img width="407" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/db2b4558-8061-4548-bfd3-65c52ea4c72c">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
