### PR TITLE
Fix: Prevent negative number input in the form fields of "Add Triage"

### DIFF
--- a/src/components/Facility/TriageForm.tsx
+++ b/src/components/Facility/TriageForm.tsx
@@ -189,6 +189,10 @@ export const TriageForm = ({ facilityId, id }: Props) => {
   };
 
   const handleFormFieldChange = (event: FieldChangeEvent<unknown>) => {
+    
+    if (!/^\d*$/.test(event.value as string) && event.name !== "entry_date")
+      return;
+
     dispatch({
       type: "set_form",
       form: { ...state.form, [event.name]: event.value },


### PR DESCRIPTION
## Proposed Changes

- Fixes #9429
- Prevent entry of negative numbers in the form fields of "Add Triage"
- Add validation to ensure only whole numbers are entered for specific fields.
- Earlier the error shows up only after clicking "Save Triage" but now it is denied in the textbox itself

@ohcnetwork/care-fe-code-reviewers
[Screencast from 2024-12-15 01-27-09.webm](https://github.com/user-attachments/assets/f572d39b-d661-4950-ace6-9a47fe133d02)


## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation in the TriageForm to accept only numeric values for specific fields, improving data integrity.
  
- **Bug Fixes**
	- Resolved issues related to non-numeric input being processed incorrectly for form fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->