### PR TITLE
Make voice autofill popup scrollable on content overflow

### DIFF
--- a/src/Components/Scribe/Scribe.tsx
+++ b/src/Components/Scribe/Scribe.tsx
@@ -490,7 +490,7 @@ export const Scribe: React.FC<ScribeProps> = ({ fields, onFormUpdate }) => {
               &#8203;
             </span>
 
-            <div className="inline-block w-full max-w-md overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+            <div className="inline-block max-h-[75vh] w-full max-w-md overflow-hidden overflow-y-auto rounded-2xl border-2 border-gray-300 bg-white p-6 text-left align-middle shadow-xl transition-all">
               <div className="flex justify-between">
                 <h3 className="text-lg font-medium leading-6 text-gray-900">
                   Voice AutoFill


### PR DESCRIPTION
## Proposed Changes

- Fixes #8033
- Adds border for the voice autofill popup window

<img width="1703" alt="image" src="https://github.com/coronasafe/care_fe/assets/25143503/922543f0-c264-4809-a404-c13887d51f69">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
