### PR TITLE
Fix avatar upload stuck state and update header after changing avatar

### DIFF
--- a/src/Utils/request/uploadFile.ts
+++ b/src/Utils/request/uploadFile.ts
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction } from "react";
 import * as Notification from "@/Utils/Notifications";
 import { handleUploadPercentage } from "@/Utils/request/utils";
 
-const uploadFile = (
+const uploadFile = async (
   url: string,
   file: File | FormData,
   reqMethod: string,
@@ -11,41 +11,47 @@ const uploadFile = (
   onLoad: (xhr: XMLHttpRequest) => void,
   setUploadPercent: Dispatch<SetStateAction<number>> | null,
   onError: () => void,
-) => {
-  const xhr = new XMLHttpRequest();
-  xhr.open(reqMethod, url);
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open(reqMethod, url);
 
-  Object.entries(headers).forEach(([key, value]) => {
-    xhr.setRequestHeader(key, value);
-  });
-
-  xhr.onload = () => {
-    onLoad(xhr);
-    if (400 <= xhr.status && xhr.status <= 499) {
-      const error = JSON.parse(xhr.responseText);
-      if (typeof error === "object" && !Array.isArray(error)) {
-        Object.values(error).forEach((msg) => {
-          Notification.Error({ msg: msg || "Something went wrong!" });
-        });
-      } else {
-        Notification.Error({ msg: error || "Something went wrong!" });
-      }
-    }
-  };
-
-  if (setUploadPercent != null) {
-    xhr.upload.onprogress = (event: ProgressEvent) => {
-      handleUploadPercentage(event, setUploadPercent);
-    };
-  }
-
-  xhr.onerror = () => {
-    Notification.Error({
-      msg: "Network Failure. Please check your internet connectivity.",
+    Object.entries(headers).forEach(([key, value]) => {
+      xhr.setRequestHeader(key, value);
     });
-    onError();
-  };
-  xhr.send(file);
-};
 
+    xhr.onload = () => {
+      onLoad(xhr);
+      if (400 <= xhr.status && xhr.status <= 499) {
+        const error = JSON.parse(xhr.responseText);
+        if (typeof error === "object" && !Array.isArray(error)) {
+          Object.values(error).forEach((msg) => {
+            Notification.Error({ msg: msg || "Something went wrong!" });
+          });
+        } else {
+          Notification.Error({ msg: error || "Something went wrong!" });
+        }
+        reject(new Error("Client error"));
+      } else {
+        resolve();
+      }
+    };
+
+    if (setUploadPercent != null) {
+      xhr.upload.onprogress = (event: ProgressEvent) => {
+        handleUploadPercentage(event, setUploadPercent);
+      };
+    }
+
+    xhr.onerror = () => {
+      Notification.Error({
+        msg: "Network Failure. Please check your internet connectivity.",
+      });
+      onError();
+      reject(new Error("Network error"));
+    };
+
+    xhr.send(file);
+  });
+};
 export default uploadFile;

--- a/src/Utils/request/uploadFile.ts
+++ b/src/Utils/request/uploadFile.ts
@@ -23,7 +23,12 @@ const uploadFile = async (
     xhr.onload = () => {
       onLoad(xhr);
       if (400 <= xhr.status && xhr.status <= 499) {
-        const error = JSON.parse(xhr.responseText);
+        let error;
+        try {
+          error = JSON.parse(xhr.responseText);
+        } catch {
+          error = xhr.responseText;
+        }
         if (typeof error === "object" && !Array.isArray(error)) {
           Object.values(error).forEach((msg) => {
             Notification.Error({ msg: msg || "Something went wrong!" });

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -114,20 +114,25 @@ const AvatarEditModal = ({
   };
 
   const uploadAvatar = async () => {
-    if (!selectedFile) {
-      closeModal();
-      return;
-    }
+    try {
+      if (!selectedFile) {
+        closeModal();
+        return;
+      }
 
-    setIsProcessing(true);
-    setIsCaptureImgBeingUploaded(true);
-    await handleUpload(selectedFile, () => {
-      setSelectedFile(undefined);
-      setPreview(undefined);
-      setPreviewImage(null);
+      setIsProcessing(true);
+      setIsCaptureImgBeingUploaded(true);
+      await handleUpload(selectedFile, () => {
+        setSelectedFile(undefined);
+        setPreview(undefined);
+        setPreviewImage(null);
+        setIsCaptureImgBeingUploaded(false);
+        setIsProcessing(false);
+      });
+    } finally {
       setIsCaptureImgBeingUploaded(false);
       setIsProcessing(false);
-    });
+    }
   };
 
   const deleteAvatar = async () => {

--- a/src/components/Users/UserAvatar.tsx
+++ b/src/components/Users/UserAvatar.tsx
@@ -19,7 +19,13 @@ import uploadFile from "@/Utils/request/uploadFile";
 import useTanStackQueryInstead from "@/Utils/request/useQuery";
 import { formatDisplayName, sleep } from "@/Utils/utils";
 
-export default function UserAvatar({ username }: { username: string }) {
+export default function UserAvatar({
+  username,
+  refetchUserData: userDataRefetch,
+}: {
+  username: string;
+  refetchUserData?: () => void;
+}) {
   const { t } = useTranslation();
   const [editAvatar, setEditAvatar] = useState(false);
   const authUser = useAuthUser();
@@ -43,7 +49,7 @@ export default function UserAvatar({ username }: { username: string }) {
     formData.append("profile_picture", file);
     const url = `${careConfig.apiUrl}/api/v1/users/${userData.username}/profile_picture/`;
 
-    uploadFile(
+    await uploadFile(
       url,
       formData,
       "POST",
@@ -54,7 +60,7 @@ export default function UserAvatar({ username }: { username: string }) {
       async (xhr: XMLHttpRequest) => {
         if (xhr.status === 200) {
           await sleep(1000);
-          refetchUserData();
+          userDataRefetch?.();
           Notification.Success({ msg: t("avatar_updated_success") });
           setEditAvatar(false);
         }
@@ -73,6 +79,7 @@ export default function UserAvatar({ username }: { username: string }) {
     if (res?.ok) {
       Notification.Success({ msg: "Profile picture deleted" });
       await refetchUserData();
+      await userDataRefetch?.();
       setEditAvatar(false);
     } else {
       onError();

--- a/src/components/Users/UserAvatar.tsx
+++ b/src/components/Users/UserAvatar.tsx
@@ -21,7 +21,7 @@ import { formatDisplayName, sleep } from "@/Utils/utils";
 
 export default function UserAvatar({
   username,
-  refetchUserData: userDataRefetch,
+  refetchUserData,
 }: {
   username: string;
   refetchUserData?: () => void;
@@ -30,15 +30,14 @@ export default function UserAvatar({
   const [editAvatar, setEditAvatar] = useState(false);
   const authUser = useAuthUser();
 
-  const {
-    data: userData,
-    loading: isLoading,
-    refetch: refetchUserData,
-  } = useTanStackQueryInstead(routes.getUserDetails, {
-    pathParams: {
-      username: username,
+  const { data: userData, loading: isLoading } = useTanStackQueryInstead(
+    routes.getUserDetails,
+    {
+      pathParams: {
+        username: username,
+      },
     },
-  });
+  );
 
   if (isLoading || !userData) {
     return <Loading />;
@@ -60,7 +59,7 @@ export default function UserAvatar({
       async (xhr: XMLHttpRequest) => {
         if (xhr.status === 200) {
           await sleep(1000);
-          userDataRefetch?.();
+          refetchUserData?.();
           Notification.Success({ msg: t("avatar_updated_success") });
           setEditAvatar(false);
         }
@@ -78,8 +77,7 @@ export default function UserAvatar({
     });
     if (res?.ok) {
       Notification.Success({ msg: "Profile picture deleted" });
-      await refetchUserData();
-      await userDataRefetch?.();
+      refetchUserData?.();
       setEditAvatar(false);
     } else {
       onError();


### PR DESCRIPTION
## Proposed Changes

- Fixes #9426 
- [x] Loading state gets stuck when an error occurs during avatar upload.
- [x] Header does not update to reflect the new avatar after changing it.

**Video of Solution:**

https://github.com/user-attachments/assets/6ad88d62-4d9f-4bd2-b72e-cafa9db22b55

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for file uploads, including improved notifications for client and network errors.
	- Added an optional `refetchUserData` parameter to the `UserAvatar` component to refresh user data after avatar updates.

- **Bug Fixes**
	- Improved state management in the `AvatarEditModal` to ensure UI reflects the correct status during upload attempts.

- **Documentation**
	- Updated method signatures to reflect changes in function parameters and return types across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->