### PR TITLE
Fix: Error Messages Persist in UserAdd Component

### DIFF
--- a/src/Components/Users/UserAdd.tsx
+++ b/src/Components/Users/UserAdd.tsx
@@ -294,6 +294,7 @@ export const UserAdd = (props: UserProps) => {
 
   const handleDateChange = (e: FieldChangeEvent<Date>) => {
     if (dayjs(e.value).isValid()) {
+      const errors = { ...state.errors, [e.name]: "" };
       dispatch({
         type: "set_form",
         form: {
@@ -301,10 +302,12 @@ export const UserAdd = (props: UserProps) => {
           [e.name]: dayjs(e.value).format("YYYY-MM-DD"),
         },
       });
+      dispatch({ type: "set_errors", errors });
     }
   };
 
   const handleFieldChange = (event: FieldChangeEvent<unknown>) => {
+    const errors = { ...state.errors, [event.name]: "" };
     dispatch({
       type: "set_form",
       form: {
@@ -312,6 +315,7 @@ export const UserAdd = (props: UserProps) => {
         [event.name]: event.value,
       },
     });
+    dispatch({ type: "set_errors", errors });
   };
 
   useAbortableEffect(() => {


### PR DESCRIPTION
## Proposed Changes

- Fixes #8720 
- Clear error messages when the user starts typing in an input field.
- Clear error messages when the user selects an item from a dropdown.
- Improved user experience by ensuring error messages are only shown when necessary.

@ohcnetwork/care-fe-code-reviewers
## Video of change:

## Merge Checklist

https://github.com/user-attachments/assets/c8ddded3-265a-4253-aea3-8ea0086fd2cb


- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
