### PR TITLE
Reduce the cypress GitHub runner utilization to 4

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -8,17 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup:
-    name: Setup Backend and Frontend
-    if: github.repository == 'ohcnetwork/care_fe'  # Ensures job runs only for the care_fe repository
+  setup_and_test:
+    name: Setup and Run Cypress Tests
+    if: github.repository == 'ohcnetwork/care_fe'
     runs-on: ubuntu-latest
-    outputs:
-      backend_url: ${{ steps.backend-url.outputs.backend_url }}
+    env:
+      REACT_CARE_API_URL: http://localhost:9000
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-        with:
-          path: repo
 
       - name: Set Backend Branch
         id: backend-branch
@@ -33,16 +34,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ohcnetwork/care
-          path: repo/care
+          path: care
           ref: ${{ steps.backend-branch.outputs.branch }}
 
       - name: Start Backend Services
         run: |
-          cd repo/care
+          cd care
           echo DISABLE_RATELIMIT=True >> docker/.prebuilt.env
           echo "CORS_ALLOWED_ORIGINS=\"[\\\"http://localhost:4000\\\"]\"" >> docker/.prebuilt.env
           echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.prebuilt.env
-          docker-compose -f docker-compose.pre-built.yaml up -d
+          make docker_config_file=docker-compose.pre-built.yaml up
+          make docker_config_file=docker-compose.pre-built.yaml load-dummy-data
           cd ..
         env:
           JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}
@@ -63,73 +65,34 @@ jobs:
       - name: Cache Node Modules
         uses: actions/cache@v3
         with:
-          path: repo/frontend/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('repo/frontend/package-lock.json') }}
+          path: frontend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Install Frontend Dependencies
         run: |
-          cd repo/frontend
+          cd frontend
           npm ci
-          cd ../..
+          cd ..
 
       - name: Build Frontend
         run: |
-          cd repo/frontend
+          cd frontend
           npm run build
-          cd ../..
-
-  test:
-    name: Run Cypress Tests
-    if: github.repository == 'ohcnetwork/care_fe'  # Ensures job runs only for the care_fe repository
-    needs: setup
-    runs-on: ubuntu-latest
-    env:
-      REACT_CARE_API_URL: http://localhost:9000
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NODE_OPTIONS: --max_old_space_size=4096
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          path: repo
+          cd ..
 
       - name: Determine PR Origin
         id: pr_origin
         run: echo "::set-output name=is_forked::$( echo ${{ github.event.pull_request.head.repo.fork }})"
 
-      - name: Wait for Backend Health Check
+      - name: Run Cypress Tests
         run: |
-          for i in {1..10}; do
-            response=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:9000/health)
-            if [ "$response" -eq 200 ]; then
-              echo "Backend is healthy!"
-              break
-            else
-              echo "Waiting for backend to be healthy..."
-              sleep 10
-            fi
-          done
-
-      - name: Cypress Run for Non-Forked PRs
-        if: steps.pr_origin.outputs.is_forked == 'false'
-        run: |
-          cd repo/frontend
-          npx cypress run --parallel --record --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts"
+          cd frontend
+          if [ "${{ steps.pr_origin.outputs.is_forked }}" == "false" ]; then
+            npx cypress run --parallel --record --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts"
+          else
+            npx cypress-split run --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts" --env CYPRESS_SPLIT_TESTS="true"
+          fi
         env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          NODE_OPTIONS: --max_old_space_size=4096
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
-
-      - name: Cypress Run for Forked PRs
-        if: steps.pr_origin.outputs.is_forked == 'true'
-        run: |
-          cd repo/frontend
-          npx cypress-split run --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts" --env CYPRESS_SPLIT_TESTS="true"
-        env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          NODE_OPTIONS: --max_old_space_size=4096
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
 
@@ -138,11 +101,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cypress-screenshots
-          path: repo/frontend/cypress/screenshots
+          path: frontend/cypress/screenshots
 
       - name: Upload Cypress Videos
         if: failure() && steps.pr_origin.outputs.is_forked == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: cypress-videos
-          path: repo/frontend/cypress/videos
+          path: frontend/cypress/videos

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3,4]
+        containers: [1, 2, 3, 4]
     env:
       REACT_CARE_API_URL: http://localhost:9000
     steps:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -11,20 +11,16 @@ on:
 
 jobs:
   cypress-run:
