### PR TITLE
Events: Set as default tab; Fixes nested objects not rendered in events; Limit precision for numeric values;

### DIFF
--- a/cypress/e2e/patient_spec/patient_logupdate.cy.ts
+++ b/cypress/e2e/patient_spec/patient_logupdate.cy.ts
@@ -110,6 +110,7 @@ describe("Patient Log Update in Normal, Critical and TeleIcu", () => {
     patientLogupdate.typeDiastolic(patientModifiedDiastolic);
     cy.submitButton("Continue");
     cy.verifyNotification("Normal Log Updates details updated successfully");
+    cy.contains("Daily Rounds").click();
     patientLogupdate.clickLogupdateCard("#dailyround-entry", patientCategory);
     cy.verifyContentPresence("#consultation-preview", [
       patientModifiedDiastolic,

--- a/cypress/e2e/patient_spec/patient_logupdate.cy.ts
+++ b/cypress/e2e/patient_spec/patient_logupdate.cy.ts
@@ -89,6 +89,7 @@ describe("Patient Log Update in Normal, Critical and TeleIcu", () => {
     cy.verifyNotification("Normal Log Updates details created successfully");
     cy.closeNotification();
     // edit the card and verify the data.
+    cy.contains("Daily Rounds").click();
     patientLogupdate.clickLogupdateCard("#dailyround-entry", patientCategory);
     cy.verifyContentPresence("#consultation-preview", [
       patientCategory,

--- a/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
@@ -37,7 +37,7 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
   const [ventilatorSocketUrl, setVentilatorSocketUrl] = useState<string>();
   const [monitorBedData, setMonitorBedData] = useState<AssetBedModel>();
   const [ventilatorBedData, setVentilatorBedData] = useState<AssetBedModel>();
-  const [showEvents, setShowEvents] = useState(false);
+  const [showEvents, setShowEvents] = useState(true);
 
   const vitals = useVitalsAspectRatioConfig({
     default: undefined,

--- a/src/Components/Facility/ConsultationDetails/Events/EventsList.tsx
+++ b/src/Components/Facility/ConsultationDetails/Events/EventsList.tsx
@@ -47,11 +47,11 @@ export default function EventsList() {
                     isLast={items.indexOf(item) == items.length - 1}
                   >
                     {(() => {
-                      const values = Object.entries(item.value).filter(
-                        ([_, value]) => value !== null && value !== undefined,
+                      const entries = Object.entries(item.value).filter(
+                        ([_, value]) => value != null && value !== "",
                       );
 
-                      if (values.length === 0) {
+                      if (entries.length === 0) {
                         return (
                           <div className="flex w-full flex-col items-center gap-2 md:flex-row">
                             <span className="text-xs uppercase text-gray-700">
@@ -60,6 +60,8 @@ export default function EventsList() {
                           </div>
                         );
                       }
+
+                      const values = Object.fromEntries(entries);
 
                       switch (item.event_type.name) {
                         case "INTERNAL_TRANSFER":

--- a/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
+++ b/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
@@ -50,16 +50,20 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
       return value.toLocaleString();
     }
 
-    if (Object.entries(value).length === 0) {
+    const entries = Object.entries(value).filter(
+      ([_, value]) => value != null && value !== "",
+    );
+
+    if (entries.length === 0) {
       return `No ${key?.replaceAll(/_/g, " ")}`;
     }
 
-    return Object.entries(value).map(([key, value]) => (
+    return entries.map(([key, value]) => (
       <div className="flex flex-col items-center gap-2 md:flex-row">
         <span className="text-xs uppercase text-gray-700">
           {key.replaceAll(/_/g, " ")}
         </span>
-        <span className="text-sm font-semibold text-gray-700">
+        <span className="text-sm font-semibold capitalize text-gray-700">
           {formatValue(value, key)}
         </span>
       </div>

--- a/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
+++ b/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
@@ -17,7 +17,7 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
   }
 
   if (typeof value === "number") {
-    return value;
+    return value % 1 ? value.toFixed(2) : value;
   }
 
   if (typeof value === "string") {

--- a/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
+++ b/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
@@ -70,7 +70,6 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
 };
 
 export default function GenericEvent(props: IProps) {
-  console.log({ values: props.values });
   return (
     <div className="flex w-full flex-col gap-4 rounded-lg border border-gray-400 p-4 @container">
       {Object.entries(props.values).map(([key, value]) => (

--- a/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
+++ b/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
@@ -1,14 +1,13 @@
 import type { ReactNode } from "react";
 interface IProps {
-  values: Record<string, any>;
+  values: Record<string, unknown>;
 }
 
 /**
  * object - array, date
  */
-
 const formatValue = (value: unknown, key?: string): ReactNode => {
-  if (value === undefined || value === null) {
+  if (value == null) {
     return "N/A";
   }
 
@@ -21,7 +20,7 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
   }
 
   if (typeof value === "string") {
-    const trimmed = value.trim();
+    const trimmed = value.trim().replaceAll(/_/g, " ");
 
     if (trimmed === "") {
       return "Empty";
@@ -41,7 +40,7 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
   if (typeof value === "object") {
     if (Array.isArray(value)) {
       if (value.length === 0) {
-        return `No ${key?.replace(/_/g, " ")}`;
+        return `No ${key?.replaceAll(/_/g, " ")}`;
       }
 
       return value.map((v) => formatValue(v, key)).join(", ");
@@ -52,13 +51,13 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
     }
 
     if (Object.entries(value).length === 0) {
-      return `No ${key?.replace(/_/g, " ")}`;
+      return `No ${key?.replaceAll(/_/g, " ")}`;
     }
 
     return Object.entries(value).map(([key, value]) => (
       <div className="flex flex-col items-center gap-2 md:flex-row">
         <span className="text-xs uppercase text-gray-700">
-          {key.replace(/_/g, " ")}
+          {key.replaceAll(/_/g, " ")}
         </span>
         <span className="text-sm font-semibold text-gray-700">
           {formatValue(value, key)}
@@ -70,14 +69,14 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
   return JSON.stringify(value);
 };
 
-export default function GenericEvent({ values }: IProps) {
-  console.log("value", values);
+export default function GenericEvent(props: IProps) {
+  console.log({ values: props.values });
   return (
     <div className="flex w-full flex-col gap-4 rounded-lg border border-gray-400 p-4 @container">
-      {values.map(([key, value]: [string, any]) => (
+      {Object.entries(props.values).map(([key, value]) => (
         <div className="flex w-full flex-col items-center gap-2 md:flex-row">
           <span className="text-xs uppercase text-gray-700">
-            {key.replace(/_/g, " ")}
+            {key.replaceAll(/_/g, " ")}
           </span>
           <span className="break-all text-sm font-semibold text-gray-700">
             {formatValue(value, key)}

--- a/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
+++ b/src/Components/Facility/ConsultationDetails/Events/GenericEvent.tsx
@@ -43,7 +43,7 @@ const formatValue = (value: unknown, key?: string): ReactNode => {
         return `No ${key?.replaceAll(/_/g, " ")}`;
       }
 
-      return value.map((v) => formatValue(v, key)).join(", ");
+      return value.map((v) => formatValue(v, key));
     }
 
     if (value instanceof Date) {


### PR DESCRIPTION
## Required Backends

- https://github.com/coronasafe/care/pull/2170

## Proposed Changes

- Follow up of #7752
- Switch to events as the default tab

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
