### PR TITLE
Always show "online" for authenticated user profiles

### DIFF
--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -134,8 +134,8 @@ export const UserStatusIndicator = ({
   className?: string;
   addPadding?: boolean;
 }) => {
-  const authUser = useAuthUser(); 
-  const isAuthUser = user.id === authUser.id; 
+  const authUser = useAuthUser();
+  const isAuthUser = user.id === authUser.id;
   const cur_online = isUserOnline(user) || isAuthUser;
   const { t } = useTranslation();
 
@@ -235,7 +235,7 @@ export const UserGrid = ({
 }: {
   users?: UserModel[] | UserAssignedModel[];
 }) => (
-  <div className="grid grid-cols-1 gap-4 @xl:grid-cols-3 @4xl:grid-cols-4 @6xl:grid-cols-5 lg:grid-cols-2"> 
+  <div className="grid grid-cols-1 gap-4 @xl:grid-cols-3 @4xl:grid-cols-4 @6xl:grid-cols-5 lg:grid-cols-2">
     {users?.map((user) => <UserCard key={user.id} user={user} />)}
   </div>
 );

--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -160,7 +160,12 @@ export const UserStatusIndicator = ({
           cur_online ? "text-green-700" : "text-gray-500",
         )}
       >
-        {cur_online ? t("online") : t("offline")}
+        //{cur_online ? t("online") : t("offline")}
+        {cur_online
+          ? t("online")
+          : user.last_login
+            ? relativeTime(user.last_login)
+            : t("never")}
       </span>
     </div>
   );

--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -136,7 +136,7 @@ export const UserStatusIndicator = ({
 }) => {
   const authUser = useAuthUser();
   const isAuthUser = user.id === authUser.id;
-  const cur_online = isUserOnline(user) || isAuthUser;
+  const isOnline = isUserOnline(user) || isAuthUser;
   const { t } = useTranslation();
 
   return (

--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -160,7 +160,6 @@ export const UserStatusIndicator = ({
           cur_online ? "text-green-700" : "text-gray-500",
         )}
       >
-        //{cur_online ? t("online") : t("offline")}
         {cur_online
           ? t("online")
           : user.last_login
@@ -236,7 +235,7 @@ export const UserGrid = ({
 }: {
   users?: UserModel[] | UserAssignedModel[];
 }) => (
-  <div className="grid grid-cols-1 gap-4 @xl:grid-cols-3 @4xl:grid-cols-4 @6xl:grid-cols-5 lg:grid-cols-2">
+  <div className="grid grid-cols-1 gap-4 @xl:grid-cols-3 @4xl:grid-cols-4 @6xl:grid-cols-5 lg:grid-cols-2"> 
     {users?.map((user) => <UserCard key={user.id} user={user} />)}
   </div>
 );

--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -136,7 +136,7 @@ export const UserStatusIndicator = ({
 }) => {
   const authUser = useAuthUser();
   const isAuthUser = user.id === authUser.id;
-  const cur_online = isUserOnline(user) || isAuthUser;
+  const isOnline = isUserOnline(user) || isAuthUser;
   const { t } = useTranslation();
 
   return (
@@ -144,23 +144,23 @@ export const UserStatusIndicator = ({
       className={classNames(
         "inline-flex items-center gap-2 rounded-full",
         addPadding ? "px-3 py-1" : "py-px",
-        cur_online ? "bg-green-100" : "bg-gray-100",
+        isOnline ? "bg-green-100" : "bg-gray-100",
         className,
       )}
     >
       <span
         className={classNames(
           "inline-block h-2 w-2 shrink-0 rounded-full",
-          cur_online ? "bg-green-500" : "bg-gray-400",
+          isOnline ? "bg-green-500" : "bg-gray-400",
         )}
       ></span>
       <span
         className={classNames(
           "whitespace-nowrap text-xs",
-          cur_online ? "text-green-700" : "text-gray-500",
+          isOnline ? "text-green-700" : "text-gray-500",
         )}
       >
-        {cur_online
+        {isOnline
           ? t("online")
           : user.last_login
             ? relativeTime(user.last_login)

--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -134,8 +134,12 @@ export const UserStatusIndicator = ({
   className?: string;
   addPadding?: boolean;
 }) => {
-  const cur_online = isUserOnline(user);
+  const authUser = useAuthUser(); // Get the authenticated user's details
+  const isAuthUser = user.id === authUser.id; // Check if the user is the authenticated user
+  const cur_online = isUserOnline(user) || isAuthUser; // Assume always online if it's the authenticated user
+  
   const { t } = useTranslation();
+
   return (
     <div
       className={classNames(
@@ -157,11 +161,7 @@ export const UserStatusIndicator = ({
           cur_online ? "text-green-700" : "text-gray-500",
         )}
       >
-        {cur_online
-          ? t("online")
-          : user.last_login
-            ? relativeTime(user.last_login)
-            : t("never")}
+        {cur_online ? t("online") : t("offline")}
       </span>
     </div>
   );

--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -134,10 +134,9 @@ export const UserStatusIndicator = ({
   className?: string;
   addPadding?: boolean;
 }) => {
-  const authUser = useAuthUser(); // Get the authenticated user's details
-  const isAuthUser = user.id === authUser.id; // Check if the user is the authenticated user
-  const cur_online = isUserOnline(user) || isAuthUser; // Assume always online if it's the authenticated user
-  
+  const authUser = useAuthUser(); 
+  const isAuthUser = user.id === authUser.id; 
+  const cur_online = isUserOnline(user) || isAuthUser;
   const { t } = useTranslation();
 
   return (


### PR DESCRIPTION
## Proposed Changes

- Fixes #9570 
- Change 1: Modified UserStatusIndicator to always display "Online now" for the authenticated user viewing their own profile.


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user status indicator to accurately reflect the online status of the authenticated user.
- **Style**
	- Minor formatting adjustment in the UserStatusIndicator component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->