### PR TITLE
Fix compatibility issue in RangeAutocompleteFormField

### DIFF
--- a/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
+++ b/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
@@ -26,7 +26,7 @@ export default function RangeAutocompleteFormField(props: Props) {
     const sortedThresholds = props.thresholds?.sort(compareBy("value")) || [];
 
     const getThreshold = (value: number) => {
-      const threshold = sortedThresholds.findLast(
+      const threshold = [...sortedThresholds].reverse().find(
         (threshold) => value >= threshold.value,
       );
       return threshold;


### PR DESCRIPTION
Related to #8004

Fixes the `TypeError: a.findLast is not a function` error in the `RangeAutocompleteFormField` component by replacing the `findLast` method with a combination of `reverse` and `find`.

- **Updates `getThreshold` function**: Implements an alternative method to find the last threshold that meets the condition by reversing the sorted thresholds array and then using `find`. This change ensures compatibility across all JavaScript environments, addressing the issue where `findLast` was not supported.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/coronasafe/care_fe/issues/8004?shareId=e41f4e6b-c574-42b7-8851-f507e1baf66e).