-    permissions: write-all
-    if: github.repository == 'ohcnetwork/care_fe'
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       REACT_CARE_API_URL: http://localhost:9000
     steps:
-      - name: Checkout 📥
+      - name: Checkout Backend and Frontend
         uses: actions/checkout@v3
+        with:
+          path: repo
 
-      - name: Set backend branch
+      - name: Set Backend Branch
         id: backend-branch
         run: |
           if [[ '${{ github.event.pull_request.base.ref }}' == 'staging' ]]; then
@@ -33,26 +29,14 @@ jobs:
             echo "branch=develop" >> $GITHUB_OUTPUT
           fi
 
-      - name: Checkout care 📥
-        uses: actions/checkout@v3
-        with:
-          repository: ohcnetwork/care
-          path: care
-          ref: ${{ steps.backend-branch.outputs.branch }}
-
-      - name: Start care docker containers 🐳
+      - name: Setup Docker Backend Cache
         run: |
-          cd care
-          echo DISABLE_RATELIMIT=True >> docker/.prebuilt.env
-          echo "CORS_ALLOWED_ORIGINS=\"[\\\"http://localhost:4000\\\"]\"" >> docker/.prebuilt.env
-          echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.prebuilt.env
-          make docker_config_file=docker-compose.pre-built.yaml up 
-          make docker_config_file=docker-compose.pre-built.yaml load-dummy-data
-          cd ..
-        env:
-          JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}
+          # Build and cache the backend Docker image here
+          cd repo/care
+          docker-compose up -d --build
+          cd ../..
 
-      - name: Wait for care to be up ♻
+      - name: Wait for Backend to Be Up
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 1
@@ -60,80 +44,21 @@ jobs:
           command: curl -o /dev/null -s -w "%{http_code}\n" http://localhost:9000
           on_retry_command: sleep 5
 
-      - name: Determine PR Origin
-        id: pr_origin
-        run: echo "::set-output name=is_forked::$( echo ${{ github.event.pull_request.head.repo.fork }})"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies 📦
-        run: npm run install-all
-
-      - name: Build ⚙️
-        run: npm run build
-
-      - name: Install Specific Chrome Version
+      - name: Install Frontend Dependencies
         run: |
-          sudo apt-get install -y wget
-          sudo wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo apt-get install ./google-chrome-stable_current_amd64.deb
+          cd repo/frontend
+          npm ci
+          npm run build
+          cd ../..
 
-      - name: Cypress run for Non-Forked PRs 🥬
-        if: steps.pr_origin.outputs.is_forked == 'false'
-        uses: cypress-io/github-action@v5
-        with:
-          env: SKIP_PREFLIGHT_CHECK=true
-          install: false
-          start: "npx vite preview --host"
-          wait-on: "http://localhost:4000"
-          wait-on-timeout: 300
-          browser: chrome
-          record: true
-          parallel: true
-          group: "UI-Chrome"
+      - name: Cypress Parallel Tests within Single Runner
+        run: |
+          # Run Cypress in parallel using a single runner with 6 processes
+          # Here we split tests in Node, simulating "parallelization"
+          npx cypress run --parallel --record --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max_old_space_size=4096
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
           COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
-
-      - name: Cypress run for Forked PRs 🥬
-        if: steps.pr_origin.outputs.is_forked == 'true'
-        uses: cypress-io/github-action@v5
-        with:
-          env: SKIP_PREFLIGHT_CHECK=true
-          install: false
-          start: "npx vite preview --host"
-          wait-on: "http://localhost:4000"
-          wait-on-timeout: 300
-          browser: chrome
-          record: true
-          parallel: true
-          group: "UI-Chrome"
-        env:
-          CYPRESS_SPLIT_TESTS: "true"
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: --max_old_space_size=4096
-          COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
-          COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
-          SPLIT: ${{ strategy.job-total }}
-          SPLIT_INDEX: ${{ strategy.job-index }}
-
-      - name: Upload cypress screenshots on failure 📸
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots
-
-      - name: Upload cypress videos 📹
-        uses: actions/upload-artifact@v3
-        if: steps.pr_origin.outputs.is_forked == 'true'
-        with:
-          name: cypress-videos
-          path: cypress/videos

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -77,6 +77,14 @@ jobs:
           sudo wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
