### PR TITLE
displaying full names on hover for long names only

### DIFF
--- a/src/components/Assets/AssetsList.tsx
+++ b/src/components/Assets/AssetsList.tsx
@@ -248,15 +248,7 @@ const AssetsList = () => {
                       {asset.name}
                     </p>
                     {asset.name.length > 16 && (
-                      <span
-                        className="absolute z-10 hidden rounded bg-gray-700 px-2 py-1 text-xs text-white group-hover:block"
-                        style={{
-                          whiteSpace: "nowrap",
-                          bottom: "100%",
-                          left: "0",
-                          marginBottom: "5px",
-                        }}
-                      >
+                      <span className="absolute bottom-full z-10 hidden whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white group-hover:block">
                         {asset.name}
                       </span>
                     )}

--- a/src/components/Assets/AssetsList.tsx
+++ b/src/components/Assets/AssetsList.tsx
@@ -240,12 +240,27 @@ const AssetsList = () => {
                       className="text-2xl"
                     />
                   </span>
-                  <p
-                    className="w-48 truncate"
-                    data-testid="created-asset-list-name"
-                  >
-                    {asset.name}
-                  </p>
+                  <div className="group relative w-48">
+                    <p
+                      className="truncate"
+                      data-testid="created-asset-list-name"
+                    >
+                      {asset.name}
+                    </p>
+                    {asset.name.length > 16 && (
+                      <span
+                        className="absolute z-10 hidden rounded bg-gray-700 px-2 py-1 text-xs text-white group-hover:block"
+                        style={{
+                          whiteSpace: "nowrap",
+                          bottom: "100%",
+                          left: "0",
+                          marginBottom: "5px",
+                        }}
+                      >
+                        {asset.name}
+                      </span>
+                    )}
+                  </div>
                 </p>
               </div>
               <p className="text-sm font-normal">

--- a/src/components/Assets/AssetsList.tsx
+++ b/src/components/Assets/AssetsList.tsx
@@ -240,15 +240,15 @@ const AssetsList = () => {
                       className="text-2xl"
                     />
                   </span>
-                  <div className="group relative w-48">
+                  <div className="tooltip group relative w-48">
                     <p
                       className="truncate"
                       data-testid="created-asset-list-name"
                     >
                       {asset.name}
                     </p>
-                    {asset.name.length > 16 && (
-                      <span className="absolute bottom-full z-10 hidden whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white group-hover:block">
+                    {asset.name.length > 20 && (
+                      <span className="tooltip-text tooltip-top absolute z-10 -translate-x-1/2 whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white group-hover:block">
                         {asset.name}
                       </span>
                     )}

--- a/src/components/Assets/AssetsList.tsx
+++ b/src/components/Assets/AssetsList.tsx
@@ -240,7 +240,7 @@ const AssetsList = () => {
                       className="text-2xl"
                     />
                   </span>
-                  <div className="tooltip group relative w-48">
+                  <div className="tooltip w-48">
                     <p
                       className="truncate"
                       data-testid="created-asset-list-name"
@@ -248,7 +248,7 @@ const AssetsList = () => {
                       {asset.name}
                     </p>
                     {asset.name.length > 20 && (
-                      <span className="tooltip-text tooltip-top absolute z-10 -translate-x-1/2 whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white group-hover:block">
+                      <span className="tooltip-text tooltip-top -translate-x-1/2">
                         {asset.name}
                       </span>
                     )}


### PR DESCRIPTION
## Proposed Changes

- Fixes #7787
- Displaying asset names for long names only
- asset.name > 18 seems logical considering w-48 remains constant, but if we change w-48 to some other value, we can increase 18 to something else, but don't think w-48 will change, even if it does, we can adjust 18 to some sensible mid-number like 15-16

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a tooltip for asset names that exceed 20 characters, providing full visibility without cluttering the interface.

- **Bug Fixes**
	- Improved error handling for QR code processing, ensuring consistent management of the loading state and clarity in error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->