### PR TITLE
Update setup-care-apps scripts to remove existing apps that are not configured in env if any

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ cypress/fixtures/token.json
 # Care Apps
 /apps/*
 src/pluginMap.ts
+/apps_backup/*

--- a/scripts/setup-care-apps.js
+++ b/scripts/setup-care-apps.js
@@ -53,6 +53,20 @@ const installApp = (app) => {
   );
 };
 
+fs.readdirSync(appsDir, { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => dirent.name)
+  .filter(
+    (dir) =>
+      !appsConfig
+        .map((app) => path.join(appsDir, app.package.split("/")[1]))
+        .includes(dir),
+  )
+  .forEach((unusedApp) => {
+    console.log(`Removing existing app '${unusedApp}' as not configured.`);
+    fs.rmSync(path.join(appsDir, unusedApp), { recursive: true, force: true });
+  });
+
 // Clone or pull care apps
 appsConfig.forEach((app) => {
   const appDir = path.join(appsDir, app.package.split("/")[1]);

--- a/scripts/setup-care-apps.js
+++ b/scripts/setup-care-apps.js
@@ -57,10 +57,7 @@ fs.readdirSync(appsDir, { withFileTypes: true })
   .filter((dirent) => dirent.isDirectory())
   .map((dirent) => dirent.name)
   .filter(
-    (dir) =>
-      !appsConfig
-        .map((app) => path.join(appsDir, app.package.split("/")[1]))
-        .includes(dir),
+    (dir) => !appsConfig.map((app) => app.package.split("/")[1]).includes(dir),
   )
   .forEach((unusedApp) => {
     console.log(`Removing existing app '${unusedApp}' as not configured.`);

--- a/scripts/setup-care-apps.js
+++ b/scripts/setup-care-apps.js
@@ -65,18 +65,21 @@ try {
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name)
     .filter(
-      (dir) => !appsConfig.map((app) => app.package.split("/")[1]).includes(dir),
+      (dir) =>
+        !appsConfig.map((app) => app.package.split("/")[1]).includes(dir),
     )
     .forEach((unusedApp) => {
       const appPath = path.join(appsDir, unusedApp);
       const backupPath = path.join(backupDir, `${unusedApp}_${Date.now()}`);
       console.log(`Backing up '${unusedApp}' to ${backupPath}`);
       fs.cpSync(appPath, backupPath, { recursive: true });
-      console.log(`Removing existing app '${unusedApp}' as it is not configured.`);
+      console.log(
+        `Removing existing app '${unusedApp}' as it is not configured.`,
+      );
       fs.rmSync(appPath, { recursive: true, force: true });
     });
 } catch (error) {
-  console.error('Error during cleanup:', error);
+  console.error("Error during cleanup:", error);
   process.exit(1);
 }
 

--- a/scripts/setup-care-apps.js
+++ b/scripts/setup-care-apps.js
@@ -53,16 +53,32 @@ const installApp = (app) => {
   );
 };
 
-fs.readdirSync(appsDir, { withFileTypes: true })
-  .filter((dirent) => dirent.isDirectory())
-  .map((dirent) => dirent.name)
-  .filter(
-    (dir) => !appsConfig.map((app) => app.package.split("/")[1]).includes(dir),
-  )
-  .forEach((unusedApp) => {
-    console.log(`Removing existing app '${unusedApp}' as not configured.`);
-    fs.rmSync(path.join(appsDir, unusedApp), { recursive: true, force: true });
-  });
+const backupDir = path.join(__dirname, "..", "apps_backup");
+
+// Create backup directory if needed
+if (!fs.existsSync(backupDir)) {
+  fs.mkdirSync(backupDir);
+}
+
+try {
+  fs.readdirSync(appsDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name)
+    .filter(
+      (dir) => !appsConfig.map((app) => app.package.split("/")[1]).includes(dir),
+    )
+    .forEach((unusedApp) => {
+      const appPath = path.join(appsDir, unusedApp);
+      const backupPath = path.join(backupDir, `${unusedApp}_${Date.now()}`);
+      console.log(`Backing up '${unusedApp}' to ${backupPath}`);
+      fs.cpSync(appPath, backupPath, { recursive: true });
+      console.log(`Removing existing app '${unusedApp}' as it is not configured.`);
+      fs.rmSync(appPath, { recursive: true, force: true });
+    });
+} catch (error) {
+  console.error('Error during cleanup:', error);
+  process.exit(1);
+}
 
 // Clone or pull care apps
 appsConfig.forEach((app) => {


### PR DESCRIPTION
## Proposed Changes

- Update setup-care-apps scripts to remove (backup to another folder) existing apps that are not configured in env if any

<img width="939" alt="image" src="https://github.com/user-attachments/assets/8e95dea9-e87c-4b66-bc51-a435d19dde3a">


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced management of applications in the `apps` directory by automatically removing unused application directories.
	- Improved logging for identified and removed directories.

- **Bug Fixes**
	- Retained existing functionality for cloning or updating applications while integrating new cleanup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->