### PR TITLE
First added diagnosis in create consultation removal

### DIFF
--- a/src/Components/Diagnosis/ConsultationDiagnosisBuilder/ConsultationDiagnosisBuilder.tsx
+++ b/src/Components/Diagnosis/ConsultationDiagnosisBuilder/ConsultationDiagnosisBuilder.tsx
@@ -30,7 +30,9 @@ export const CreateDiagnosesBuilder = (props: CreateDiagnosesProps) => {
                 value={diagnosis}
                 onChange={(action) => {
                   if (action.type === "remove") {
-                    props.onChange([...props.value].splice(index, 1));
+                    const updatedDiagnoses = [...props.value];
+                    updatedDiagnoses.splice(index, 1);
+                    props.onChange(updatedDiagnoses);
                   }
 
                   if (action.type === "edit") {


### PR DESCRIPTION
## The first added diagnosis is removing

- Fixes #8849 
- Change 1: Fixed logic to ensure the first added diagnosis is removable in the create consultation form.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
