### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@
 #### Install the required dependencies
 
 ```sh
-npm run install-all
+npm install
 ```
+
 #### First-time setup
 
 For first-time setup, run the following command to generate the pluginMap and install plugin configurations:


### PR DESCRIPTION
## Proposed Changes

Looks like `npm run install-all` went away after recent changes.

```
npm run install-all
npm ERR! Missing script: "install-all"
npm ERR! 
npm ERR! Did you mean one of these?
npm ERR!     npm install # Install a package
npm ERR!     npm install-test # Install package(s) and run tests
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run
```

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README installation instructions
	- Added new "First-time setup" section
	- Simplified dependency installation process
	- Clarified setup steps for new users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->