+      - name: Start Frontend Server in Background 🌐
+        run: |
+          nohup npx vite preview --host &
+
+      - name: Wait for Frontend to be Up 🕒
+        run: |
+          npx wait-on http://localhost:4000 --timeout 300000  # Wait for frontend
+
       - name: Cypress run for Non-Forked PRs 🥬
         if: steps.pr_origin.outputs.is_forked == 'false'
         run: |

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -19,6 +19,12 @@ jobs:
     env:
       REACT_CARE_API_URL: http://localhost:9000
     steps:
+      - name: Cache Docker Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/docker
+          key: ${{ runner.os }}-docker-${{ hashFiles('care/Dockerfile') }}
+
       - name: Checkout 📥
         uses: actions/checkout@v3
 

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -1,8 +1,6 @@
 name: Cypress Tests
 
 on:
-  schedule:
-    - cron: "30 22 * * *"
   pull_request:
     branches:
       - develop
@@ -14,6 +12,10 @@ jobs:
     permissions: write-all
     if: github.repository == 'ohcnetwork/care_fe'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4]
     env:
       REACT_CARE_API_URL: http://localhost:9000
     steps:
@@ -77,35 +79,48 @@ jobs:
           sudo wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
-      - name: Start Frontend Server in Background 🌐
-        run: |
-          nohup npx vite preview --host &
-
-      - name: Wait for Frontend to be Up 🕒
-        run: |
-          npx wait-on http://localhost:4000 --timeout 300000  # Wait for frontend
-
       - name: Cypress run for Non-Forked PRs 🥬
         if: steps.pr_origin.outputs.is_forked == 'false'
-        run: |
-          npx cypress run --record --parallel --ci-build-id ${{ github.run_id }} --group "UI-Chrome" --spec "cypress/e2e/**/*.cy.ts"
+        uses: cypress-io/github-action@v5
+        with:
+          env: SKIP_PREFLIGHT_CHECK=true
+          install: false
+          start: "npx vite preview --host"
+          wait-on: "http://localhost:4000"
+          wait-on-timeout: 300
+          browser: chrome
+          record: true
+          parallel: true
+          group: "UI-Chrome"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max_old_space_size=4096
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
+          COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
 
       - name: Cypress run for Forked PRs 🥬
         if: steps.pr_origin.outputs.is_forked == 'true'
-        run: |
-          npx cypress-split run --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts" --env CYPRESS_SPLIT_TESTS="true"
+        uses: cypress-io/github-action@v5
+        with:
+          env: SKIP_PREFLIGHT_CHECK=true
+          install: false
+          start: "npx vite preview --host"
+          wait-on: "http://localhost:4000"
+          wait-on-timeout: 300
+          browser: chrome
+          record: true
+          parallel: true
+          group: "UI-Chrome"
         env:
+          CYPRESS_SPLIT_TESTS: "true"
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max_old_space_size=4096
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
+          COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
+          SPLIT: ${{ strategy.job-total }}
+          SPLIT_INDEX: ${{ strategy.job-index }}
 
       - name: Upload cypress screenshots on failure 📸
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -73,12 +73,6 @@ jobs:
       - name: Build ⚙️
         run: npm run build
 
-      - name: Install Specific Chrome Version
-        run: |
-          sudo apt-get install -y wget
-          sudo wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo apt-get install ./google-chrome-stable_current_amd64.deb
-
       - name: Cypress run for Non-Forked PRs 🥬
         if: steps.pr_origin.outputs.is_forked == 'false'
         uses: cypress-io/github-action@v5
@@ -88,10 +82,9 @@ jobs:
           start: "npx vite preview --host"
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
-          browser: chrome
           record: true
           parallel: true
-          group: "UI-Chrome"
+          group: "UI-Electron"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -108,10 +101,9 @@ jobs:
           start: "npx vite preview --host"
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
-          browser: chrome
           record: true
           parallel: true
-          group: "UI-Chrome"
+          group: "UI-Electron"
         env:
           CYPRESS_SPLIT_TESTS: "true"
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4]
+        containers: [1, 2, 3]
     env:
       REACT_CARE_API_URL: http://localhost:9000
     steps:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   setup_and_test:
     name: Setup and Run Cypress Tests
-    if: github.repository == 'ohcnetwork/care_fe'
+    if: github.repository == 'ohcnetwork/care_fe'  # Ensures job runs only for the care_fe repository
     runs-on: ubuntu-latest
     env:
       REACT_CARE_API_URL: http://localhost:9000
