### PR TITLE
Remove asset detail popup in asset configure's camera feed

### DIFF
--- a/src/Components/Assets/AssetConfigure.tsx
+++ b/src/Components/Assets/AssetConfigure.tsx
@@ -61,11 +61,7 @@ const AssetConfigure = ({ assetId, facilityId }: AssetConfigureProps) => {
       }}
       backUrl={`/facility/${facilityId}/assets/${assetId}`}
     >
-      <ConfigureCamera
-        asset={asset}
-        onUpdated={() => refetch()}
-        hideMonitorAsset={true}
-      />
+      <ConfigureCamera asset={asset} onUpdated={() => refetch()} />
     </Page>
   );
 };

--- a/src/Components/Assets/AssetConfigure.tsx
+++ b/src/Components/Assets/AssetConfigure.tsx
@@ -64,7 +64,7 @@ const AssetConfigure = ({ assetId, facilityId }: AssetConfigureProps) => {
       <ConfigureCamera
         asset={asset}
         onUpdated={() => refetch()}
-        isAssetConfigure={true}
+        hideMonitorAsset={true}
       />
     </Page>
   );

--- a/src/Components/Assets/AssetConfigure.tsx
+++ b/src/Components/Assets/AssetConfigure.tsx
@@ -64,7 +64,7 @@ const AssetConfigure = ({ assetId, facilityId }: AssetConfigureProps) => {
       <ConfigureCamera
         asset={asset}
         onUpdated={() => refetch()}
-        isAssetCongfigure={true}
+        isAssetConfigure={true}
       />
     </Page>
   );

--- a/src/Components/Assets/AssetConfigure.tsx
+++ b/src/Components/Assets/AssetConfigure.tsx
@@ -61,7 +61,11 @@ const AssetConfigure = ({ assetId, facilityId }: AssetConfigureProps) => {
       }}
       backUrl={`/facility/${facilityId}/assets/${assetId}`}
     >
-      <ConfigureCamera asset={asset} onUpdated={() => refetch()} />
+      <ConfigureCamera
+        asset={asset}
+        onUpdated={() => refetch()}
+        isAssetCongfigure={true}
+      />
     </Page>
   );
 };

