### PR TITLE
Fixes facility cover image from not reloading after upload

### DIFF
--- a/src/Components/Facility/CoverImageEditModal.tsx
+++ b/src/Components/Facility/CoverImageEditModal.tsx
@@ -127,9 +127,14 @@ const CoverImageEditModal = ({
         Authorization:
           "Bearer " + localStorage.getItem(LocalStorageKeys.accessToken),
       },
-      (xhr: XMLHttpRequest) => {
+      async (xhr: XMLHttpRequest) => {
         if (xhr.status === 200) {
           Success({ msg: "Cover image updated." });
+          setIsProcessing(false);
+          setIsCaptureImgBeingUploaded(false);
+          await sleep(1000);
+          onSave?.();
+          closeModal();
         } else {
           Notification.Error({
             msg: "Something went wrong!",
@@ -145,12 +150,6 @@ const CoverImageEditModal = ({
         setIsProcessing(false);
       },
     );
-
-    await sleep(1000);
-    setIsProcessing(false);
-    setIsCaptureImgBeingUploaded(false);
-    onSave && onSave();
-    closeModal();
   };
 
   const handleDelete = async () => {

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -126,11 +126,20 @@ export const FacilityHome = ({ facilityId }: Props) => {
   );
 
   const CoverImage = () => (
-    <img
-      src={`${facilityData?.read_cover_image_url}`}
-      alt={facilityData?.name}
-      className="h-full w-full rounded-lg object-cover"
-    />
+    <>
+      <img
+        src={`${facilityData?.read_cover_image_url}`}
+        alt={facilityData?.name}
+        className="h-full w-full rounded-lg object-cover"
+      />
+      {coverImageEdited && (
+        <div className="absolute inset-x-0 bottom-0 w-full rounded-b-md bg-black/70 px-2 pb-0.5 backdrop-blur-sm">
+          <span className="text-center text-xs font-medium text-secondary-100">
+            {t("cover_image_updated_note")}
+          </span>
+        </div>
+      )}
+    </>
   );
 
   return (
@@ -208,16 +217,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
                   }
                 >
                   {hasCoverImage ? (
-                    <div>
-                      <CoverImage />
-                      {coverImageEdited && (
-                        <div className="mt-2 rounded border border-secondary-300 bg-secondary-50 px-2 py-1">
-                          <span className="text-center text-xs font-medium text-secondary-700">
-                            {t("cover_image_updated_note")}
-                          </span>
-                        </div>
-                      )}
-                    </div>
+                    <CoverImage />
                   ) : (
                     <div className="flex h-80 w-[88px] items-center justify-center rounded-lg bg-secondary-200 font-medium text-secondary-700 lg:h-80 lg:w-80">
                       <svg

--- a/src/Components/Facility/FacilityHome.tsx
+++ b/src/Components/Facility/FacilityHome.tsx
@@ -58,6 +58,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
   const { t } = useTranslation();
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
   const [editCoverImage, setEditCoverImage] = useState(false);
+  const [coverImageEdited, setCoverImageEdited] = useState(false);
   const authUser = useAuthUser();
 
   useMessageListener((data) => console.log(data));
@@ -155,7 +156,10 @@ export const FacilityHome = ({ facilityId }: Props) => {
       />
       <CoverImageEditModal
         open={editCoverImage}
-        onSave={() => facilityFetch()}
+        onSave={() => {
+          facilityFetch();
+          setCoverImageEdited(true);
+        }}
         onClose={() => setEditCoverImage(false)}
         onDelete={() => facilityFetch()}
         facility={facilityData ?? ({} as FacilityModel)}
@@ -204,7 +208,16 @@ export const FacilityHome = ({ facilityId }: Props) => {
                   }
                 >
                   {hasCoverImage ? (
-                    <CoverImage />
+                    <div>
+                      <CoverImage />
+                      {coverImageEdited && (
+                        <div className="mt-2 rounded border border-secondary-300 bg-secondary-50 px-2 py-1">
+                          <span className="text-center text-xs font-medium text-secondary-700">
+                            {t("cover_image_updated_note")}
+                          </span>
+                        </div>
+                      )}
+                    </div>
                   ) : (
                     <div className="flex h-80 w-[88px] items-center justify-center rounded-lg bg-secondary-200 font-medium text-secondary-700 lg:h-80 lg:w-80">
                       <svg

--- a/src/Locale/en/Facility.json
+++ b/src/Locale/en/Facility.json
@@ -58,5 +58,6 @@
   "duplicate_patient_record_confirmation": "Admit the patient record to your facility by adding the year of birth",
   "duplicate_patient_record_rejection": "I confirm that the suspect / patient I want to create is not on the list.",
   "duplicate_patient_record_birth_unknown": "Please contact your district care coordinator, the shifting facility or the patient themselves if you are not sure about the patient's year of birth.",
-  "patient_transfer_birth_match_note": "Note: Year of birth must match the patient to process the transfer request."
+  "patient_transfer_birth_match_note": "Note: Year of birth must match the patient to process the transfer request.",
+  "cover_image_updated_note": "It could take a while to see the updated cover image"
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes #8401
- Regression from #7368 
- Adds a note about time taken for cache invalidation when updated

<img width="444" alt="image" src="https://github.com/user-attachments/assets/9ccbecec-713a-4199-b9d1-5de5d5e0f892">


<img width="617" alt="image" src="https://github.com/user-attachments/assets/b56b81b8-02de-4b8f-8a87-e878c841a1aa">






@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
