### PR TITLE
Disable switching to "Refer to another facility"/"Declare Death" in Decision after consultation in edit consultation form

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -363,10 +363,10 @@ export const SAMPLE_TEST_RESULT = [
 export const CONSULTATION_SUGGESTION = [
   { id: "HI", text: "Home Isolation", deprecated: true }, // # Deprecated. Preserving option for backward compatibility (use only for readonly operations)
   { id: "A", text: "Admission" },
-  { id: "R", text: "Refer to another Hospital" },
+  { id: "R", text: "Refer to another Hospital", editDisabled: true },
   { id: "OP", text: "OP Consultation" },
   { id: "DC", text: "Domiciliary Care" },
-  { id: "DD", text: "Declare Death" },
+  { id: "DD", text: "Declare Death", editDisabled: true },
 ] as const;
 
 export type ConsultationSuggestionValue =

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1148,6 +1148,14 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                       options={CONSULTATION_SUGGESTION.filter(
                         (option) => !("deprecated" in option),
                       )}
+                      optionDisabled={(option) =>
+                        isUpdate && "editDisabled" in option
+                      }
+                      optionDescription={(option) =>
+                        isUpdate && "editDisabled" in option
+                          ? "Not allowed to switch to this option in edit consultation"
+                          : undefined
+                      }
                     />
                   </div>
 

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -1153,7 +1153,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                       }
                       optionDescription={(option) =>
                         isUpdate && "editDisabled" in option
-                          ? "Not allowed to switch to this option in edit consultation"
+                          ? t("encounter_suggestion_edit_disallowed")
                           : undefined
                       }
                     />

--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -17,6 +17,7 @@ type AutocompleteFormFieldProps<T, V> = FormFieldBaseProps<V> & {
   optionValue?: OptionCallback<T, V>;
   optionDescription?: OptionCallback<T, string>;
   optionIcon?: OptionCallback<T, React.ReactNode>;
+  optionDisabled?: OptionCallback<T, boolean>;
   onQuery?: (query: string) => void;
   dropdownIcon?: React.ReactNode | undefined;
   isLoading?: boolean;
@@ -43,6 +44,7 @@ const AutocompleteFormField = <T, V>(
         optionIcon={props.optionIcon}
         optionValue={props.optionValue}
         optionDescription={props.optionDescription}
+        optionDisabled={props.optionDisabled}
         onQuery={props.onQuery}
         isLoading={props.isLoading}
         allowRawInput={props.allowRawInput}
@@ -65,6 +67,7 @@ type AutocompleteProps<T, V = T> = {
   optionIcon?: OptionCallback<T, React.ReactNode>;
   optionValue?: OptionCallback<T, V>;
   optionDescription?: OptionCallback<T, React.ReactNode>;
+  optionDisabled?: OptionCallback<T, boolean>;
   className?: string;
   onQuery?: (query: string) => void;
   requiredError?: boolean;
@@ -105,6 +108,7 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
       search: label.toLowerCase(),
       icon: props.optionIcon?.(option),
       value: props.optionValue ? props.optionValue(option) : option,
+      disabled: props.optionDisabled?.(option),
     };
   });
 
@@ -123,6 +127,7 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
         search: query.toLowerCase(),
         icon: <CareIcon icon="l-plus" />,
         value: query,
+        disabled: undefined,
       },
       ...mappedOptions,
     ];
@@ -204,6 +209,7 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
                   key={`${props.id}-option-${option.label}-value-${index}`}
                   className={dropdownOptionClassNames}
                   value={option}
+                  disabled={option.disabled}
                 >
                   {({ active }) => (
                     <div className="flex flex-col">

--- a/src/Components/Form/FormFields/Autocomplete.tsx
+++ b/src/Components/Form/FormFields/Autocomplete.tsx
@@ -220,8 +220,12 @@ export const Autocomplete = <T, V>(props: AutocompleteProps<T, V>) => {
                       {option.description && (
                         <div
                           className={classNames(
-                            "text-sm",
-                            active ? "text-primary-200" : "text-gray-700",
+                            "text-sm font-normal",
+                            option.disabled
+                              ? "text-gray-700"
+                              : active
+                                ? "text-primary-200"
+                                : "text-gray-700",
                           )}
                         >
                           {option.description}

--- a/src/Components/Form/FormFields/AutocompleteMultiselect.tsx
+++ b/src/Components/Form/FormFields/AutocompleteMultiselect.tsx
@@ -17,6 +17,7 @@ type AutocompleteMultiSelectFormFieldProps<T, V> = FormFieldBaseProps<V[]> & {
   options: T[];
   optionLabel: OptionCallback<T, string>;
   optionValue?: OptionCallback<T, V>;
+  optionDisabled?: OptionCallback<T, boolean>;
   onQuery?: (query: string) => void;
   dropdownIcon?: React.ReactNode | undefined;
   isLoading?: boolean;
@@ -50,6 +51,7 @@ type AutocompleteMutliSelectProps<T, V = T> = {
   optionDescription?: OptionCallback<T, ReactNode>;
   optionLabel: OptionCallback<T, string>;
   optionValue?: OptionCallback<T, V>;
+  optionDisabled?: OptionCallback<T, boolean>;
   className?: string;
   onChange: OptionCallback<V[], void>;
   onQuery?: (query: string) => void;
@@ -87,6 +89,7 @@ export const AutocompleteMutliSelect = <T, V>(
       description: props.optionDescription?.(option),
       search: label.toLowerCase(),
       value: (props.optionValue ? props.optionValue(option) : option) as V,
+      disabled: props.optionDisabled?.(option),
     };
   });
 
@@ -187,6 +190,7 @@ export const AutocompleteMutliSelect = <T, V>(
                       onClick={() => {
                         handleSingleSelect(option);
                       }}
+                      disabled={option.disabled}
                     >
                       {({ selected }) => (
                         <>

--- a/src/Components/Form/FormFields/AutocompleteMultiselect.tsx
+++ b/src/Components/Form/FormFields/AutocompleteMultiselect.tsx
@@ -192,7 +192,7 @@ export const AutocompleteMutliSelect = <T, V>(
                       }}
                       disabled={option.disabled}
                     >
-                      {({ selected }) => (
+                      {({ active, selected }) => (
                         <>
                           <div className="flex justify-between">
                             {option.label}
@@ -202,9 +202,14 @@ export const AutocompleteMutliSelect = <T, V>(
                           </div>
                           {option.description && (
                             <p
-                              className={`font-normal ${
-                                selected ? "text-primary-200" : "text-gray-700"
-                              }`}
+                              className={classNames(
+                                "text-sm font-normal",
+                                option.disabled
+                                  ? "text-gray-700"
+                                  : active
+                                    ? "text-primary-200"
+                                    : "text-gray-700",
+                              )}
                             >
                               {option.description}
                             </p>

--- a/src/Components/Form/FormFields/SelectFormField.tsx
+++ b/src/Components/Form/FormFields/SelectFormField.tsx
@@ -14,6 +14,7 @@ type SelectFormFieldProps<T, V = T> = FormFieldBaseProps<V> & {
   optionDescription?: OptionCallback<T, React.ReactNode>;
   optionIcon?: OptionCallback<T, React.ReactNode>;
   optionValue?: OptionCallback<T, V>;
+  optionDisabled?: OptionCallback<T, boolean>;
 };
 
 export const SelectFormField = <T, V>(props: SelectFormFieldProps<T, V>) => {
@@ -34,6 +35,7 @@ export const SelectFormField = <T, V>(props: SelectFormFieldProps<T, V>) => {
         optionDescription={props.optionDescription}
         optionIcon={props.optionIcon}
         optionValue={props.optionValue}
+        optionDisabled={props.optionDisabled}
         requiredError={field.error ? props.required : false}
       />
     </FormField>
@@ -48,6 +50,7 @@ type MultiSelectFormFieldProps<T, V = T> = FormFieldBaseProps<V[]> & {
   optionDescription?: OptionCallback<T, React.ReactNode>;
   optionIcon?: OptionCallback<T, React.ReactNode>;
   optionValue?: OptionCallback<T, V>;
+  optionDisabled?: OptionCallback<T, boolean>;
 };
 
 export const MultiSelectFormField = <T, V>(
@@ -67,6 +70,7 @@ export const MultiSelectFormField = <T, V>(
         optionSelectedLabel={props.optionSelectedLabel}
         optionDescription={props.optionDescription}
         optionIcon={props.optionIcon}
+        optionDisabled={props.optionDisabled}
         optionValue={props.optionValue}
       />
     </FormField>

--- a/src/Components/Form/MultiSelectMenuV2.tsx
+++ b/src/Components/Form/MultiSelectMenuV2.tsx
@@ -16,6 +16,7 @@ type Props<T, V = T> = {
   optionDescription?: OptionCallback<T, ReactNode>;
   optionIcon?: OptionCallback<T, ReactNode>;
   optionValue?: OptionCallback<T, V>;
+  optionDisabled?: OptionCallback<T, boolean>;
   className?: string;
   disabled?: boolean;
   renderSelectedOptions?: OptionCallback<T[], ReactNode>;
@@ -42,9 +43,10 @@ const MultiSelectMenuV2 = <T, V>(props: Props<T, V>) => {
       option,
       label,
       selectedLabel,
-      description: props.optionDescription && props.optionDescription(option),
-      icon: props.optionIcon && props.optionIcon(option),
+      description: props.optionDescription?.(option),
+      icon: props.optionIcon?.(option),
       value,
+      disabled: props.optionDisabled?.(option),
       isSelected: props.value?.includes(value as any) ?? false,
       displayChip: (
         <div className="rounded-full border border-secondary-400 bg-secondary-100 px-2 text-xs text-gray-900">
@@ -138,6 +140,7 @@ const MultiSelectMenuV2 = <T, V>(props: Props<T, V>) => {
                       className={dropdownOptionClassNames}
                       value={option}
                       onClick={() => handleSingleSelect(option)}
+                      disabled={option.disabled}
                     >
                       {({ active }) => (
                         <div className="flex flex-col gap-2">
@@ -205,17 +208,20 @@ export const MultiSelectOptionChip = ({
 interface OptionRenderPropArg {
   active: boolean;
   selected: boolean;
+  disabled: boolean;
 }
 
 export const dropdownOptionClassNames = ({
   active,
   selected,
+  disabled,
 }: OptionRenderPropArg) => {
   return classNames(
     "group/option relative w-full cursor-default select-none p-4 text-sm transition-colors duration-75 ease-in-out",
-    active && "bg-primary-500 text-white",
-    !active && selected && "text-primary-500",
-    !active && !selected && "text-gray-900",
+    !disabled && active && "bg-primary-500 text-white",
+    !disabled && !active && selected && "text-primary-500",
+    !disabled && !active && !selected && "text-gray-900",
+    disabled && "cursor-not-allowed text-gray-800",
     selected ? "font-semibold" : "font-normal",
   );
 };

--- a/src/Components/Form/MultiSelectMenuV2.tsx
+++ b/src/Components/Form/MultiSelectMenuV2.tsx
@@ -155,9 +155,14 @@ const MultiSelectMenuV2 = <T, V>(props: Props<T, V>) => {
                           </div>
                           {option.description && (
                             <p
-                              className={`font-normal ${
-                                active ? "text-primary-200" : "text-gray-700"
-                              }`}
+                              className={classNames(
+                                "text-sm font-normal",
+                                option.disabled
+                                  ? "text-gray-700"
+                                  : active
+                                    ? "text-primary-200"
+                                    : "text-gray-700",
+                              )}
                             >
                               {option.description}
                             </p>

--- a/src/Components/Form/SelectMenuV2.tsx
+++ b/src/Components/Form/SelectMenuV2.tsx
@@ -148,9 +148,14 @@ const SelectMenuV2 = <T, V>(props: SelectMenuProps<T, V>) => {
                             </div>
                             {option.description && (
                               <p
-                                className={`font-normal ${
-                                  active ? "text-primary-200" : "text-gray-700"
-                                }`}
+                                className={classNames(
+                                  "text-sm font-normal",
+                                  option.disabled
+                                    ? "text-gray-700"
+                                    : active
+                                      ? "text-primary-200"
+                                      : "text-gray-700",
+                                )}
                               >
                                 {option.description}
                               </p>

--- a/src/Components/Form/SelectMenuV2.tsx
+++ b/src/Components/Form/SelectMenuV2.tsx
@@ -19,6 +19,7 @@ type SelectMenuProps<T, V = T> = {
   optionDescription?: OptionCallback<T, ReactNode>;
   optionIcon?: OptionCallback<T, ReactNode>;
   optionValue?: OptionCallback<T, V>;
+  optionDisabled?: OptionCallback<T, boolean>;
   showIconWhenSelected?: boolean;
   showChevronIcon?: boolean;
   className?: string;
@@ -51,9 +52,10 @@ const SelectMenuV2 = <T, V>(props: SelectMenuProps<T, V>) => {
       selectedLabel: props.optionSelectedLabel
         ? props.optionSelectedLabel(option)
         : label,
-      description: props.optionDescription && props.optionDescription(option),
-      icon: props.optionIcon && props.optionIcon(option),
+      description: props.optionDescription?.(option),
+      icon: props.optionIcon?.(option),
       value: props.optionValue ? props.optionValue(option) : option,
+      disabled: props.optionDisabled?.(option),
     };
   });
 
@@ -67,6 +69,7 @@ const SelectMenuV2 = <T, V>(props: SelectMenuProps<T, V>) => {
     description: undefined,
     icon: undefined,
     value: undefined,
+    disabled: undefined,
   };
 
   const options = props.required
@@ -128,6 +131,7 @@ const SelectMenuV2 = <T, V>(props: SelectMenuProps<T, V>) => {
                         key={index}
                         className={dropdownOptionClassNames}
                         value={option}
+                        disabled={option.disabled}
                       >
                         {({ active, selected }) => (
                           <div className="flex flex-col gap-2">

--- a/src/Locale/en/Consultation.json
+++ b/src/Locale/en/Consultation.json
@@ -34,5 +34,6 @@
   "generate_report": "Generate Report",
   "prev_sessions": "Prev Sessions",
   "next_sessions": "Next Sessions",
-  "no_changes": "No changes"
+  "no_changes": "No changes",
+  "encounter_suggestion_edit_disallowed": "Not allowed to switch to this option in edit consultation"
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes #7939
- Adds support for disabling individual options in dropdown menu

<img width="918" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/f4fa763c-b209-4a79-ae26-5f94d198f8e9">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
