### PR TITLE
Fix: Infinite Loading State When Notification is blocked or granted

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -2,7 +2,7 @@ import { navigate } from "raviger";
 import { useEffect, useState } from "react";
 import Spinner from "../Common/Spinner";
 import { NOTIFICATION_EVENTS } from "../../Common/constants";
-import { Error } from "../../Utils/Notifications.js";
+import { Error, Success, Warn } from "../../Utils/Notifications.js";
 import { classNames, formatDateTime } from "../../Utils/utils";
 import CareIcon, { IconName } from "../../CAREUI/icons/CareIcon";
 import * as Sentry from "@sentry/browser";
@@ -194,6 +194,30 @@ export default function NotificationsList({
     if (open) document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [open]);
+  useEffect(() => {
+    let intervalId: ReturnType<typeof setTimeout>;
+    if (isSubscribing) {
+      const checkNotificationPermission = () => {
+        if (Notification.permission === "denied") {
+          Warn({
+            msg: t("notification_permission_denied"),
+          });
+          setIsSubscribing(false);
+          clearInterval(intervalId);
+        } else if (Notification.permission === "granted") {
+          Success({
+            msg: t("notification_permission_granted"),
+          });
+          setIsSubscribing(false);
+          clearInterval(intervalId);
+        }
+      };
+
+      checkNotificationPermission();
+      intervalId = setInterval(checkNotificationPermission, 1000);
+    }
+    return () => clearInterval(intervalId);
+  }, [isSubscribing]);
 
   const intialSubscriptionState = async () => {
     try {

--- a/src/Locale/en/Notifications.json
+++ b/src/Locale/en/Notifications.json
@@ -4,6 +4,8 @@
   "mark_as_unread": "Mark as Unread",
   "subscribe": "Subscribe",
   "subscribe_on_this_device": "Subscribe on this device",
+  "notification_permission_denied": "Notification permission denied",
+  "notification_permission_granted": "Notification permission granted",
   "show_unread_notifications": "Show Unread",
   "show_all_notifications": "Show All",
   "filter_by_category": "Filter by category",

--- a/src/Locale/hi/Notifications.json
+++ b/src/Locale/hi/Notifications.json
@@ -4,6 +4,8 @@
   "mark_as_unread": "अपठित के रूप में चिह्नित करें",
   "subscribe": "सदस्यता लें",
   "subscribe_on_this_device": "इस डिवाइस पर सदस्यता लें",
+  "notification_permission_denied": "सूचना अनुमति नामंजूर",
+  "notification_permission_granted": "सूचना अनुमति प्रदान की गई",
   "show_unread_notifications": "अपठित दिखाएँ",
   "show_all_notifications": "सब दिखाएं",
   "filter_by_category": "श्रेणी के अनुसार फ़िल्टर करें",

--- a/src/Locale/kn/Notifications.json
+++ b/src/Locale/kn/Notifications.json
@@ -4,6 +4,8 @@
   "mark_as_unread": "ಓದದಿರುವಂತೆ ಗುರುತಿಸಿ",
   "subscribe": "ಚಂದಾದಾರರಾಗಿ",
   "subscribe_on_this_device": "ಈ ಸಾಧನದಲ್ಲಿ ಚಂದಾದಾರರಾಗಿ",
+  "notification_permission_denied": "ಅಧಿಸೂಚನೆ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ",
+  "notification_permission_granted": "ಅಧಿಸೂಚನೆ ಅನುಮತಿ ನೀಡಲಾಗಿದೆ",
   "show_unread_notifications": "ಓದದಿರುವುದನ್ನು ತೋರಿಸಿ",
   "show_all_notifications": "ಎಲ್ಲವನ್ನೂ ತೋರಿಸು",
   "filter_by_category": "ವರ್ಗದ ಪ್ರಕಾರ ಫಿಲ್ಟರ್ ಮಾಡಿ",

--- a/src/Locale/ml/Notifications.json
+++ b/src/Locale/ml/Notifications.json
@@ -4,6 +4,8 @@
   "mark_as_unread": "വായിക്കാത്തതായി അടയാളപ്പെടുത്തുക",
   "subscribe": "സബ്സ്ക്രൈബ് ചെയ്യുക",
   "subscribe_on_this_device": "ഈ ഉപകരണത്തിൽ സബ്സ്ക്രൈബ് ചെയ്യുക",
+  "notification_permission_denied": "അറിയിപ്പ് അനുമതി നിഷേധിച്ചു",
+  "notification_permission_granted": "അറിയിപ്പ് അനുമതി നൽകി",
   "show_unread_notifications": "വായിക്കാത്തത് കാണിക്കുക",
   "show_all_notifications": "എല്ലാം കാണിക്കുക",
   "filter_by_category": "വിഭാഗം അനുസരിച്ച് ഫിൽട്ടർ ചെയ്യുക",

--- a/src/Locale/ta/Notifications.json
+++ b/src/Locale/ta/Notifications.json
@@ -4,6 +4,8 @@
   "mark_as_unread": "படிக்காதது எனக் குறி",
   "subscribe": "குழுசேர்",
   "subscribe_on_this_device": "இந்தச் சாதனத்தில் குழுசேரவும்",
+  "notification_permission_denied": "அறிவிப்பு அனுமதி நிராகரிக்கப்பட்டது",
+  "notification_permission_granted": "அறிவிப்பு அனுமதி அளிக்கப்பட்டது",
   "show_unread_notifications": "படிக்காததைக் காட்டு",
   "show_all_notifications": "அனைத்தையும் காட்டு",
   "filter_by_category": "வகையின்படி வடிகட்டவும்",


### PR DESCRIPTION
## Proposed Changes

- Fixes #8658 
- Fixes infinite loading state when notification permission is blocked or granted.
- Adds warning toast when notifications are blocked.
- Adds success toast when notifications are granted.
## Videos of changes:

https://github.com/user-attachments/assets/b206cf55-aba8-4529-b0c8-52cd8f38b196


https://github.com/user-attachments/assets/c0f90984-d205-403e-ba60-a1ed7c06d402


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
