### PR TITLE
Fix: UI issue in facilities page

### DIFF
--- a/src/components/Facility/FacilityCard.tsx
+++ b/src/components/Facility/FacilityCard.tsx
@@ -63,7 +63,7 @@ export const FacilityCard = (props: {
           <div className="h-full w-full grow">
             <Link
               href={`/facility/${facility.id}`}
-              className="group relative z-0 flex w-full min-w-[15%] items-center justify-center self-stretch min-[425px]:hidden"
+              className="group relative z-0 flex w-full min-w-[15%] items-center justify-center self-stretch min-[640px]:hidden"
             >
               <Avatar
                 name={facility.name || ""}


### PR DESCRIPTION
## Proposed Changes

- Fixes #9577 
- Updated the maximum visibility width of the larger image from 425px to 640px, ensuring that mobile devices with a width less than 640px use the larger image, while devices with a width of 640px or greater use the smaller image.

## Video of Solution:
<video src="https://github.com/user-attachments/assets/2b2a4f7e-8074-4675-9373-d974de2fe5dd" controls></video>

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the responsive behavior of the FacilityCard component to remain visible on screens wider than 640 pixels. 

- **Bug Fixes**
	- Adjusted visibility settings to enhance user experience on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->