@@ -43,8 +43,8 @@ jobs:
           echo DISABLE_RATELIMIT=True >> docker/.prebuilt.env
           echo "CORS_ALLOWED_ORIGINS=\"[\\\"http://localhost:4000\\\"]\"" >> docker/.prebuilt.env
           echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.prebuilt.env
-          make docker_config_file=docker-compose.pre-built.yaml up
-          make docker_config_file=docker-compose.pre-built.yaml load-dummy-data
+          docker-compose -f docker-compose.pre-built.yaml up -d
+          docker-compose -f docker-compose.pre-built.yaml load-dummy-data
           cd ..
         env:
           JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   setup:
     name: Setup Backend and Frontend
+    if: github.repository == 'ohcnetwork/care_fe'  # Ensures job runs only for the care_fe repository
     runs-on: ubuntu-latest
     outputs:
       backend_url: ${{ steps.backend-url.outputs.backend_url }}
@@ -79,6 +80,7 @@ jobs:
 
   test:
     name: Run Cypress Tests
+    if: github.repository == 'ohcnetwork/care_fe'  # Ensures job runs only for the care_fe repository
     needs: setup
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -19,12 +19,6 @@ jobs:
     env:
       REACT_CARE_API_URL: http://localhost:9000
     steps:
-      - name: Cache Docker Images
-        uses: actions/cache@v2
-        with:
-          path: /tmp/docker
-          key: ${{ runner.os }}-docker-${{ hashFiles('care/Dockerfile') }}
-
       - name: Checkout 📥
         uses: actions/checkout@v3
 
@@ -79,6 +73,12 @@ jobs:
       - name: Build ⚙️
         run: npm run build
 
+      - name: Install Specific Chrome Version
+        run: |
+          sudo apt-get install -y wget
+          sudo wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt-get install ./google-chrome-stable_current_amd64.deb
+
       - name: Cypress run for Non-Forked PRs 🥬
         if: steps.pr_origin.outputs.is_forked == 'false'
         uses: cypress-io/github-action@v5
@@ -88,9 +88,10 @@ jobs:
           start: "npx vite preview --host"
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
+          browser: chrome
           record: true
           parallel: true
-          group: "UI-Electron"
+          group: "UI-Chrome"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,9 +108,10 @@ jobs:
           start: "npx vite preview --host"
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
+          browser: chrome
           record: true
           parallel: true
-          group: "UI-Electron"
+          group: "UI-Chrome"
         env:
           CYPRESS_SPLIT_TESTS: "true"
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -1,6 +1,8 @@
 name: Cypress Tests
 
 on:
+  schedule:
+    - cron: "30 22 * * *"
   pull_request:
     branches:
       - develop
@@ -8,20 +10,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup_and_test:
-    name: Setup and Run Cypress Tests
-    if: github.repository == 'ohcnetwork/care_fe'  # Ensures job runs only for the care_fe repository
+  cypress-run:
+    permissions: write-all
+    if: github.repository == 'ohcnetwork/care_fe'
     runs-on: ubuntu-latest
     env:
       REACT_CARE_API_URL: http://localhost:9000
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NODE_OPTIONS: --max_old_space_size=4096
     steps:
-      - name: Checkout Repository
+      - name: Checkout 📥
         uses: actions/checkout@v3
 
-      - name: Set Backend Branch
+      - name: Set backend branch
         id: backend-branch
         run: |
           if [[ '${{ github.event.pull_request.base.ref }}' == 'staging' ]]; then
@@ -30,82 +29,86 @@ jobs:
             echo "branch=develop" >> $GITHUB_OUTPUT
           fi
 
-      - name: Checkout Backend Repository
+      - name: Checkout care 📥
         uses: actions/checkout@v3
         with:
           repository: ohcnetwork/care
           path: care
           ref: ${{ steps.backend-branch.outputs.branch }}
 
-      - name: Start Backend Services
+      - name: Start care docker containers 🐳
         run: |
           cd care
           echo DISABLE_RATELIMIT=True >> docker/.prebuilt.env
           echo "CORS_ALLOWED_ORIGINS=\"[\\\"http://localhost:4000\\\"]\"" >> docker/.prebuilt.env
           echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.prebuilt.env
-          docker-compose -f docker-compose.pre-built.yaml up -d
-          docker-compose -f docker-compose.pre-built.yaml load-dummy-data
+          make docker_config_file=docker-compose.pre-built.yaml up 
+          make docker_config_file=docker-compose.pre-built.yaml load-dummy-data
           cd ..
         env:
           JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}
 