--- a/src/Components/CameraFeed/CameraFeed.tsx
+++ b/src/Components/CameraFeed/CameraFeed.tsx
@@ -28,6 +28,8 @@ interface Props {
   shortcutsDisabled?: boolean;
   onMove?: () => void;
   operate: ReturnType<typeof useOperateCamera>["operate"];
+  //Assest Configuration
+  isAssetConfigurationPage?: boolean;
 }
 
 export default function CameraFeed(props: Props) {
@@ -145,6 +147,8 @@ export default function CameraFeed(props: Props) {
     />
   );
 
+  const isAssetConfigurationPage = props.isAssetConfigurationPage || false;
+
   return (
     <div ref={playerWrapperRef} className="flex h-full flex-col justify-center">
       <div
@@ -183,15 +187,18 @@ export default function CameraFeed(props: Props) {
             {props.children}
           </div>
           <div className="flex w-full flex-col items-end justify-end md:flex-row md:items-center md:gap-4">
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-bold md:text-sm">
-                {props.asset.name}
-              </span>
-              <MonitorAssetPopover
-                asset={props.asset}
-                className="absolute z-[100] mt-2 w-56 -translate-x-full -translate-y-4 rounded-md bg-white md:w-[350px] md:-translate-x-full md:-translate-y-2"
-              />
-            </div>
+            {!isAssetConfigurationPage && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-bold md:text-sm">
+                  {props.asset.name}
+                </span>
+                <MonitorAssetPopover
+                  asset={props.asset}
+                  className="absolute z-[100] mt-2 w-56 -translate-x-full -translate-y-4 rounded-md bg-white md:w-[350px] md:-translate-x-full md:-translate-y-2"
+                />
+              </div>
+            )}
+
             {!isIOS && (
               <div
                 className={classNames(

--- a/src/Components/CameraFeed/CameraFeed.tsx
+++ b/src/Components/CameraFeed/CameraFeed.tsx
@@ -12,7 +12,7 @@ import useFullscreen from "../../Common/hooks/useFullscreen";
 import useBreakpoints from "../../Common/hooks/useBreakpoints";
 import { GetPresetsResponse } from "./routes";
 import VideoPlayer from "./videoPlayer";
-import MonitorAssetPopover from "../Common/MonitorAssetPopover";
+import AssetInfoPopover from "../Common/AssetInfoPopover";
 
 interface Props {
   children?: React.ReactNode;
@@ -28,8 +28,7 @@ interface Props {
   shortcutsDisabled?: boolean;
   onMove?: () => void;
   operate: ReturnType<typeof useOperateCamera>["operate"];
-  //Monitor Hide or Show
-  hideMonitorAsset?: boolean;
+  hideAssetInfo?: boolean;
 }
 
 export default function CameraFeed(props: Props) {
@@ -147,8 +146,6 @@ export default function CameraFeed(props: Props) {
     />
   );
 
-  const hideMonitorAsset = props.hideMonitorAsset || false;
-
   return (
     <div ref={playerWrapperRef} className="flex h-full flex-col justify-center">
       <div
@@ -187,12 +184,12 @@ export default function CameraFeed(props: Props) {
             {props.children}
           </div>
           <div className="flex w-full flex-col items-end justify-end md:flex-row md:items-center md:gap-4">
-            {!hideMonitorAsset && (
+            {!props.hideAssetInfo && (
               <div className="flex items-center gap-2">
                 <span className="text-xs font-bold md:text-sm">
                   {props.asset.name}
                 </span>
-                <MonitorAssetPopover
+                <AssetInfoPopover
                   asset={props.asset}
                   className="absolute z-[100] mt-2 w-56 -translate-x-full -translate-y-4 rounded-md bg-white md:w-[350px] md:-translate-x-full md:-translate-y-2"
                 />

--- a/src/Components/CameraFeed/CameraFeed.tsx
+++ b/src/Components/CameraFeed/CameraFeed.tsx
@@ -28,8 +28,8 @@ interface Props {
   shortcutsDisabled?: boolean;
   onMove?: () => void;
   operate: ReturnType<typeof useOperateCamera>["operate"];
-  //Assest Configuration
-  isAssetConfigurationPage?: boolean;
+  //Monitor Hide or Show
+  hideMonitorAsset?: boolean;
 }
 
 export default function CameraFeed(props: Props) {
@@ -147,7 +147,7 @@ export default function CameraFeed(props: Props) {
     />
   );
 
-  const isAssetConfigurationPage = props.isAssetConfigurationPage || false;
+  const hideMonitorAsset = props.hideMonitorAsset || false;
 
   return (
     <div ref={playerWrapperRef} className="flex h-full flex-col justify-center">
@@ -187,7 +187,7 @@ export default function CameraFeed(props: Props) {
             {props.children}
           </div>
           <div className="flex w-full flex-col items-end justify-end md:flex-row md:items-center md:gap-4">
-            {!isAssetConfigurationPage && (
+            {!hideMonitorAsset && (
               <div className="flex items-center gap-2">
                 <span className="text-xs font-bold md:text-sm">
                   {props.asset.name}

--- a/src/Components/CameraFeed/ConfigureCamera.tsx
+++ b/src/Components/CameraFeed/ConfigureCamera.tsx
@@ -33,6 +33,7 @@ import CheckBoxFormField from "../Form/FormFields/CheckBoxFormField";
 interface Props {
   asset: AssetData;
   onUpdated: () => void;
+  isAssetCongfigure?: boolean;
 }
 
 type OnvifPreset = { name: string; value: number };
@@ -58,6 +59,7 @@ export default function ConfigureCamera(props: Props) {
   }>();
   const [presetName, setPresetName] = useState("");
   const [showUnlinkConfirmation, setShowUnlinkConfirmation] = useState(false);
+  const isAssetCongfigure = props.isAssetCongfigure || false;
 
   const assetBedsQuery = useQuery(routes.listAssetBeds, {
     query: { asset: props.asset.id, limit: 50 },
@@ -106,7 +108,12 @@ export default function ConfigureCamera(props: Props) {
   if (!["DistrictAdmin", "StateAdmin"].includes(authUser.user_type)) {
     return (
       <div className="w-full overflow-hidden rounded-lg bg-white shadow">
-        <CameraFeed asset={props.asset} key={key} operate={operate} />
+        <CameraFeed
+          asset={props.asset}
+          key={key}
+          operate={operate}
+          isAssetConfigurationPage={isAssetCongfigure}
+        />
       </div>
     );
   }
@@ -246,6 +253,7 @@ export default function ConfigureCamera(props: Props) {
                 );
               }
             }}
+            isAssetConfigurationPage={isAssetCongfigure}
           >
             <div className="flex items-center gap-2">
               <Listbox
@@ -552,6 +560,7 @@ export default function ConfigureCamera(props: Props) {
                         <div className="flex flex-col">
                           <span className="font-semibold">{preset.name}</span>
                           <span className="text-xs">
+                            asudhbu
                             <RecordMeta
                               prefix="last updated"
                               time={preset.modified_date}

--- a/src/Components/CameraFeed/ConfigureCamera.tsx
+++ b/src/Components/CameraFeed/ConfigureCamera.tsx
@@ -560,7 +560,6 @@ export default function ConfigureCamera(props: Props) {
                         <div className="flex flex-col">
                           <span className="font-semibold">{preset.name}</span>
                           <span className="text-xs">
-                            asudhbu
                             <RecordMeta
                               prefix="last updated"
                               time={preset.modified_date}

--- a/src/Components/CameraFeed/ConfigureCamera.tsx
+++ b/src/Components/CameraFeed/ConfigureCamera.tsx
@@ -33,8 +33,6 @@ import CheckBoxFormField from "../Form/FormFields/CheckBoxFormField";
 interface Props {
   asset: AssetData;
   onUpdated: () => void;
-  //show or hide camera pop-up
-  hideMonitorAsset?: boolean;
 }
 
 type OnvifPreset = { name: string; value: number };
@@ -60,7 +58,6 @@ export default function ConfigureCamera(props: Props) {
   }>();
   const [presetName, setPresetName] = useState("");
   const [showUnlinkConfirmation, setShowUnlinkConfirmation] = useState(false);
-  const hideMonitorAsset = props.hideMonitorAsset || false;
 
   const assetBedsQuery = useQuery(routes.listAssetBeds, {
     query: { asset: props.asset.id, limit: 50 },
@@ -113,7 +110,7 @@ export default function ConfigureCamera(props: Props) {
           asset={props.asset}
           key={key}
           operate={operate}
-          hideMonitorAsset={hideMonitorAsset}
+          hideAssetInfo
         />
       </div>
     );
@@ -254,7 +251,7 @@ export default function ConfigureCamera(props: Props) {
                 );
               }
             }}
-            hideMonitorAsset={hideMonitorAsset}
+            hideAssetInfo
           >
             <div className="flex items-center gap-2">
               <Listbox

--- a/src/Components/CameraFeed/ConfigureCamera.tsx
+++ b/src/Components/CameraFeed/ConfigureCamera.tsx
@@ -33,7 +33,7 @@ import CheckBoxFormField from "../Form/FormFields/CheckBoxFormField";
 interface Props {
   asset: AssetData;
   onUpdated: () => void;
-  isAssetCongfigure?: boolean;
+  isAssetConfigure?: boolean;
 }
 
 type OnvifPreset = { name: string; value: number };
@@ -59,7 +59,7 @@ export default function ConfigureCamera(props: Props) {
   }>();
   const [presetName, setPresetName] = useState("");
   const [showUnlinkConfirmation, setShowUnlinkConfirmation] = useState(false);
-  const isAssetCongfigure = props.isAssetCongfigure || false;
+  const isAssetConfigure = props.isAssetConfigure || false;
 
   const assetBedsQuery = useQuery(routes.listAssetBeds, {
     query: { asset: props.asset.id, limit: 50 },
@@ -112,7 +112,7 @@ export default function ConfigureCamera(props: Props) {
           asset={props.asset}
           key={key}
           operate={operate}
-          isAssetConfigurationPage={isAssetCongfigure}
+          isAssetConfigurationPage={isAssetConfigure}
         />
       </div>
     );
@@ -253,7 +253,7 @@ export default function ConfigureCamera(props: Props) {
                 );
               }
             }}
-            isAssetConfigurationPage={isAssetCongfigure}
+            isAssetConfigurationPage={isAssetConfigure}
           >
             <div className="flex items-center gap-2">
               <Listbox

--- a/src/Components/CameraFeed/ConfigureCamera.tsx
+++ b/src/Components/CameraFeed/ConfigureCamera.tsx
@@ -33,7 +33,8 @@ import CheckBoxFormField from "../Form/FormFields/CheckBoxFormField";
 interface Props {
   asset: AssetData;
   onUpdated: () => void;
-  isAssetConfigure?: boolean;
+  //show or hide camera pop-up
+  hideMonitorAsset?: boolean;
 }
 
 type OnvifPreset = { name: string; value: number };
@@ -59,7 +60,7 @@ export default function ConfigureCamera(props: Props) {
   }>();
   const [presetName, setPresetName] = useState("");
   const [showUnlinkConfirmation, setShowUnlinkConfirmation] = useState(false);
-  const isAssetConfigure = props.isAssetConfigure || false;
+  const hideMonitorAsset = props.hideMonitorAsset || false;
 
   const assetBedsQuery = useQuery(routes.listAssetBeds, {
     query: { asset: props.asset.id, limit: 50 },
@@ -112,7 +113,7 @@ export default function ConfigureCamera(props: Props) {
           asset={props.asset}
           key={key}
           operate={operate}
-          isAssetConfigurationPage={isAssetConfigure}
+          hideMonitorAsset={hideMonitorAsset}
         />
       </div>
     );
@@ -253,7 +254,7 @@ export default function ConfigureCamera(props: Props) {
                 );
               }
             }}
-            isAssetConfigurationPage={isAssetConfigure}
+            hideMonitorAsset={hideMonitorAsset}
           >
             <div className="flex items-center gap-2">
               <Listbox

--- a/src/Components/Common/AssetInfoPopover.tsx
+++ b/src/Components/Common/AssetInfoPopover.tsx
@@ -1,6 +1,6 @@
 import CareIcon from "../../CAREUI/icons/CareIcon";
 import { AssetData, assetClassProps } from "../Assets/AssetTypes";
-import ButtonV2 from "../Common/components/ButtonV2";
+import ButtonV2 from "./components/ButtonV2";
 import { navigate } from "raviger";
 import { useTranslation } from "react-i18next";
 import {
@@ -10,15 +10,12 @@ import {
   Transition,
 } from "@headlessui/react";
 
-interface MonitorAssetPopoverProps {
+interface AssetInfoPopoverProps {
   asset?: AssetData;
   className?: string;
 }
 
-const MonitorAssetPopover = ({
-  asset,
-  className,
-}: MonitorAssetPopoverProps) => {
+const AssetInfoPopover = ({ asset, className }: AssetInfoPopoverProps) => {
   const { t } = useTranslation();
 
   return (
@@ -87,4 +84,4 @@ const MonitorAssetPopover = ({
   );
 };
 
-export default MonitorAssetPopover;
+export default AssetInfoPopover;

--- a/src/Components/VitalsMonitor/VitalsMonitorFooter.tsx
+++ b/src/Components/VitalsMonitor/VitalsMonitorFooter.tsx
@@ -1,5 +1,5 @@
 import { AssetData } from "../Assets/AssetTypes";
-import MonitorAssetPopover from "../Common/MonitorAssetPopover";
+import AssetInfoPopover from "../Common/AssetInfoPopover";
 
 interface IVitalsMonitorFooterProps {
   asset?: AssetData;
@@ -9,7 +9,7 @@ const VitalsMonitorFooter = ({ asset }: IVitalsMonitorFooterProps) => {
   return (
     <div className="flex w-full items-center gap-2 text-xs tracking-wide md:text-sm">
       <p className="text-secondary-500">{asset?.name}</p>
-      <MonitorAssetPopover
+      <AssetInfoPopover
         asset={asset}
         className="absolute z-[100] mt-2 w-56 -translate-x-1/3 translate-y-[-280px] rounded-md bg-white md:w-[350px] md:-translate-y-full md:translate-x-6"
       />


### PR DESCRIPTION
## Proposed Changes

- Fixes #8844 
- Removal of the camera name and details pop-up from the camera feed component on the asset configuration page
- Ensured that this change does not affect the functionality of the camera feed component on other pages.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
