### PR TITLE
Fixed: Transfer patient pop-up behavior

### DIFF
--- a/src/Components/Facility/DuplicatePatientDialog.tsx
+++ b/src/Components/Facility/DuplicatePatientDialog.tsx
@@ -7,13 +7,12 @@ interface Props {
   patientList: Array<DupPatientModel>;
   handleOk: (action: string) => void;
   handleCancel: () => void;
-  isNew: boolean;
 }
 
 const tdClass = "border border-secondary-400 p-2 text-left";
 
 const DuplicatePatientDialog = (props: Props) => {
-  const { patientList, handleOk, handleCancel, isNew } = props;
+  const { patientList, handleOk, handleCancel } = props;
   const [action, setAction] = useState("");
 
   return (
@@ -118,7 +117,7 @@ const DuplicatePatientDialog = (props: Props) => {
         <Cancel
           onClick={handleCancel}
           className="mb-2 sm:mb-0"
-          label={`Cancel ${isNew ? "Registration" : "Update"}`}
+          label={"Close"}
         />
         <Submit
           id="submit-continue-button"

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -192,6 +192,7 @@ export const PatientRegister = (props: PatientRegisterProps) => {
   });
   const [careExtId, setCareExtId] = useState("");
   const [formField, setFormField] = useState<any>();
+  const [resetNum, setResetNum] = useState(false);
   const [isDistrictLoading, setIsDistrictLoading] = useState(false);
   const [isLocalbodyLoading, setIsLocalbodyLoading] = useState(false);
   const [isWardLoading, setIsWardLoading] = useState(false);
@@ -1003,7 +1004,10 @@ export const PatientRegister = (props: PatientRegisterProps) => {
         <DuplicatePatientDialog
           patientList={statusDialog.patientList}
           handleOk={handleDialogClose}
-          handleCancel={goBack}
+          handleCancel={() => {
+            setStatusDialog({ ...statusDialog, show: false });
+            setResetNum(true);
+          }}
           isNew={!id}
         />
       )}
@@ -1134,6 +1138,13 @@ export const PatientRegister = (props: PatientRegisterProps) => {
               >
                 {(field) => {
                   if (!formField) setFormField(field);
+                  if (resetNum) {
+                    field("phone_number").onChange({
+                      name: "phone_number",
+                      value: "+91",
+                    });
+                    setResetNum(false);
+                  }
                   return (
                     <>
                       <div className="mb-2 overflow-visible rounded border border-secondary-200 p-4">

--- a/src/Components/Patient/PatientRegister.tsx
+++ b/src/Components/Patient/PatientRegister.tsx
@@ -1005,23 +1005,28 @@ export const PatientRegister = (props: PatientRegisterProps) => {
           patientList={statusDialog.patientList}
           handleOk={handleDialogClose}
           handleCancel={() => {
-            setStatusDialog({ ...statusDialog, show: false });
+            handleDialogClose("close");
             setResetNum(true);
           }}
-          isNew={!id}
         />
       )}
       {statusDialog.transfer && (
         <DialogModal
           show={statusDialog.transfer}
-          onClose={() => handleDialogClose("back")}
+          onClose={() => {
+            setResetNum(true);
+            handleDialogClose("close");
+          }}
           title="Patient Transfer Form"
           className="max-w-md md:min-w-[600px]"
         >
           <TransferPatientDialog
             patientList={statusDialog.patientList}
             handleOk={() => handleDialogClose("close")}
-            handleCancel={() => handleDialogClose("back")}
+            handleCancel={() => {
+              setResetNum(true);
+              handleDialogClose("close");
+            }}
             facilityId={facilityId}
           />
         </DialogModal>


### PR DESCRIPTION
## Proposed Changes

- Fixes #8187 
- Renamed "Cancel Registration" button to "Close"
- Updated ```DuplicatePatientDialog``` ```handleCancel``` to close the pop-up and reset phone number
- Added a resetNum state to know when to reset number


https://github.com/user-attachments/assets/37af145b-11b5-44ac-89c1-f88a23c5b7dd



@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
