### PR TITLE
Fix camera preset save button disable logic for cases of last moved position

### DIFF
--- a/src/Components/Facility/ConsultationDetails/ConsultationFeedTab.tsx
+++ b/src/Components/Facility/ConsultationDetails/ConsultationFeedTab.tsx
@@ -145,6 +145,8 @@ export const ConsultationFeedTab = (props: ConsultationTabProps) => {
     return <span>No bed/asset linked allocated</span>;
   }
 
+  const cannotSaveToPreset = !hasMoved || !preset?.id;
+
   return (
     <>
       <ConfirmDialog
@@ -231,13 +233,13 @@ export const ConsultationFeedTab = (props: ConsultationTabProps) => {
                 ) : (
                   <ButtonV2
                     size="small"
-                    variant={hasMoved ? "secondary" : "secondary"}
-                    disabled={!hasMoved}
+                    variant="secondary"
+                    disabled={cannotSaveToPreset}
                     border
-                    ghost={!hasMoved}
-                    shadow={hasMoved}
+                    ghost={cannotSaveToPreset}
+                    shadow={!cannotSaveToPreset}
                     tooltip={
-                      hasMoved
+                      !cannotSaveToPreset
                         ? "Save current position to selected preset"
                         : "Change camera position to update preset"
                     }


### PR DESCRIPTION


## Proposed Changes

- Fix camera preset save button disable logic for cases of last moved position
- Fixes #8343

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
