### PR TITLE
Fix comment overflow and ensure content fits within div

### DIFF
--- a/src/Components/Resource/CommentSection.tsx
+++ b/src/Components/Resource/CommentSection.tsx
@@ -86,7 +86,16 @@ export const Comment = ({
 }: IComment) => (
   <div className="mt-4 flex w-full flex-col rounded-lg border border-secondary-300 bg-white p-4 text-secondary-800">
     <div className="flex w-full">
-      <p className="text-justify">{comment}</p>
+      <p
+        className="text-justify"
+        style={{
+          whiteSpace: "normal",
+          wordBreak: "break-all",
+          overflowWrap: "break-word",
+        }}
+      >
+        {comment}
+      </p>
     </div>
     <div className="mt-3">
       <span className="text-xs text-secondary-500">

--- a/src/Components/Shifting/CommentsSection.tsx
+++ b/src/Components/Shifting/CommentsSection.tsx
@@ -95,7 +95,16 @@ export const Comment = ({
       className="mt-4 flex w-full flex-col rounded-lg border border-secondary-300 bg-white p-4 text-secondary-800"
     >
       <div className="flex w-full">
-        <p className="text-justify">{comment}</p>
+        <p
+          className="text-justify"
+          style={{
+            whiteSpace: "normal",
+            wordBreak: "break-all",
+            overflowWrap: "break-word",
+          }}
+        >
+          {comment}
+        </p>
       </div>
       <div className="mt-3">
         <span className="text-xs text-secondary-500">


### PR DESCRIPTION
## Proposed Changes

- Fixes #8699 
- Fixed the comment overflow issue in shifting and Resource to ensure content stays within the div 


@ohcnetwork/care-fe-code-reviewers

<img width="1440" alt="Screenshot 2024-10-04 at 7 13 46 AM" src="https://github.com/user-attachments/assets/bf47ec60-fcdb-4778-87c1-c081cace4a0a">


## Merge Checklist

- [X] Add specs that demonstrate bug / test a new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [X] Completion of QA
