### PR TITLE
Fixes neurological tab from crashing in older browsers

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -716,27 +716,27 @@ export const NURSING_CARE_PROCEDURES = [
 ] as const;
 
 export const EYE_OPEN_SCALE = [
-  { value: 4, text: "Spontaneous" },
-  { value: 3, text: "To Speech" },
-  { value: 2, text: "To Pain" },
   { value: 1, text: "No Response" },
+  { value: 2, text: "To Pain" },
+  { value: 3, text: "To Speech" },
+  { value: 4, text: "Spontaneous" },
 ];
 
 export const VERBAL_RESPONSE_SCALE = [
-  { value: 5, text: "Oriented to Time, Place and Person" },
-  { value: 4, text: "Confused/Irritable" },
-  { value: 3, text: "Inappropriate words/Cry to Pain" },
-  { value: 2, text: "Incomprehensible words/Moans to pain" },
   { value: 1, text: "No Response" },
+  { value: 2, text: "Incomprehensible words/Moans to pain" },
+  { value: 3, text: "Inappropriate words/Cry to Pain" },
+  { value: 4, text: "Confused/Irritable" },
+  { value: 5, text: "Oriented to Time, Place and Person" },
 ];
 
 export const MOTOR_RESPONSE_SCALE = [
-  { value: 6, text: "Obeying commands/Normal acrivity" },
-  { value: 5, text: "Moves to localized pain" },
-  { value: 4, text: "Flexion/Withdrawal from pain" },
-  { value: 3, text: "Abnormal Flexion(decorticate)" },
-  { value: 2, text: "Abnormal Extension(decerebrate)" },
   { value: 1, text: "No Response" },
+  { value: 2, text: "Abnormal Extension(decerebrate)" },
+  { value: 3, text: "Abnormal Flexion(decorticate)" },
+  { value: 4, text: "Flexion/Withdrawal from pain" },
+  { value: 5, text: "Moves to localized pain" },
+  { value: 6, text: "Obeying commands/Normal acrivity" },
 ];
 export const CONSULTATION_TABS = [
   { text: "UPDATES", desc: "Overview" },

--- a/src/Components/LogUpdate/Sections/NeurologicalMonitoring.tsx
+++ b/src/Components/LogUpdate/Sections/NeurologicalMonitoring.tsx
@@ -97,7 +97,7 @@ const NeurologicalMonitoring = ({ log, onChange }: LogUpdateSectionProps) => {
       <div className="p-2">
         <RadioFormField
           label={<b>Eye Opening Response</b>}
-          options={EYE_OPEN_SCALE.toReversed()}
+          options={EYE_OPEN_SCALE}
           optionDisplay={(c) => c.value + " - " + c.text}
           optionValue={(c) => `${c.value}`}
           name="eye_opening_response"
@@ -109,7 +109,7 @@ const NeurologicalMonitoring = ({ log, onChange }: LogUpdateSectionProps) => {
         />
         <RadioFormField
           label={<b>Verbal Response</b>}
-          options={VERBAL_RESPONSE_SCALE.toReversed()}
+          options={VERBAL_RESPONSE_SCALE}
           optionDisplay={(c) => c.value + " - " + c.text}
           optionValue={(c) => `${c.value}`}
           name="verbal_response"
@@ -123,7 +123,7 @@ const NeurologicalMonitoring = ({ log, onChange }: LogUpdateSectionProps) => {
         />
         <RadioFormField
           label={<b>Motor Response</b>}
-          options={MOTOR_RESPONSE_SCALE.toReversed()}
+          options={MOTOR_RESPONSE_SCALE}
           optionDisplay={(c) => c.value + " - " + c.text}
           optionValue={(c) => `${c.value}`}
           name="motor_response"


### PR DESCRIPTION
> [!IMPORTANT]  
> Base branch is `staging`

## Proposed Changes

- Patch to staging for issue: #8389 (same as #8392)
- Avoids `toReversed` fn. calls for "Eye Open Scale", "Verbal Response Scale" and "Motor Response Scale" in Neurological Monitoring

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
