### PR TITLE
Fixes last active filter badge showing up when filters other than the last active filter is applied

### DIFF
--- a/src/Components/Users/ManageUsers.tsx
+++ b/src/Components/Users/ManageUsers.tsx
@@ -561,9 +561,11 @@ export default function ManageUsers() {
             value(
               "Last Active",
               "last_active_days",
-              qParams.last_active_days === "never"
-                ? "Never"
-                : `in the last ${qParams.last_active_days} day${qParams.last_active_days > 1 ? "s" : ""}`,
+              (() => {
+                if (!qParams.last_active_days) return "";
+                if (qParams.last_active_days === "never") return "Never";
+                return `in the last ${qParams.last_active_days} day${qParams.last_active_days > 1 ? "s" : ""}`;
+              })(),
             ),
           ]}
         />


### PR DESCRIPTION

## Proposed Changes

- Fixes last active filter badge showing up when filters other than the last active filter is applied

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
