### PR TITLE
Fixed: Misalignment of placeholder text inside date component in the …

### DIFF
--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -256,7 +256,7 @@ const DateInputV2: React.FC<Props> = ({
                   type="text"
                   readOnly
                   disabled={disabled}
-                  className={`cui-input-base cursor-pointer !px-2 pl-4 disabled:cursor-not-allowed ${className}`}
+                  className={`cui-input-base cursor-pointer disabled:cursor-not-allowed ${className}`}
                   placeholder={placeholder ?? t("select_date")}
                   value={value && dayjs(value).format("DD/MM/YYYY")}
                 />

--- a/src/Components/Common/DateInputV2.tsx
+++ b/src/Components/Common/DateInputV2.tsx
@@ -256,7 +256,7 @@ const DateInputV2: React.FC<Props> = ({
                   type="text"
                   readOnly
                   disabled={disabled}
-                  className={`cui-input-base cursor-pointer !px-2 disabled:cursor-not-allowed ${className}`}
+                  className={`cui-input-base cursor-pointer !px-2 pl-4 disabled:cursor-not-allowed ${className}`}
                   placeholder={placeholder ?? t("select_date")}
                   value={value && dayjs(value).format("DD/MM/YYYY")}
                 />


### PR DESCRIPTION
Misalignment of placeholder text inside date component in the add user page #8239

## Proposed Changes

- Fixes #8239
- Changed the CSS to add padding on the left to align the placeholder in DateInputV2

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

![Screenshot 2024-08-02 005250](https://github.com/user-attachments/assets/b3319d47-0ab7-4e73-a4d9-91a4627de3f7)
