### PR TITLE
fix: Show validation error message on facility cover image upload (#8625)

### DIFF
--- a/src/Components/Facility/CoverImageEditModal.tsx
+++ b/src/Components/Facility/CoverImageEditModal.tsx
@@ -92,30 +92,11 @@ const CoverImageEditModal = ({
     onClose?.();
   };
 
-  const maxWidth = 1024;
-  const maxHeight = 1024;
-
   useEffect(() => {
     if (selectedFile) {
-      const img = new Image();
       const objectUrl = URL.createObjectURL(selectedFile);
-      img.onload = () => {
-        const width = img.width;
-        const height = img.height;
-        if (width > maxWidth || height > maxHeight) {
-          Notification.Error({
-            msg: `Image dimensions (${width}x${height}) exceed allowed size of ${maxWidth}x${maxHeight} pixels.`,
-          });
-        } else {
-          setPreview(objectUrl);
-        }
-      };
-
-      img.src = objectUrl;
-
-      return () => {
-        URL.revokeObjectURL(objectUrl);
-      };
+      setPreview(objectUrl);
+      return () => URL.revokeObjectURL(objectUrl);
     }
   }, [selectedFile]);
 
@@ -149,6 +130,7 @@ const CoverImageEditModal = ({
           "Bearer " + localStorage.getItem(LocalStorageKeys.accessToken),
       },
       async (xhr: XMLHttpRequest) => {
+        const errorResponse = JSON.parse(xhr.responseText);
         if (xhr.status === 200) {
           Success({ msg: "Cover image updated." });
           setIsProcessing(false);
@@ -158,7 +140,8 @@ const CoverImageEditModal = ({
           closeModal();
         } else {
           Notification.Error({
-            msg: "Something went wrong!",
+            msg:
+              errorResponse?.cover_image?.join(" ") || "Something went wrong!",
           });
           setIsProcessing(false);
         }

--- a/src/Components/Facility/CoverImageEditModal.tsx
+++ b/src/Components/Facility/CoverImageEditModal.tsx
@@ -92,11 +92,30 @@ const CoverImageEditModal = ({
     onClose?.();
   };
 
+  const maxWidth = 1024;
+  const maxHeight = 1024;
+
   useEffect(() => {
     if (selectedFile) {
+      const img = new Image();
       const objectUrl = URL.createObjectURL(selectedFile);
-      setPreview(objectUrl);
-      return () => URL.revokeObjectURL(objectUrl);
+      img.onload = () => {
+        const width = img.width;
+        const height = img.height;
+        if (width > maxWidth || height > maxHeight) {
+          Notification.Error({
+            msg: `Image dimensions (${width}x${height}) exceed allowed size of ${maxWidth}x${maxHeight} pixels.`,
+          });
+        } else {
+          setPreview(objectUrl);
+        }
+      };
+
+      img.src = objectUrl;
+
+      return () => {
+        URL.revokeObjectURL(objectUrl);
+      };
     }
   }, [selectedFile]);
 

--- a/src/Components/Facility/CoverImageEditModal.tsx
+++ b/src/Components/Facility/CoverImageEditModal.tsx
@@ -13,7 +13,6 @@ import Webcam from "react-webcam";
 import { FacilityModel } from "./models";
 import useWindowDimensions from "../../Common/hooks/useWindowDimensions";
 import CareIcon from "../../CAREUI/icons/CareIcon";
-import * as Notification from "../../Utils/Notifications.js";
 import { useTranslation } from "react-i18next";
 import { LocalStorageKeys } from "../../Common/constants";
 import DialogModal from "../Common/Dialog";
@@ -130,26 +129,17 @@ const CoverImageEditModal = ({
           "Bearer " + localStorage.getItem(LocalStorageKeys.accessToken),
       },
       async (xhr: XMLHttpRequest) => {
+        setIsProcessing(false);
         if (xhr.status === 200) {
           Success({ msg: "Cover image updated." });
-          setIsProcessing(false);
           setIsCaptureImgBeingUploaded(false);
           await sleep(1000);
           onSave?.();
           closeModal();
-        } else {
-          const error = JSON.parse(xhr.responseText);
-          Notification.Error({
-            msg: error?.cover_image?.join(" ") || "Something went wrong!",
-          });
-          setIsProcessing(false);
         }
       },
       null,
       () => {
-        Notification.Error({
-          msg: "Network Failure. Please check your internet connectivity.",
-        });
         setIsProcessing(false);
       },
     );

--- a/src/Components/Facility/CoverImageEditModal.tsx
+++ b/src/Components/Facility/CoverImageEditModal.tsx
@@ -130,7 +130,6 @@ const CoverImageEditModal = ({
           "Bearer " + localStorage.getItem(LocalStorageKeys.accessToken),
       },
       async (xhr: XMLHttpRequest) => {
-        const errorResponse = JSON.parse(xhr.responseText);
         if (xhr.status === 200) {
           Success({ msg: "Cover image updated." });
           setIsProcessing(false);
@@ -139,9 +138,9 @@ const CoverImageEditModal = ({
           onSave?.();
           closeModal();
         } else {
+          const error = JSON.parse(xhr.responseText);
           Notification.Error({
-            msg:
-              errorResponse?.cover_image?.join(" ") || "Something went wrong!",
+            msg: error?.cover_image?.join(" ") || "Something went wrong!",
           });
           setIsProcessing(false);
         }

--- a/src/Utils/request/uploadFile.ts
+++ b/src/Utils/request/uploadFile.ts
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction } from "react";
 import { handleUploadPercentage } from "./utils";
+import * as Notification from "../../Utils/Notifications.js";
 
 const uploadFile = (
   url: string,
@@ -19,6 +20,16 @@ const uploadFile = (
 
   xhr.onload = () => {
     onLoad(xhr);
+    if (400 <= xhr.status && xhr.status <= 499) {
+      const error = JSON.parse(xhr.responseText);
+      if (typeof error === "object" && !Array.isArray(error)) {
+        Object.values(error).forEach((msg) => {
+          Notification.Error({ msg: msg || "Something went wrong!" });
+        });
+      } else {
+        Notification.Error({ msg: error || "Something went wrong!" });
+      }
+    }
   };
 
   if (setUploadPercent != null) {
@@ -28,6 +39,9 @@ const uploadFile = (
   }
 
   xhr.onerror = () => {
+    Notification.Error({
+      msg: "Network Failure. Please check your internet connectivity.",
+    });
     onError();
   };
   xhr.send(file);


### PR DESCRIPTION
## Proposed Changes

- Fixes #8625
- Added frontend validation for image dimensions (width and height) before uploading the facility cover image.
- Displayed a specific error message when the image exceeds the allowed 1024x1024 pixel size.

**Video Demo**:  
https://github.com/user-attachments/assets/f0c8d680-8885-4856-a2ee-77fbebd27964

@ohcnetwork/care-fe-code-reviewers  
@nihal467  

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews.
- [ ] Completion of QA.