-      - name: Wait for Backend to be Up
+      - name: Wait for care to be up ♻
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 2
-          max_attempts: 10
+          timeout_minutes: 1
+          max_attempts: 5
           command: curl -o /dev/null -s -w "%{http_code}\n" http://localhost:9000
-          on_retry_command: sleep 10
+          on_retry_command: sleep 5
+
+      - name: Determine PR Origin
+        id: pr_origin
+        run: echo "::set-output name=is_forked::$( echo ${{ github.event.pull_request.head.repo.fork }})"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
-      - name: Cache Node Modules
-        uses: actions/cache@v3
-        with:
-          path: frontend/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
+      - name: Install dependencies 📦
+        run: npm run install-all
 
-      - name: Install Frontend Dependencies
+      - name: Build ⚙️
+        run: npm run build
+
+      - name: Install Specific Chrome Version
         run: |
-          cd frontend
-          npm ci
-          cd ..
+          sudo apt-get install -y wget
+          sudo wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
-      - name: Build Frontend
+      - name: Cypress run for Non-Forked PRs 🥬
+        if: steps.pr_origin.outputs.is_forked == 'false'
         run: |
-          cd frontend
-          npm run build
-          cd ..
-
-      - name: Determine PR Origin
-        id: pr_origin
-        run: echo "::set-output name=is_forked::$( echo ${{ github.event.pull_request.head.repo.fork }})"
-
-      - name: Run Cypress Tests
-        run: |
-          cd frontend
-          if [ "${{ steps.pr_origin.outputs.is_forked }}" == "false" ]; then
-            npx cypress run --parallel --record --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts"
-          else
-            npx cypress-split run --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts" --env CYPRESS_SPLIT_TESTS="true"
-          fi
+          npx cypress run --record --parallel --ci-build-id ${{ github.run_id }} --group "UI-Chrome" --spec "cypress/e2e/**/*.cy.ts"
         env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: --max_old_space_size=4096
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
 
-      - name: Upload Cypress Screenshots on Failure
-        if: failure()
+      - name: Cypress run for Forked PRs 🥬
+        if: steps.pr_origin.outputs.is_forked == 'true'
+        run: |
+          npx cypress-split run --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts" --env CYPRESS_SPLIT_TESTS="true"
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: --max_old_space_size=4096
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Upload cypress screenshots on failure 📸
         uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: cypress-screenshots
-          path: frontend/cypress/screenshots
+          path: cypress/screenshots
 
-      - name: Upload Cypress Videos
-        if: failure() && steps.pr_origin.outputs.is_forked == 'true'
+      - name: Upload cypress videos 📹
         uses: actions/upload-artifact@v3
+        if: steps.pr_origin.outputs.is_forked == 'true'
         with:
           name: cypress-videos
-          path: frontend/cypress/videos
+          path: cypress/videos

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -50,10 +50,10 @@ jobs:
       - name: Wait for Backend to be Up
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 1
-          max_attempts: 5
+          timeout_minutes: 2
+          max_attempts: 10
           command: curl -o /dev/null -s -w "%{http_code}\n" http://localhost:9000
-          on_retry_command: sleep 5
+          on_retry_command: sleep 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -97,6 +97,19 @@ jobs:
       - name: Determine PR Origin
         id: pr_origin
         run: echo "::set-output name=is_forked::$( echo ${{ github.event.pull_request.head.repo.fork }})"
+
+      - name: Wait for Backend Health Check
+        run: |
+          for i in {1..10}; do
+            response=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:9000/health)
+            if [ "$response" -eq 200 ]; then
+              echo "Backend is healthy!"
+              break
+            else
+              echo "Waiting for backend to be healthy..."
+              sleep 10
+            fi
+          done
 
       - name: Cypress Run for Non-Forked PRs
         if: steps.pr_origin.outputs.is_forked == 'false'

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -1,8 +1,6 @@
 name: Cypress Tests
 
 on:
-  schedule:
-    - cron: "30 22 * * *"
   pull_request:
     branches:
       - develop
@@ -10,12 +8,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  cypress-run:
+  setup:
+    name: Setup Backend and Frontend
     runs-on: ubuntu-latest
-    env:
-      REACT_CARE_API_URL: http://localhost:9000
+    outputs:
+      backend_url: ${{ steps.backend-url.outputs.backend_url }}
     steps:
