### PR TITLE
Fixes oxygen flow rate not getting submitted in Critical Care

### DIFF
--- a/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
+++ b/src/Components/CriticalCareRecording/VentilatorParametersEditor/CriticalCare__VentilatorParametersEditor.res
@@ -115,7 +115,7 @@ let makePayload = (state: VentilatorParameters.state) => {
   DictUtils.setOptionalNumber("ventilator_tidal_volume", state.ventilator_tidal_volume, payload)
   DictUtils.setOptionalNumber(
     "ventilator_oxygen_modality_oxygen_rate",
-    state.ventilator_interface === UNKNOWN &&
+    state.ventilator_interface === OXYGEN_SUPPORT &&
       state.ventilator_oxygen_modality !== HIGH_FLOW_NASAL_CANNULA
       ? state.ventilator_oxygen_modality_oxygen_rate
       : None,


### PR DESCRIPTION
## Proposed Changes

- Fixes #8144

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
