### PR TITLE
Handle exceptions raised by the addSourceBuffer method

### DIFF
--- a/src/Common/hooks/useMSEplayer.ts
+++ b/src/Common/hooks/useMSEplayer.ts
@@ -171,9 +171,14 @@ export const useMSEMediaPlayer = ({
                 } else {
                   mimeCodec = Utf8ArrayToStr(decoded_arr);
                 }
-                mseSourceBuffer = mse.addSourceBuffer(
-                  `video/mp4; codecs="${mimeCodec}"`,
-                );
+                try {
+                  mseSourceBuffer = mse.addSourceBuffer(
+                    `video/mp4; codecs="${mimeCodec}"`,
+                  );
+                } catch (error) {
+                  onError && onError(error);
+                  return;
+                }
                 mseSourceBuffer.mode = "segments";
                 if (mseQueue.length > 0 && !mseSourceBuffer.updating) {
                   mseSourceBuffer.addEventListener("updateend", pushPacket);

--- a/src/Common/hooks/useMSEplayer.ts
+++ b/src/Common/hooks/useMSEplayer.ts
@@ -176,7 +176,7 @@ export const useMSEMediaPlayer = ({
                     `video/mp4; codecs="${mimeCodec}"`,
                   );
                 } catch (error) {
-                  onError && onError(error);
+                  onError?.(error);
                   return;
                 }
                 mseSourceBuffer.mode = "segments";


### PR DESCRIPTION
This pull request addresses an issue where exceptions raised by the `addSourceBuffer` method were not being handled properly. 
https://developer.mozilla.org/en-US/docs/Web/API/MediaSource/addSourceBuffer#exceptions

fixes #8200