### PR TITLE
Removes unused field `temperature_measured_at`

### DIFF
--- a/src/Components/Facility/Consultations/DailyRounds/VirtualNursingAssistantLogUpdateCard.tsx
+++ b/src/Components/Facility/Consultations/DailyRounds/VirtualNursingAssistantLogUpdateCard.tsx
@@ -33,19 +33,10 @@ interface Props {
 
 const extractVirtualNursingAssistantFields = (round?: DailyRoundsModel) => {
   if (!round) return;
-  const {
-    temperature,
-    temperature_measured_at,
-    bp,
-    resp,
-    spo2,
-    ventilator_spo2,
-    pulse,
-  } = round;
+  const { temperature, bp, resp, spo2, ventilator_spo2, pulse } = round;
 
   return {
     temperature,
-    temperature_measured_at,
     bp,
     resp,
     spo2,

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -309,7 +309,6 @@ export interface DailyRoundsModel {
   pulse?: number;
   resp?: number;
   temperature?: string;
-  temperature_measured_at?: string;
   physical_examination_info?: string;
   other_details?: string;
   consultation?: number;


### PR DESCRIPTION
## Proposed Changes

- Part of #7827 
- Backend https://github.com/coronasafe/care/pull/2171
- Fixes #8370

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
