### PR TITLE
Remove unwanted covid fields

### DIFF
--- a/cypress/e2e/shifting_spec/filter.cy.ts
+++ b/cypress/e2e/shifting_spec/filter.cy.ts
@@ -36,8 +36,6 @@ describe("Shifting section filter", () => {
       "MODERATE",
       "9999999999",
     );
-
-    shiftingPage.diseaseStatusBadge().should("exist");
     shiftingPage.orderingBadge().should("exist");
     shiftingPage.breathlessnessLevelBadge().should("exist");
     shiftingPage.phoneNumberBadge().should("exist");

--- a/cypress/e2e/shifting_spec/filter.cy.ts
+++ b/cypress/e2e/shifting_spec/filter.cy.ts
@@ -20,7 +20,7 @@ describe("Shifting section filter", () => {
     shiftingPage.filterByFacility(
       "Dummy Shifting",
       "Dummy Shifting",
-      "District"
+      "District",
     );
 
     shiftingPage.facilityAssignedBadge().should("exist");
@@ -32,10 +32,9 @@ describe("Shifting section filter", () => {
       "ASC Created Date",
       "yes",
       "yes",
-      "POSITIVE",
       "no",
       "MODERATE",
-      "9999999999"
+      "9999999999",
     );
 
     shiftingPage.diseaseStatusBadge().should("exist");

--- a/cypress/pageobject/Shift/ShiftFilters.ts
+++ b/cypress/pageobject/Shift/ShiftFilters.ts
@@ -27,10 +27,6 @@ class ShiftingPage {
     return cy.get("#is-up-shift");
   }
 
-  diseaseStatusInput() {
-    return cy.get("#disease-status");
-  }
-
   isAntenatalInput() {
     return cy.get("#is-antenatal");
   }
@@ -61,10 +57,6 @@ class ShiftingPage {
 
   currentFacilityBadge() {
     return cy.get("[data-testid='Current facility']");
-  }
-
-  diseaseStatusBadge() {
-    return cy.get("[data-testid='Disease status']");
   }
 
   orderingBadge() {

--- a/cypress/pageobject/Shift/ShiftFilters.ts
+++ b/cypress/pageobject/Shift/ShiftFilters.ts
@@ -98,7 +98,7 @@ class ShiftingPage {
   filterByFacility(
     origin_facility: string,
     assigned_facility: string,
-    assigned_to: string
+    assigned_to: string,
   ) {
     this.originFacilityInput().click().type(origin_facility);
     cy.get("[role='option']").contains(origin_facility).click();
@@ -116,10 +116,9 @@ class ShiftingPage {
     ordering: string,
     emergency: string,
     is_up_shift: string,
-    disease_status: string,
     is_antenatal: string,
     breathlessness_level: string,
-    patient_phone_number: string
+    patient_phone_number: string,
   ) {
     this.orderingInput().click();
     cy.get("[role='option']").contains(ordering).click();
@@ -129,9 +128,6 @@ class ShiftingPage {
 
     this.isUpShiftInput().click();
     cy.get("[role='option']").contains(is_up_shift).click();
-
-    this.diseaseStatusInput().click();
-    cy.get("[role='option']").contains(disease_status).click();
 
     this.isAntenatalInput().click();
     cy.get("[role='option']").contains(is_antenatal).click();
@@ -148,7 +144,7 @@ class ShiftingPage {
     created_date_start: string,
     created_date_end: string,
     modified_date_start: string,
-    modified_date_end: string
+    modified_date_end: string,
   ) {
     this.createdDateStartInput().click();
     cy.get("[id^='headlessui-popover-panel-'] .care-l-angle-left-b")

--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -470,13 +470,6 @@ export const SAMPLE_FLOW_RULES = {
   RECEIVED_AT_LAB: ["COMPLETED"],
 };
 
-export const DISEASE_STATUS = [
-  "POSITIVE",
-  "SUSPECTED",
-  "NEGATIVE",
-  "RECOVERED",
-];
-
 export const TEST_TYPE = [
   "UNK",
   "ANTIGEN",

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -164,7 +164,6 @@ export const PatientManager = () => {
     is_active:
       !qParams.last_consultation__new_discharge_reason &&
       (qParams.is_active || "True"),
-    disease_status: qParams.disease_status || undefined,
     phone_number: qParams.phone_number
       ? parsePhoneNumber(qParams.phone_number)
       : undefined,
@@ -207,7 +206,6 @@ export const PatientManager = () => {
       qParams.last_consultation__new_discharge_reason || undefined,
     last_consultation_current_bed__location:
       qParams.last_consultation_current_bed__location || undefined,
-    srf_id: qParams.srf_id || undefined,
     number_of_doses: qParams.number_of_doses || undefined,
     covin_id: qParams.covin_id || undefined,
     is_kasp: qParams.is_kasp || undefined,
@@ -595,14 +593,6 @@ export const PatientManager = () => {
                         text={`IP Days: ${dayjs().diff(patient.last_consultation.encounter_date, "day")}`}
                       />
                     )}
-                  {patient.disease_status === "POSITIVE" && (
-                    <Chip
-                      size="small"
-                      variant="danger"
-                      startIcon="l-coronavirus"
-                      text="Positive"
-                    />
-                  )}
                   {patient.gender === 2 &&
                     patient.is_antenatal &&
                     isAntenatal(patient.last_menstruation_start_date) &&
@@ -622,14 +612,6 @@ export const PatientManager = () => {
                       className="bg-blue-100 text-blue-600"
                       startIcon="l-user-md"
                       text="Medical Worker"
-                    />
-                  )}
-                  {patient.disease_status === "EXPIRED" && (
-                    <Chip
-                      size="small"
-                      variant="warning"
-                      startIcon="l-exclamation-triangle"
-                      text="Patient Expired"
                     />
                   )}
                   {(!patient.last_consultation ||
@@ -1009,7 +991,6 @@ export const PatientManager = () => {
             ),
             ordering(),
             value("Category", "category", getTheCategoryFromId()),
-            badge("Disease Status", "disease_status"),
             value(
               "Respiratory Support",
               "ventilator_interface",
@@ -1027,7 +1008,6 @@ export const PatientManager = () => {
               paramKey: "last_consultation_admitted_to",
             },
             ...range("Age", "age"),
-            badge("SRF ID", "srf_id"),
             {
               name: "LSG Body",
               value: qParams.lsgBody ? LocalBodyData?.name || "" : "",

--- a/src/Components/Patient/ManagePatients.tsx
+++ b/src/Components/Patient/ManagePatients.tsx
@@ -188,8 +188,6 @@ export const PatientManager = () => {
       qParams.date_declared_positive_before || undefined,
     date_declared_positive_after:
       qParams.date_declared_positive_after || undefined,
-    date_of_result_before: qParams.date_of_result_before || undefined,
-    date_of_result_after: qParams.date_of_result_after || undefined,
     last_consultation_medico_legal_case:
       qParams.last_consultation_medico_legal_case || undefined,
     last_consultation_encounter_date_before:
@@ -257,7 +255,6 @@ export const PatientManager = () => {
     [params.created_date_before, params.created_date_after],
     [params.modified_date_before, params.modified_date_after],
     [params.date_declared_positive_before, params.date_declared_positive_after],
-    [params.date_of_result_before, params.date_of_result_after],
     [params.last_vaccinated_date_before, params.last_vaccinated_date_after],
     [
       params.last_consultation_encounter_date_before,
@@ -1021,7 +1018,6 @@ export const PatientManager = () => {
               ),
             ),
             badge("Declared Status", "is_declared_positive"),
-            ...dateRange("Result", "date_of_result"),
             ...dateRange("Declared positive", "date_declared_positive"),
             ...dateRange(
               "Symptoms onset",

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -50,8 +50,6 @@ export default function PatientFilter(props: any) {
     district_ref: null,
     date_declared_positive_before: filter.date_declared_positive_before || null,
     date_declared_positive_after: filter.date_declared_positive_after || null,
-    date_of_result_before: filter.date_of_result_before || null,
-    date_of_result_after: filter.date_of_result_after || null,
     created_date_before: filter.created_date_before || null,
     created_date_after: filter.created_date_after || null,
     modified_date_before: filter.modified_date_before || null,
@@ -60,7 +58,6 @@ export default function PatientFilter(props: any) {
     gender: filter.gender || null,
     age_min: filter.age_min || null,
     age_max: filter.age_max || null,
-    date_of_result: filter.date_of_result || null,
     date_declared_positive: filter.date_declared_positive || null,
     last_consultation_medico_legal_case:
       filter.last_consultation_medico_legal_case || null,
@@ -166,8 +163,6 @@ export default function PatientFilter(props: any) {
       lsgBody,
       date_declared_positive_before,
       date_declared_positive_after,
-      date_of_result_before,
-      date_of_result_after,
       created_date_before,
       created_date_after,
       modified_date_before,
@@ -176,7 +171,6 @@ export default function PatientFilter(props: any) {
       gender,
       age_min,
       age_max,
-      date_of_result,
       last_consultation_medico_legal_case,
       last_consultation_encounter_date_before,
       last_consultation_encounter_date_after,
@@ -216,13 +210,10 @@ export default function PatientFilter(props: any) {
       date_declared_positive_after: dateQueryString(
         date_declared_positive_after,
       ),
-      date_of_result_before: dateQueryString(date_of_result_before),
-      date_of_result_after: dateQueryString(date_of_result_after),
       created_date_before: dateQueryString(created_date_before),
       created_date_after: dateQueryString(created_date_after),
       modified_date_before: dateQueryString(modified_date_before),
       modified_date_after: dateQueryString(modified_date_after),
-      date_of_result: dateQueryString(date_of_result),
       last_consultation_medico_legal_case:
         last_consultation_medico_legal_case || "",
       last_consultation_encounter_date_before: dateQueryString(
@@ -719,17 +710,6 @@ export default function PatientFilter(props: any) {
             />
           </div>
 
-          <DateRangeFormField
-            labelClassName="text-sm"
-            name="date_of_result"
-            label="Date of result of COVID Test"
-            value={{
-              start: getDate(filterState.date_of_result_after),
-              end: getDate(filterState.date_of_result_before),
-            }}
-            onChange={handleDateRangeChange}
-            errorClassName="hidden"
-          />
           <DateRangeFormField
             labelClassName="text-sm"
             name="date_declared_positive"

--- a/src/Components/Patient/PatientFilter.tsx
+++ b/src/Components/Patient/PatientFilter.tsx
@@ -4,7 +4,6 @@ import FiltersSlideover from "../../CAREUI/interactive/FiltersSlideover";
 import {
   ADMITTED_TO,
   DISCHARGE_REASONS,
-  DISEASE_STATUS,
   FACILITY_TYPES,
   GENDER_TYPES,
   PATIENT_FILTER_CATEGORIES,
@@ -59,7 +58,6 @@ export default function PatientFilter(props: any) {
     modified_date_after: filter.modified_date_after || null,
     category: filter.category || null,
     gender: filter.gender || null,
-    disease_status: filter.disease_status || null,
     age_min: filter.age_min || null,
     age_max: filter.age_max || null,
     date_of_result: filter.date_of_result || null,
@@ -82,7 +80,6 @@ export default function PatientFilter(props: any) {
       filter.last_consultation_current_bed__location || "",
     last_consultation__new_discharge_reason:
       filter.last_consultation__new_discharge_reason || null,
-    srf_id: filter.srf_id || null,
     number_of_doses: filter.number_of_doses || null,
     covin_id: filter.covin_id || null,
     is_kasp: filter.is_kasp || null,
@@ -177,7 +174,6 @@ export default function PatientFilter(props: any) {
       modified_date_after,
       category,
       gender,
-      disease_status,
       age_min,
       age_max,
       date_of_result,
@@ -191,7 +187,6 @@ export default function PatientFilter(props: any) {
       last_consultation_current_bed__location,
       number_of_doses,
       covin_id,
-      srf_id,
       is_kasp,
       is_declared_positive,
       last_consultation_symptoms_onset_date_before,
@@ -244,15 +239,12 @@ export default function PatientFilter(props: any) {
       ),
       category: category || "",
       gender: gender || "",
-      disease_status:
-        (disease_status == "Show All" ? "" : disease_status) || "",
       age_min: age_min || "",
       age_max: age_max || "",
       last_consultation_admitted_bed_type_list:
         last_consultation_admitted_bed_type_list || [],
       last_consultation__new_discharge_reason:
         last_consultation__new_discharge_reason || "",
-      srf_id: srf_id || "",
       number_of_doses: number_of_doses || "",
       covin_id: covin_id || "",
       is_kasp: is_kasp || "",
@@ -681,18 +673,6 @@ export default function PatientFilter(props: any) {
           )}
 
           <div className="w-full flex-none">
-            <FieldLabel className="text-sm">COVID Disease status</FieldLabel>
-            <SelectMenuV2
-              placeholder="Show all"
-              options={DISEASE_STATUS}
-              optionLabel={(o) => o}
-              value={filterState.disease_status}
-              onChange={(v) =>
-                setFilterState({ ...filterState, disease_status: v })
-              }
-            />
-          </div>
-          <div className="w-full flex-none">
             <FieldLabel className="text-sm">COVID Vaccinated</FieldLabel>
             <SelectMenuV2
               placeholder="Show all"
@@ -727,17 +707,6 @@ export default function PatientFilter(props: any) {
             />
           </div>
 
-          <div className="w-full flex-none">
-            <TextFormField
-              id="srf_id"
-              name="srf_id"
-              placeholder="Filter by SRF ID"
-              label={<span className="text-sm">SRF ID</span>}
-              value={filterState.srf_id}
-              onChange={handleFormFieldChange}
-              errorClassName="hidden"
-            />
-          </div>
           <div className="w-full flex-none">
             <TextFormField
               id="covin_id"

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -753,14 +753,7 @@ export const PatientHome = (props: any) => {
               activeShiftingData.results.map((shift: any) => (
                 <div key={`shift_${shift.id}`} className="mx-2 ">
                   <div className="h-full overflow-hidden rounded-lg bg-white shadow">
-                    <div
-                      className={
-                        "flex h-full flex-col justify-between p-4 " +
-                        (shift.patient_object.disease_status === "POSITIVE"
-                          ? "bg-red-600/5"
-                          : "")
-                      }
-                    >
+                    <div className="flex h-full flex-col justify-between p-4">
                       <div>
                         <div className="mt-1 flex justify-between">
                           <div>

--- a/src/Components/Patient/PatientHome.tsx
+++ b/src/Components/Patient/PatientHome.tsx
@@ -393,20 +393,6 @@ export const PatientHome = (props: any) => {
                         )}
                       </>
                     )}
-                    {patientData.contact_with_confirmed_carrier && (
-                      <Chip
-                        variant="danger"
-                        startIcon="l-exclamation-triangle"
-                        text="Contact with confirmed carrier"
-                      />
-                    )}
-                    {patientData.contact_with_suspected_carrier && (
-                      <Chip
-                        variant="warning"
-                        startIcon="l-exclamation-triangle"
-                        text="Contact with suspected carrier"
-                      />
-                    )}
                     {patientData.past_travel && (
                       <Chip
                         variant="warning"

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -375,7 +375,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
             health_id: data.abha_number_object?.health_id || "",
             nationality: data.nationality ? data.nationality : "India",
             gender: data.gender ? data.gender : undefined,
-            cluster_name: data.cluster_name ? data.cluster_name : "",
             state: data.state ? data.state : "",
             district: data.district ? data.district : "",
             blood_group: data.blood_group

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -2,11 +2,9 @@ import * as Notification from "../../Utils/Notifications.js";
 
 import {
   BLOOD_GROUPS,
-  DISEASE_STATUS,
   GENDER_TYPES,
   MEDICAL_HISTORY_CHOICES,
   OCCUPATION_TYPES,
-  TEST_TYPE,
   VACCINES,
 } from "../../Common/constants";
 import {
@@ -89,11 +87,9 @@ const medicalHistoryChoices = MEDICAL_HISTORY_CHOICES.reduce(
   [],
 );
 const genderTypes = GENDER_TYPES;
-const diseaseStatus = [...DISEASE_STATUS];
 const bloodGroups = [...BLOOD_GROUPS];
 const occupationTypes = OCCUPATION_TYPES;
-const testType = [...TEST_TYPE];
-const vaccines = ["Select", ...VACCINES];
+const vaccines = [...VACCINES];
 
 const initForm: any = {
   name: "",
@@ -103,7 +99,6 @@ const initForm: any = {
   phone_number: "+91",
   emergency_phone_number: "+91",
   blood_group: "",
-  disease_status: diseaseStatus[2],
   is_declared_positive: "false",
   date_declared_positive: new Date(),
   date_of_birth: null,
@@ -121,25 +116,13 @@ const initForm: any = {
   allergies: "",
   pincode: "",
   present_health: "",
-  contact_with_confirmed_carrier: "false",
-  contact_with_suspected_carrier: "false",
-
-  estimated_contact_date: null,
   date_of_return: null,
-
-  number_of_primary_contacts: "",
-  number_of_secondary_contacts: "",
   is_antenatal: "false",
   date_of_test: null,
-  date_of_result: null,
-  test_id: "",
-  srf_id: "",
-  test_type: testType[0],
   treatment_plan: false,
   ongoing_medication: "",
   designation_of_health_care_worker: "",
   instituion_of_health_care_worker: "",
-  cluster_name: "",
   covin_id: "",
   is_vaccinated: "false",
   number_of_doses: "0",
@@ -324,14 +307,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
           : state.form.gender,
       });
       field.onChange({
-        name: "test_id",
-        value: data.test_id ? data.test_id : state.form.test_id,
-      });
-      field.onChange({
-        name: "srf_id",
-        value: data.srf_id ? data.srf_id : state.form.srf_id,
-      });
-      field.onChange({
         name: "state",
         value: data.district_object
           ? data.district_object.state
@@ -354,26 +329,10 @@ export const PatientRegister = (props: PatientRegisterProps) => {
         value: data.village ? data.village : state.form.village,
       });
       field.onChange({
-        name: "disease_status",
-        value: data.result
-          ? data.result.toUpperCase()
-          : state.form.disease_status,
-      });
-      field.onChange({
-        name: "test_type",
-        value: data.test_type
-          ? data.test_type.toUpperCase()
-          : state.form.test_type,
-      });
-      field.onChange({
         name: "date_of_test",
         value: data.sample_collection_date
           ? data.sample_collection_date
           : state.form.date_of_test,
-      });
-      field.onChange({
-        name: "date_of_result",
-        value: data.result_date ? data.result_date : state.form.date_of_result,
       });
       field.onChange({
         name: "phone_number",
@@ -453,19 +412,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
             occupation: data.meta_info?.occupation
               ? parseOccupationFromExt(data.meta_info.occupation)
               : null,
-
-            number_of_primary_contacts: data.number_of_primary_contacts
-              ? data.number_of_primary_contacts
-              : "",
-            number_of_secondary_contacts: data.number_of_secondary_contacts
-              ? data.number_of_secondary_contacts
-              : "",
-            contact_with_confirmed_carrier: data.contact_with_confirmed_carrier
-              ? String(data.contact_with_confirmed_carrier)
-              : "false",
-            contact_with_suspected_carrier: data.contact_with_suspected_carrier
-              ? String(data.contact_with_suspected_carrier)
-              : "false",
             is_vaccinated: String(data.is_vaccinated),
             number_of_doses: data.number_of_doses
               ? String(data.number_of_doses)
@@ -645,39 +591,11 @@ export const PatientRegister = (props: PatientRegisterProps) => {
             errors[field] = "Please enter valid phone number";
           }
           return;
-
-        case "estimated_contact_date":
-          if (
-            JSON.parse(form.contact_with_confirmed_carrier) ||
-            JSON.parse(form.contact_with_suspected_carrier)
-          ) {
-            if (!form[field]) {
-              errors[field] = "Please enter the estimated date of contact";
-            }
-          }
-          return;
-        case "cluster_name":
-          if (
-            JSON.parse(form.contact_with_confirmed_carrier) ||
-            JSON.parse(form.contact_with_suspected_carrier)
-          ) {
-            if (!form[field]) {
-              errors[field] = "Please enter the name / cluster of the contact";
-            }
-          }
-          return;
         case "blood_group":
           if (!form[field]) {
             errors[field] = "Please select a blood group";
           }
           return;
-        case "number_of_primary_contacts":
-        case "number_of_secondary_contacts":
-          if (form[field] && form[field] < 0) {
-            errors[field] = "Value cannot be negative";
-          }
-          return;
-
         case "is_vaccinated":
           if (form.is_vaccinated === "true") {
             if (form.number_of_doses === "0") {
@@ -691,23 +609,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
             if (!form.last_vaccinated_date) {
               errors["last_vaccinated_date"] =
                 "Please enter last vaccinated date";
-            }
-          }
-          return;
-
-        case "date_of_result":
-          if (form[field] < form.date_of_test) {
-            errors[field] =
-              "Date should not be before the date of sample collection";
-          }
-          return;
-        case "disease_status":
-          if (form[field] === "POSITIVE") {
-            if (!form.date_of_test) {
-              errors["date_of_test"] = "Please fill the date of sample testing";
-            }
-            if (!form.date_of_result) {
-              errors["date_of_result"] = "Please fill the date of result";
             }
           }
           return;
@@ -780,18 +681,12 @@ export const PatientRegister = (props: PatientRegisterProps) => {
           ? dateQueryString(formData.date_of_birth)
           : null,
       year_of_birth: ageInputType === "age" ? formData.year_of_birth : null,
-      disease_status: formData.disease_status,
       date_of_test: formData.date_of_test ? formData.date_of_test : undefined,
-      date_of_result: formData.date_of_result
-        ? formData.date_of_result
-        : undefined,
       date_declared_positive:
         JSON.parse(formData.is_declared_positive) &&
         formData.date_declared_positive
           ? formData.date_declared_positive
           : null,
-      test_id: formData.test_id,
-      srf_id: formData.srf_id,
       covin_id:
         formData.is_vaccinated === "true" ? formData.covin_id : undefined,
       is_vaccinated: formData.is_vaccinated,
@@ -811,7 +706,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
             ? formData.last_vaccinated_date
             : null
           : null,
-      test_type: formData.test_type,
       name: _.startCase(_.toLower(formData.name)),
       pincode: formData.pincode ? formData.pincode : undefined,
       gender: Number(formData.gender),
@@ -847,33 +741,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
       present_health: formData.present_health
         ? formData.present_health
         : undefined,
-      contact_with_confirmed_carrier: JSON.parse(
-        formData.contact_with_confirmed_carrier,
-      ),
-      contact_with_suspected_carrier: JSON.parse(
-        formData.contact_with_suspected_carrier,
-      ),
-      estimated_contact_date:
-        (JSON.parse(formData.contact_with_confirmed_carrier) ||
-          JSON.parse(formData.contact_with_suspected_carrier)) &&
-        formData.estimated_contact_date
-          ? formData.estimated_contact_date
-          : null,
-      cluster_name:
-        (JSON.parse(formData.contact_with_confirmed_carrier) ||
-          JSON.parse(formData.contact_with_suspected_carrier)) &&
-        formData.cluster_name
-          ? formData.cluster_name
-          : null,
       allergies: formData.allergies,
-      number_of_primary_contacts: Number(formData.number_of_primary_contacts)
-        ? Number(formData.number_of_primary_contacts)
-        : undefined,
-      number_of_secondary_contacts: Number(
-        formData.number_of_secondary_contacts,
-      )
-        ? Number(formData.number_of_secondary_contacts)
-        : undefined,
       ongoing_medication: formData.ongoing_medication,
       is_declared_positive: JSON.parse(formData.is_declared_positive),
       designation_of_health_care_worker:
@@ -1864,37 +1732,11 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                         >
                           <div>
                             <div className="mt-5 grid w-full grid-cols-1 gap-4 sm:grid-cols-3 xl:gap-x-20 xl:gap-y-6">
-                              <div>
+                              <div className="col-span-full">
                                 <RadioFormField
                                   label="Is patient Vaccinated against COVID?"
                                   aria-label="is_vaccinated"
                                   {...field("is_vaccinated")}
-                                  options={[
-                                    { label: "Yes", value: "true" },
-                                    { label: "No", value: "false" },
-                                  ]}
-                                  optionDisplay={(option) => option.label}
-                                  optionValue={(option) => option.value}
-                                />
-                              </div>
-                              <div id="contact_with_confirmed_carrier-div">
-                                <RadioFormField
-                                  {...field("contact_with_confirmed_carrier")}
-                                  label="Contact with confirmed Covid patient?"
-                                  aria-label="contact_with_confirmed_carrier"
-                                  options={[
-                                    { label: "Yes", value: "true" },
-                                    { label: "No", value: "false" },
-                                  ]}
-                                  optionDisplay={(option) => option.label}
-                                  optionValue={(option) => option.value}
-                                />
-                              </div>
-                              <div id="contact_with_suspected_carrier-div">
-                                <RadioFormField
-                                  {...field("contact_with_suspected_carrier")}
-                                  label="Contact with Covid suspect?"
-                                  aria-label="contact_with_suspected_carrier"
                                   options={[
                                     { label: "Yes", value: "true" },
                                     { label: "No", value: "false" },
@@ -1957,73 +1799,8 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                   </div>
                                 }
                               </CollapseV2>
-                              <CollapseV2
-                                opened={
-                                  JSON.parse(
-                                    field("contact_with_confirmed_carrier")
-                                      .value ?? "{}",
-                                  ) ||
-                                  JSON.parse(
-                                    field("contact_with_suspected_carrier")
-                                      .value ?? "{}",
-                                  )
-                                }
-                              >
-                                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:gap-x-20 xl:gap-y-6">
-                                  <div id="estimated_contact_date-div">
-                                    <DateFormField
-                                      {...field("estimated_contact_date")}
-                                      id="estimated_contact_date"
-                                      label="Estimate date of contact"
-                                      disableFuture
-                                      required
-                                      position="LEFT"
-                                    />
-                                  </div>
-
-                                  <div id="cluster_name-div">
-                                    <TextFormField
-                                      {...field("cluster_name")}
-                                      id="cluster_name"
-                                      label="Name / Cluster of Contact"
-                                      placeholder="Name / Cluster of Contact"
-                                      required
-                                    />
-                                  </div>
-                                </div>
-                              </CollapseV2>
-                              <div
-                                data-testid="disease-status"
-                                id="disease_status-div"
-                              >
-                                <SelectFormField
-                                  {...field("disease_status")}
-                                  id="disease_status"
-                                  label="COVID Disease Status"
-                                  options={diseaseStatus}
-                                  optionLabel={(o) => o}
-                                  optionValue={(o) => o}
-                                  required
-                                />
-                              </div>
-                              <div id="test_type-div">
-                                <SelectFormField
-                                  {...field("test_type")}
-                                  id="test_type"
-                                  label="COVID Test Type"
-                                  options={testType}
-                                  optionLabel={(o) => o}
-                                  optionValue={(o) => o}
-                                  required
-                                />
-                              </div>
-                              <div id="srf_id-div">
-                                <TextFormField
-                                  {...field("srf_id")}
-                                  id="srf_id"
-                                  label="SRF Id for COVID Test"
-                                />
-                              </div>
+                            </div>
+                            <div className="mt-5 grid w-full grid-cols-1 gap-4 xl:gap-x-20 xl:gap-y-6">
                               <div id="is_declared_positive-div">
                                 <RadioFormField
                                   {...field("is_declared_positive")}
@@ -2054,15 +1831,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                   </div>
                                 </CollapseV2>
                               </div>
-                              <div id="test_id-div">
-                                <TextFormField
-                                  {...field("test_id")}
-                                  id="test_id"
-                                  label="COVID Positive ID issued by ICMR"
-                                  type="number"
-                                />
-                              </div>
-
                               <div id="date_of_test-div">
                                 <DateFormField
                                   {...field("date_of_test")}
@@ -2070,32 +1838,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                   label="Date of Sample given for COVID Test"
                                   disableFuture
                                   position="LEFT"
-                                />
-                              </div>
-                              <div id="date_of_result-div">
-                                <DateFormField
-                                  {...field("date_of_result")}
-                                  id="date_of_result"
-                                  label="Date of Result for COVID Test"
-                                  disableFuture
-                                  position="LEFT"
-                                />
-                              </div>
-
-                              <div id="number_of_primary_contacts-div">
-                                <TextFormField
-                                  {...field("number_of_primary_contacts")}
-                                  id="number_of_primary_contacts"
-                                  label="Number Of Primary Contacts for COVID"
-                                  type="number"
-                                />
-                              </div>
-                              <div id="number_of_secondary_contacts-div">
-                                <TextFormField
-                                  {...field("number_of_secondary_contacts")}
-                                  id="number_of_secondary_contacts"
-                                  label="Number Of Secondary Contacts for COVID"
-                                  type="number"
                                 />
                               </div>
                             </div>

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -49,7 +49,6 @@ export interface AbhaObject {
 }
 
 export interface PatientModel {
-  test_id?: string;
   id?: string;
   action?: number;
   name?: string;
@@ -87,19 +86,14 @@ export interface PatientModel {
   sameAddress?: boolean;
   village?: string;
   pincode?: number;
-  contact_with_confirmed_carrier?: boolean;
-  contact_with_suspected_carrier?: boolean;
   is_medical_worker?: boolean;
   designation_of_health_care_worker?: string;
   instituion_of_health_care_worker?: string;
   frontline_worker?: string;
-  estimated_contact_date?: string;
   past_travel?: boolean;
   ongoing_medication?: string;
   countries_travelled?: Array<string>;
   transit_details?: string;
-  number_of_primary_contacts?: number;
-  number_of_secondary_contacts?: number;
   present_health?: string;
   has_SARI?: boolean;
   local_body?: number;
@@ -107,11 +101,7 @@ export interface PatientModel {
   state?: number;
   nationality?: string;
   passport_no?: string;
-  disease_status?: string;
-  test_type?: string;
   date_of_test?: string;
-  date_of_result?: string;
-  srf_id?: string;
   covin_id?: string;
   is_vaccinated?: boolean;
   vaccine_name?: string;
@@ -124,7 +114,6 @@ export interface PatientModel {
   review_interval?: number;
   review_time?: string;
   date_of_return?: string;
-  cluster_name?: string;
   number_of_aged_dependents?: number;
   number_of_chronic_diseased_dependents?: number;
   will_donate_blood?: boolean;

--- a/src/Components/Patient/models.tsx
+++ b/src/Components/Patient/models.tsx
@@ -102,6 +102,7 @@ export interface PatientModel {
   nationality?: string;
   passport_no?: string;
   date_of_test?: string;
+  date_of_result?: string; // keeping this to avoid errors in Death report
   covin_id?: string;
   is_vaccinated?: boolean;
   vaccine_name?: string;

--- a/src/Components/Shifting/BadgesList.tsx
+++ b/src/Components/Shifting/BadgesList.tsx
@@ -48,7 +48,6 @@ export default function BadgesList(props: any) {
         badge(t("patient_name"), "patient_name"),
         ...dateRange(t("created"), "created_date"),
         ...dateRange(t("modified"), "modified_date"),
-        badge(t("disease_status"), "disease_status"),
         badge(t("breathlessness_level"), "breathlessness_level"),
         value(
           t("assigned_to"),

--- a/src/Components/Shifting/Commons.tsx
+++ b/src/Components/Shifting/Commons.tsx
@@ -19,7 +19,6 @@ export const initialFilterData = {
   ordering: null,
   is_kasp: "",
   assigned_to: "",
-  disease_status: "",
   is_antenatal: "",
   breathlessness_level: "",
 };
@@ -55,7 +54,6 @@ export const formatFilter = (params: any) => {
     patient_phone_number: filter.patient_phone_number || undefined,
     ordering: filter.ordering || undefined,
     assigned_to: filter.assigned_to || undefined,
-    disease_status: filter.disease_status || undefined,
     breathlessness_level: filter.breathlessness_level || undefined,
     is_kasp:
       (filter.is_kasp && filter.is_kasp) === ""

--- a/src/Components/Shifting/ListFilter.tsx
+++ b/src/Components/Shifting/ListFilter.tsx
@@ -1,6 +1,5 @@
 import {
   BREATHLESSNESS_LEVEL,
-  DISEASE_STATUS,
   SHIFTING_FILTER_ORDER,
 } from "../../Common/constants";
 import { DateRange } from "../Common/DateRangeInputV2";
@@ -60,7 +59,6 @@ export default function ListFilter(props: any) {
     status: filter.status || null,
     assigned_user_ref: null,
     assigned_to: filter.assigned_to || "",
-    disease_status: filter.disease_status || "",
 
     is_antenatal: filter.is_antenatal || "",
     breathlessness_level: filter.breathlessness_level || "",
@@ -155,7 +153,6 @@ export default function ListFilter(props: any) {
       is_kasp,
       status,
       assigned_to,
-      disease_status,
       is_antenatal,
       breathlessness_level,
     } = filterState;
@@ -177,7 +174,6 @@ export default function ListFilter(props: any) {
       is_kasp: is_kasp || "",
       status: status || "",
       assigned_to: assigned_to || "",
-      disease_status: disease_status || "",
       is_antenatal: is_antenatal || "",
       breathlessness_level: breathlessness_level || "",
     };
@@ -334,19 +330,6 @@ export default function ListFilter(props: any) {
         label={t("is_upshift_case")}
         value={filterState.is_up_shift}
         options={["yes", "no"]}
-        optionLabel={(option) => option}
-        optionValue={(option) => option}
-        onChange={(option) => handleFormFieldChange(option)}
-        errorClassName="hidden"
-      />
-
-      <SelectFormField
-        name="disease_status"
-        id="disease-status"
-        placeholder="Show all"
-        label={t("disease_status")}
-        value={filterState.disease_status}
-        options={DISEASE_STATUS}
         optionLabel={(option) => option}
         optionValue={(option) => option}
         onChange={(option) => handleFormFieldChange(option)}

--- a/src/Components/Shifting/ListView.tsx
+++ b/src/Components/Shifting/ListView.tsx
@@ -78,14 +78,7 @@ export default function ListView() {
     return data.map((shift: any) => (
       <div key={`shift_${shift.id}`} className="mt-6 w-full">
         <div className="h-full overflow-hidden rounded-lg bg-white shadow">
-          <div
-            className={
-              "flex h-full flex-col justify-between p-4 " +
-              (shift.patient_object.disease_status == "POSITIVE"
-                ? "bg-red-50"
-                : "")
-            }
-          >
+          <div className="flex h-full flex-col justify-between p-4">
             <div>
               <div className="flex justify-between">
                 <div className="mb-2 text-xl font-bold capitalize">

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -85,10 +85,6 @@ export default function ShiftDetails(props: { id: string }) {
 
   const copyContent = (data: any) => {
     let formattedText =
-      t("disease_status") +
-      ": *" +
-      data?.patient_object?.disease_status +
-      "* \n" +
       t("name") +
       ":" +
       data?.patient_object?.name +
@@ -150,14 +146,6 @@ export default function ShiftDetails(props: { id: string }) {
               <span className="badge badge-pill badge-primary">{t("yes")}</span>
             </div>
           )}
-          <div>
-            <span className="font-semibold leading-relaxed">
-              {t("disease_status")}{" "}
-            </span>
-            <span className="badge badge-pill badge-warning">
-              {patientData?.disease_status}
-            </span>
-          </div>
           <div>
             <span className="font-semibold leading-relaxed">
               {t("test_type")}:{" "}

--- a/src/Components/Shifting/ShiftDetails.tsx
+++ b/src/Components/Shifting/ShiftDetails.tsx
@@ -4,7 +4,6 @@ import {
   GENDER_TYPES,
   SHIFTING_CHOICES_PEACETIME,
   SHIFTING_CHOICES_WARTIME,
-  TEST_TYPE_CHOICES,
 } from "../../Common/constants";
 import { Link, navigate } from "raviger";
 import { lazy, useState } from "react";
@@ -125,9 +124,6 @@ export default function ShiftDetails(props: { id: string }) {
     const patientGender = GENDER_TYPES.find(
       (i) => i.id === patientData?.gender,
     )?.text;
-    const testType = TEST_TYPE_CHOICES.find(
-      (i) => i.id === patientData?.test_type,
-    )?.text;
 
     return (
       <div className="mr-3 mt-2 h-full rounded-lg border bg-white p-4 text-black shadow md:mr-8">
@@ -146,12 +142,6 @@ export default function ShiftDetails(props: { id: string }) {
               <span className="badge badge-pill badge-primary">{t("yes")}</span>
             </div>
           )}
-          <div>
-            <span className="font-semibold leading-relaxed">
-              {t("test_type")}:{" "}
-            </span>
-            {(patientData?.test_type && testType) || "-"}
-          </div>
           <div>
             <span className="font-semibold leading-relaxed">
               {t("facility")}:{" "}
@@ -307,9 +297,6 @@ export default function ShiftDetails(props: { id: string }) {
     const patientGender = GENDER_TYPES.find(
       (i) => i.id === patientData?.gender,
     )?.text;
-    const testType = TEST_TYPE_CHOICES.find(
-      (i) => i.id === patientData?.test_type,
-    )?.text;
 
     return (
       <div id="section-to-print" className="print bg-white ">
@@ -414,12 +401,6 @@ export default function ShiftDetails(props: { id: string }) {
               {(patientData?.date_of_test &&
                 formatDateTime(patientData?.date_of_test)) ||
                 "-"}
-            </div>
-            <div>
-              <span className="font-semibold leading-relaxed">
-                {t("test_type")}:{" "}
-              </span>
-              {(patientData?.test_type && testType) || "-"}
             </div>
           </div>
 

--- a/src/Components/Shifting/ShiftingBoard.tsx
+++ b/src/Components/Shifting/ShiftingBoard.tsx
@@ -82,12 +82,7 @@ const ShiftCard = ({ shift, filter }: any) => {
           cursor: isDragging ? "grabbing" : "grab",
         }}
       >
-        <div
-          className={classNames(
-            "flex h-full flex-col justify-between p-4",
-            shift.patient_object.disease_status == "POSITIVE" && "bg-red-50",
-          )}
-        >
+        <div className="flex h-full flex-col justify-between p-4">
           <div>
             <div className="flex justify-between">
               <div className="mb-2 text-xl font-bold capitalize">
@@ -316,7 +311,6 @@ export default function ShiftingBoard({
     filterProp.ordering,
     filterProp.is_kasp,
     filterProp.assigned_to,
-    filterProp.disease_status,
     filterProp.is_antenatal,
     filterProp.breathlessness_level,
   ]);


### PR DESCRIPTION
## Proposed Changes

- Fixes #7825 
- Removed the following fields from the patient registration form
  - disease status
  - contact_with_confirmed_carrier
  - contact_with_suspected_carrier
  - estimated_contact_date
  - number_of_primary_contacts
  - number_of_secondary_contacts
  - date_of_result
  - test_id
  - srf_id
  - test_type
- Removed disease status filter from shifting filters
- Removed disease status, srf id and date of result range filters from patient filters
- Removed disease status and test type from shifting details page
- Removed card highlighting based on disease status (red background in shifting and patient cards)
- Removed contact_with_confirmed_carrier and contact_with_suspected_carrier badges on patient details page
- Removed all the above mentioned fields from the patient model
- Removed respective cypress tests 

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers
