### PR TITLE
Fix InvalidStateError in useMSEplayer hook

### DIFF
--- a/src/Common/hooks/useMSEplayer.ts
+++ b/src/Common/hooks/useMSEplayer.ts
@@ -106,6 +106,11 @@ export const useMSEMediaPlayer = ({
     if (!mseSourceBuffer.updating) {
       if (mseQueue.length > 0) {
         const packet = mseQueue.shift();
+        // Check if SourceBuffer has been removed before appending buffer
+        if (mseSourceBuffer.removed) {
+          console.error("Attempted to append to a removed SourceBuffer.");
+          return;
+        }
         mseSourceBuffer.appendBuffer(packet);
       } else {
         mseStreamingStarted = false;
@@ -122,6 +127,11 @@ export const useMSEMediaPlayer = ({
 
   const readPacket = (packet: any) => {
     if (!mseStreamingStarted) {
+      // Check if SourceBuffer has been removed before appending buffer
+      if (mseSourceBuffer.removed) {
+        console.error("Attempted to append to a removed SourceBuffer.");
+        return;
+      }
       mseSourceBuffer.appendBuffer(packet);
       mseStreamingStarted = true;
       return;


### PR DESCRIPTION
Related to #7999

Adds checks to prevent `InvalidStateError` in `useMSEMediaPlayer` hook by ensuring `SourceBuffer` is not removed before attempting to append buffers.

- Implements a condition to check if `mseSourceBuffer` has been marked as removed before calling `mseSourceBuffer.appendBuffer(packet)` in both `pushPacket` and `readPacket` functions.
- Logs an error message to the console if an attempt is made to append to a removed `SourceBuffer`, preventing the execution of the `appendBuffer` method in such cases.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/coronasafe/care_fe/issues/7999?shareId=0276621c-1855-4d1d-b45e-4d2d24715ea6).

Sentry: https://coronasafe-network.sentry.io/issues/5015520076/?project=5183632&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&stream_index=2