### PR TITLE
fix: modified bed creation notification to show proper action-related message #8627

### DIFF
--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -128,7 +128,6 @@ export const AddBedForm = ({ facilityId, locationId, bedId }: Props) => {
       const { res } = await request(routes.createFacilityBed, {
         body: { ...data, facility: facilityId, location: locationId },
       });
-      console.log(res);
       res?.ok && numberOfBeds > 1
         ? onSuccess("Bed(s) created successfully")
         : onSuccess("Bed created successfully");

--- a/src/Components/Facility/AddBedForm.tsx
+++ b/src/Components/Facility/AddBedForm.tsx
@@ -124,10 +124,14 @@ export const AddBedForm = ({ facilityId, locationId, bedId }: Props) => {
       res?.ok && onSuccess("Bed updated successfully");
     } else {
       // Create
+
       const { res } = await request(routes.createFacilityBed, {
         body: { ...data, facility: facilityId, location: locationId },
       });
-      res?.ok && onSuccess("Bed(s) created successfully");
+      console.log(res);
+      res?.ok && numberOfBeds > 1
+        ? onSuccess("Bed(s) created successfully")
+        : onSuccess("Bed created successfully");
     }
   };
 


### PR DESCRIPTION
fix: modify bed creation notification to show proper action-related message #8627

## Proposed Changes

- Fixes #8627
- Updated notification to display appropriate messages based on the number of beds created:
  - Single bed: "Bed created successfully."
  - Multiple beds: "Beds created successfully."

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to the issue.
- [x] Request for Peer Reviews.
- [ ] Completion of QA.

Here is a screenshot of the fix:

![care_fe bed Bug fix](https://github.com/user-attachments/assets/d4f1a8a7-320d-40b5-ad83-078c52c75f99)
