### PR TITLE
Sort only `en` locale file in the sort-locale script; Update docker and CI to use `npm run install-all`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
     "cpus": 4
   },
   "waitFor": "onCreateCommand",
-  "postCreateCommand": "npm install",
+  "postCreateCommand": "npm run install-all",
   "postAttachCommand": {
     "server": "npm run dev"
   },

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -70,7 +70,7 @@ jobs:
           node-version: "20"
 
       - name: Install dependencies 📦
-        run: npm install
+        run: npm run install-all
 
       - name: Build ⚙️
         run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN npm install
 
 COPY . .
 
+RUN npm run setup
+
 RUN npm run build
 
 

--- a/scripts/sort-locales.js
+++ b/scripts/sort-locales.js
@@ -1,26 +1,15 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require("fs");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const path = require("path");
 
-const directory = "src/Locale";
+const file = "src/Locale/en.json";
 
-fs.readdir(directory, (err, files) => {
-  if (err) throw err;
+const data = JSON.parse(fs.readFileSync(file, "utf8"));
 
-  files.forEach((file) => {
-    if (file.endsWith(".json")) {
-      const filePath = path.join(directory, file);
-      const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+const sortedData = Object.keys(data)
+  .sort()
+  .reduce((acc, key) => {
+    acc[key] = data[key];
+    return acc;
+  }, {});
 
-      const sortedData = Object.keys(data)
-        .sort()
-        .reduce((acc, key) => {
-          acc[key] = data[key];
-          return acc;
-        }, {});
-
-      fs.writeFileSync(filePath, JSON.stringify(sortedData, null, 2) + "\n");
-    }
-  });
-});
+fs.writeFileSync(file, JSON.stringify(sortedData, null, 2) + "\n");


### PR DESCRIPTION
## Proposed Changes

- Enhancement based on review comment: https://github.com/ohcnetwork/care_fe/pull/8806#discussion_r1803264797
- Updated docker and CI scripts to use `npm run install-all`/`npm run setup` instead of `npm i`

@ohcnetwork/care-fe-code-reviewers


