### PR TITLE
fix build workflows after the org rename

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   test:
-    if: github.repository == 'coronasafe/care_fe'
+    if: github.repository == 'ohcnetwork/care_fe'
     runs-on: ubuntu-latest
     name: Test
     steps:


### PR DESCRIPTION
## Proposed Changes

- This pr fixes build workflows getting skipped due to the org rename, this was causing the staging and prod deploys to fail

@coronasafe/care-fe-code-reviewers @coronasafe/code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.coronasafe.network/coronasafe-care-documentation/architecture/architecture-and-layering-of-care).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
