### PR TITLE
Reorder classnames only on pre-commit

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -7,8 +7,5 @@
   "arrowParens": "always",
   "tailwindFunctions": [
     "classNames"
-  ],
-  "plugins": [
-    "prettier-plugin-tailwindcss"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
-      "prettier --write --ignore-unknown",
+      "prettier --write --ignore-unknown --plugin prettier-plugin-tailwindcss",
       "eslint --fix",
       "git update-index --again"
     ]


### PR DESCRIPTION
## Proposed Changes

- Makes sure prettier does not format classes while you are working on them. 
- Will run the format only on precommit.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
