### PR TITLE
Treating physician: Fixes an edge case where clearing query leads to field getting disabled

### DIFF
--- a/src/Components/Common/UserAutocompleteFormField.tsx
+++ b/src/Components/Common/UserAutocompleteFormField.tsx
@@ -59,10 +59,11 @@ export default function UserAutocomplete(props: UserSearchProps) {
     }
 
     if (data.results.length === 0) {
+      console.log({ query });
       setDisabled(true);
       field.handleChange(undefined as unknown as UserBareMinimum);
     }
-  }, [loading, query, field.required, data?.results, props.noResultsError]);
+  }, [loading, field.required, data?.results, props.noResultsError]);
 
   return (
     <FormField field={field}>

--- a/src/Components/Common/UserAutocompleteFormField.tsx
+++ b/src/Components/Common/UserAutocompleteFormField.tsx
@@ -59,7 +59,6 @@ export default function UserAutocomplete(props: UserSearchProps) {
     }
 
     if (data.results.length === 0) {
-      console.log({ query });
       setDisabled(true);
       field.handleChange(undefined as unknown as UserBareMinimum);
     }


### PR DESCRIPTION
## Proposed Changes

- Removed unintended dependency on `query` for the `useEffect` that handles the logic of whether to disable the field or not. Dependency on `data.results` is enough for achieving the same effect, as `data.results` gets updated asynchronously anyways when `query` changes, and hence prevents unintended triggers before event the `query` is executed.

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
