### PR TITLE
resolves age field NaN issue for shifting patient copy to clipboard

### DIFF
--- a/src/components/Shifting/ShiftDetails.tsx
+++ b/src/components/Shifting/ShiftDetails.tsx
@@ -90,7 +90,7 @@ export default function ShiftDetails(props: { id: string }) {
       "\n" +
       t("age") +
       ":" +
-      +(data?.patient_object
+      (data?.patient_object
         ? formatPatientAge(data.patient_object, true)
         : "") +
       "\n" +


### PR DESCRIPTION

## Proposed Changes
- Fixes #8981
- Basically there was an extra '+' operator in formattedText variable in copyContent function, removal of which resolved the issue

@ohcnetwork/care-fe-code-reviewers

Please find the screenshot attached
![image](https://github.com/user-attachments/assets/9e414b53-4214-4337-bd04-5ae2bb260913)
