### PR TITLE
Hides prescription related action buttons for non-home facility users + Adds reusable component to hide child component if authzn. requirements not met

### DIFF
--- a/src/CAREUI/misc/AuthorizedChild.tsx
+++ b/src/CAREUI/misc/AuthorizedChild.tsx
@@ -1,4 +1,7 @@
+import { ReactNode } from "react";
+import useAuthUser from "../../Common/hooks/useAuthUser";
 import { useIsAuthorized } from "../../Common/hooks/useIsAuthorized";
+import useSlug from "../../Common/hooks/useSlug";
 import { AuthorizedForCB } from "../../Utils/AuthorizeFor";
 
 interface Props {
@@ -12,3 +15,20 @@ const AuthorizedChild = (props: Props) => {
 };
 
 export default AuthorizedChild;
+
+export const AuthorizedForConsultationRelatedActions = (props: {
+  children: ReactNode;
+}) => {
+  const me = useAuthUser();
+  const facilityId = useSlug("facility");
+
+  if (
+    me.home_facility_object?.id === facilityId ||
+    me.user_type === "DistrictAdmin" ||
+    me.user_type === "StateAdmin"
+  ) {
+    return props.children;
+  }
+
+  return null;
+};

--- a/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationUpdatesTab.tsx
@@ -249,7 +249,6 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
                         <div className="overflow-x-auto overflow-y-hidden">
                           <PrescriptionsTable
                             is_prn={false}
-                            readonly
                             prescription_type="DISCHARGE"
                           />
                         </div>
@@ -257,7 +256,6 @@ export const ConsultationUpdatesTab = (props: ConsultationTabProps) => {
                         <div className="overflow-x-auto overflow-y-hidden">
                           <PrescriptionsTable
                             is_prn
-                            readonly
                             prescription_type="DISCHARGE"
                           />
                         </div>

--- a/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/AdministrationTableRow.tsx
@@ -14,6 +14,7 @@ import CareIcon from "../../../CAREUI/icons/CareIcon";
 import EditPrescriptionForm from "../EditPrescriptionForm";
 import AdministrationEventSeperator from "./AdministrationEventSeperator";
 import AdministrationEventCell from "./AdministrationEventCell";
+import { AuthorizedForConsultationRelatedActions } from "../../../CAREUI/misc/AuthorizedChild";
 
 interface Props {
   prescription: Prescription;
@@ -93,46 +94,48 @@ export default function MedicineAdministrationTableRow({
                 onClick={() => setShowDetails(false)}
                 label={t("close")}
               />
-              {!props.readonly && (
-                <>
-                  <Submit
-                    disabled={
-                      prescription.discontinued ||
-                      prescription.prescription_type === "DISCHARGE"
-                    }
-                    variant="danger"
-                    onClick={() => setShowDiscontinue(true)}
-                  >
-                    <CareIcon icon="l-ban" className="text-lg" />
-                    {t("discontinue")}
-                  </Submit>
-                  <Submit
-                    disabled={
-                      prescription.discontinued ||
-                      prescription.prescription_type === "DISCHARGE"
-                    }
-                    variant="secondary"
-                    border
-                    onClick={() => {
-                      setShowDetails(false);
-                      setShowEdit(true);
-                    }}
-                  >
-                    <CareIcon icon="l-pen" className="text-lg" />
-                    {t("edit")}
-                  </Submit>
-                  <Submit
-                    disabled={
-                      prescription.discontinued ||
-                      prescription.prescription_type === "DISCHARGE"
-                    }
-                    onClick={() => setShowAdminister(true)}
-                  >
-                    <CareIcon icon="l-syringe" className="text-lg" />
-                    {t("administer")}
-                  </Submit>
-                </>
-              )}
+              <AuthorizedForConsultationRelatedActions>
+                {!props.readonly && (
+                  <>
+                    <Submit
+                      disabled={
+                        prescription.discontinued ||
+                        prescription.prescription_type === "DISCHARGE"
+                      }
+                      variant="danger"
+                      onClick={() => setShowDiscontinue(true)}
+                    >
+                      <CareIcon icon="l-ban" className="text-lg" />
+                      {t("discontinue")}
+                    </Submit>
+                    <Submit
+                      disabled={
+                        prescription.discontinued ||
+                        prescription.prescription_type === "DISCHARGE"
+                      }
+                      variant="secondary"
+                      border
+                      onClick={() => {
+                        setShowDetails(false);
+                        setShowEdit(true);
+                      }}
+                    >
+                      <CareIcon icon="l-pen" className="text-lg" />
+                      {t("edit")}
+                    </Submit>
+                    <Submit
+                      disabled={
+                        prescription.discontinued ||
+                        prescription.prescription_type === "DISCHARGE"
+                      }
+                      onClick={() => setShowAdminister(true)}
+                    >
+                      <CareIcon icon="l-syringe" className="text-lg" />
+                      {t("administer")}
+                    </Submit>
+                  </>
+                )}
+              </AuthorizedForConsultationRelatedActions>
             </div>
           </div>
         </DialogModal>
@@ -252,18 +255,20 @@ export default function MedicineAdministrationTableRow({
 
         {/* Action Buttons */}
         <td className="space-x-1 pr-2 text-right">
-          {!props.readonly && (
-            <ButtonV2
-              type="button"
-              size="small"
-              disabled={prescription.discontinued}
-              ghost
-              border
-              onClick={() => setShowAdminister(true)}
-            >
-              {t("administer")}
-            </ButtonV2>
-          )}
+          <AuthorizedForConsultationRelatedActions>
+            {!props.readonly && (
+              <ButtonV2
+                type="button"
+                size="small"
+                disabled={prescription.discontinued}
+                ghost
+                border
+                onClick={() => setShowAdminister(true)}
+              >
+                {t("administer")}
+              </ButtonV2>
+            )}
+          </AuthorizedForConsultationRelatedActions>
         </td>
       </tr>
     </>

--- a/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
+++ b/src/Components/Medicine/MedicineAdministrationSheet/index.tsx
@@ -13,6 +13,7 @@ import useRangePagination from "../../../Common/hooks/useRangePagination";
 import MedicineAdministrationTable from "./AdministrationTable";
 import Loading from "../../Common/Loading";
 import ScrollOverlay from "../../../CAREUI/interactive/ScrollOverlay";
+import { AuthorizedForConsultationRelatedActions } from "../../../CAREUI/misc/AuthorizedChild";
 
 interface Props {
   readonly?: boolean;
@@ -89,7 +90,7 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
         options={
           !readonly &&
           !!data?.results && (
-            <>
+            <AuthorizedForConsultationRelatedActions>
               <ButtonV2
                 id="edit-prescription"
                 variant="secondary"
@@ -107,7 +108,7 @@ const MedicineAdministrationSheet = ({ readonly, is_prn }: Props) => {
                 prescriptions={data.results}
                 onDone={() => refetch()}
               />
-            </>
+            </AuthorizedForConsultationRelatedActions>
           )
         }
       />

--- a/src/Components/Medicine/PrescriptionBuilder.tsx
+++ b/src/Components/Medicine/PrescriptionBuilder.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import useQuery from "../../Utils/request/useQuery";
 import MedicineRoutes from "./routes";
 import useSlug from "../../Common/hooks/useSlug";
+import { AuthorizedForConsultationRelatedActions } from "../../CAREUI/misc/AuthorizedChild";
 
 interface Props {
   prescription_type?: Prescription["prescription_type"];
@@ -75,20 +76,27 @@ export default function PrescriptionBuilder({
           />
         ))}
       </div>
-      <ButtonV2
-        type="button"
-        onClick={() => setShowCreate(true)}
-        variant="secondary"
-        className="mt-4 w-full bg-gray-200 text-gray-700 hover:bg-gray-300 hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900"
-        disabled={disabled}
-      >
-        <div className="flex w-full justify-start gap-2" id="add-prescription">
-          <CareIcon icon="l-plus" className="text-lg" />
-          <span className="font-bold">
-            {t(is_prn ? "add_prn_prescription" : "add_prescription_medication")}
-          </span>
-        </div>
-      </ButtonV2>
+      <AuthorizedForConsultationRelatedActions>
+        <ButtonV2
+          type="button"
+          onClick={() => setShowCreate(true)}
+          variant="secondary"
+          className="mt-4 w-full bg-gray-200 text-gray-700 hover:bg-gray-300 hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900"
+          disabled={disabled}
+        >
+          <div
+            className="flex w-full justify-start gap-2"
+            id="add-prescription"
+          >
+            <CareIcon icon="l-plus" className="text-lg" />
+            <span className="font-bold">
+              {t(
+                is_prn ? "add_prn_prescription" : "add_prescription_medication",
+              )}
+            </span>
+          </div>
+        </ButtonV2>
+      </AuthorizedForConsultationRelatedActions>
       {showCreate && (
         <DialogModal
           onClose={() => setShowCreate(false)}

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -5,6 +5,7 @@ import ReadMore from "../Common/components/Readmore";
 import ButtonV2 from "../Common/components/ButtonV2";
 import { useTranslation } from "react-i18next";
 import RecordMeta from "../../CAREUI/display/RecordMeta";
+import { AuthorizedForConsultationRelatedActions } from "../../CAREUI/misc/AuthorizedChild";
 
 export default function PrescriptionDetailCard({
   prescription,
@@ -56,33 +57,35 @@ export default function PrescriptionDetailCard({
 
             {!props.readonly &&
               prescription.prescription_type !== "DISCHARGE" && (
-                <div className="flex flex-col-reverse items-end gap-2 sm:flex-row">
-                  <ButtonV2
-                    id="administer-medicine"
-                    disabled={prescription.discontinued}
-                    onClick={props.onAdministerClick}
-                    type="button"
-                    size="small"
-                    variant="secondary"
-                    ghost
-                    border
-                  >
-                    <CareIcon icon="l-syringe" className="text-base" />
-                    {t("administer")}
-                  </ButtonV2>
-                  <ButtonV2
-                    disabled={prescription.discontinued}
-                    type="button"
-                    size="small"
-                    variant="danger"
-                    ghost
-                    border
-                    onClick={props.onDiscontinueClick}
-                  >
-                    <CareIcon icon="l-ban" className="text-base" />
-                    {t("discontinue")}
-                  </ButtonV2>
-                </div>
+                <AuthorizedForConsultationRelatedActions>
+                  <div className="flex flex-col-reverse items-end gap-2 sm:flex-row">
+                    <ButtonV2
+                      id="administer-medicine"
+                      disabled={prescription.discontinued}
+                      onClick={props.onAdministerClick}
+                      type="button"
+                      size="small"
+                      variant="secondary"
+                      ghost
+                      border
+                    >
+                      <CareIcon icon="l-syringe" className="text-base" />
+                      {t("administer")}
+                    </ButtonV2>
+                    <ButtonV2
+                      disabled={prescription.discontinued}
+                      type="button"
+                      size="small"
+                      variant="danger"
+                      ghost
+                      border
+                      onClick={props.onDiscontinueClick}
+                    >
+                      <CareIcon icon="l-ban" className="text-base" />
+                      {t("discontinue")}
+                    </ButtonV2>
+                  </div>
+                </AuthorizedForConsultationRelatedActions>
               )}
           </div>
         </div>

--- a/src/Components/Medicine/PrescriptionsTable.tsx
+++ b/src/Components/Medicine/PrescriptionsTable.tsx
@@ -3,12 +3,8 @@ import ResponsiveMedicineTable from "./ResponsiveMedicineTables";
 import { formatDateTime } from "../../Utils/utils";
 import { Prescription } from "./models";
 import CareIcon from "../../CAREUI/icons/CareIcon";
-import ButtonV2, { Cancel, Submit } from "../Common/components/ButtonV2";
-import SlideOver from "../../CAREUI/interactive/SlideOver";
-import MedicineAdministration from "./MedicineAdministration";
-import DiscontinuePrescription from "./DiscontinuePrescription";
+import { Cancel } from "../Common/components/ButtonV2";
 import RecordMeta from "../../CAREUI/display/RecordMeta";
-import AdministerMedicine from "./AdministerMedicine";
 import DialogModal from "../Common/Dialog";
 import PrescriptionDetailCard from "./PrescriptionDetailCard";
 import { useTranslation } from "react-i18next";
@@ -19,21 +15,14 @@ import MedicineRoutes from "./routes";
 interface Props {
   is_prn?: boolean;
   prescription_type?: Prescription["prescription_type"];
-  onChange?: () => void;
-  readonly?: boolean;
 }
 
 export default function PrescriptionsTable({
   is_prn = false,
   prescription_type = "REGULAR",
-  onChange,
-  readonly,
 }: Props) {
   const consultation = useSlug("consultation");
   const { t } = useTranslation();
-  const [showBulkAdminister, setShowBulkAdminister] = useState(false);
-  const [showDiscontinueFor, setShowDiscontinueFor] = useState<Prescription>();
-  const [showAdministerFor, setShowAdministerFor] = useState<Prescription>();
   const [detailedViewFor, setDetailedViewFor] = useState<Prescription>();
 
   const { data } = useQuery(MedicineRoutes.listPrescriptions, {
@@ -57,42 +46,6 @@ export default function PrescriptionsTable({
 
   return (
     <div>
-      {data?.results && (
-        <SlideOver
-          title={t("administer_medicines")}
-          dialogClass="w-full max-w-sm sm:max-w-md md:max-w-[1200px]"
-          open={showBulkAdminister}
-          setOpen={setShowBulkAdminister}
-        >
-          <MedicineAdministration
-            prescriptions={data?.results}
-            onDone={() => {
-              setShowBulkAdminister(false);
-              onChange?.();
-            }}
-          />
-        </SlideOver>
-      )}
-      {showDiscontinueFor && (
-        <DiscontinuePrescription
-          prescription={showDiscontinueFor}
-          onClose={(success) => {
-            setShowDiscontinueFor(undefined);
-            if (success) onChange?.();
-          }}
-          key={showDiscontinueFor.id}
-        />
-      )}
-      {showAdministerFor && (
-        <AdministerMedicine
-          prescription={showAdministerFor}
-          onClose={(success) => {
-            setShowAdministerFor(undefined);
-            if (success) onChange?.();
-          }}
-          key={showAdministerFor.id}
-        />
-      )}
       {detailedViewFor && (
         <DialogModal
           onClose={() => setDetailedViewFor(undefined)}
@@ -111,27 +64,6 @@ export default function PrescriptionsTable({
                 onClick={() => setDetailedViewFor(undefined)}
                 label={t("close")}
               />
-              <Submit
-                disabled={
-                  detailedViewFor.discontinued ||
-                  detailedViewFor.prescription_type === "DISCHARGE"
-                }
-                variant="danger"
-                onClick={() => setShowDiscontinueFor(detailedViewFor)}
-              >
-                <CareIcon icon="l-ban" className="text-lg" />
-                {t("discontinue")}
-              </Submit>
-              <Submit
-                disabled={
-                  detailedViewFor.discontinued ||
-                  detailedViewFor.prescription_type === "DISCHARGE"
-                }
-                onClick={() => setShowAdministerFor(detailedViewFor)}
-              >
-                <CareIcon icon="l-syringe" className="text-lg" />
-                {t("administer")}
-              </Submit>
             </div>
           </div>
         </DialogModal>
@@ -148,34 +80,6 @@ export default function PrescriptionsTable({
             </span>
           </div>
         </div>
-        {prescription_type === "REGULAR" && (
-          <div className="mt-2 flex w-full flex-col justify-end gap-2 sm:flex-row md:mt-0 md:w-auto">
-            <ButtonV2
-              disabled={readonly}
-              variant="secondary"
-              border
-              href="prescriptions"
-              className="w-full lg:w-auto"
-            >
-              <CareIcon icon="l-pen" className="text-lg" />
-              <span className="hidden lg:block">{t("edit_prescriptions")}</span>
-              <span className="block lg:hidden">{t("edit")}</span>
-            </ButtonV2>
-            <ButtonV2
-              disabled={readonly}
-              ghost
-              border
-              onClick={() => setShowBulkAdminister(true)}
-              className="w-full lg:w-auto"
-            >
-              <CareIcon icon="l-syringe" className="text-lg" />
-              <span className="hidden lg:block">
-                {t("administer_medicines")}
-              </span>
-              <span className="block lg:hidden">{t("administer")}</span>
-            </ButtonV2>
-          </div>
-        )}
       </div>
       <div className="flex flex-col">
         <div className="-my-2 overflow-x-auto py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
@@ -209,63 +113,6 @@ export default function PrescriptionsTable({
               }
               objectKeys={Object.values(tkeys)}
               fieldsToDisplay={[2, 3]}
-              actions={
-                !readonly
-                  ? (med: Prescription) => {
-                      if (med.prescription_type === "DISCHARGE") {
-                        return (
-                          <div className="flex w-full items-center justify-center gap-1 font-medium text-gray-700">
-                            <span className="text-sm">
-                              {t("discharge_prescription")}
-                            </span>
-                          </div>
-                        );
-                      }
-
-                      if (med.discontinued) {
-                        return (
-                          <div className="flex w-full items-center justify-center gap-1 font-medium text-gray-700">
-                            <CareIcon icon="l-ban" />
-                            <span className="text-sm">{t("discontinued")}</span>
-                          </div>
-                        );
-                      }
-
-                      return (
-                        <div className="flex gap-1">
-                          <ButtonV2
-                            type="button"
-                            size="small"
-                            variant="secondary"
-                            ghost
-                            border
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setShowAdministerFor(med);
-                            }}
-                          >
-                            <CareIcon icon="l-syringe" className="text-base" />
-                            {t("administer")}
-                          </ButtonV2>
-                          <ButtonV2
-                            type="button"
-                            size="small"
-                            variant="danger"
-                            ghost
-                            border
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setShowDiscontinueFor(med);
-                            }}
-                          >
-                            <CareIcon icon="l-ban" className="text-base" />
-                            {t("discontinue")}
-                          </ButtonV2>
-                        </div>
-                      );
-                    }
-                  : undefined
-              }
             />
             {data?.results.length === 0 && (
               <div className="text-semibold flex items-center justify-center py-2 text-gray-600">

--- a/src/Components/Medicine/PrescrpitionTimeline.tsx
+++ b/src/Components/Medicine/PrescrpitionTimeline.tsx
@@ -15,6 +15,7 @@ import ConfirmDialog from "../Common/ConfirmDialog";
 import request from "../../Utils/request/request";
 import RecordMeta from "../../CAREUI/display/RecordMeta";
 import CareIcon from "../../CAREUI/icons/CareIcon";
+import { AuthorizedForConsultationRelatedActions } from "../../CAREUI/misc/AuthorizedChild";
 
 interface MedicineAdministeredEvent extends TimelineEvent<"administered"> {
   administration: MedicineAdministrationRecord;
@@ -131,15 +132,17 @@ const MedicineAdministeredNode = ({
         actions={
           !event.cancelled &&
           !hideArchive && (
-            <ButtonV2
-              size="small"
-              border
-              ghost
-              variant="secondary"
-              onClick={() => setShowArchiveConfirmation(true)}
-            >
-              Archive
-            </ButtonV2>
+            <AuthorizedForConsultationRelatedActions>
+              <ButtonV2
+                size="small"
+                border
+                ghost
+                variant="secondary"
+                onClick={() => setShowArchiveConfirmation(true)}
+              >
+                Archive
+              </ButtonV2>
+            </AuthorizedForConsultationRelatedActions>
           )
         }
         isLast={isLastNode}


### PR DESCRIPTION
## Proposed Changes

- Partly solves #7755 (will close once backend restrictions are also done; https://github.com/coronasafe/care/pull/2133)
- Added a reusable component `AuthorizedForConsultationRelatedActions` that checks home facility and user type access based on context from URL and auth user. Hides child elements if requirements are not met.
- Removed logically unused code from old prescriptions table component which had configurable props that were never used.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
