### PR TITLE
Fixed vite config not reading env file

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react-swc";
 import checker from "vite-plugin-checker";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { treeShakeCareIcons } from "./plugins/treeShakeCareIcons";
+import { loadEnv } from "vite";
 
 const pdfWorkerPath = path.join(
   path.dirname(
@@ -23,105 +24,108 @@ const cdnUrls =
   ].join(" ");
 
 /** @type {import('vite').UserConfig} */
-export default {
-  envPrefix: "REACT_",
-  plugins: [
-    viteStaticCopy({
-      targets: [
-        {
-          src: pdfWorkerPath,
-          dest: "",
-        },
-      ],
-    }),
-    react(),
-    checker({ typescript: true }),
-    treeShakeCareIcons({
-      iconWhitelist: ["default"],
-    }),
-    VitePWA({
-      strategies: "injectManifest",
-      srcDir: "src",
-      filename: "service-worker.ts",
-      injectRegister: "script-defer",
-      devOptions: {
-        enabled: true,
-        type: "module",
-      },
-      injectManifest: {
-        maximumFileSizeToCacheInBytes: 7000000,
-      },
-      manifest: {
-        name: "Care",
-        short_name: "Care",
-        theme_color: "#0e9f6e",
-        background_color: "#ffffff",
-        display: "standalone",
-        icons: [
+export default ({ mode }) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
+  return {
+    envPrefix: "REACT_",
+    plugins: [
+      viteStaticCopy({
+        targets: [
           {
-            src: "images/icons/pwa-64x64.png",
-            sizes: "64x64",
-            type: "image/png",
-          },
-          {
-            src: "images/icons/pwa-192x192.png",
-            sizes: "192x192",
-            type: "image/png",
-          },
-          {
-            src: "images/icons/pwa-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "any",
-          },
-          {
-            src: "images/icons/maskable-icon-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "maskable",
+            src: pdfWorkerPath,
+            dest: "",
           },
         ],
-      },
-    }),
-  ],
-  build: {
-    outDir: "build",
-    assetsDir: "bundle",
-    sourcemap: true,
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes("node_modules")) {
-            return "vendor";
-          }
+      }),
+      react(),
+      checker({ typescript: true }),
+      treeShakeCareIcons({
+        iconWhitelist: ["default"],
+      }),
+      VitePWA({
+        strategies: "injectManifest",
+        srcDir: "src",
+        filename: "service-worker.ts",
+        injectRegister: "script-defer",
+        devOptions: {
+          enabled: true,
+          type: "module",
+        },
+        injectManifest: {
+          maximumFileSizeToCacheInBytes: 7000000,
+        },
+        manifest: {
+          name: "Care",
+          short_name: "Care",
+          theme_color: "#0e9f6e",
+          background_color: "#ffffff",
+          display: "standalone",
+          icons: [
+            {
+              src: "images/icons/pwa-64x64.png",
+              sizes: "64x64",
+              type: "image/png",
+            },
+            {
+              src: "images/icons/pwa-192x192.png",
+              sizes: "192x192",
+              type: "image/png",
+            },
+            {
+              src: "images/icons/pwa-512x512.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "any",
+            },
+            {
+              src: "images/icons/maskable-icon-512x512.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "maskable",
+            },
+          ],
+        },
+      }),
+    ],
+    build: {
+      outDir: "build",
+      assetsDir: "bundle",
+      sourcemap: true,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes("node_modules")) {
+              return "vendor";
+            }
+          },
         },
       },
     },
-  },
-  server: {
-    port: 4000,
-    proxy: {
-      "/api": {
-        target: process.env.CARE_API ?? "https://careapi.ohc.network",
-        changeOrigin: true,
+    server: {
+      port: 4000,
+      proxy: {
+        "/api": {
+          target: process.env.CARE_API ?? "https://careapi.ohc.network",
+          changeOrigin: true,
+        },
       },
     },
-  },
-  preview: {
-    headers: {
-      "Content-Security-Policy-Report-Only": `default-src 'self';\
+    preview: {
+      headers: {
+        "Content-Security-Policy-Report-Only": `default-src 'self';\
       script-src 'self' blob: 'nonce-f51b9742' https://plausible.10bedicu.in;\
       style-src 'self' 'unsafe-inline';\
       connect-src 'self' https://plausible.10bedicu.in;\
       img-src 'self' https://cdn.ohc.network ${cdnUrls};\
       object-src 'self' ${cdnUrls};`,
-    },
-    port: 4000,
-    proxy: {
-      "/api": {
-        target: process.env.CARE_API ?? "https://careapi.ohc.network",
-        changeOrigin: true,
+      },
+      port: 4000,
+      proxy: {
+        "/api": {
+          target: process.env.CARE_API ?? "https://careapi.ohc.network",
+          changeOrigin: true,
+        },
       },
     },
-  },
+  }
 };


### PR DESCRIPTION
## Proposed Changes

- Currently when we need to run care with local backend, we need to specify the CARE_API env variable before npm run dev even if specified in `.env.local`
- This will make sure that envs are picked up from `.env.local` before running the dev server.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
