### PR TITLE
changed modified_date to created_date on PatientHome page

### DIFF
--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -664,8 +664,8 @@ export const PatientHome = (props: {
                             ? formatDateTime(patientData.created_date)
                             : "--:--"}
                         </span>
-                        {patientData.modified_date
-                          ? relativeDate(patientData.modified_date)
+                        {patientData.created_date
+                          ? relativeDate(patientData.created_date)
                           : "--:--"}
                       </div>
                     </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #9307 
- changed modified_date to created_date for displaying "who created patient" correctly
- hover effect was right, nothing changed in that

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the patient profile display to show the creation date instead of the last modified date.

- **Bug Fixes**
	- Improved error handling for assigned volunteer information, ensuring errors are managed more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->