### PR TITLE
Remove "read more" for prescription notes in detailed view

### DIFF
--- a/src/Components/Common/components/Readmore.tsx
+++ b/src/Components/Common/components/Readmore.tsx
@@ -25,10 +25,7 @@ export default function ReadMore(props: { text: string; minChars: number }) {
       {props.text.length > props.minChars && (
         <button
           className="m-0 w-full bg-white p-0 text-left font-bold text-blue-500"
-          onClick={(e) => {
-            e.stopPropagation();
-            setExpanded(!isExpanded);
-          }}
+          onClick={(_) => setExpanded(!isExpanded)}
         >
           {isExpanded ? "Read Less" : "Read More"}
         </button>

--- a/src/Components/Common/components/Readmore.tsx
+++ b/src/Components/Common/components/Readmore.tsx
@@ -25,7 +25,10 @@ export default function ReadMore(props: { text: string; minChars: number }) {
       {props.text.length > props.minChars && (
         <button
           className="m-0 w-full bg-white p-0 text-left font-bold text-blue-500"
-          onClick={(_) => setExpanded(!isExpanded)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(!isExpanded);
+          }}
         >
           {isExpanded ? "Read Less" : "Read More"}
         </button>

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -226,7 +226,8 @@ export default function PrescriptionDetailCard({
 
             {prescription.notes && (
               <Detail className="col-span-10" label={t("notes")}>
-                <ReadMore text={prescription.notes} minChars={120} />
+                {prescription.notes}
+                {/* <ReadMore text={prescription.notes} minChars={120} /> */}
               </Detail>
             )}
 

--- a/src/Components/Medicine/PrescriptionDetailCard.tsx
+++ b/src/Components/Medicine/PrescriptionDetailCard.tsx
@@ -227,7 +227,6 @@ export default function PrescriptionDetailCard({
             {prescription.notes && (
               <Detail className="col-span-10" label={t("notes")}>
                 {prescription.notes}
-                {/* <ReadMore text={prescription.notes} minChars={120} /> */}
               </Detail>
             )}
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #8643
- Removed ReadMore from notes in prescription

@ohcnetwork/care-fe-code-reviewers

![careifx](https://github.com/user-attachments/assets/81fa8a64-094a-4f11-b997-9530dd4aefc3)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
