### PR TITLE
added skeleton loader for consent records

### DIFF
--- a/src/Components/Patient/PatientConsentRecordBlock.tsx
+++ b/src/Components/Patient/PatientConsentRecordBlock.tsx
@@ -44,14 +44,18 @@ export default function PatientConsentRecordBlockGroup(props: {
       offset: 0,
     },
     onResponse: (response) => {
+      /*
       if (consentRecord.deleted === true && response.data?.results) {
         const unarchivedFiles = response.data.results;
+        console.log("checking for unarchived files on this deleted consent record")
         for (const file of unarchivedFiles) {
+          console.log("archiving file", file)
           archiveFile(file, consentRecord.id, {
             reason: "Consent Record Archived",
           });
         }
       }
+      */
 
       if ((response.data?.results?.length || 0) > 0) {
         props.onFilesFound();
@@ -81,7 +85,10 @@ export default function PatientConsentRecordBlockGroup(props: {
   );
 
   const data = showArchive
-    ? archivedFilesQuery.data?.results
+    ? [
+        ...(archivedFilesQuery.data?.results || []),
+        ...(consentRecord.deleted ? filesQuery.data?.results || [] : []),
+      ]
     : filesQuery.data?.results;
 
   const loading = archivedFilesQuery.loading || filesQuery.loading;

--- a/src/Components/Patient/PatientConsentRecordBlock.tsx
+++ b/src/Components/Patient/PatientConsentRecordBlock.tsx
@@ -63,6 +63,10 @@ export default function PatientConsentRecordBlockGroup(props: {
       ]
     : filesQuery.data?.results;
 
+  const loading = showArchive
+    ? archivedFilesQuery.loading && filesQuery.loading
+    : filesQuery.loading;
+
   useEffect(() => {
     filesQuery.refetch();
     archivedFilesQuery.refetch();
@@ -104,54 +108,55 @@ export default function PatientConsentRecordBlockGroup(props: {
         )}
       */}
       </div>
-
-      {data?.map((file: FileUploadModel, i: number) => (
-        <div
-          key={i}
-          className={`flex items-center justify-between rounded-lg border border-gray-300 ${showArchive ? "text-gray-600" : "bg-white"}  px-4 py-2 transition-all hover:bg-gray-100`}
-        >
-          <div className="flex items-center gap-4 ">
-            <div>
-              <CareIcon icon="l-file" className="text-5xl text-gray-600" />
+      {loading && <div className="skeleton-animate-alpha h-32 rounded-lg" />}
+      {!loading &&
+        data?.map((file: FileUploadModel, i: number) => (
+          <div
+            key={i}
+            className={`flex items-center justify-between rounded-lg border border-gray-300 ${showArchive ? "text-gray-600" : "bg-white"}  px-4 py-2 transition-all hover:bg-gray-100`}
+          >
+            <div className="flex items-center gap-4 ">
+              <div>
+                <CareIcon icon="l-file" className="text-5xl text-gray-600" />
+              </div>
+              <div className="min-w-[40%] break-all">
+                <div className="">
+                  {file.name}
+                  {file.extension} {file.is_archived && "(Archived)"}
+                </div>
+                <div className="text-xs text-gray-700">
+                  {dayjs(file.created_date).format("DD MMM YYYY, hh:mm A")}
+                </div>
+              </div>
             </div>
-            <div className="min-w-[40%] break-all">
-              <div className="">
-                {file.name}
-                {file.extension} {file.is_archived && "(Archived)"}
-              </div>
-              <div className="text-xs text-gray-700">
-                {dayjs(file.created_date).format("DD MMM YYYY, hh:mm A")}
-              </div>
+            <div className="flex shrink-0 gap-2">
+              {!file.is_archived && (
+                <ButtonV2
+                  onClick={() => previewFile(file, consentRecord.id)}
+                  className=""
+                >
+                  <CareIcon icon="l-eye" />
+                  View
+                </ButtonV2>
+              )}
+              {(file.is_archived ||
+                file?.uploaded_by?.username === authUser.username ||
+                authUser.user_type === "DistrictAdmin" ||
+                authUser.user_type === "StateAdmin") && (
+                <ButtonV2
+                  variant={file.is_archived ? "primary" : "secondary"}
+                  onClick={() => archiveFile(file, consentRecord.id)}
+                  className=""
+                >
+                  <CareIcon
+                    icon={file.is_archived ? "l-info-circle" : "l-archive"}
+                  />
+                  {file.is_archived ? "More Info" : "Archive"}
+                </ButtonV2>
+              )}
             </div>
           </div>
-          <div className="flex shrink-0 gap-2">
-            {!file.is_archived && (
-              <ButtonV2
-                onClick={() => previewFile(file, consentRecord.id)}
-                className=""
-              >
-                <CareIcon icon="l-eye" />
-                View
-              </ButtonV2>
-            )}
-            {(file.is_archived ||
-              file?.uploaded_by?.username === authUser.username ||
-              authUser.user_type === "DistrictAdmin" ||
-              authUser.user_type === "StateAdmin") && (
-              <ButtonV2
-                variant={file.is_archived ? "primary" : "secondary"}
-                onClick={() => archiveFile(file, consentRecord.id)}
-                className=""
-              >
-                <CareIcon
-                  icon={file.is_archived ? "l-info-circle" : "l-archive"}
-                />
-                {file.is_archived ? "More Info" : "Archive"}
-              </ButtonV2>
-            )}
-          </div>
-        </div>
-      ))}
+        ))}
     </div>
   );
 }

--- a/src/Components/Patient/PatientConsentRecordBlock.tsx
+++ b/src/Components/Patient/PatientConsentRecordBlock.tsx
@@ -137,7 +137,7 @@ export default function PatientConsentRecordBlockGroup(props: {
         data?.map((file: FileUploadModel, i: number) => (
           <div
             key={i}
-            className={`flex items-center justify-between rounded-lg border border-gray-300 ${showArchive ? "text-gray-600" : "bg-white"}  px-4 py-2 transition-all hover:bg-gray-100`}
+            className={`flex flex-col justify-between gap-2 rounded-lg border border-gray-300 md:flex-row md:items-center ${showArchive ? "text-gray-600" : "bg-white"}  px-4 py-2 transition-all hover:bg-gray-100`}
           >
             <div className="flex items-center gap-4 ">
               <div>
@@ -153,7 +153,7 @@ export default function PatientConsentRecordBlockGroup(props: {
                 </div>
               </div>
             </div>
-            <div className="flex shrink-0 gap-2">
+            <div className="flex shrink-0 justify-end gap-2">
               {!file.is_archived && (
                 <ButtonV2
                   onClick={() => previewFile(file, consentRecord.id)}

--- a/src/Components/Patient/PatientConsentRecords.tsx
+++ b/src/Components/Patient/PatientConsentRecords.tsx
@@ -43,8 +43,6 @@ export default function PatientConsentRecords(props: {
     type: "CONSENT_RECORD",
     onArchive: async () => {
       refetch();
-      setShowArchived(true);
-      setShowArchived(false);
     },
   });
 

--- a/src/Components/Patient/PatientConsentRecords.tsx
+++ b/src/Components/Patient/PatientConsentRecords.tsx
@@ -51,7 +51,11 @@ export default function PatientConsentRecords(props: {
       id: patientId,
     },
   });
-  const { data: consultation, refetch } = useQuery(routes.getConsultation, {
+  const {
+    data: consultation,
+    refetch,
+    loading,
+  } = useQuery(routes.getConsultation, {
     pathParams: { id: consultationId! },
     onResponse: (data) => {
       if (data.data && data.data.consent_records) {
@@ -280,25 +284,28 @@ export default function PatientConsentRecords(props: {
           </div>
         </div>
         <div className="flex-1">
-          {tabConsents?.length === 0 ||
-            (!filesFound && (
-              <div className="flex h-32 items-center justify-center text-gray-500">
-                No records found
-              </div>
-            ))}
+          {!loading && (tabConsents?.length === 0 || !filesFound) && (
+            <div className="flex h-32 items-center justify-center text-gray-500">
+              No records found
+            </div>
+          )}
           <div className="flex flex-col gap-4">
-            {tabConsents?.map((record, index) => (
-              <PatientConsentRecordBlockGroup
-                key={index}
-                consentRecord={record}
-                previewFile={fileManager.viewFile}
-                archiveFile={fileManager.archiveFile}
-                onDelete={(record) => setShowDeleteConsent(record.id)}
-                refreshTrigger={consultation}
-                showArchive={showArchived}
-                onFilesFound={() => setFilesFound(true)}
-              />
-            ))}
+            {loading && (
+              <div className="skeleton-animate-alpha h-32 rounded-lg" />
+            )}
+            {!loading &&
+              tabConsents?.map((record, index) => (
+                <PatientConsentRecordBlockGroup
+                  key={index}
+                  consentRecord={record}
+                  previewFile={fileManager.viewFile}
+                  archiveFile={fileManager.archiveFile}
+                  onDelete={(record) => setShowDeleteConsent(record.id)}
+                  refreshTrigger={consultation}
+                  showArchive={showArchived}
+                  onFilesFound={() => setFilesFound(true)}
+                />
+              ))}
           </div>
         </div>
       </div>

--- a/src/Components/Patient/PatientConsentRecords.tsx
+++ b/src/Components/Patient/PatientConsentRecords.tsx
@@ -134,7 +134,7 @@ export default function PatientConsentRecords(props: {
     return () => clearTimeout(timeout);
   }, [consentRecords]);
 
-  const tabConsents = consentRecords;
+  const tabConsents = consentRecords?.filter((c) => showArchived || !c.deleted);
 
   useEffect(() => {
     setFilesFound(false);
@@ -194,7 +194,7 @@ export default function PatientConsentRecords(props: {
         className="w-auto"
       />
       <SwitchTabs
-        tab1="Files"
+        tab1="Active"
         tab2="Archived"
         className="my-4"
         onClickTab1={() => setShowArchived(false)}

--- a/src/Components/Patient/PatientConsentRecords.tsx
+++ b/src/Components/Patient/PatientConsentRecords.tsx
@@ -43,6 +43,8 @@ export default function PatientConsentRecords(props: {
     type: "CONSENT_RECORD",
     onArchive: async () => {
       refetch();
+      setShowArchived(true);
+      setShowArchived(false);
     },
   });
 
@@ -134,13 +136,15 @@ export default function PatientConsentRecords(props: {
     return () => clearTimeout(timeout);
   }, [consentRecords]);
 
-  const tabConsents = consentRecords?.filter(
-    (record) => showArchived || record.deleted !== true,
-  );
+  const tabConsents = consentRecords;
 
   useEffect(() => {
     setFilesFound(false);
   }, [showArchived]);
+
+  useEffect(() => {
+    console.log(filesFound);
+  }, [filesFound]);
 
   return (
     <Page
@@ -284,15 +288,14 @@ export default function PatientConsentRecords(props: {
           </div>
         </div>
         <div className="flex-1">
-          {!loading && (tabConsents?.length === 0 || !filesFound) && (
-            <div className="flex h-32 items-center justify-center text-gray-500">
-              No records found
-            </div>
-          )}
           <div className="flex flex-col gap-4">
-            {loading && (
+            {loading ? (
               <div className="skeleton-animate-alpha h-32 rounded-lg" />
-            )}
+            ) : tabConsents?.length === 0 || !filesFound ? (
+              <div className="flex h-32 items-center justify-center text-gray-500">
+                No records found
+              </div>
+            ) : null}
             {!loading &&
               tabConsents?.map((record, index) => (
                 <PatientConsentRecordBlockGroup

--- a/src/Components/Patient/PatientConsentRecords.tsx
+++ b/src/Components/Patient/PatientConsentRecords.tsx
@@ -201,8 +201,8 @@ export default function PatientConsentRecords(props: {
         onClickTab2={() => setShowArchived(true)}
         isTab2Active={showArchived}
       />
-      <div className="mt-8 flex flex-col gap-4 md:flex-row-reverse">
-        <div className="shrink-0 md:w-[350px]">
+      <div className="mt-8 flex flex-col gap-4 lg:flex-row-reverse">
+        <div className="shrink-0 lg:w-[350px]">
           <h4 className="font-black">Add New Record</h4>
           <SelectFormField
             {...selectField("consent_type")}

--- a/src/Components/Patient/PatientConsentRecords.tsx
+++ b/src/Components/Patient/PatientConsentRecords.tsx
@@ -142,10 +142,6 @@ export default function PatientConsentRecords(props: {
     setFilesFound(false);
   }, [showArchived]);
 
-  useEffect(() => {
-    console.log(filesFound);
-  }, [filesFound]);
-
   return (
     <Page
       title={"Patient Consent Records"}
@@ -249,6 +245,7 @@ export default function PatientConsentRecords(props: {
                     const diffPCS = consentRecords?.find(
                       (record) =>
                         record.type === 2 &&
+                        newConsent.type === 2 &&
                         record.patient_code_status !==
                           newConsent.patient_code_status &&
                         record.deleted !== true,

--- a/src/Utils/useFileManager.tsx
+++ b/src/Utils/useFileManager.tsx
@@ -18,7 +18,11 @@ export interface FileManagerOptions {
 
 export interface FileManagerResult {
   viewFile: (file: FileUploadModel, associating_id: string) => void;
-  archiveFile: (file: FileUploadModel, associating_id: string) => void;
+  archiveFile: (
+    file: FileUploadModel,
+    associating_id: string,
+    skipPrompt?: { reason: string },
+  ) => void;
   Dialogues: React.ReactNode;
 }
 
@@ -97,7 +101,7 @@ export default function useFileManager(
     }
   };
 
-  const handleFileArchive = async () => {
+  const handleFileArchive = async (archiveFile: typeof archiveDialogueOpen) => {
     if (!validateArchiveReason(archiveReason)) {
       setArchiving(false);
       return;
@@ -106,9 +110,9 @@ export default function useFileManager(
     const { res } = await request(routes.editUpload, {
       body: { is_archived: true, archive_reason: archiveReason },
       pathParams: {
-        id: archiveDialogueOpen?.id || "",
+        id: archiveFile?.id || "",
         fileType,
-        associatingId: archiveDialogueOpen?.associating_id || "",
+        associatingId: archiveFile?.associating_id || "",
       },
     });
 
@@ -122,7 +126,20 @@ export default function useFileManager(
     return res;
   };
 
-  const archiveFile = (file: FileUploadModel, associating_id: string) => {
+  const archiveFile = (
+    file: FileUploadModel,
+    associating_id: string,
+    skipPrompt?: { reason: string },
+  ) => {
+    if (skipPrompt) {
+      setArchiving(true);
+      setArchiveReason(skipPrompt.reason);
+      handleFileArchive({
+        ...file,
+        associating_id,
+      });
+      return;
+    }
     setArchiveDialogueOpen({ ...file, associating_id });
   };
 
@@ -174,7 +191,7 @@ export default function useFileManager(
         <form
           onSubmit={(event: any) => {
             event.preventDefault();
-            handleFileArchive();
+            handleFileArchive(archiveDialogueOpen);
           }}
           className="mx-2 my-4 flex w-full flex-col"
         >

--- a/src/Utils/useFileManager.tsx
+++ b/src/Utils/useFileManager.tsx
@@ -122,6 +122,7 @@ export default function useFileManager(
 
     setArchiveDialogueOpen(null);
     setArchiving(false);
+    setArchiveReason("");
     onArchive && onArchive();
     return res;
   };

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -429,6 +429,12 @@ button:disabled,
     }
 }
 
+.skeleton-animate-alpha {
+    animation: skeletonShimmer 3s infinite linear;
+    background: linear-gradient(to right, rgba(0, 0, 0, 0.1) 10%, rgba(0, 0, 0, 0.05) 40%, rgba(0, 0, 0, 0.1) 70%);
+    background-size: 1000px 100%;
+}
+
 
 @media print {
     body * {


### PR DESCRIPTION
## Proposed Changes

- Fixes #7900 
- Fixes #7897
- Adds a skeleton loader at consent records page

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
