### PR TITLE
Rename procedure `Tracheostomy Tube Change` and fix oral issue not getting unselected

### DIFF
--- a/src/Common/constants.tsx
+++ b/src/Common/constants.tsx
@@ -759,7 +759,7 @@ export const NURSING_CARE_PROCEDURES = [
   "restrain",
   "chest_tube_care",
   "tracheostomy_care",
-  "tracheostomy_change",
+  "tracheostomy_tube_change",
   "stoma_care",
   "catheter_care",
   "catheter_change",

--- a/src/Components/Patient/DailyRounds.tsx
+++ b/src/Components/Patient/DailyRounds.tsx
@@ -444,6 +444,10 @@ export const DailyRounds = (props: any) => {
       form["investigations_dirty"] = true;
     }
 
+    if (event.name === "nutrition_route" && event.value !== "ORAL") {
+      form["oral_issue"] = undefined;
+    }
+
     dispatch({ type: "set_form", form });
   };
 

--- a/src/Locale/en/LogUpdate.json
+++ b/src/Locale/en/LogUpdate.json
@@ -131,7 +131,7 @@
   "NURSING_CARE_PROCEDURE__restrain": "Restrain",
   "NURSING_CARE_PROCEDURE__chest_tube_care": "Chest Tube Care",
   "NURSING_CARE_PROCEDURE__tracheostomy_care": "Tracheostomy Care",
-  "NURSING_CARE_PROCEDURE__tracheostomy_change": "Tracheostomy change ",
+  "NURSING_CARE_PROCEDURE__tracheostomy_tube_change": "Tracheostomy Tube Change",
   "NURSING_CARE_PROCEDURE__stoma_care": "Stoma Care",
   "NURSING_CARE_PROCEDURE__catheter_care": "Catheter Care",
   "NURSING_CARE_PROCEDURE__catheter_change": "Catheter Change",


### PR DESCRIPTION
## Proposed Changes

- changed nursing care procedure label `Tracheostomy Change` to `Tracheostomy Tube Change`
- Unselect selected "Oral Issue" if nutrition route changed to non-oral

@ohcnetwork/care-fe-code-reviewers

