### PR TITLE
fix: resolved issue #8583 - Increased width to remove unnecessary scrollbar

### DIFF
--- a/src/CAREUI/misc/PrintPreview.tsx
+++ b/src/CAREUI/misc/PrintPreview.tsx
@@ -24,7 +24,7 @@ export default function PrintPreview(props: Props) {
 
       {/* PREVIOUS WIDTH = 50REM
 
-      UPDATED WIDTH = 57REM */}
+      UPDATED WIDTH = 64REM */}
 
       <div className="mx-auto my-8 lg:w-[64rem]">
         <div className="top-0 z-20 flex gap-2 bg-secondary-100 px-2 py-4 xl:absolute xl:right-6 xl:top-8 xl:justify-end">

--- a/src/CAREUI/misc/PrintPreview.tsx
+++ b/src/CAREUI/misc/PrintPreview.tsx
@@ -20,7 +20,13 @@ export default function PrintPreview(props: Props) {
 
   return (
     <Page title={props.title}>
-      <div className="mx-auto my-8 w-[50rem]">
+      {/* INCREASED WIDTH TO REMOVE SCROLLBAR  */}
+
+      {/* PREVIOUS WIDTH = 50REM
+
+      UPDATED WIDTH = 57REM */}
+
+      <div className="mx-auto my-8 lg:w-[64rem]">
         <div className="top-0 z-20 flex gap-2 bg-secondary-100 px-2 py-4 xl:absolute xl:right-6 xl:top-8 xl:justify-end">
           <ButtonV2 disabled={props.disabled} onClick={print}>
             <CareIcon icon="l-print" className="text-lg" />


### PR DESCRIPTION
## Proposed Changes

- Fixes #8583 
- Increased the width of the `PrintPreview` page to 64rem to remove the unnecessary scrollbar on the investigation details page.
- Cleaned up CSS to ensure better layout responsiveness.
- Ensured that the page works properly on both large and small screens.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to the issue.
- [x] Request for Peer Reviews.
- [ ] Completion of QA.

Here is a screenshot of the fix:  
![bugfix_care-fe](https://github.com/user-attachments/assets/c8035ab8-55a6-4f06-a14e-6eeb72387680)
![error fixed](https://github.com/user-attachments/assets/92dd2dcc-8baa-4f42-8b3b-5ad87a4285b3)

