### PR TITLE
Fix/software notification overlap with updated cypress tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -114,7 +114,16 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add("verifyNotification", (text) => {
-  return cy.get(".pnotify-container").should("exist").contains(text);
+  cy.get("body").then(($body) => {
+    if ($body.find(".pnotify-container").length > 0) {
+      cy.get(".pnotify-container", { timeout: 10000 })
+        .should("be.visible")
+        .and("contain.text", text); // Check if the notification contains the expected text
+    } else {
+      cy.log("Notification not found in the DOM.");
+      throw new Error("Notification not found in the DOM.");
+    }
+  });
 });
 
 Cypress.Commands.add("clearAllFilters", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@tailwindcss/forms": "^0.5.9",
         "@tailwindcss/typography": "^0.5.15",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/cypress": "^0.1.6",
         "@types/dompurify": "^3.0.5",
         "@types/events": "^3.0.3",
         "@types/google.maps": "^3.58.1",
@@ -5085,6 +5086,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cypress": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-0.1.6.tgz",
+      "integrity": "sha512-FYKQLvCsRYxZ3fp+XsoCiJZ1aK3x17RmaZjHI4Ou43khFkXPycrQaXo9b1J07PNlEfWnRtUc9loxHXzKjSsbYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.15",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/cypress": "^0.1.6",
     "@types/dompurify": "^3.0.5",
     "@types/events": "^3.0.3",
     "@types/google.maps": "^3.58.1",

--- a/src/Utils/Notifications.js
+++ b/src/Utils/Notifications.js
@@ -87,3 +87,7 @@ export const BadRequest = ({ errs }) => {
     notifyError(errs);
   }
 };
+
+export function Info(_arg0) {
+  throw new Error("Function not implemented.");
+}

--- a/src/components/Users/UserProfile.tsx
+++ b/src/components/Users/UserProfile.tsx
@@ -370,24 +370,16 @@ export default function UserProfile() {
     setDirty(true);
   };
 
-  const getDate = (value: string | Date | undefined) =>
+  const getDate = (value: any) =>
     value && dayjs(value).isValid() && dayjs(value).toDate();
-
-  interface FormState {
-    [key: string]: string | number | boolean | undefined;
-  }
-
-  interface ErrorState {
-    [key: string]: string | undefined;
-  }
 
   const fieldProps = (name: string) => {
     return {
       name,
       id: name,
-      value: (states.form as FormState)[name],
+      value: (states.form as any)[name],
       onChange: handleFieldChange,
-      error: (states.errors as ErrorState)[name],
+      error: (states.errors as any)[name],
     };
   };
 

--- a/src/components/Users/UserProfile.tsx
+++ b/src/components/Users/UserProfile.tsx
@@ -36,7 +36,6 @@ import request from "@/Utils/request/request";
 import uploadFile from "@/Utils/request/uploadFile";
 import useQuery from "@/Utils/request/useQuery";
 import {
-  classNames,
   dateQueryString,
   formatDate,
   formatDisplayName,
@@ -371,16 +370,24 @@ export default function UserProfile() {
     setDirty(true);
   };
 
-  const getDate = (value: any) =>
+  const getDate = (value: string | Date | undefined) =>
     value && dayjs(value).isValid() && dayjs(value).toDate();
+
+  interface FormState {
+    [key: string]: string | number | boolean | undefined;
+  }
+
+  interface ErrorState {
+    [key: string]: string | undefined;
+  }
 
   const fieldProps = (name: string) => {
     return {
       name,
       id: name,
-      value: (states.form as any)[name],
+      value: (states.form as FormState)[name],
       onChange: handleFieldChange,
-      error: (states.errors as any)[name],
+      error: (states.errors as ErrorState)[name],
     };
   };
 
@@ -452,6 +459,9 @@ export default function UserProfile() {
       setUpdateStatus({
         isUpdateAvailable: true,
         isChecking: false,
+      });
+      Notification.Info({
+        msg: "A new update is available. Click 'Update' to proceed.",
       });
     } else {
       setUpdateStatus({
@@ -1006,9 +1016,9 @@ export default function UserProfile() {
             </p>
           </div>
         </div>
-        {updateStatus.isUpdateAvailable && (
+        {updateStatus.isUpdateAvailable && !updateStatus.isChecking && (
           <UpdatableApp silentlyAutoUpdate={false}>
-            <ButtonV2 disabled={true}>
+            <ButtonV2 onClick={checkUpdates} disabled={false}>
               <div className="flex items-center gap-4">
                 <CareIcon icon="l-exclamation" className="text-2xl" />
                 {t("update_available")}
@@ -1016,21 +1026,23 @@ export default function UserProfile() {
             </ButtonV2>
           </UpdatableApp>
         )}
+        {/* Show "Check for Update" Button if update is not available and check is not in progress */}
         <div className="mt-5 md:col-span-2 md:mt-0">
-          {!updateStatus.isUpdateAvailable && (
-            <ButtonV2 disabled={updateStatus.isChecking} onClick={checkUpdates}>
-              {" "}
+          {!updateStatus.isUpdateAvailable && !updateStatus.isChecking && (
+            <ButtonV2 onClick={checkUpdates}>
               <div className="flex items-center gap-4">
-                <CareIcon
-                  icon="l-sync"
-                  className={classNames(
-                    "text-2xl",
-                    updateStatus.isChecking && "animate-spin",
-                  )}
-                />
-                {updateStatus.isChecking
-                  ? t("checking_for_update")
-                  : t("check_for_update")}
+                <CareIcon icon="l-sync" className="text-2xl" />
+                {t("check_for_update")}
+              </div>
+            </ButtonV2>
+          )}
+
+          {/* Show "Checking for Update" Button when the update check is in progress */}
+          {updateStatus.isChecking && (
+            <ButtonV2 disabled={true}>
+              <div className="flex items-center gap-4">
+                <CareIcon icon="l-sync" className="text-2xl animate-spin" />
+                {t("checking_for_update")}
               </div>
             </ButtonV2>
           )}


### PR DESCRIPTION
- Fixes https://github.com/ohcnetwork/care_fe/issues/9039

#### Changes :
- Conditional Display of "Update Available" Button
- Conditional Display of "Check for Update" Button
- Separate "Checking for Update" Button

This code improves user experience by clearly differentiating button states. It ensures users see the "Update Available" button only when applicable, while "Check for Update" and "Checking for Update" buttons guide actions intuitively. This separation prevents overlap, avoids confusion, and provides visual feedback during update checks, making the interface more responsive and user-friendly.

![Screenshot from 2024-11-15 13-22-38](https://github.com/user-attachments/assets/3bd9700b-f545-41ec-8e78-1fb0fc22922a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced notification system with a new `Info` function placeholder for future implementation.
	- UserProfile component now displays a notification when a new update is available, improving user awareness.
  
- **Improvements**
	- Refined update checking logic in UserProfile for better user experience, including conditional button rendering.
  
- **Bug Fixes**
	- Adjusted error handling for password change scenarios to provide clearer notifications.

- **Dependencies**
	- Added `@types/cypress` for improved type safety in Cypress testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->