### PR TITLE
fix #8220 made date component responsive

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -256,7 +256,7 @@ const DateInputV2: React.FC<Props> = ({
                   type="text"
                   readOnly
                   disabled={disabled}
-                  className={`cui-input-base cursor-pointer disabled:cursor-not-allowed ${className}`}
+                  className={`cui-input-base cursor-pointer disabled:cursor-not-allowed max-sm:!px-2 ${className}`}
                   placeholder={placeholder ?? t("select_date")}
                   value={value && dayjs(value).format("DD/MM/YYYY")}
                 />

--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -256,7 +256,7 @@ const DateInputV2: React.FC<Props> = ({
                   type="text"
                   readOnly
                   disabled={disabled}
-                  className={`cui-input-base cursor-pointer disabled:cursor-not-allowed max-sm:!px-2 ${className}`}
+                  className={`cui-input-base cursor-pointer !px-2 disabled:cursor-not-allowed ${className}`}
                   placeholder={placeholder ?? t("select_date")}
                   value={value && dayjs(value).format("DD/MM/YYYY")}
                 />

--- a/src/Components/Facility/ConsultationForm.tsx
+++ b/src/Components/Facility/ConsultationForm.tsx
@@ -932,11 +932,11 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
             );
           })}
         </div>
-        <div className="flex h-full w-full overflow-auto xl:ml-72">
+        <div className="flex h-full w-full overflow-auto xl:ml-64 2xl:ml-72 ">
           <div className="w-full max-w-4xl">
             <form
               onSubmit={handleSubmit}
-              className="rounded bg-white p-6 transition-all sm:rounded-xl sm:p-12"
+              className="rounded bg-white p-6 transition-all sm:rounded-xl sm:p-8 "
             >
               <DraftSection
                 handleDraftSelect={(newState: any) => {

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -487,7 +487,7 @@ export const DailyRounds = (props: any) => {
           }}
         />
       </div>
-      <form className="w-full max-w-4xl rounded-lg bg-white px-8 py-5 shadow md:m-4 md:px-16 md:py-11">
+      <form className="w-full max-w-4xl rounded-lg bg-white px-3 py-5 shadow sm:px-8 md:m-4 md:px-16 md:py-11">
         <DraftSection
           handleDraftSelect={(newState) => {
             dispatch({ type: "set_state", state: newState });

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -487,7 +487,7 @@ export const DailyRounds = (props: any) => {
           }}
         />
       </div>
-      <form className="w-full max-w-4xl rounded-lg bg-white px-3 py-5 shadow sm:px-8 md:m-4 md:px-16 md:py-11">
+      <form className="w-full max-w-4xl rounded-lg bg-white px-3 py-5 shadow sm:px-6 md:py-11">
         <DraftSection
           handleDraftSelect={(newState) => {
             dispatch({ type: "set_state", state: newState });

--- a/src/Components/Symptoms/SymptomsBuilder.tsx
+++ b/src/Components/Symptoms/SymptomsBuilder.tsx
@@ -176,9 +176,9 @@ const SymptomEntry = (props: {
   const disabled =
     props.disabled || symptom.clinical_impression_status === "entered-in-error";
   return (
-    <div className="grid grid-cols-6 items-center gap-2 md:grid-cols-5">
+    <div className="grid grid-cols-6 items-center gap-2 lg:grid-cols-8 xl:grid-cols-5">
       <DateFormField
-        className="col-span-3 w-full md:col-span-1"
+        className="col-span-3 w-full lg:col-span-2 xl:col-span-1 "
         name="onset_date"
         value={new Date(symptom.onset_date)}
         disableFuture
@@ -187,7 +187,7 @@ const SymptomEntry = (props: {
         errorClassName="hidden"
       />
       <DateFormField
-        className="col-span-3 w-full md:col-span-1"
+        className="col-span-3 w-full lg:col-span-2 xl:col-span-1"
         name="cure_date"
         value={symptom.cure_date ? new Date(symptom.cure_date) : undefined}
         disableFuture
@@ -198,7 +198,7 @@ const SymptomEntry = (props: {
         onChange={props.onChange}
         errorClassName="hidden"
       />
-      <div className="col-span-6 flex items-center gap-2 md:col-span-3">
+      <div className="col-span-6 flex items-center gap-2 lg:col-span-4 xl:col-span-3">
         <div
           className={classNames(
             "cui-input-base w-full font-medium",


### PR DESCRIPTION
## Made Date Component responsive

- Fixes #8220 
- made date input component responsive

![Screenshot (676)](https://github.com/user-attachments/assets/a403bf5a-092e-4f36-b272-c2fc0984b551)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews

