### PR TITLE
Adding of clear and cancel button in create preset form

### DIFF
--- a/src/components/CameraFeed/ConfigureCamera.tsx
+++ b/src/components/CameraFeed/ConfigureCamera.tsx
@@ -389,16 +389,37 @@ export default function ConfigureCamera(props: Props) {
                     setPresetName("");
                   }}
                 >
-                  <TextFormField
-                    name="preset-name"
-                    className="py-4"
-                    value={presetName}
-                    onChange={({ value }) => setPresetName(value)}
-                    errorClassName="hidden"
-                    placeholder={t("preset_name_placeholder")}
-                    suggestions={presetNameSuggestions}
-                  />
-                  <div className="cui-form-button-group">
+                  <div className="relative w-full">
+                    <TextFormField
+                      name="preset-name"
+                      className="w-full py-4"
+                      value={presetName}
+                      onChange={({ value }) => setPresetName(value)}
+                      errorClassName="hidden"
+                      placeholder={t("preset_name_placeholder")}
+                      suggestions={presetNameSuggestions}
+                    />
+                    {presetName && (
+                      <button
+                        type="button"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 transform text-gray-500"
+                        onClick={() => setPresetName("")}
+                      >
+                        <CareIcon icon="l-times-circle" className="text-lg" />
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="cui-form-button-group mt-4 flex w-full flex-col justify-end space-y-2 sm:flex-row sm:space-x-2 sm:space-y-0">
+                    <Cancel
+                      shadow={false}
+                      onClick={() => {
+                        setCreatePreset(undefined);
+                        setPresetName("");
+                      }}
+                      className="ml-0 w-full sm:ml-2 sm:w-auto"
+                    />
+
                     <Submit
                       onClick={async () => {
                         const { res } = await request(FeedRoutes.createPreset, {
@@ -417,6 +438,7 @@ export default function ConfigureCamera(props: Props) {
                         cameraPresetsQuery.refetch();
                       }}
                       disabled={!presetName}
+                      className="w-full sm:w-auto"
                     />
                   </div>
                 </DialogModal>

--- a/src/components/CameraFeed/ConfigureCamera.tsx
+++ b/src/components/CameraFeed/ConfigureCamera.tsx
@@ -389,26 +389,23 @@ export default function ConfigureCamera(props: Props) {
                     setPresetName("");
                   }}
                 >
-                  <div className="relative w-full">
-                    <TextFormField
-                      name="preset-name"
-                      className="w-full py-4"
-                      value={presetName}
-                      onChange={({ value }) => setPresetName(value)}
-                      errorClassName="hidden"
-                      placeholder={t("preset_name_placeholder")}
-                      suggestions={presetNameSuggestions}
-                      isClear={true}
-                    />
-                  </div>
+                  <TextFormField
+                    name="preset-name"
+                    className="w-full py-4"
+                    value={presetName}
+                    onChange={({ value }) => setPresetName(value)}
+                    errorClassName="hidden"
+                    placeholder={t("preset_name_placeholder")}
+                    suggestions={presetNameSuggestions}
+                    clearable={true}
+                  />
 
-                  <div className="cui-form-button-group mt-4 flex w-full flex-col justify-end space-y-2 sm:flex-row sm:space-x-2 sm:space-y-0">
+                  <div className="cui-form-button-group">
                     <Cancel
                       onClick={() => {
                         setCreatePreset(undefined);
                         setPresetName("");
                       }}
-                      className="ml-0 w-full sm:ml-2 sm:w-auto"
                     />
 
                     <Submit
@@ -429,7 +426,6 @@ export default function ConfigureCamera(props: Props) {
                         cameraPresetsQuery.refetch();
                       }}
                       disabled={!presetName}
-                      className="w-full sm:w-auto"
                     />
                   </div>
                 </DialogModal>

--- a/src/components/CameraFeed/ConfigureCamera.tsx
+++ b/src/components/CameraFeed/ConfigureCamera.tsx
@@ -398,16 +398,8 @@ export default function ConfigureCamera(props: Props) {
                       errorClassName="hidden"
                       placeholder={t("preset_name_placeholder")}
                       suggestions={presetNameSuggestions}
+                      isClear={true}
                     />
-                    {presetName && (
-                      <button
-                        type="button"
-                        className="absolute right-2 top-1/2 -translate-y-1/2 transform text-gray-500"
-                        onClick={() => setPresetName("")}
-                      >
-                        <CareIcon icon="l-times-circle" className="text-lg" />
-                      </button>
-                    )}
                   </div>
 
                   <div className="cui-form-button-group mt-4 flex w-full flex-col justify-end space-y-2 sm:flex-row sm:space-x-2 sm:space-y-0">

--- a/src/components/CameraFeed/ConfigureCamera.tsx
+++ b/src/components/CameraFeed/ConfigureCamera.tsx
@@ -412,7 +412,6 @@ export default function ConfigureCamera(props: Props) {
 
                   <div className="cui-form-button-group mt-4 flex w-full flex-col justify-end space-y-2 sm:flex-row sm:space-x-2 sm:space-y-0">
                     <Cancel
-                      shadow={false}
                       onClick={() => {
                         setCreatePreset(undefined);
                         setPresetName("");

--- a/src/components/CameraFeed/ConfigureCamera.tsx
+++ b/src/components/CameraFeed/ConfigureCamera.tsx
@@ -407,7 +407,6 @@ export default function ConfigureCamera(props: Props) {
                         setPresetName("");
                       }}
                     />
-
                     <Submit
                       onClick={async () => {
                         const { res } = await request(FeedRoutes.createPreset, {

--- a/src/components/Form/FormFields/TextFormField.tsx
+++ b/src/components/Form/FormFields/TextFormField.tsx
@@ -24,7 +24,7 @@ export type TextFormFieldProps = FormFieldBaseProps<string> &
     trailingPadding?: string | undefined;
     leadingPadding?: string | undefined;
     suggestions?: string[];
-    isClear?: boolean;
+    clearable?: boolean | undefined;
   };
 
 const TextFormField = forwardRef((props: TextFormFieldProps, ref) => {
@@ -36,7 +36,6 @@ const TextFormField = forwardRef((props: TextFormFieldProps, ref) => {
   const hasTrailing = !!(trailing || trailingFocused);
   const hasIcon = hasLeading || hasTrailing;
   const [showPassword, setShowPassword] = useState(false);
-  const isClear = props.isClear || false;
 
   const getPasswordFieldType = () => {
     return showPassword ? "text" : "password";
@@ -66,7 +65,7 @@ const TextFormField = forwardRef((props: TextFormFieldProps, ref) => {
         required={field.required}
         onChange={(e) => field.handleChange(e.target.value)}
       />
-      {isClear && field.value && (
+      {props.clearable && field.value && (
         <button
           type="button"
           className="absolute right-2 top-1/2 -translate-y-1/2 transform text-gray-500"

--- a/src/components/Form/FormFields/TextFormField.tsx
+++ b/src/components/Form/FormFields/TextFormField.tsx
@@ -41,10 +41,6 @@ const TextFormField = forwardRef((props: TextFormFieldProps, ref) => {
     return showPassword ? "text" : "password";
   };
 
-  const handleClear = () => {
-    field.handleChange("");
-  };
-
   let child = (
     <div className="relative">
       <input
@@ -69,7 +65,7 @@ const TextFormField = forwardRef((props: TextFormFieldProps, ref) => {
         <button
           type="button"
           className="absolute right-2 top-1/2 -translate-y-1/2 transform text-gray-500"
-          onClick={handleClear}
+          onClick={() => field.handleChange("")}
           aria-label="Clear input"
         >
           <CareIcon icon="l-times-circle" className="text-lg" />

--- a/src/components/Form/FormFields/TextFormField.tsx
+++ b/src/components/Form/FormFields/TextFormField.tsx
@@ -24,6 +24,7 @@ export type TextFormFieldProps = FormFieldBaseProps<string> &
     trailingPadding?: string | undefined;
     leadingPadding?: string | undefined;
     suggestions?: string[];
+    isClear?: boolean;
   };
 
 const TextFormField = forwardRef((props: TextFormFieldProps, ref) => {
@@ -35,30 +36,47 @@ const TextFormField = forwardRef((props: TextFormFieldProps, ref) => {
   const hasTrailing = !!(trailing || trailingFocused);
   const hasIcon = hasLeading || hasTrailing;
   const [showPassword, setShowPassword] = useState(false);
+  const isClear = props.isClear || false;
 
   const getPasswordFieldType = () => {
     return showPassword ? "text" : "password";
   };
 
+  const handleClear = () => {
+    field.handleChange("");
+  };
+
   let child = (
-    <input
-      {...props}
-      ref={ref as React.Ref<HTMLInputElement>}
-      id={field.id}
-      className={classNames(
-        "cui-input-base peer",
-        hasLeading && (props.leadingPadding || "pl-10"),
-        hasTrailing && (props.trailingPadding || "pr-10"),
-        field.error && "border-danger-500",
-        props.inputClassName,
+    <div className="relative">
+      <input
+        {...props}
+        ref={ref as React.Ref<HTMLInputElement>}
+        id={field.id}
+        className={classNames(
+          "cui-input-base peer",
+          hasLeading && (props.leadingPadding || "pl-10"),
+          hasTrailing && (props.trailingPadding || "pr-10"),
+          field.error && "border-danger-500",
+          props.inputClassName,
+        )}
+        disabled={field.disabled}
+        type={props.type === "password" ? getPasswordFieldType() : props.type}
+        name={field.name}
+        value={field.value}
+        required={field.required}
+        onChange={(e) => field.handleChange(e.target.value)}
+      />
+      {isClear && field.value && (
+        <button
+          type="button"
+          className="absolute right-2 top-1/2 -translate-y-1/2 transform text-gray-500"
+          onClick={handleClear}
+          aria-label="Clear input"
+        >
+          <CareIcon icon="l-times-circle" className="text-lg" />
+        </button>
       )}
-      disabled={field.disabled}
-      type={props.type === "password" ? getPasswordFieldType() : props.type}
-      name={field.name}
-      value={field.value}
-      required={field.required}
-      onChange={(e) => field.handleChange(e.target.value)}
-    />
+    </div>
   );
 
   if (props.type === "password") {


### PR DESCRIPTION
## Proposed Changes

- Fixes #8902 
- Added a Cancel button adjacent to the Submit button for closing the pop-up.
- Added a Clear button within the preset input field to clear the input value.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA

![Screenshot 2024-10-24 223310](https://github.com/user-attachments/assets/7afd1673-b165-4fcb-91be-bb8e3bf7b77d)
