### PR TITLE
Sample Test Details: Fix Padding and enclose status and result with i18n

### DIFF
--- a/src/components/Patient/SampleDetails.tsx
+++ b/src/components/Patient/SampleDetails.tsx
@@ -265,7 +265,7 @@ export const SampleDetails = ({ id }: DetailRoute) => {
   const renderFlow = (flow: FlowModel) => {
     return (
       <Card key={flow.id}>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="mr-3 p-4 text-black md:mr-8 grid grid-cols-1 gap-4 md:grid-cols-2">
           <div>
             <span className="font-semibold leading-relaxed">
               {t("status")}:{" "}
@@ -323,16 +323,16 @@ export const SampleDetails = ({ id }: DetailRoute) => {
               <div className="text-sm text-muted-foreground">
                 {t("status")}:{" "}
               </div>
-              <Badge variant="outline" className="font-semibold">
-                {sampleDetails?.status}
+              <Badge variant="outline" className="font-semibold uppercase">
+                {t(`SAMPLE_TEST_HISTORY__${sampleDetails?.status}`)}
               </Badge>
             </div>
             <div className="space-y-1 sm:text-right flex gap-2 items-center ">
               <div className="text-sm text-muted-foreground">
                 {t("result")}:{" "}
               </div>
-              <Badge variant="secondary" className="font-semibold">
-                {sampleDetails?.result}
+              <Badge variant="secondary" className="font-semibold uppercase">
+                {t(`SAMPLE_TEST_RESULT__${sampleDetails?.result}`)}
               </Badge>
             </div>
           </div>
@@ -540,7 +540,7 @@ export const SampleDetails = ({ id }: DetailRoute) => {
         <h4 className="mt-8">{t("sample_test_history")}</h4>
         {sampleDetails?.flow &&
           sampleDetails.flow.map((flow: FlowModel) => (
-            <div key={flow.id} className="mb-2">
+            <div key={flow.id} className="mb-2 py-2">
               {renderFlow(flow)}
             </div>
           ))}


### PR DESCRIPTION
> Issue reported by @nihal467 ; caused recently by #9138 cc: @modamaan 

## Proposed Changes

- Fixes padding for sample test history card in sample details page
- Enclose sample details status and result options i18n.

| Before | After |
|--------|--------|
| <img width="1710" alt="image" src="https://github.com/user-attachments/assets/5107830a-eb4c-4078-a6f6-07e35bf738ee" /> | <img width="1710" alt="image" src="https://github.com/user-attachments/assets/183e3ac8-77b8-4e75-ab7a-941a31880b09" /> | 
| <img width="471" alt="image" src="https://github.com/user-attachments/assets/b5c1d553-657a-4943-95ea-c91fc0eb2e80" /> | <img width="471" alt="image" src="https://github.com/user-attachments/assets/4f8b5c12-d8d7-4de0-88d7-bdc6456b4016" /> |

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved rendering of sample details and patient information with enhanced spacing.
	- Updated `Badge` components for better localization and uppercase formatting.

- **Bug Fixes**
	- Retained error handling for navigation to a "not-found" page on unsuccessful queries.

- **Style**
	- Adjusted layout for improved visual presentation of sample and patient details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->