### PR TITLE
Prefill Searched Phone Number in Patient Creation form

### DIFF
--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -53,11 +53,12 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
   });
 
   const handleCreatePatient = useCallback(() => {
-  const queryParams = phoneNumber ? { phone_number: phoneNumber } : {};
+    const queryParams = phoneNumber ? { phone_number: phoneNumber } : {};
 
-  navigate(`/facility/${facilityId}/patient/create`, {
-    query: queryParams
-  });
+    navigate(`/facility/${facilityId}/patient/create`, {
+      query: queryParams,
+    });
+  }, [facilityId, phoneNumber]);
 
   function AddPatientButton({ outline }: { outline?: boolean }) {
     return (

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -53,8 +53,15 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
   });
 
   const handleCreatePatient = useCallback(() => {
-    navigate(`/facility/${facilityId}/patient/create`);
-  }, [facilityId]);
+    navigate(
+      `/facility/${facilityId}/patient/create`,
+      phoneNumber
+        ? {
+            query: { phone_number: phoneNumber },
+          }
+        : {},
+    );
+  }, [facilityId, phoneNumber]);
 
   function AddPatientButton({ outline }: { outline?: boolean }) {
     return (

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -53,15 +53,11 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
   });
 
   const handleCreatePatient = useCallback(() => {
-    navigate(
-      `/facility/${facilityId}/patient/create`,
-      phoneNumber
-        ? {
-            query: { phone_number: phoneNumber },
-          }
-        : {},
-    );
-  }, [facilityId, phoneNumber]);
+  const queryParams = phoneNumber ? { phone_number: phoneNumber } : {};
+
+  navigate(`/facility/${facilityId}/patient/create`, {
+    query: queryParams
+  });
 
   function AddPatientButton({ outline }: { outline?: boolean }) {
     return (

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -60,8 +60,7 @@ interface PatientRegistrationPageProps {
 export default function PatientRegistration(
   props: PatientRegistrationPageProps,
 ) {
-  const [qParams] = useQueryParams();
-  const { phone_number } = qParams;
+  const [{ phone_number }] = useQueryParams();
   const { patientId, facilityId } = props;
   const { t } = useTranslation();
   const { goBack } = useAppHistory();

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -72,7 +72,7 @@ export default function PatientRegistration(
   const [showAutoFilledPincode, setShowAutoFilledPincode] = useState(false);
   const [form, setForm] = useState<Partial<PatientModel>>({
     nationality: "India",
-    phone_number: "+91",
+    phone_number: phone_number || "+91",
     emergency_phone_number: "+91",
   });
   const [feErrors, setFeErrors] = useState<
@@ -81,12 +81,6 @@ export default function PatientRegistration(
   const [suppressDuplicateWarning, setSuppressDuplicateWarning] =
     useState(!!patientId);
   const [debouncedNumber, setDebouncedNumber] = useState<string>();
-
-  useEffect(() => {
-    if (phone_number) {
-      setForm((f) => ({ ...f, phone_number }));
-    }
-  }, [phone_number]);
 
   const sidebarItems = [
     { label: t("patient__general-info"), id: "general-info" },

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -1,6 +1,6 @@
 import careConfig from "@careConfig";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { navigate } from "raviger";
+import { navigate, useQueryParams } from "raviger";
 import { Fragment, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -60,6 +60,8 @@ interface PatientRegistrationPageProps {
 export default function PatientRegistration(
   props: PatientRegistrationPageProps,
 ) {
+  const [qParams] = useQueryParams();
+  const { phone_number } = qParams;
   const { patientId, facilityId } = props;
   const { t } = useTranslation();
   const { goBack } = useAppHistory();
@@ -79,6 +81,12 @@ export default function PatientRegistration(
   const [suppressDuplicateWarning, setSuppressDuplicateWarning] =
     useState(!!patientId);
   const [debouncedNumber, setDebouncedNumber] = useState<string>();
+
+  useEffect(() => {
+    if (phone_number) {
+      setForm((f) => ({ ...f, phone_number }));
+    }
+  }, [phone_number]);
 
   const sidebarItems = [
     { label: t("patient__general-info"), id: "general-info" },


### PR DESCRIPTION
## Proposed Changes

- Fixes #9544 
- Pass searched Phone Number to Patient Registration form and prefill Phone Number field

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced patient registration process to support phone number pre-filling from URL query parameters.
	- Added real-time duplicate patient detection during registration.

- **Improvements**
	- Improved handling of phone number input during patient creation.
	- Added dynamic navigation with phone number query support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->