### PR TITLE
Fix loading state management in useQuery when requests are aborted

### DIFF
--- a/src/Utils/request/request.ts
+++ b/src/Utils/request/request.ts
@@ -70,6 +70,9 @@ export default async function request<TData, TBody>(
       return result;
     } catch (error: any) {
       result = { error, res: undefined, data: undefined };
+      if (error.name === "AbortError") {
+        return result;
+      }
     }
   }
 

--- a/src/Utils/request/useMutation.ts
+++ b/src/Utils/request/useMutation.ts
@@ -31,8 +31,10 @@ export default function useMutation<TData, TBody>(
 
       setIsProcessing(true);
       const response = await request(route, { ...resolvedOptions, controller });
-      setResponse(response);
-      setIsProcessing(false);
+      if (response.error?.name !== "AbortError") {
+        setResponse(response);
+        setIsProcessing(false);
+      }
       return response;
     },
     [route, JSON.stringify(options)],

--- a/src/Utils/request/useMutation.ts
+++ b/src/Utils/request/useMutation.ts
@@ -10,7 +10,7 @@ import { mergeRequestOptions } from "@/Utils/request/utils";
 
 export default function useMutation<TData, TBody>(
   route: MutationRoute<TData, TBody>,
-  options: RequestOptions<TData>,
+  options: RequestOptions<TData, TBody>,
 ) {
   const [response, setResponse] = React.useState<RequestResult<TData>>();
   const [isProcessing, setIsProcessing] = React.useState(false);
@@ -18,7 +18,7 @@ export default function useMutation<TData, TBody>(
   const controllerRef = React.useRef<AbortController>();
 
   const runQuery = React.useCallback(
-    async (overrides?: RequestOptions<TData>) => {
+    async (overrides?: RequestOptions<TData, TBody>) => {
       controllerRef.current?.abort();
 
       const controller = new AbortController();

--- a/src/Utils/request/useQuery.ts
+++ b/src/Utils/request/useQuery.ts
@@ -37,8 +37,10 @@ export default function useQuery<TData>(
 
       setLoading(true);
       const response = await request(route, { ...resolvedOptions, controller });
-      setResponse(response);
-      setLoading(false);
+      if (response.error?.name !== "AbortError") {
+        setResponse(response);
+        setLoading(false);
+      }
       return response;
     },
     [route, JSON.stringify(options)],


### PR DESCRIPTION
> Was originally fixed in an ongoing PR: [`029d11e` (#9076)](https://github.com/ohcnetwork/care_fe/pull/9076/commits/029d11e6d258ad24ba1e145b3785fa1fc348ed8e)
Created a separate PR as it solves other existing issues in Care too.

## Proposed Changes

- Resolves #8030
- Resolves #9202

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for aborted requests in the `request` function.
	- Improved type safety and flexibility in the `useMutation` and `useQuery` hooks.

- **Bug Fixes**
	- Updated logic in `useQuery` to prevent state updates when a request is aborted.
	- Refined error handling in `useMutation` to manage response states more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->