### PR TITLE
Rename resources to users; disable heatmap

### DIFF
--- a/care.config.ts
+++ b/care.config.ts
@@ -107,7 +107,7 @@ const careConfig = {
     // Kill switch in-case the heatmap API doesn't scale as expected
     useAvailabilityStatsAPI: boolean(
       "REACT_APPOINTMENTS_USE_AVAILABILITY_STATS_API",
-      true,
+      false,
     ),
   },
 

--- a/src/Utils/request/api.tsx
+++ b/src/Utils/request/api.tsx
@@ -11,11 +11,6 @@ import {
   FileUploadModel,
 } from "@/components/Patient/models";
 import {
-  Appointment,
-  AppointmentCreate,
-  SlotAvailability,
-} from "@/components/Schedule/types";
-import {
   SkillModel,
   UpdatePasswordForm,
   UserAssignedModel,
@@ -798,23 +793,6 @@ const routes = {
         value: "Bearer {token}",
         type: "header",
       },
-    },
-    getSlotsForDay: {
-      path: "/api/v1/otp/slots/get_slots_for_day/",
-      method: "POST",
-      TRes: Type<{ results: SlotAvailability[] }>(),
-      TBody: Type<{ facility: string; resource: string; day: string }>(),
-    },
-    getAppointments: {
-      path: "/api/v1/otp/slots/get_appointments/",
-      method: "GET",
-      TRes: Type<{ results: Appointment[] }>(),
-    },
-    createAppointment: {
-      path: "/api/v1/otp/slots/{id}/create_appointment/",
-      method: "POST",
-      TRes: Type<Appointment>(),
-      TBody: Type<AppointmentCreate>(),
     },
   },
 

