### PR TITLE
Fix #8858: Allow decimal places for pCO2, pO2,. Fix #8859: Add additional unit of measure for pCO2 and pO2.

### DIFF
--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -537,6 +537,13 @@ export const celsiusToFahrenheit = (celsius: number) => {
 export const fahrenheitToCelsius = (fahrenheit: number) => {
   return ((fahrenheit - 32) * 5) / 9;
 };
+export const mmHgToKPa = (mmHg: number) => {
+  return mmHg * 0.133322;
+};
+
+export const kPaToMmHg = (kPa: number) => {
+  return kPa / 0.133322;
+};
 
 /**
  * Although same as `Objects.keys(...)`, this provides better type-safety.

--- a/src/components/Form/FormFields/RangeFormField.tsx
+++ b/src/components/Form/FormFields/RangeFormField.tsx
@@ -26,7 +26,7 @@ type PropsWithUnit = BaseProps & {
   units?: undefined;
 };
 
-type PropsWithUnits = BaseProps & {
+export type PropsWithUnits = BaseProps & {
   unit?: undefined;
   units: {
     label: string;

--- a/src/components/LogUpdate/Sections/ABGAnalysis.tsx
+++ b/src/components/LogUpdate/Sections/ABGAnalysis.tsx
@@ -1,13 +1,19 @@
 import { ReactNode } from "react";
 
 import RangeFormField from "@/components/Form/FormFields/RangeFormField";
+import { PropsWithUnits } from "@/components/Form/FormFields/RangeFormField";
 import {
   LogUpdateSectionMeta,
   LogUpdateSectionProps,
 } from "@/components/LogUpdate/utils";
 import { DailyRoundsModel } from "@/components/Patient/models";
 
-import { ValueDescription, rangeValueDescription } from "@/Utils/utils";
+import {
+  ValueDescription,
+  kPaToMmHg,
+  mmHgToKPa,
+  rangeValueDescription,
+} from "@/Utils/utils";
 
 export const ABGAnalysisFields = [
   {
@@ -17,10 +23,18 @@ export const ABGAnalysisFields = [
         PO<sub>2</sub>
       </span>
     ),
-    unit: "mmHg",
-    min: 10,
-    max: 400,
-    valueDescription: rangeValueDescription({ low: 49, high: 200 }),
+    min: 0,
+    max: 20,
+    step: 0.01,
+    valueDescription: rangeValueDescription({ low: 10.5, high: 13.5 }),
+    units: [
+      { label: "kPa" },
+      {
+        label: "mmHg",
+        conversionFn: kPaToMmHg,
+        inversionFn: mmHgToKPa,
+      },
+    ],
   },
   {
     key: "pco2",
@@ -29,10 +43,18 @@ export const ABGAnalysisFields = [
         PCO<sub>2</sub>
       </span>
     ),
-    unit: "mmHg",
-    min: 10,
-    max: 200,
-    valueDescription: rangeValueDescription({ low: 34, high: 45 }),
+    min: 0,
+    max: 20,
+    step: 0.01,
+    valueDescription: rangeValueDescription({ low: 5.1, high: 5.6 }),
+    units: [
+      { label: "kPa" },
+      {
+        label: "mmHg",
+        conversionFn: kPaToMmHg,
+        inversionFn: mmHgToKPa,
+      },
+    ],
   },
   {
     key: "ph",
@@ -40,7 +62,7 @@ export const ABGAnalysisFields = [
     unit: "",
     min: 0,
     max: 10,
-    step: 0.1,
+    step: 0.01,
     valueDescription: rangeValueDescription({ low: 7.35, high: 7.45 }),
   },
   {
@@ -94,11 +116,16 @@ export const ABGAnalysisFields = [
 ] satisfies {
   key: keyof DailyRoundsModel;
   label: ReactNode;
-  unit: string;
+  unit?: string;
   min: number;
   max: number;
   step?: number;
   valueDescription: ValueDescription[];
+  units?: {
+    label: string;
+    conversionFn?: (val: number) => number;
+    inversionFn?: (val: number) => number;
+  }[];
 }[];
 
 const ABGAnalysis = ({ log, onChange }: LogUpdateSectionProps) => {
@@ -108,7 +135,9 @@ const ABGAnalysis = ({ log, onChange }: LogUpdateSectionProps) => {
         <RangeFormField
           key={index}
           label={field.label}
-          unit={field.unit}
+          {...(field.unit
+            ? { unit: field.unit }
+            : ({ units: field.units } as PropsWithUnits))}
           name={field.key}
           onChange={(c) => onChange({ [field.key]: c.value })}
           value={log[field.key] as number}

--- a/src/components/LogUpdate/Sections/ABGAnalysis.tsx
+++ b/src/components/LogUpdate/Sections/ABGAnalysis.tsx
@@ -62,7 +62,7 @@ export const ABGAnalysisFields = [
     unit: "",
     min: 0,
     max: 10,
-    step: 0.01,
+    step: 0.001,
     valueDescription: rangeValueDescription({ low: 7.35, high: 7.45 }),
   },
   {


### PR DESCRIPTION

## Proposed Changes

Fix #8858: Allowed decimal places for pCO2, pO2, and pH, enabling more precise input values.
Fix #8859: Added the option to switch units for pCO2 and pO2 between kPa and mmHg on ABG analysis fields.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functions for converting pressure measurements between mmHg and kPa.
	- Enhanced the `ABGAnalysis` component to support multiple unit options and conversion functions.

- **Improvements**
	- Adjusted field properties in the `ABGAnalysis` component for better flexibility and usability.
	- Made the `PropsWithUnits` type publicly accessible for broader use in other components.

- **Bug Fixes**
	- Updated min/max values and step values for specific fields to ensure accurate data entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->