### PR TITLE
Hide Spokes on Facility Create Page

### DIFF
--- a/src/Components/Facility/FacilityCreate.tsx
+++ b/src/Components/Facility/FacilityCreate.tsx
@@ -851,14 +851,14 @@ export const FacilityCreate = (props: FacilityProps) => {
                     required
                     types={["mobile", "landline"]}
                   />
-                  <div className="py-4 md:col-span-2">
-                    <h4 className="mb-4">{t("spokes")}</h4>
-                    {facilityId && (
+                  {facilityId && (
+                    <div className="py-4 md:col-span-2">
+                      <h4 className="mb-4">{t("spokes")}</h4>
                       <SpokeFacilityEditor
                         facility={{ ...facilityQuery.data, id: facilityId }}
                       />
-                    )}
-                  </div>
+                    </div>
+                  )}
                   <div className="grid grid-cols-1 gap-4 py-4 sm:grid-cols-2 md:col-span-2 xl:grid-cols-4">
                     <TextFormField
                       {...field("oxygen_capacity")}


### PR DESCRIPTION
## Proposed Changes

- Partially #8624 

Following the conversation on slack, hiding spokes heading on facility creation page.

Before

![image](https://github.com/user-attachments/assets/26ee23df-a9c4-405d-945f-431d45c441e6)

After

![image](https://github.com/user-attachments/assets/18d67faf-562b-4a63-9d71-a86f370a0221)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
