### PR TITLE
Improve strength of the caution message for potentially incorrect discharge dates

### DIFF
--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -204,18 +204,18 @@ const DischargeModal = ({
     }));
   };
 
-  const encounterDuration = dayjs
-    .duration(
-      dayjs(
-        preDischargeForm[
-          discharge_reason ===
-          DISCHARGE_REASONS.find((i) => i.text == "Expired")?.id
-            ? "death_datetime"
-            : "discharge_date"
-        ],
-      ).diff(consultationData.encounter_date),
-    )
-    .humanize();
+  const encounterDuration = dayjs.duration(
+    dayjs(
+      preDischargeForm[
+        discharge_reason ===
+        DISCHARGE_REASONS.find((i) => i.text == "Expired")?.id
+          ? "death_datetime"
+          : "discharge_date"
+      ],
+    ).diff(consultationData.encounter_date),
+  );
+
+  const durationNeedsAttention = encounterDuration.asDays() >= 30;
 
   return (
     <DialogModal
@@ -386,9 +386,19 @@ const DischargeModal = ({
       )}
 
       <div className="py-4">
-        <span className="text-gray-700">
+        <span
+          className={
+            durationNeedsAttention ? "text-warning-500" : "text-gray-700"
+          }
+        >
+          {durationNeedsAttention && (
+            <>
+              <CareIcon icon="l-exclamation-triangle" className="text-lg" />
+              <strong> Caution: </strong>
+            </>
+          )}
           {t("encounter_duration_confirmation")}{" "}
-          <strong>{encounterDuration}</strong>.
+          <strong>{encounterDuration.humanize()}</strong>.
         </span>
       </div>
       <div className="cui-form-button-group">

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -224,7 +224,9 @@ const DischargeModal = ({
           <p>Discharge patient from CARE</p>
           <span className="mt-1 flex gap-1 text-sm font-medium text-warning-500">
             <CareIcon icon="l-exclamation-triangle" className="text-base" />
-            <p>Caution: this action is irreversible.</p>
+            <p>
+              {t("caution")}: {t("action_irreversible")}
+            </p>
           </span>
         </div>
       }

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -390,7 +390,7 @@ const DischargeModal = ({
       <div className="py-4">
         <span
           className={
-            durationNeedsAttention ? "text-warning-500" : "text-secondary-700"
+            durationNeedsAttention ? "text-danger-500" : "text-secondary-700"
           }
         >
           {durationNeedsAttention && (

--- a/src/Components/Facility/DischargeModal.tsx
+++ b/src/Components/Facility/DischargeModal.tsx
@@ -394,7 +394,7 @@ const DischargeModal = ({
           {durationNeedsAttention && (
             <>
               <CareIcon icon="l-exclamation-triangle" className="text-lg" />
-              <strong> Caution: </strong>
+              <strong> {t("caution")}: </strong>
             </>
           )}
           {t("encounter_duration_confirmation")}{" "}

--- a/src/Locale/en/Common.json
+++ b/src/Locale/en/Common.json
@@ -172,5 +172,6 @@
   "ration_card__NO_CARD": "Non-card holder",
   "ration_card__BPL": "BPL",
   "ration_card__APL": "APL",
-  "caution": "Caution"
+  "caution": "Caution",
+  "action_irreversible": "This action is irreversible"
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes #8150
- The strength of the caution message conveyed is increased when the encounter duration based on the discharge date specified in the input would be more than 30 days.

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/3f58c24c-b0b2-4c58-9d95-dee26da330ba">


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
