### PR TITLE
Fix: Enable Remove button functionality in Add Insurance section

### DIFF
--- a/src/Components/HCX/InsuranceDetailsBuilder.tsx
+++ b/src/Components/HCX/InsuranceDetailsBuilder.tsx
@@ -44,17 +44,25 @@ export default function InsuranceDetailsBuilder(props: Props) {
   };
 
   const handleRemove = (index: number) => {
-    return () => {
-      field.handleChange(
-        (props.value || [])?.filter(async (obj, i) => {
-          if (obj.id && i === index) {
-            await request(routes.hcx.policies.delete, {
-              pathParams: { external_id: obj.id },
-            });
-          }
-          return i !== index;
-        }),
-      );
+    return async () => {
+      const updatedPolicies = [...(props.value || [])];
+      const policyToRemove = updatedPolicies[index];
+
+      if (policyToRemove?.id) {
+        try {
+          await request(routes.hcx.policies.delete, {
+            pathParams: { external_id: policyToRemove.id },
+          });
+
+          updatedPolicies.splice(index, 1);
+          field.handleChange(updatedPolicies);
+        } catch (error) {
+          console.error("Failed to delete the policy", error);
+        }
+      } else {
+        updatedPolicies.splice(index, 1);
+        field.handleChange(updatedPolicies);
+      }
     };
   };
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #8664 
- Implemented functionality for the "Remove" button in the "Add Insurance" section.
   Ensured that the button removes the corresponding input fields without affecting other data.


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

-  [X] Add specs that demonstrate bug / test a new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [X] Completion of QA
