### PR TITLE
Fixed delete button size in asset details & consent record pages

### DIFF
--- a/src/components/Assets/AssetManage.tsx
+++ b/src/components/Assets/AssetManage.tsx
@@ -461,7 +461,7 @@ const AssetManage = (props: AssetManageProps) => {
                   data-testid="asset-delete-button"
                   className="inline-flex"
                 >
-                  <CareIcon icon="l-trash" className="h-4" />
+                  <CareIcon icon="l-trash" className="h-5" />
                   <span className="md:hidden">{t("delete")}</span>
                 </ButtonV2>
               )}

--- a/src/components/Assets/AssetManage.tsx
+++ b/src/components/Assets/AssetManage.tsx
@@ -432,7 +432,7 @@ const AssetManage = (props: AssetManageProps) => {
                 data-testid="asset-update-button"
                 authorizeFor={NonReadOnlyUsers}
               >
-                <CareIcon icon="l-pen" className="mr-1 h-4" />
+                <CareIcon icon="l-pen" className="text-lg" />
                 {t("update")}
               </ButtonV2>
               {asset?.asset_class &&
@@ -449,7 +449,7 @@ const AssetManage = (props: AssetManageProps) => {
                     id="configure-asset"
                     data-testid="asset-configure-button"
                   >
-                    <CareIcon icon="l-setting" className="h-4" />
+                    <CareIcon icon="l-setting" className="text-lg" />
                     {t("configure")}
                   </ButtonV2>
                 )}
@@ -459,10 +459,9 @@ const AssetManage = (props: AssetManageProps) => {
                   onClick={() => setShowDeleteDialog(true)}
                   variant="danger"
                   data-testid="asset-delete-button"
-                  className="inline-flex"
                 >
-                  <CareIcon icon="l-trash" className="h-5" />
-                  <span className="md:hidden">{t("delete")}</span>
+                  <CareIcon icon="l-trash" className="text-lg" />
+                  <span>{t("delete")}</span>
                 </ButtonV2>
               )}
             </div>

--- a/src/components/Patient/PatientConsentRecords.tsx
+++ b/src/components/Patient/PatientConsentRecords.tsx
@@ -219,7 +219,8 @@ export default function PatientConsentRecords(props: {
                   onClick={fileUpload.clearFiles}
                   disabled={fileUpload.uploading}
                 >
-                  <CareIcon icon="l-trash-alt" className="h-5" />
+                  <CareIcon icon="l-trash" className="text-lg" />
+                  <span>{t("delete")}</span>
                 </ButtonV2>
               </>
             ) : (

--- a/src/components/Patient/PatientConsentRecords.tsx
+++ b/src/components/Patient/PatientConsentRecords.tsx
@@ -219,7 +219,7 @@ export default function PatientConsentRecords(props: {
                   onClick={fileUpload.clearFiles}
                   disabled={fileUpload.uploading}
                 >
-                  <CareIcon icon="l-trash-alt" className="" />
+                  <CareIcon icon="l-trash-alt" className="h-5" />
                 </ButtonV2>
               </>
             ) : (


### PR DESCRIPTION
## Proposed Changes

- Fixes #issue_number
- Change 1
- Change 2
- More?

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user interface for the asset management and consent records components.
	- Improved file upload process with checks for existing consent records.
	- Added skeleton loader for better user experience during data loading.

- **Bug Fixes**
	- Refined confirmation logic for consent record actions to ensure correct identification.

- **Style**
	- Increased icon size for buttons in the AssetManage and PatientConsentRecords components for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->