### PR TITLE
Add Abdominal Drain and Change Rules to Ryles on Ouptput DropDown

### DIFF
--- a/src/Components/LogUpdate/Sections/IOBalance.tsx
+++ b/src/Components/LogUpdate/Sections/IOBalance.tsx
@@ -38,7 +38,7 @@ export const IOBalanceSections = [
     fields: [
       {
         name: "Output",
-        options: ["Urine", "Rules Tube Aspiration", "ICD"],
+        options: ["Urine", "Ryles Tube Aspiration", "ICD", "Abdominal Drain"],
         key: "output",
       },
     ],


### PR DESCRIPTION
## Required Backends
- https://github.com/coronasafe/care/pull/2366

## Proposed Changes

- Fixes #8305
- Add "Abdominal Drain" on Output dropdown.
- Correct the spelling of Ryles tube aspiration on the dropdown.

![image](https://github.com/user-attachments/assets/a5feab7e-a6af-41c8-84c1-740bcab19a5f)


@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
