### PR TITLE
Fix : Advanced Filters Autofilling on Revisit to Patient Tab

### DIFF
--- a/src/components/Patient/ManagePatients.tsx
+++ b/src/components/Patient/ManagePatients.tsx
@@ -1143,7 +1143,10 @@ export const PatientManager = () => {
         />
       </div>
       <div>
-        <PatientFilter {...advancedFilter} key={window.location.search} />
+        <PatientFilter
+          {...advancedFilter}
+          key={JSON.stringify(advancedFilter.filter)}
+        />
         <TabPanel value={tabValue} index={0}>
           <div className="mb-4">{managePatients}</div>
         </TabPanel>


### PR DESCRIPTION
## Proposed Changes

- Fixes #9250 
- Implemented autofill functionality to retain advanced filter form details when revisiting the Patients tab with applied filters.

on revisit
![image](https://github.com/user-attachments/assets/5970d329-b014-4da5-bdcd-4e0c758a40e2)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced patient filtering mechanism for improved accuracy.
  
- **Bug Fixes**
  - Improved validation for phone number inputs to ensure only valid numbers are processed.
  - Clarified conditions for clearing phone number query parameters.
  
- **Style**
  - Minor layout adjustments for a more consistent user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->