### PR TITLE
Adds watermark to Camera Feed and disables access to context menu.

### DIFF
--- a/src/Components/CameraFeed/CameraFeed.tsx
+++ b/src/Components/CameraFeed/CameraFeed.tsx
@@ -10,6 +10,7 @@ import FeedNetworkSignal from "./FeedNetworkSignal";
 import NoFeedAvailable from "./NoFeedAvailable";
 import FeedControls from "./FeedControls";
 import Fullscreen from "../../CAREUI/misc/Fullscreen";
+import FeedWatermark from "./FeedWatermark";
 
 interface Props {
   children?: React.ReactNode;
@@ -87,6 +88,8 @@ export default function CameraFeed(props: Props) {
     initializeStream();
   };
 
+  console.log({ isIOS });
+
   return (
     <Fullscreen fullscreen={isFullscreen} onExit={() => setFullscreen(false)}>
       <div
@@ -115,6 +118,7 @@ export default function CameraFeed(props: Props) {
         <div className="group relative aspect-video">
           {/* Notifications */}
           <FeedAlert state={state} />
+          {player.status === "playing" && <FeedWatermark />}
 
           {/* No Feed informations */}
           {state === "host_unreachable" && (
@@ -145,6 +149,7 @@ export default function CameraFeed(props: Props) {
                 url={streamUrl}
                 ref={playerRef.current as LegacyRef<ReactPlayer>}
                 controls={false}
+                pip={false}
                 playsinline
                 playing
                 muted
@@ -162,10 +167,12 @@ export default function CameraFeed(props: Props) {
             </div>
           ) : (
             <video
+              onContextMenu={(e) => e.preventDefault()}
               className="absolute inset-0 w-full"
               id="mse-video"
               autoPlay
               muted
+              disablePictureInPicture
               playsInline
               onPlay={player.onPlayCB}
               onEnded={() => player.setStatus("stop")}

--- a/src/Components/CameraFeed/CameraFeed.tsx
+++ b/src/Components/CameraFeed/CameraFeed.tsx
@@ -87,9 +87,6 @@ export default function CameraFeed(props: Props) {
     setState("loading");
     initializeStream();
   };
-
-  console.log({ isIOS });
-
   return (
     <Fullscreen fullscreen={isFullscreen} onExit={() => setFullscreen(false)}>
       <div

--- a/src/Components/CameraFeed/FeedWatermark.tsx
+++ b/src/Components/CameraFeed/FeedWatermark.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+import useAuthUser from "../../Common/hooks/useAuthUser";
+
+export default function FeedWatermark() {
+  const me = useAuthUser();
+  return (
+    <>
+      <Watermark className="left-1/3 top-1/3 -translate-x-1/2 -translate-y-1/2">
+        {me.username}
+      </Watermark>
+      <Watermark className="right-1/3 top-1/3 -translate-y-1/2 translate-x-1/2">
+        {me.username}
+      </Watermark>
+      <Watermark className="bottom-1/3 left-1/3 -translate-x-1/2 translate-y-1/2">
+        {me.username}
+      </Watermark>
+      <Watermark className="bottom-1/3 right-1/3 translate-x-1/2 translate-y-1/2">
+        {me.username}
+      </Watermark>
+    </>
+  );
+}
+
+const Watermark = (props: { children: string; className: string }) => {
+  const ref = useRef<HTMLSpanElement>(null);
+  const parentRef = useRef<HTMLElement | null>(null);
+
+  // This adds the element back if the element was removed from the DOM
+  useEffect(() => {
+    parentRef.current = ref.current?.parentElement || null;
+    let animationFrameId: number;
+
+    const checkWatermark = () => {
+      const watermark = ref.current;
+      const parent = parentRef.current;
+      if (watermark && parent && !parent.contains(watermark)) {
+        parent.appendChild(watermark);
+      }
+      animationFrameId = requestAnimationFrame(checkWatermark);
+    };
+
+    animationFrameId = requestAnimationFrame(checkWatermark);
+
+    return () => cancelAnimationFrame(animationFrameId);
+  }, []);
+
+  return (
+    <span
+      ref={ref}
+      className={`absolute z-10 text-2xl font-bold text-white/30 ${props.className}`}
+    >
+      {props.children}
+    </span>
+  );
+};


### PR DESCRIPTION
## Proposed Changes

- Fixes #7872
- Added logic to ensure watermark cannot be removed from the DOM.
- Disable context menu access for Camera Feed's video element.

<img width="1822" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/8a1d20a6-f787-4e1c-8664-ce810ba1fbe4">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
