### PR TITLE
fixes overflow text, z-index and reply functionality breaking in Notes

### DIFF
--- a/src/Components/Facility/ConsultationDoctorNotes/index.tsx
+++ b/src/Components/Facility/ConsultationDoctorNotes/index.tsx
@@ -128,7 +128,7 @@ const ConsultationDoctorNotes = (props: ConsultationDoctorNotesProps) => {
       backUrl={`/facility/${facilityId}/patient/${patientId}`}
     >
       <div className="relative mx-3 my-2 flex grow flex-col overflow-hidden rounded-lg border border-secondary-300 bg-white p-2 sm:mx-10 sm:my-5 sm:p-5">
-        <div className="absolute inset-x-0 top-0 flex bg-secondary-200 text-sm shadow-md">
+        <div className="absolute inset-x-0 top-0 z-10 flex bg-secondary-200 text-sm shadow-md">
           {keysOf(PATIENT_NOTES_THREADS).map((current) => (
             <button
               id={`patient-note-tab-${current}`}
@@ -176,7 +176,7 @@ const ConsultationDoctorNotes = (props: ConsultationDoctorNotesProps) => {
             <ButtonV2
               onClick={onAddNote}
               border={false}
-              className="absolute right-2"
+              className="absolute right-2 border-2 border-transparent focus:border-green-500 focus:shadow-md focus:shadow-green-400"
               ghost
               size="small"
               disabled={!patientActive}

--- a/src/Components/Facility/DoctorNoteReplyPreviewCard.tsx
+++ b/src/Components/Facility/DoctorNoteReplyPreviewCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { PaitentNotesReplyModel } from "./models";
 import { USER_TYPES_MAP } from "../../Common/constants";
 import { formatDateTime, relativeDate } from "../../Utils/utils";
@@ -14,8 +14,12 @@ const DoctorNoteReplyPreviewCard = ({
   children,
   cancelReply,
 }: Props) => {
+  useEffect(() => {
+    const pages = window.document.getElementById("pages");
+    pages?.scrollTo(0, pages.scrollHeight);
+  }, [parentNote?.note]);
   return (
-    <div className="">
+    <div>
       {parentNote ? (
         <div className="mt-4 flex w-full flex-col rounded-lg border border-gray-300 bg-gray-200 p-2 text-gray-800">
           <div className="flex flex-col px-2">
@@ -50,7 +54,9 @@ const DoctorNoteReplyPreviewCard = ({
                 </div>
               )}
             </div>
-            <div className="pb-2 text-sm text-gray-700">{parentNote.note}</div>
+            <div className="max-h-[100px] overflow-auto break-words pb-2 text-sm text-gray-700">
+              {parentNote.note}
+            </div>
           </div>
           <div>{children}</div>
         </div>

--- a/src/Components/Facility/PatientNoteCard.tsx
+++ b/src/Components/Facility/PatientNoteCard.tsx
@@ -18,6 +18,7 @@ import dayjs from "dayjs";
 import Spinner from "../Common/Spinner";
 import useAuthUser from "../../Common/hooks/useAuthUser";
 import useSlug from "../../Common/hooks/useSlug";
+import useKeyboardShortcut from "use-keyboard-shortcut";
 
 const PatientNoteCard = ({
   note,
@@ -71,6 +72,16 @@ const PatientNoteCard = ({
       setReload(true);
     }
   };
+
+  useKeyboardShortcut(
+    ["Escape"],
+    () => {
+      setIsEditing(false);
+    },
+    {
+      ignoreInputFields: false,
+    },
+  );
 
   return (
     <>
@@ -161,6 +172,7 @@ const PatientNoteCard = ({
                   rows={2}
                   className="h-20 w-full resize-none rounded-lg border border-secondary-300 p-2"
                   value={noteField}
+                  autoFocus={isEditing}
                   onChange={(e) => setNoteField(e.target.value)}
                 ></textarea>
                 <div className="mt-2 flex justify-end gap-2">
@@ -176,6 +188,11 @@ const PatientNoteCard = ({
                   >
                     <CareIcon icon="l-times-circle" className="h-5 w-5" />
                     Cancel
+                    <div className="inset-y-0 hidden gap-1 md:flex">
+                      <kbd className="inline-flex items-center rounded border border-secondary-200 bg-white px-2 font-sans text-sm font-medium text-secondary-500">
+                        Esc
+                      </kbd>
+                    </div>
                   </ButtonV2>
                   <ButtonV2
                     className="py-1"
@@ -188,7 +205,9 @@ const PatientNoteCard = ({
                 </div>
               </div>
             ) : (
-              <div className="text-sm text-secondary-700">{noteField}</div>
+              <div className="break-words text-sm text-secondary-700">
+                {noteField}
+              </div>
             )}
           </div>
         }
@@ -217,7 +236,7 @@ const PatientNoteCard = ({
                 return (
                   <div
                     key={index}
-                    className="my-2 flex flex-col justify-between rounded-lg border border-secondary-300 p-4 py-2 transition-colors duration-200 hover:bg-secondary-100"
+                    className="my-2 flex w-fit flex-col justify-between rounded-lg border border-secondary-300 p-4 py-2 transition-colors duration-200 hover:bg-secondary-100"
                   >
                     <div className="flex">
                       <div className="grow">

--- a/src/Components/Patient/PatientNotes.tsx
+++ b/src/Components/Patient/PatientNotes.tsx
@@ -111,7 +111,7 @@ const PatientNotes = (props: PatientNotesProps) => {
       backUrl={`/facility/${facilityId}/patient/${patientId}`}
     >
       <div className="relative mx-3 my-2 flex grow flex-col rounded-lg border border-secondary-300 bg-white p-2 sm:mx-10 sm:my-5 sm:p-5">
-        <div className="absolute inset-x-0 top-0 flex bg-secondary-200 text-sm shadow-md">
+        <div className="absolute inset-x-0 top-0 z-10 flex bg-secondary-200 text-sm shadow-md">
           {keysOf(PATIENT_NOTES_THREADS).map((current) => (
             <button
               id={`patient-note-tab-${current}`}
@@ -158,7 +158,7 @@ const PatientNotes = (props: PatientNotesProps) => {
             <ButtonV2
               onClick={onAddNote}
               border={false}
-              className="absolute right-2"
+              className="absolute right-2 border-2 border-transparent focus:border-green-500 focus:shadow-md focus:shadow-green-400"
               ghost
               size="small"
               disabled={!patientActive}


### PR DESCRIPTION
## Proposed Changes

- Fixes #8662 
- Fixed the overflow issue caused by long single words in the notes section.
- Corrected `z-index` problems where elements in the single chat header (such as "created at") were overlapping improperly.
- Fixed the UI breaking issue when long text or replies are entered into the notes section, ensuring proper word wrapping and container behavior.
- Ensured that the "Edit History" popup handles large text inputs without breaking the UI.
## Video of changes:

https://github.com/user-attachments/assets/922ad183-f6d9-497a-bb5c-9373899cc783

### UI Improvements:

* [`src/Components/Facility/ConsultationDoctorNotes/index.tsx`](diffhunk://#diff-90957ab8e5fc1093c9e44932898865e7e5d716caa0b073a6ae862d67d32aaf3cL131-R131): Added `z-10` class to the top div to ensure it appears above other elements.
* [`src/Components/Facility/DoctorNoteReplyPreviewCard.tsx`](diffhunk://#diff-7ef258e460f3103e15f1a0f1b4997484e1ce70b608e8c582b049e562add7b285R17-R22): Added a `useEffect` hook to scroll to the bottom of the notes when a new note is added.
* [`src/Components/Facility/DoctorNoteReplyPreviewCard.tsx`](diffhunk://#diff-7ef258e460f3103e15f1a0f1b4997484e1ce70b608e8c582b049e562add7b285L53-R59): Limited the height of the note display area and added overflow auto for better readability.
* [`src/Components/Facility/PatientNoteCard.tsx`](diffhunk://#diff-11ae38d4747996f1930aff85540db2e5a42f59f7999bc5897efcf9f788104e11R175): Ensured the note field breaks words and added `autoFocus` to the text area when editing. [[1]](diffhunk://#diff-11ae38d4747996f1930aff85540db2e5a42f59f7999bc5897efcf9f788104e11R175) [[2]](diffhunk://#diff-11ae38d4747996f1930aff85540db2e5a42f59f7999bc5897efcf9f788104e11L191-R210)

### Functional Enhancements:

* [`src/Components/Facility/PatientNoteCard.tsx`](diffhunk://#diff-11ae38d4747996f1930aff85540db2e5a42f59f7999bc5897efcf9f788104e11R76-R85): Integrated `useKeyboardShortcut` to allow closing the edit mode with the `Escape` key.
* [`src/Components/Facility/PatientNoteCard.tsx`](diffhunk://#diff-11ae38d4747996f1930aff85540db2e5a42f59f7999bc5897efcf9f788104e11R191-R195): Added visual keyboard shortcut hint for the `Escape` key.

### Consistency Updates:

* [`src/Components/Facility/ConsultationDoctorNotes/index.tsx`](diffhunk://#diff-90957ab8e5fc1093c9e44932898865e7e5d716caa0b073a6ae862d67d32aaf3cL179-R179): Updated button styling to include focus states for better accessibility.
* [`src/Components/Patient/PatientNotes.tsx`](diffhunk://#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL114-R114): Applied similar changes as in `ConsultationDoctorNotes` to maintain consistency across components. [[1]](diffhunk://#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL114-R114) [[2]](diffhunk://#diff-329491648052c140490b697045689a6f7235a2ffc97610874e026b9a1972655cL161-R161)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
