### PR TITLE
Fix: Clearing Facilities Field Causes White Screen #8610

### DIFF
--- a/cypress/e2e/patient_spec/PatientConsultationCreation.cy.ts
+++ b/cypress/e2e/patient_spec/PatientConsultationCreation.cy.ts
@@ -35,7 +35,7 @@ describe("Patient Consultation in multiple combination", () => {
   const patientWeight = "70";
   const patientHeight = "170";
   const medicineOne = "DOLOLUP";
-  const patientIpNumber = Math.random().toString(36).substring(7);
+  const patientIpNumber = `${Math.floor(Math.random() * 90 + 10)}/${Math.floor(Math.random() * 9000 + 1000)}`;
 
   before(() => {
     loginPage.loginAsDisctrictAdmin();
@@ -94,7 +94,7 @@ describe("Patient Consultation in multiple combination", () => {
     cy.submitButton("Create Consultation");
     // the above submit should fail as IP number is missing
     patientConsultationPage.typePatientNumber(patientIpNumber);
-    patientConsultationPage.selectBed("Dummy Bed 1");
+    patientConsultationPage.selectBed("Dummy Bed 6");
     cy.submitButton("Create Consultation");
     cy.verifyNotification("Consultation created successfully");
     // Below code for the prescription module only present while creating a new consultation

--- a/cypress/e2e/patient_spec/PatientPrescription.cy.ts
+++ b/cypress/e2e/patient_spec/PatientPrescription.cy.ts
@@ -5,7 +5,7 @@ import { PatientPage } from "../../pageobject/Patient/PatientCreation";
 const patientPrescription = new PatientPrescription();
 const loginPage = new LoginPage();
 const patientPage = new PatientPage();
-const medicineNameOne = "DOLO";
+const medicineNameOne = "AGCON";
 const medicineNameTwo = "FDEP PLUS";
 const medicineBaseDosage = "4";
 const medicineTargetDosage = "9";

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -325,7 +325,8 @@ export const UserAdd = (props: UserProps) => {
   }, [state.form.phone_number_is_whatsapp, state.form.phone_number]);
 
   const setFacility = (selected: FacilityModel | FacilityModel[] | null) => {
-    setSelectedFacility(selected as FacilityModel[]);
+    const newSelectedFacilities = selected ? (Array.isArray(selected) ? selected : [selected]) : [];
+    setSelectedFacility(newSelectedFacilities as FacilityModel[]);
     const form = { ...state.form };
     form.facilities = selected
       ? (selected as FacilityModel[]).map((i) => i.id!)

--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -325,7 +325,11 @@ export const UserAdd = (props: UserProps) => {
   }, [state.form.phone_number_is_whatsapp, state.form.phone_number]);
 
   const setFacility = (selected: FacilityModel | FacilityModel[] | null) => {
-    const newSelectedFacilities = selected ? (Array.isArray(selected) ? selected : [selected]) : [];
+    const newSelectedFacilities = selected
+      ? Array.isArray(selected)
+        ? selected
+        : [selected]
+      : [];
     setSelectedFacility(newSelectedFacilities as FacilityModel[]);
     const form = { ...state.form };
     form.facilities = selected


### PR DESCRIPTION
- Fixes #8610 
- The `selectedFacility` state was encountering issues due to a `null` value being passed by the `AutoCompleteAsync` component when clicking the clear icon. To address this, I added a check to ensure that if the value is `null`, an empty array is passed instead. 

### Screenshot of the `AutoCompleteAsync` Component:
![AutoCompleteAsync Component Screenshot](https://github.com/user-attachments/assets/1fea5881-f8ff-495e-97cf-5500836c04c4)

### Video Recording:
[Watch the demo video here](https://github.com/user-attachments/assets/606eba4a-53d1-4542-889f-32d0e2e863c1)

### Reviewers:
@nihal467 
@ohcnetwork/care-fe-code-reviewers

## Merge Checklist:

- [x] Add specifications that demonstrate the bug fix or test the new feature.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.