--- a/src/components/Questionnaire/QuestionTypes/FollowUpAppointmentQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/FollowUpAppointmentQuestion.tsx
@@ -70,7 +70,7 @@ export function FollowUpAppointmentQuestion({
 
   const resourcesQuery = useQuery({
     queryKey: ["availableResources", facilityId],
-    queryFn: query(ScheduleAPIs.appointments.availableDoctors, {
+    queryFn: query(ScheduleAPIs.appointments.availableUsers, {
       pathParams: { facility_id: facilityId },
     }),
   });
@@ -85,7 +85,7 @@ export function FollowUpAppointmentQuestion({
     queryFn: query(ScheduleAPIs.slots.getSlotsForDay, {
       pathParams: { facility_id: facilityId },
       body: {
-        resource: resource?.id,
+        user: resource?.id,
         day: dateQueryString(selectedDate),
       },
     }),

--- a/src/components/Schedule/Appointments/AppointmentCreatePage.tsx
+++ b/src/components/Schedule/Appointments/AppointmentCreatePage.tsx
@@ -51,7 +51,7 @@ export default function AppointmentCreatePage(props: Props) {
 
   const resourcesQuery = useQuery({
     queryKey: ["availableResources", props.facilityId],
-    queryFn: query(ScheduleAPIs.appointments.availableDoctors, {
+    queryFn: query(ScheduleAPIs.appointments.availableUsers, {
       pathParams: {
         facility_id: props.facilityId,
       },
@@ -75,7 +75,7 @@ export default function AppointmentCreatePage(props: Props) {
     queryFn: query(ScheduleAPIs.slots.getSlotsForDay, {
       pathParams: { facility_id: props.facilityId },
       body: {
-        resource: resourceId,
+        user: resourceId,
         day: dateQueryString(selectedDate),
       },
     }),

--- a/src/components/Schedule/Appointments/AppointmentDetailsPage.tsx
+++ b/src/components/Schedule/Appointments/AppointmentDetailsPage.tsx
@@ -194,7 +194,7 @@ const AppointmentDetails = ({
   appointment: Appointment;
   facility: FacilityModel;
 }) => {
-  const { patient, resource } = appointment;
+  const { patient, user } = appointment;
   const { t } = useTranslation();
 
   return (
@@ -335,8 +335,8 @@ const AppointmentDetails = ({
         <CardContent className="space-y-4">
           <div className="grid gap-2">
             <div className="text-sm">
-              <p className="font-medium">{formatName(resource)}</p>
-              <p className="text-gray-600">{resource.email}</p>
+              <p className="font-medium">{formatName(user)}</p>
+              <p className="text-gray-600">{user.email}</p>
             </div>
             <Separator />
             <div className="text-sm">

--- a/src/components/Schedule/Appointments/AppointmentTokenCard.tsx
+++ b/src/components/Schedule/Appointments/AppointmentTokenCard.tsx
@@ -9,7 +9,7 @@ import { formatAppointmentSlotTime } from "@/components/Schedule/Appointments/ut
 import { getFakeTokenNumber } from "@/components/Schedule/helpers";
 import { Appointment } from "@/components/Schedule/types";
 
-import { formatPatientAge } from "@/Utils/utils";
+import { formatDisplayName, formatPatientAge } from "@/Utils/utils";
 
 interface Props {
   id?: string;
@@ -76,8 +76,7 @@ const AppointmentTokenCard = ({ id, appointment, facility }: Props) => {
             <div>
               <Label>{t("practitioner")}:</Label>
               <p className="text-sm font-semibold">
-                {appointment.resource.first_name}{" "}
-                {appointment.resource.last_name}
+                {formatDisplayName(appointment.user)}
               </p>
             </div>
             <div>

--- a/src/components/Schedule/Appointments/AppointmentTokenCard.tsx
+++ b/src/components/Schedule/Appointments/AppointmentTokenCard.tsx
@@ -9,7 +9,7 @@ import { formatAppointmentSlotTime } from "@/components/Schedule/Appointments/ut
 import { getFakeTokenNumber } from "@/components/Schedule/helpers";
 import { Appointment } from "@/components/Schedule/types";
 
-import { formatDisplayName, formatPatientAge } from "@/Utils/utils";
+import { formatName, formatPatientAge } from "@/Utils/utils";
 
 interface Props {
   id?: string;
@@ -76,7 +76,7 @@ const AppointmentTokenCard = ({ id, appointment, facility }: Props) => {
             <div>
               <Label>{t("practitioner")}:</Label>
               <p className="text-sm font-semibold">
-                {formatDisplayName(appointment.user)}
+                {formatName(appointment.user)}
               </p>
             </div>
             <div>

--- a/src/components/Schedule/Appointments/AppointmentsPage.tsx
+++ b/src/components/Schedule/Appointments/AppointmentsPage.tsx
@@ -64,7 +64,12 @@ import useAuthUser from "@/hooks/useAuthUser";
 import FiltersCache from "@/Utils/FiltersCache";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
-import { dateQueryString, formatName, formatPatientAge } from "@/Utils/utils";
+import {
+  dateQueryString,
+  formatDisplayName,
+  formatName,
+  formatPatientAge,
+} from "@/Utils/utils";
 
 interface QueryParams {
   practitioner?: string;
@@ -350,7 +355,7 @@ function AppointmentColumn(props: {
         status: props.status,
         limit: 100,
         slot: props.slot,
-        resource: props.practitioner,
+        user: props.practitioner,
         date: props.date,
       },
     }),
@@ -456,7 +461,7 @@ function AppointmentRow(props: {
         status: status,
         limit: 100,
         slot: props.slot,
-        resource: props.practitioner,
+        user: props.practitioner,
         date: props.date,
       },
     }),
@@ -574,7 +579,7 @@ function AppointmentRowItem({
         <p>{"Need Room Information"}</p>
       </TableCell>
       <TableCell className="py-6 group-hover:bg-gray-100 bg-white">
-        {formatName(appointment.resource)}
+        {formatDisplayName(appointment.user)}
       </TableCell>
       <TableCell className="py-6 group-hover:bg-gray-100 bg-white">
         <p>{"Need Labels"}</p>

--- a/src/components/Schedule/Appointments/AppointmentsPage.tsx
+++ b/src/components/Schedule/Appointments/AppointmentsPage.tsx
@@ -96,7 +96,7 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
 
   const resourcesQuery = useQuery({
     queryKey: ["appointments-resources", facilityId],
-    queryFn: query(ScheduleAPIs.appointments.availableDoctors, {
+    queryFn: query(ScheduleAPIs.appointments.availableUsers, {
       pathParams: { facility_id: facilityId },
     }),
   });
@@ -109,7 +109,7 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
     queryFn: query(ScheduleAPIs.slots.getSlotsForDay, {
       pathParams: { facility_id: facilityId },
       body: {
-        resource: qParams.practitioner ?? "",
+        user: qParams.practitioner ?? "",
         day: date,
       },
     }),

--- a/src/components/Schedule/Appointments/utils.ts
+++ b/src/components/Schedule/Appointments/utils.ts
@@ -22,6 +22,7 @@ import {
 import query from "@/Utils/request/query";
 import {
   dateQueryString,
+  formatDisplayName,
   formatPatientAge,
   getMonthStartAndEnd,
 } from "@/Utils/utils";
@@ -346,7 +347,7 @@ style="
               margin: 0.25rem 0 0 0;
             "
           >
-            ${appointment.resource.first_name} ${appointment.resource.last_name}
+            ${formatDisplayName(appointment.user)}
           </p>
         </div>
         <div>

--- a/src/components/Schedule/Appointments/utils.ts
+++ b/src/components/Schedule/Appointments/utils.ts
@@ -79,7 +79,7 @@ export const useAvailabilityHeatmap = ({
   let queryFn = query(ScheduleAPIs.slots.availabilityHeatmap, {
     pathParams: { facility_id: facilityId },
     body: {
-      resource: userId,
+      user: userId,
       from_date: fromDate,
       to_date: toDate,
     },

--- a/src/components/Schedule/ScheduleExceptionForm.tsx
+++ b/src/components/Schedule/ScheduleExceptionForm.tsx
@@ -111,7 +111,7 @@ export default function ScheduleExceptionForm({ user, onRefresh }: Props) {
       valid_to: dateQueryString(data.valid_to),
       start_time: data.start_time,
       end_time: data.end_time,
-      resource: user.id,
+      user: user.id,
     });
   }
 

--- a/src/components/Schedule/ScheduleExceptionsList.tsx
+++ b/src/components/Schedule/ScheduleExceptionsList.tsx
@@ -18,14 +18,12 @@ import useSlug from "@/hooks/useSlug";
 
 import mutate from "@/Utils/request/mutate";
 import { formatTimeShort } from "@/Utils/utils";
-import { UserBase } from "@/types/user/user";
 
 interface Props {
-  user: UserBase;
   items?: ScheduleException[];
 }
 
-export default function ScheduleExceptionsList({ user, items }: Props) {
+export default function ScheduleExceptionsList({ items }: Props) {
   const { t } = useTranslation();
 
   if (items == null) {
@@ -45,16 +43,14 @@ export default function ScheduleExceptionsList({ user, items }: Props) {
     <ul className="flex flex-col gap-4">
       {items.map((exception) => (
         <li key={exception.id}>
-          <ScheduleExceptionItem {...exception} user={user} />
+          <ScheduleExceptionItem {...exception} />
         </li>
       ))}
     </ul>
   );
 }
 
-const ScheduleExceptionItem = (
-  props: ScheduleException & { user: UserBase },
-) => {
+const ScheduleExceptionItem = (props: ScheduleException) => {
   const { t } = useTranslation();
   const facilityId = useSlug("facility");
   const queryClient = useQueryClient();
@@ -69,7 +65,7 @@ const ScheduleExceptionItem = (
     onSuccess: () => {
       toast.success(t("exception_deleted"));
       queryClient.invalidateQueries({
-        queryKey: ["user-availability-exceptions", props.user.username],
+        queryKey: ["user-availability-exceptions", props.user],
       });
     },
   });

--- a/src/components/Schedule/ScheduleTemplateForm.tsx
+++ b/src/components/Schedule/ScheduleTemplateForm.tsx
@@ -133,7 +133,7 @@ export default function ScheduleTemplateForm({ user, onRefresh }: Props) {
       valid_from: dateQueryString(values.valid_from),
       valid_to: dateQueryString(values.valid_to),
       name: values.name,
-      resource: user.id as unknown as string,
+      user: user.id as unknown as string,
       availabilities: values.availabilities.map((availability) => ({
         name: availability.name,
         slot_type: availability.slot_type,

--- a/src/components/Schedule/api.ts
+++ b/src/components/Schedule/api.ts
@@ -56,13 +56,13 @@ export const ScheduleAPIs = {
       path: "/api/v1/facility/{facility_id}/slots/availability_stats/",
       method: "POST",
       TRes: Type<AvailabilityHeatmap>(),
-      TBody: Type<{ from_date: string; to_date: string; resource: string }>(),
+      TBody: Type<{ from_date: string; to_date: string; user: string }>(),
     },
     getSlotsForDay: {
       path: "/api/v1/facility/{facility_id}/slots/get_slots_for_day/",
       method: "POST",
       TRes: Type<{ results: SlotAvailability[] }>(),
-      TBody: Type<{ resource: string; day: string }>(),
+      TBody: Type<{ user: string; day: string }>(),
     },
     createAppointment: {
       path: "/api/v1/facility/{facility_id}/slots/{slot_id}/create_appointment/",
@@ -73,9 +73,8 @@ export const ScheduleAPIs = {
   },
 
   appointments: {
-    // TODO: rename this to available_resources (or something more accurate)
-    availableDoctors: {
-      path: "/api/v1/facility/{facility_id}/appointments/available_doctors/",
+    availableUsers: {
+      path: "/api/v1/facility/{facility_id}/appointments/available_users/",
       method: "GET",
       TRes: Type<{ users: UserBase[] }>(),
     },

--- a/src/components/Schedule/types.ts
+++ b/src/components/Schedule/types.ts
@@ -105,6 +105,10 @@ export interface AvailabilityHeatmap {
   [date: string]: { total_slots: number; booked_slots: number };
 }
 
+export interface CancelAppointmentRequest {
+  reason: "cancelled" | "entered_in_error";
+}
+
 export interface FollowUpAppointmentRequest {
   reason_for_visit: string;
   slot_id: string;

--- a/src/components/Schedule/types.ts
+++ b/src/components/Schedule/types.ts
@@ -5,7 +5,7 @@ import { UserBase } from "@/types/user/user";
 
 export interface ScheduleTemplate {
   readonly id: string;
-  resource: string;
+  user: string;
   name: string;
   valid_from: string;
   valid_to: string;
@@ -33,7 +33,7 @@ export type ScheduleAvailability = ScheduleTemplate["availabilities"][number];
 
 export interface ScheduleException {
   readonly id: string;
-  resource: string; // UUID of the resource
+  user: string; // UUID of user
   reason: string;
   valid_from: string; // date in YYYY-MM-DD format
   valid_to: string; // date in YYYY-MM-DD format
@@ -98,7 +98,7 @@ export interface Appointment {
   readonly booked_by: UserBase | null;
   status: (typeof AppointmentStatuses)[number];
   readonly reason_for_visit: string;
-  readonly resource: UserBase;
+  readonly user: UserBase;
 }
 
 export interface AvailabilityHeatmap {

--- a/src/components/Users/UserAvailabilityTab.tsx
+++ b/src/components/Users/UserAvailabilityTab.tsx
@@ -55,7 +55,7 @@ export default function UserAvailabilityTab({ userData: user }: Props) {
     queryKey: ["user-availability-templates", user.username],
     queryFn: query(ScheduleAPIs.templates.list, {
       pathParams: { facility_id: facilityId! },
-      queryParams: { resource: user.id },
+      queryParams: { user: user.id },
     }),
     enabled: !!facilityId,
   });
@@ -64,7 +64,7 @@ export default function UserAvailabilityTab({ userData: user }: Props) {
     queryKey: ["user-availability-exceptions", user.username],
     queryFn: query(ScheduleAPIs.exceptions.list, {
       pathParams: { facility_id: facilityId! },
-      queryParams: { resource: user.id },
+      queryParams: { user: user.id },
     }),
   });
 
@@ -274,7 +274,6 @@ export default function UserAvailabilityTab({ userData: user }: Props) {
                     ? undefined
                     : exceptionsQuery.data?.results
                 }
-                user={user}
               />
             )}
 

--- a/src/pages/Appoinments/PatientRegistration.tsx
+++ b/src/pages/Appoinments/PatientRegistration.tsx
@@ -38,12 +38,12 @@ import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import { HTTPError } from "@/Utils/request/types";
 import { dateQueryString } from "@/Utils/utils";
-import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import {
   AppointmentPatient,
   AppointmentPatientRegister,
 } from "@/pages/Patient/Utils";
 import { TokenData } from "@/types/auth/otpToken";
+import PublicAppointmentApi from "@/types/scheduling/PublicAppointmentApi";
 
 import OrganizationSelector from "../Organization/components/OrganizationSelector";
 
@@ -141,7 +141,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
 
   const { mutate: createAppointment } = useMutation({
     mutationFn: (body: AppointmentCreate) =>
-      mutate(PublicAppointmentAPIs.createAppointment, {
+      mutate(PublicAppointmentApi.createAppointment, {
         pathParams: { id: selectedSlot?.id },
         body,
         headers: {

--- a/src/pages/Appoinments/PatientRegistration.tsx
+++ b/src/pages/Appoinments/PatientRegistration.tsx
@@ -38,6 +38,7 @@ import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import { HTTPError } from "@/Utils/request/types";
 import { dateQueryString } from "@/Utils/utils";
+import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import {
   AppointmentPatient,
   AppointmentPatientRegister,
@@ -140,7 +141,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
 
   const { mutate: createAppointment } = useMutation({
     mutationFn: (body: AppointmentCreate) =>
-      mutate(routes.otp.createAppointment, {
+      mutate(PublicAppointmentAPIs.createAppointment, {
         pathParams: { id: selectedSlot?.id },
         body,
         headers: {

--- a/src/pages/Appoinments/PatientSelect.tsx
+++ b/src/pages/Appoinments/PatientSelect.tsx
@@ -22,6 +22,7 @@ import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
+import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import { AppointmentPatient } from "@/pages/Patient/Utils";
 import { TokenData } from "@/types/auth/otpToken";
 
@@ -72,7 +73,7 @@ export default function PatientSelect({
 
   const { mutate: createAppointment } = useMutation({
     mutationFn: (body: AppointmentCreate) =>
-      mutate(routes.otp.createAppointment, {
+      mutate(PublicAppointmentAPIs.createAppointment, {
         pathParams: { id: selectedSlot?.id },
         body,
         headers: {

--- a/src/pages/Appoinments/PatientSelect.tsx
+++ b/src/pages/Appoinments/PatientSelect.tsx
@@ -22,9 +22,9 @@ import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
-import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import { AppointmentPatient } from "@/pages/Patient/Utils";
 import { TokenData } from "@/types/auth/otpToken";
+import PublicAppointmentApi from "@/types/scheduling/PublicAppointmentApi";
 
 export default function PatientSelect({
   facilityId,
@@ -73,7 +73,7 @@ export default function PatientSelect({
 
   const { mutate: createAppointment } = useMutation({
     mutationFn: (body: AppointmentCreate) =>
-      mutate(PublicAppointmentAPIs.createAppointment, {
+      mutate(PublicAppointmentApi.createAppointment, {
         pathParams: { id: selectedSlot?.id },
         body,
         headers: {

--- a/src/pages/Appoinments/Schedule.tsx
+++ b/src/pages/Appoinments/Schedule.tsx
@@ -28,6 +28,7 @@ import query from "@/Utils/request/query";
 import request from "@/Utils/request/request";
 import { RequestResult } from "@/Utils/request/types";
 import { dateQueryString } from "@/Utils/utils";
+import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import { TokenData } from "@/types/auth/otpToken";
 
 interface AppointmentsProps {
@@ -84,10 +85,10 @@ export function ScheduleAppointment(props: AppointmentsProps) {
 
   const slotsQuery = useQuery<{ results: SlotAvailability[] }>({
     queryKey: ["slots", facilityId, staffId, selectedDate],
-    queryFn: query(routes.otp.getSlotsForDay, {
+    queryFn: query(PublicAppointmentAPIs.getSlotsForDay, {
       body: {
         facility: facilityId,
-        resource: staffId,
+        user: staffId,
         day: dateQueryString(selectedDate),
       },
       headers: {

--- a/src/pages/Appoinments/Schedule.tsx
+++ b/src/pages/Appoinments/Schedule.tsx
@@ -28,8 +28,8 @@ import query from "@/Utils/request/query";
 import request from "@/Utils/request/request";
 import { RequestResult } from "@/Utils/request/types";
 import { dateQueryString } from "@/Utils/utils";
-import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import { TokenData } from "@/types/auth/otpToken";
+import PublicAppointmentApi from "@/types/scheduling/PublicAppointmentApi";
 
 interface AppointmentsProps {
   facilityId: string;
@@ -85,7 +85,7 @@ export function ScheduleAppointment(props: AppointmentsProps) {
 
   const slotsQuery = useQuery<{ results: SlotAvailability[] }>({
     queryKey: ["slots", facilityId, staffId, selectedDate],
-    queryFn: query(PublicAppointmentAPIs.getSlotsForDay, {
+    queryFn: query(PublicAppointmentApi.getSlotsForDay, {
       body: {
         facility: facilityId,
         user: staffId,

--- a/src/pages/Appoinments/Success.tsx
+++ b/src/pages/Appoinments/Success.tsx
@@ -12,8 +12,8 @@ import { CarePatientTokenKey } from "@/common/constants";
 import * as Notification from "@/Utils/Notifications";
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
-import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import { TokenData } from "@/types/auth/otpToken";
+import PublicAppointmentApi from "@/types/scheduling/PublicAppointmentApi";
 
 export function AppointmentSuccess(props: { appointmentId: string }) {
   const { appointmentId } = props;
@@ -25,7 +25,7 @@ export function AppointmentSuccess(props: { appointmentId: string }) {
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["appointment", tokenData.phoneNumber],
-    queryFn: query(PublicAppointmentAPIs.getAppointments, {
+    queryFn: query(PublicAppointmentApi.getAppointments, {
       headers: {
         Authorization: `Bearer ${tokenData.token}`,
       },

--- a/src/pages/Appoinments/Success.tsx
+++ b/src/pages/Appoinments/Success.tsx
@@ -10,9 +10,9 @@ import { UserModel } from "@/components/Users/models";
 import { CarePatientTokenKey } from "@/common/constants";
 
 import * as Notification from "@/Utils/Notifications";
-import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
+import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 import { TokenData } from "@/types/auth/otpToken";
 
 export function AppointmentSuccess(props: { appointmentId: string }) {
@@ -25,7 +25,7 @@ export function AppointmentSuccess(props: { appointmentId: string }) {
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["appointment", tokenData.phoneNumber],
-    queryFn: query(routes.otp.getAppointments, {
+    queryFn: query(PublicAppointmentAPIs.getAppointments, {
       headers: {
         Authorization: `Bearer ${tokenData.token}`,
       },

--- a/src/pages/Appoinments/apis.ts
+++ b/src/pages/Appoinments/apis.ts
@@ -1,0 +1,27 @@
+import {
+  Appointment,
+  AppointmentCreate,
+  SlotAvailability,
+} from "@/components/Schedule/types";
+
+import { Type } from "@/Utils/request/api";
+
+export const PublicAppointmentAPIs = {
+  getSlotsForDay: {
+    path: "/api/v1/otp/slots/get_slots_for_day/",
+    method: "POST",
+    TRes: Type<{ results: SlotAvailability[] }>(),
+    TBody: Type<{ facility: string; user: string; day: string }>(),
+  },
+  getAppointments: {
+    path: "/api/v1/otp/slots/get_appointments/",
+    method: "GET",
+    TRes: Type<{ results: Appointment[] }>(),
+  },
+  createAppointment: {
+    path: "/api/v1/otp/slots/{id}/create_appointment/",
+    method: "POST",
+    TRes: Type<Appointment>(),
+    TBody: Type<AppointmentCreate>(),
+  },
+} as const;

--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -23,9 +23,9 @@ import { Appointment } from "@/components/Schedule/types";
 
 import { usePatientContext } from "@/hooks/useAuthOrPatientUser";
 
-import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
 import { formatName, formatPatientAge } from "@/Utils/utils";
+import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
 
 function PatientIndex() {
   const { t } = useTranslation();
@@ -45,7 +45,7 @@ function PatientIndex() {
 
   const { data: appointmentsData, isLoading } = useQuery({
     queryKey: ["appointment", tokenData?.phoneNumber],
-    queryFn: query(routes.otp.getAppointments, {
+    queryFn: query(PublicAppointmentAPIs.getAppointments, {
       headers: {
         Authorization: `Bearer ${tokenData?.token}`,
       },
@@ -118,7 +118,7 @@ function PatientIndex() {
               <div className="space-y-1">
                 <Label className="text-xs">{t("practitioner")}</Label>
                 <p className="text-base font-semibold">
-                  {formatName(appointment.resource)}
+                  {formatName(appointment.user)}
                 </p>
                 <p className="text-sm font-semibold text-gray-600">
                   {formatAppointmentSlotTime(appointment)}
@@ -165,8 +165,8 @@ function PatientIndex() {
             <div className="flex flex-col">
               <span className="text-xs font-medium">{t("practitioner")}: </span>
               <span className="text-sm">
-                {appointment?.resource
-                  ? formatName(appointment.resource)
+                {appointment?.user
+                  ? formatName(appointment.user)
                   : "Resource from BE"}
               </span>
             </div>

--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -25,7 +25,7 @@ import { usePatientContext } from "@/hooks/useAuthOrPatientUser";
 
 import query from "@/Utils/request/query";
 import { formatName, formatPatientAge } from "@/Utils/utils";
-import { PublicAppointmentAPIs } from "@/pages/Appoinments/apis";
+import PublicAppointmentApi from "@/types/scheduling/PublicAppointmentApi";
 
 function PatientIndex() {
   const { t } = useTranslation();
@@ -45,7 +45,7 @@ function PatientIndex() {
 
   const { data: appointmentsData, isLoading } = useQuery({
     queryKey: ["appointment", tokenData?.phoneNumber],
-    queryFn: query(PublicAppointmentAPIs.getAppointments, {
+    queryFn: query(PublicAppointmentApi.getAppointments, {
       headers: {
         Authorization: `Bearer ${tokenData?.token}`,
       },

--- a/src/types/scheduling/PublicAppointmentApi.ts
+++ b/src/types/scheduling/PublicAppointmentApi.ts
@@ -6,7 +6,7 @@ import {
 
 import { Type } from "@/Utils/request/api";
 
-export const PublicAppointmentAPIs = {
+export default {
   getSlotsForDay: {
     path: "/api/v1/otp/slots/get_slots_for_day/",
     method: "POST",


### PR DESCRIPTION
https://github.com/ohcnetwork/care/pull/2701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
	- Disabled default availability statistics API in care configuration

- **API Modifications**
	- Removed appointment-related API routes
	- Updated API endpoints to use "user" instead of "resource"
	- Introduced new `PublicAppointmentApi` for appointment scheduling

- **Component Updates**
	- Renamed references from "resource" to "user" across multiple components
	- Updated name formatting for practitioners
	- Simplified some component prop structures

- **New Features**
	- Added `CancelAppointmentRequest` interface for appointment cancellations

- **Refactoring**
	- Standardized terminology and data structures related to user and appointment handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->