### PR TITLE
"fix icon overlap in edit consultation page." #9077

### DIFF
--- a/src/components/Facility/ConsultationForm.tsx
+++ b/src/components/Facility/ConsultationForm.tsx
@@ -936,7 +936,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
           <div className="w-full max-w-4xl">
             <form
               onSubmit={handleSubmit}
-              className="rounded bg-white p-6 transition-all sm:rounded-xl sm:p-8"
+              className="relative z-10 rounded bg-white p-6 transition-all sm:rounded-xl sm:p-8"
             >
               <DraftSection
                 handleDraftSelect={(newState: any) => {
@@ -967,7 +967,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                         ref={fieldRef["referred_from_facility"]}
                       >
                         <FieldLabel required>
-                          Name of the referring Facility
+                          Name of the referring Facility"
                         </FieldLabel>
                         <FacilitySelect
                           name="referred_from_facility"

--- a/src/components/Facility/ConsultationForm.tsx
+++ b/src/components/Facility/ConsultationForm.tsx
@@ -967,7 +967,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                         ref={fieldRef["referred_from_facility"]}
                       >
                         <FieldLabel required>
-                          Name of the referring Facility"
+                          Name of the referring Facility
                         </FieldLabel>
                         <FacilitySelect
                           name="referred_from_facility"


### PR DESCRIPTION
## Proposed Changes

- Fixes #9077
- adding an appropriate Z-index to the forms component fixes the issue.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved visibility of the Consultation Form by ensuring it appears above overlapping elements.

- **Refactor**
	- Enhanced the stacking context of the form without altering its core functionality or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->