### PR TITLE
Feat: Allow Users to Edit and Delete Their Own Comments in shifting a…

### DIFF
--- a/src/Components/Common/components/Menu.tsx
+++ b/src/Components/Common/components/Menu.tsx
@@ -9,7 +9,8 @@ import { useIsAuthorized } from "../../../Common/hooks/useIsAuthorized";
 
 interface DropdownMenuProps {
   id?: string;
-  title: string;
+  title?: string;
+  dropdownIconVisible?: boolean;
   variant?: ButtonVariant;
   size?: ButtonSize;
   icon?: JSX.Element | undefined;
@@ -23,6 +24,7 @@ interface DropdownMenuProps {
 export default function DropdownMenu({
   variant = "primary",
   size = "default",
+  dropdownIconVisible = true,
   ...props
 }: DropdownMenuProps) {
   return (
@@ -42,12 +44,14 @@ export default function DropdownMenu({
             )}
           >
             {props.icon}
-            {props.title || "Dropdown"}
+            {props.title}
           </div>
-          <CareIcon
-            icon="l-angle-down"
-            className={size === "small" ? "text-base" : "text-lg"}
-          />
+          {dropdownIconVisible && (
+            <CareIcon
+              icon="l-angle-down"
+              className={size === "small" ? "text-base" : "text-lg"}
+            />
+          )}
         </MenuButton>
 
         <MenuItems

--- a/src/Components/Shifting/CommentsSection.tsx
+++ b/src/Components/Shifting/CommentsSection.tsx
@@ -8,6 +8,11 @@ import routes from "../../Redux/api";
 import { IComment } from "../Resource/models";
 import PaginatedList from "../../CAREUI/misc/PaginatedList";
 import request from "../../Utils/request/request";
+import { useAuthContext } from "../../Common/hooks/useAuthUser";
+import DropdownMenu, { DropdownItem } from "../Common/components/Menu";
+import CareIcon from "../../CAREUI/icons/CareIcon";
+import TextAreaFormField from "../Form/FormFields/TextAreaFormField";
+import ConfirmDialog from "../Common/ConfirmDialog";
 
 interface CommentSectionProps {
   id: string;
@@ -88,28 +93,112 @@ export const Comment = ({
   created_by_object,
   modified_date,
 }: IComment) => {
-  const { t } = useTranslation();
+  const [isCommentEditable, setIsCommentEditable] = useState(false);
+  const [openDeleteCommentDialog, setOpenDeleteCommentDialog] = useState(false);
+  const [commentBox, setCommentBox] = useState(comment);
+  const { user } = useAuthContext();
+  const handleResourceDelete = async () => {
+    const { res, error } = await request(routes.deleteShiftComments, {
+      pathParams: { id },
+    });
+    if (res?.status === 204) {
+      Notification.Success({
+        msg: "Comment deleted successfully",
+      });
+    } else {
+      Notification.Error({
+        msg: "Error while deleting comment: " + (error || ""),
+      });
+    }
+  };
+  const handleCommentUpdate = async () => {
+    const payload = {
+      comment: commentBox,
+    };
+    if (!/\S+/.test(commentBox)) {
+      Notification.Error({
+        msg: "Comment Should Contain At Least 1 Character",
+      });
+      return;
+    }
+    const { res } = await request(routes.updateShiftComments, {
+      pathParams: { id },
+      body: payload,
+    });
+    if (res?.ok) {
+      Notification.Success({ msg: "Comment updated successfully" });
+    }
+    setCommentBox("");
+    setIsCommentEditable((prev) => !prev);
+  };
   return (
     <div
       key={id}
       className="mt-4 flex w-full flex-col rounded-lg border border-secondary-300 bg-white p-4 text-secondary-800"
     >
-      <div className="flex w-full">
-        <p className="text-justify">{comment}</p>
+      <div className="flex w-full justify-between gap-2">
+        {isCommentEditable ? (
+          <TextAreaFormField
+            name="comment"
+            value={commentBox}
+            onChange={(e) => setCommentBox(e.value)}
+            className="w-full"
+          />
+        ) : (
+          <p className="break-all text-justify">{comment}</p>
+        )}
+        {created_by_object.id === user?.id && (
+          <DropdownMenu
+            variant="secondary"
+            icon={<CareIcon icon="l-ellipsis-v" className="size-6" />}
+            dropdownIconVisible={false}
+            className="w-fit bg-white px-4 hover:bg-transparent"
+            containerClassName="mr-4"
+          >
+            <DropdownItem
+              className="pl-0 text-black hover:bg-gray-200"
+              onClick={() => setIsCommentEditable((prev) => !prev)}
+            >
+              Edit
+            </DropdownItem>
+            <DropdownItem
+              className="pl-0 text-red-700 hover:bg-red-100"
+              onClick={() => setOpenDeleteCommentDialog(true)}
+            >
+              Delete
+            </DropdownItem>
+          </DropdownMenu>
+        )}
       </div>
       <div className="mt-3">
         <span className="text-xs text-secondary-500">
           {modified_date ? formatDateTime(modified_date) : "-"}
         </span>
       </div>
-      <div className="mr-auto flex items-center rounded-md border bg-secondary-100 py-1 pl-2 pr-3">
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-700 p-1 uppercase text-white">
-          {created_by_object?.first_name?.charAt(0) || t("unknown")}
+      <div className="flex justify-between">
+        <div className="mr-auto flex items-center rounded-md border bg-secondary-100 py-1 pl-2 pr-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-700 p-1 uppercase text-white">
+            {created_by_object?.first_name?.charAt(0) || "U"}
+          </div>
+          <span className="pl-2 text-sm text-secondary-700">
+            {formatName(created_by_object)}
+          </span>
         </div>
-        <span className="pl-2 text-sm text-secondary-700">
-          {formatName(created_by_object)}
-        </span>
+        {isCommentEditable && (
+          <ButtonV2 className="mr-4" onClick={handleCommentUpdate}>
+            Update
+          </ButtonV2>
+        )}
       </div>
+      <ConfirmDialog
+        title="Delete Comment"
+        description="Are you sure you want to delete this comment?"
+        action="Delete"
+        variant="danger"
+        show={openDeleteCommentDialog}
+        onClose={() => setOpenDeleteCommentDialog(false)}
+        onConfirm={handleResourceDelete}
+      />
     </div>
   );
 };

--- a/src/Redux/api.tsx
+++ b/src/Redux/api.tsx
@@ -1138,6 +1138,17 @@ const routes = {
     TBody: Type<Partial<IComment>>(),
     TRes: Type<IComment>(),
   },
+  updateShiftComments: {
+    path: "/api/v1/resource/{id}/comment/",
+    method: "PUT",
+    TRes: Type<IComment>(),
+    TBody: Type<Partial<IComment>>(),
+  },
+  deleteShiftComments: {
+    path: "/api/v1/resource/{id}/comment/",
+    method: "DELETE",
+    TRes: Type<Record<string, never>>(),
+  },
 
   // Notifications
   getNotifications: {
@@ -1309,6 +1320,17 @@ const routes = {
     method: "POST",
     TRes: Type<IComment>(),
     TBody: Type<Partial<IComment>>(),
+  },
+  updateResourceComments: {
+    path: "/api/v1/resource/{id}/comment/",
+    method: "PUT",
+    TRes: Type<IComment>(),
+    TBody: Type<Partial<IComment>>(),
+  },
+  deleteResourceComments: {
+    path: "/api/v1/resource/{id}/comment/",
+    method: "DELETE",
+    TRes: Type<Record<string, never>>(),
   },
 
   // Assets endpoints


### PR DESCRIPTION
## Proposed Changes

- Fixes #8701 
- Added users to update their comments, with changes saved upon submission.
- Allowing users to remove their comments after confirming the action.

[Screencast from 2024-10-06 01-16-46.webm](https://github.com/user-attachments/assets/db1420a0-de55-4780-8175-2c703299d38d)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA

