### PR TITLE
Fixes PDF Viewer clipping out in different display zoom settings

### DIFF
--- a/src/Components/Common/PDFViewer.tsx
+++ b/src/Components/Common/PDFViewer.tsx
@@ -13,7 +13,7 @@ export default function PDFViewer(
   pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
 
   return (
-    <div className="flex flex-col items-center justify-center">
+    <div className="flex h-full flex-col items-center justify-center">
       <div className="w-full overflow-auto">
         <Document
           file={props.url}


### PR DESCRIPTION
## Proposed Changes

- Fixes PDF Viewer clipping out in different display zoom settings

Issue reported by @nihal467 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
