### PR TITLE
Scroll to madatory empty fields

### DIFF
--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -138,8 +138,6 @@ export const DailyRounds = (props: any) => {
   const headerText = !id ? "Add Consultation Update" : "Info";
   const buttonText = !id ? "Save" : "Continue";
 
-  const patientCategory = useRef<HTMLDivElement | null>(null);
-
   const formFields = [
     "physical_examination_info",
     "other_details",

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -1,7 +1,7 @@
 import { navigate } from "raviger";
 
 import dayjs from "dayjs";
-import { lazy, useCallback, useEffect, useState, useRef } from "react";
+import { lazy, useCallback, useEffect, useState} from "react";
 import {
   CONSCIOUSNESS_LEVEL,
   PATIENT_CATEGORIES,
@@ -45,6 +45,7 @@ import { EncounterSymptomsBuilder } from "../Symptoms/SymptomsBuilder";
 import { FieldLabel } from "../Form/FormFields/FormField";
 import useAuthUser from "../../Common/hooks/useAuthUser";
 import CheckBoxFormField from "../Form/FormFields/CheckBoxFormField";
+import { scrollTo } from "../../Utils/utils";
 
 const Loading = lazy(() => import("../Common/Loading"));
 
@@ -233,7 +234,7 @@ export const DailyRounds = (props: any) => {
           if (!state.form[field]) {
             errors[field] = "Please select a category";
             invalidForm = true;
-            patientCategory.current?.scrollIntoView({ behavior: 'smooth' });
+            scrollTo('patientCategory');
           }
           return;
         case "bp": {
@@ -522,11 +523,12 @@ export const DailyRounds = (props: any) => {
               optionValue={(option) => option.id}
             />
           </div>
-          <div className="w-full md:w-1/3" ref={patientCategory}>
+          <div className="w-full md:w-1/3">
             <PatientCategorySelect
               {...field("patient_category")}
               required
               label="Category"
+              id="patientCategory"
             />
           </div>
         </div>

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -240,6 +240,7 @@ export const DailyRounds = (props: any) => {
           if (error) {
             errors.bp = error;
             invalidForm = true;
+            scrollTo('bloodPressure');
           }
           return;
         }
@@ -592,7 +593,7 @@ export const DailyRounds = (props: any) => {
             <>
               <h3 className="mb-6 md:col-span-2">Vitals</h3>
 
-              <BloodPressureFormField {...field("bp")} label="Blood Pressure" />
+              <BloodPressureFormField {...field("bp")} label="Blood Pressure" id='bloodPressure'/>
 
               <RangeAutocompleteFormField
                 {...field("pulse")}

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -1,7 +1,7 @@
 import { navigate } from "raviger";
 
 import dayjs from "dayjs";
-import { lazy, useCallback, useEffect, useState } from "react";
+import { lazy, useCallback, useEffect, useState, useRef } from "react";
 import {
   CONSCIOUSNESS_LEVEL,
   PATIENT_CATEGORIES,
@@ -137,6 +137,8 @@ export const DailyRounds = (props: any) => {
   const headerText = !id ? "Add Consultation Update" : "Info";
   const buttonText = !id ? "Save" : "Continue";
 
+  const patientCategory = useRef<HTMLDivElement | null>(null);
+
   const formFields = [
     "physical_examination_info",
     "other_details",
@@ -231,6 +233,7 @@ export const DailyRounds = (props: any) => {
           if (!state.form[field]) {
             errors[field] = "Please select a category";
             invalidForm = true;
+            patientCategory.current?.scrollIntoView({ behavior: 'smooth' });
           }
           return;
         case "bp": {
@@ -519,7 +522,7 @@ export const DailyRounds = (props: any) => {
               optionValue={(option) => option.id}
             />
           </div>
-          <div className="w-full md:w-1/3">
+          <div className="w-full md:w-1/3" ref={patientCategory}>
             <PatientCategorySelect
               {...field("patient_category")}
               required


### PR DESCRIPTION
## Proposed Changes

- Fixes ##8222
- Whenever the patient category is left empty the validation with generating error scroll the page to the specific field


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