-      - name: Checkout Backend and Frontend
+      - name: Checkout Repository
         uses: actions/checkout@v3
         with:
           path: repo
@@ -29,14 +28,25 @@ jobs:
             echo "branch=develop" >> $GITHUB_OUTPUT
           fi
 
-      - name: Setup Docker Backend Cache
-        run: |
-          # Build and cache the backend Docker image here
-          cd repo/care
-          docker-compose up -d --build
-          cd ../..
+      - name: Checkout Backend Repository
+        uses: actions/checkout@v3
+        with:
+          repository: ohcnetwork/care
+          path: repo/care
+          ref: ${{ steps.backend-branch.outputs.branch }}
 
-      - name: Wait for Backend to Be Up
+      - name: Start Backend Services
+        run: |
+          cd repo/care
+          echo DISABLE_RATELIMIT=True >> docker/.prebuilt.env
+          echo "CORS_ALLOWED_ORIGINS=\"[\\\"http://localhost:4000\\\"]\"" >> docker/.prebuilt.env
+          echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.prebuilt.env
+          docker-compose -f docker-compose.pre-built.yaml up -d
+          cd ..
+        env:
+          JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}
+
+      - name: Wait for Backend to be Up
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 1
@@ -44,21 +54,80 @@ jobs:
           command: curl -o /dev/null -s -w "%{http_code}\n" http://localhost:9000
           on_retry_command: sleep 5
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache Node Modules
+        uses: actions/cache@v3
+        with:
+          path: repo/frontend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('repo/frontend/package-lock.json') }}
+
       - name: Install Frontend Dependencies
         run: |
           cd repo/frontend
           npm ci
+          cd ../..
+
+      - name: Build Frontend
+        run: |
+          cd repo/frontend
           npm run build
           cd ../..
 
-      - name: Cypress Parallel Tests within Single Runner
+  test:
+    name: Run Cypress Tests
+    needs: setup
+    runs-on: ubuntu-latest
+    env:
+      REACT_CARE_API_URL: http://localhost:9000
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_OPTIONS: --max_old_space_size=4096
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          path: repo
+
+      - name: Determine PR Origin
+        id: pr_origin
+        run: echo "::set-output name=is_forked::$( echo ${{ github.event.pull_request.head.repo.fork }})"
+
+      - name: Cypress Run for Non-Forked PRs
+        if: steps.pr_origin.outputs.is_forked == 'false'
         run: |
-          # Run Cypress in parallel using a single runner with 6 processes
-          # Here we split tests in Node, simulating "parallelization"
+          cd repo/frontend
           npx cypress run --parallel --record --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max_old_space_size=4096
-          COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
-          COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Cypress Run for Forked PRs
+        if: steps.pr_origin.outputs.is_forked == 'true'
+        run: |
+          cd repo/frontend
+          npx cypress-split run --group "UI-Chrome" --ci-build-id ${{ github.run_id }} --spec "cypress/e2e/**/*.cy.ts" --env CYPRESS_SPLIT_TESTS="true"
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          NODE_OPTIONS: --max_old_space_size=4096
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Upload Cypress Screenshots on Failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-screenshots
+          path: repo/frontend/cypress/screenshots
+
+      - name: Upload Cypress Videos
+        if: failure() && steps.pr_origin.outputs.is_forked == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-videos
+          path: repo/frontend/cypress/videos

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3]
+        containers: [1, 2, 3,4]
     env:
       REACT_CARE_API_URL: http://localhost:9000
     steps:

--- a/cypress/pageobject/Users/UserSearch.ts
+++ b/cypress/pageobject/Users/UserSearch.ts
@@ -23,7 +23,7 @@ export class UserPage {
   }
 
   checkUsernameText(username: string) {
-    cy.get(this.usernameText).should("have.text", username);
+    cy.get(this.usernameText).should("contain.text", username);
   }
 
   checkUsernameBadgeVisibility(shouldBeVisible: boolean) {


### PR DESCRIPTION
## Proposed Changes

- reduce the runner count, which bring the utilisation from 56 Minutes to 35 Minutes
- individual runner entire setup will be completed in 8 minute 36 second rather than 6 minutes 36 seconds
- the entire test file completion will be increased by 1 minute

![image](https://github.com/user-attachments/assets/0d48d292-8b24-4990-9ff2-bf97bd603638)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA
