### PR TITLE
Fixes PR thank you msg. from potentially tagging the PR author twice

### DIFF
--- a/.github/workflows/thank-you.yml
+++ b/.github/workflows/thank-you.yml
@@ -25,7 +25,7 @@ jobs:
               repo: context.repo.repo,
             };
 
-            const { assignees, user } = await github.rest.issues.get(options);
+            const { data : { assignees, user } } = await github.rest.issues.get(options);
 
             const uniqueUsers = new Set(
               assignees.length > 0

--- a/.github/workflows/thank-you.yml
+++ b/.github/workflows/thank-you.yml
@@ -18,24 +18,24 @@ jobs:
         uses: actions/github-script@v6.3.3
         with:
           script: |
-            const thankyouNote = 'Your efforts have helped advance digital healthcare and TeleICU systems. :rocket: Thank you for taking the time out to make CARE better. We hope you continue to innovate and contribute; your impact is immense! :raised_hands:'
+            const thankyouNote = 'Your efforts have helped advance digital healthcare and TeleICU systems. :rocket: Thank you for taking the time out to make CARE better. We hope you continue to innovate and contribute; your impact is immense! :raised_hands:';
             const options = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-            }
+            };
 
-            const result = await github.rest.issues.get({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            })
+            const { assignees, user } = await github.rest.issues.get(options);
 
-            const { assignees, user } = result.data
+            const uniqueUsers = new Set(
+              assignees.length > 0
+                ? assignees.map(u => u.login)
+                : [user.login]
+            );
 
-            const taggedUsers = assignees.length > 0 
-              ? assignees.map((u) => '@' + u.login).join(' ') 
-              : '@' + user.login;
+            const taggedUsers = Array.from(uniqueUsers)
+              .map(login => '@' + login)
+              .join(' ');
 
             await github.rest.issues.createComment({ 
               ...options, 

--- a/.github/workflows/thank-you.yml
+++ b/.github/workflows/thank-you.yml
@@ -33,11 +33,11 @@ jobs:
 
             const { assignees, user } = result.data
 
-            const assignees_tagged = assignees.map((user) => '@' + user.login).join(' ')
-            const owner_tagged = '@' + user.login
+            const taggedUsers = assignees.length > 0 
+              ? assignees.map((u) => '@' + u.login).join(' ') 
+              : '@' + user.login;
 
-            if (assignees.length == 0) {
-              await github.rest.issues.createComment({ ...options, body: `${owner_tagged} ${thankyouNote}` })
-            } else {
-              await github.rest.issues.createComment({ ...options, body: `${assignees_tagged} ${owner_tagged} ${thankyouNote}` })
-            }
+            await github.rest.issues.createComment({ 
+              ...options, 
+              body: `${taggedUsers} ${thankyouNote}` 
+            });

--- a/.github/workflows/thank-you.yml
+++ b/.github/workflows/thank-you.yml
@@ -27,15 +27,9 @@ jobs:
 
             const { data : { assignees, user } } = await github.rest.issues.get(options);
 
-            const uniqueUsers = new Set(
-              assignees.length > 0
-                ? assignees.map(u => u.login)
-                : [user.login]
-            );
-
-            const taggedUsers = Array.from(uniqueUsers)
-              .map(login => '@' + login)
-              .join(' ');
+            const taggedUsers = [...new Set(
+              assignees.map(u => "@"+u.login).concat("@"+user.login)  
+            )].join(" ")
 
             await github.rest.issues.createComment({ 
               ...options, 


### PR DESCRIPTION
## Proposed Changes

- Fixes #9224 
- Change 1: Updated the logic to prevent multiple tagging of contributors in the thank-you comment

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [[product documentation](https://docs.ohc.network/)](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved the workflow for tagging contributors in thank-you notes, ensuring a consistent and streamlined approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->