### PR TITLE
Fix array search compatibility in RangeAutocompleteFormField

### DIFF
--- a/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
+++ b/src/Components/Form/FormFields/RangeAutocompleteFormField.tsx
@@ -26,7 +26,8 @@ export default function RangeAutocompleteFormField(props: Props) {
     const sortedThresholds = props.thresholds?.sort(compareBy("value")) || [];
 
     const getThreshold = (value: number) => {
-      const threshold = sortedThresholds.findLast(
+      const reversedThresholds = [...sortedThresholds].reverse();
+      const threshold = reversedThresholds.find(
         (threshold) => value >= threshold.value,
       );
       return threshold;


### PR DESCRIPTION
Related to #8020

Updates the `RangeAutocompleteFormField` component to ensure compatibility with older browsers by replacing the `Array.findLast()` method with a combination of `Array.reverse()` and `Array.find()`.
- Replaces the usage of `findLast` with a sequence of creating a shallow copy of the thresholds array, reversing it, and then using `find` to locate the desired threshold. This change avoids mutating the original array and ensures the functionality is supported across all targeted browser environments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/coronasafe/care_fe/issues/8020?shareId=b76955b0-bb71-47c5-b226-b48b2ace342c).