### PR TITLE
patient-dashboard layout fixed

### DIFF
--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -344,13 +344,13 @@ export const PatientHome = (props: any) => {
 
         <section className="lg:flex" data-testid="patient-dashboard">
           <div className="lg:w-2/3">
-            <div className="flex h-full flex-col justify-between rounded-lg bg-white pb-5 pl-9 pt-11 shadow">
+            <div className="flex h-full flex-col justify-between rounded-lg bg-white px-5 pb-5 pt-11 shadow md:pl-9">
               <div>
-                <div className="flex flex-row gap-4">
+                <div className="flex flex-row gap-3">
                   <h1 className="flex flex-row pb-3 text-2xl font-bold capitalize">
                     {patientData.name} - {formatPatientAge(patientData, true)}
                   </h1>
-                  <div className="ml-auto mr-9 flex flex-wrap gap-3">
+                  <div className="ml-auto flex flex-wrap gap-3">
                     {patientData.is_vaccinated && (
                       <Chip
                         variant="custom"
@@ -564,10 +564,10 @@ export const PatientHome = (props: any) => {
               </div>
             </div>
           </div>
-          <div className="h-full px-2 lg:w-1/3">
+          <div className="mt-4 h-full lg:mt-0 lg:w-1/3">
             <div
               id="actions"
-              className="flex h-full flex-col justify-between space-y-2 px-2"
+              className="flex h-full flex-col justify-between space-y-2 lg:px-4"
             >
               <div>
                 {patientData.review_time &&


### PR DESCRIPTION
## Patient-dashboard ui layout issue

Fixes ui issue #8927
- patient-dashboard ui layout is fixed with respective to the screen size

## Before change
![image](https://github.com/user-attachments/assets/4f27ff84-80a0-4cac-ab22-c49c486bd3b5)
![image](https://github.com/user-attachments/assets/8223ffff-6a47-4e87-8255-46959aa3d5c2)

## After changes
![image](https://github.com/user-attachments/assets/40855c49-00ac-44ff-8493-483145a11e0c)
![image](https://github.com/user-attachments/assets/54c6ab1d-b56e-4d29-ae67-794ff4413561)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [X] Add specs that demonstrate bug / test a new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [X] Completion of QA
