### PR TITLE
fixes up/down arrow of numeric inputs not clickable in facility create and other places

### DIFF
--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1103,7 +1103,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                         placeholder="Weight"
                         trailingPadding=" "
                         trailing={
-                          <p className="mr-8 text-sm text-gray-700">
+                          <p className="right-10 text-sm text-gray-700">
                             Weight (kg)
                           </p>
                         }
@@ -1116,7 +1116,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                         placeholder="Height"
                         trailingPadding=" "
                         trailing={
-                          <p className="mr-8 text-sm text-gray-700">
+                          <p className="right-10 text-sm text-gray-700">
                             Height (cm)
                           </p>
                         }

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1103,7 +1103,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                         placeholder="Weight"
                         trailingPadding=" "
                         trailing={
-                          <p className="right-10 text-sm text-gray-700">
+                          <p className="absolute right-10 whitespace-nowrap text-sm text-gray-700">
                             Weight (kg)
                           </p>
                         }
@@ -1116,7 +1116,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                         placeholder="Height"
                         trailingPadding=" "
                         trailing={
-                          <p className="right-10 text-sm text-gray-700">
+                          <p className="absolute right-10 whitespace-nowrap text-sm text-gray-700">
                             Height (cm)
                           </p>
                         }

--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -1001,5 +1001,5 @@ export const FacilityCreate = (props: FacilityProps) => {
 };
 
 const FieldUnit = ({ unit }: { unit: string }) => {
-  return <p className="mr-8 text-xs text-gray-700">{unit}</p>;
+  return <p className="absolute right-10 text-xs text-gray-700">{unit}</p>;
 };

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1345,8 +1345,9 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                     <TextFormField
                                       {...field("age")}
                                       errorClassName="hidden"
+                                      trailingPadding="pr-4"
                                       trailing={
-                                        <p className="relative right-4 space-x-1 text-xs text-gray-700 sm:right-14 sm:text-sm md:right-4 lg:right-14">
+                                        <p className="absolute right-10 space-x-1 whitespace-nowrap text-xs text-gray-700 sm:text-sm">
                                           {field("age").value !== "" && (
                                             <>
                                               <span className="hidden sm:inline md:hidden lg:inline">
@@ -1364,7 +1365,6 @@ export const PatientRegister = (props: PatientRegisterProps) => {
                                         </p>
                                       }
                                       placeholder="Enter the age"
-                                      className="col-span-6 sm:col-span-3"
                                       type="number"
                                       min={0}
                                     />


### PR DESCRIPTION
## Proposed Changes

- Fixes #7572

### Affects the following places

- Numeric fields in Facility Create
- Numeric fields "weight" and "height" in Consultation Form
- Numeric field "Age" in patient register form

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
