### PR TITLE
changed OP Number to Registration Number

### DIFF
--- a/src/components/Facility/ConsultationForm.tsx
+++ b/src/components/Facility/ConsultationForm.tsx
@@ -1314,7 +1314,7 @@ export const ConsultationForm = ({ facilityId, patientId, id }: Props) => {
                       label={
                         state.form.suggestion === "A"
                           ? "IP Number"
-                          : "OP Number"
+                          : "Registration Number"
                       }
                       required={state.form.suggestion === "A"}
                     />


### PR DESCRIPTION
## Proposed Changes

- Fixes #9513 
- change 1
![Screenshot 2024-12-20 152705](https://github.com/user-attachments/assets/56015f13-1a3f-4b9c-a19a-abeda67e7b31)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated label for the `patient_no` field from "OP Number" to "Registration Number" when the suggestion is not "A".
	- Enhanced validation for the `patient_no` field to ensure it is required when the suggestion is "A".
	- Adjusted handling of the `suggestion` field to set specific values in the form state, including setting `consultation_notes` to "Patient declared dead" for suggestion "DD".

- **Bug Fixes**
	- Improved error handling logic to display appropriate error messages based on form state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->