### PR TITLE
Enable Facility Cover Image Uploads on Mobile Screens

### DIFF
--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -97,8 +97,8 @@ export const FacilityHome = ({ facilityId }: Props) => {
   const hasCoverImage = !!facilityData?.read_cover_image_url;
 
   const StaffUserTypeIndex = USER_TYPES.findIndex((type) => type === "Staff");
-  const hasPermissionToEditCoverImage = true;
-  !(authUser.user_type as string).includes("ReadOnly") &&
+  const hasPermissionToEditCoverImage = 
+    !(authUser.user_type as string).includes("ReadOnly") &&
     USER_TYPES.findIndex((type) => type == authUser.user_type) >=
       StaffUserTypeIndex;
 

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -97,8 +97,8 @@ export const FacilityHome = ({ facilityId }: Props) => {
   const hasCoverImage = !!facilityData?.read_cover_image_url;
 
   const StaffUserTypeIndex = USER_TYPES.findIndex((type) => type === "Staff");
-  const hasPermissionToEditCoverImage =
-    !(authUser.user_type as string).includes("ReadOnly") &&
+  const hasPermissionToEditCoverImage = true;
+  !(authUser.user_type as string).includes("ReadOnly") &&
     USER_TYPES.findIndex((type) => type == authUser.user_type) >=
       StaffUserTypeIndex;
 
@@ -109,7 +109,10 @@ export const FacilityHome = ({ facilityId }: Props) => {
   const editCoverImageTooltip = hasPermissionToEditCoverImage && (
     <div
       id="facility-coverimage"
-      className="absolute right-0 top-0 z-10 flex h-full w-full flex-col items-center justify-center rounded-t-lg bg-black text-sm text-secondary-300 opacity-0 transition-opacity hover:opacity-60 md:h-[88px]"
+      className={
+        "absolute right-0 top-0 z-10 flex h-full w-full cursor-pointer flex-col items-center justify-center rounded-t-lg bg-black text-sm text-secondary-300 opacity-0 transition-opacity hover:opacity-60 md:h-[88px]"
+      }
+      onClick={() => setEditCoverImage(true)}
     >
       <CareIcon icon="l-pen" className="text-lg" />
       <span className="mt-2">{`${hasCoverImage ? "Edit" : "Upload"}`}</span>

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -33,6 +33,10 @@ import { LocationSelect } from "../Common/LocationSelect.js";
 import { CameraFeedPermittedUserTypes } from "../../Utils/permissions.js";
 import { FacilityStaffList } from "./FacilityStaffList.js";
 
+type Props = {
+  facilityId: string;
+};
+
 const Loading = lazy(() => import("../Common/Loading"));
 
 export const getFacilityFeatureIcon = (featureId: number) => {
@@ -45,12 +49,10 @@ export const getFacilityFeatureIcon = (featureId: number) => {
   );
 };
 
-export const FacilityHome = (props: any) => {
+export const FacilityHome = ({ facilityId }: Props) => {
   const { t } = useTranslation();
-  const { facilityId } = props;
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
   const [editCoverImage, setEditCoverImage] = useState(false);
-  const [imageKey, setImageKey] = useState(Date.now());
   const authUser = useAuthUser();
 
   useMessageListener((data) => console.log(data));
@@ -116,7 +118,7 @@ export const FacilityHome = (props: any) => {
 
   const CoverImage = () => (
     <img
-      src={`${facilityData?.read_cover_image_url}?imgKey=${imageKey}`}
+      src={`${facilityData?.read_cover_image_url}`}
       alt={facilityData?.name}
       className="h-full w-full rounded-lg object-cover"
     />
@@ -145,11 +147,7 @@ export const FacilityHome = (props: any) => {
       />
       <CoverImageEditModal
         open={editCoverImage}
-        onSave={() =>
-          facilityData?.read_cover_image_url
-            ? setImageKey(Date.now())
-            : facilityFetch()
-        }
+        onSave={() => facilityFetch()}
         onClose={() => setEditCoverImage(false)}
         onDelete={() => facilityFetch()}
         facility={facilityData ?? ({} as FacilityModel)}

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -97,7 +97,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
   const hasCoverImage = !!facilityData?.read_cover_image_url;
 
   const StaffUserTypeIndex = USER_TYPES.findIndex((type) => type === "Staff");
-  const hasPermissionToEditCoverImage = 
+  const hasPermissionToEditCoverImage =
     !(authUser.user_type as string).includes("ReadOnly") &&
     USER_TYPES.findIndex((type) => type == authUser.user_type) >=
       StaffUserTypeIndex;


### PR DESCRIPTION
## Proposed Changes

- Fixes cover image edit for mobile devices
- Remove imageKey Implementation for Cover Images
- Fix `Edit Cover Image` for Mobile Devices

@rithviknishad Can you confirm that removing the imageKey wouldn't cause any issues

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
