### PR TITLE
"disable "Save Button" if no file is selected." #9110

### DIFF
--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -292,7 +292,7 @@ const AvatarEditModal = ({
                 <ButtonV2
                   id="save-cover-image"
                   onClick={uploadAvatar}
-                  disabled={isProcessing}
+                  disabled={isProcessing || !selectedFile}
                 >
                   {isProcessing ? (
                     <CareIcon


### PR DESCRIPTION
## Proposed Changes

- Fixes #9110 
- disable the `Save` button if the user selects no file to update/set as facility cover.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the upload button in the Avatar Edit Modal to be disabled when no file is selected, improving user experience during file uploads.

- **Bug Fixes**
	- Fixed the upload button functionality to prevent uploads without a selected file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->