### PR TITLE
Fix : Avoid negative number in Add Triage option in Facilities Page

### DIFF
--- a/src/components/Facility/FacilityHomeTriage.tsx
+++ b/src/components/Facility/FacilityHomeTriage.tsx
@@ -21,11 +21,11 @@ export function FacilityHomeTriage({ facilityId }: FacilityHomeTriageProps) {
   const tableRows =
     data?.results?.map((result) => [
       String(result.entry_date),
-      String(result.num_patients_visited),
-      String(result.num_patients_home_quarantine),
-      String(result.num_patients_isolation),
-      String(result.num_patient_referred),
-      String(result.num_patient_confirmed_positive),
+      String(Math.max(0, result.num_patients_visited || 0)),
+      String(Math.max(0, result.num_patients_home_quarantine || 0)),
+      String(Math.max(0, result.num_patients_isolation || 0)),
+      String(Math.max(0, result.num_patient_referred || 0)),
+      String(Math.max(0, result.num_patient_confirmed_positive || 0)),
       <ButtonV2
         key={result.id}
         id="edit-button"


### PR DESCRIPTION
## Proposed Changes

- Fixes #9429 
- Changed the table rows such that it takes value equals to 0 or higher and initiates it to 0 if value is undefined.

Code Reviewers : @Jacobjeevan @rithviknishad @bodhish @nihal467 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of numerical values in the Facility Home Triage component to prevent undefined or null values from causing display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->