### PR TITLE
Fix: Forgot password error should be handled properly 

### DIFF
--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -105,13 +105,17 @@ const Login = (props: { forgot?: boolean }) => {
       });
       return response;
     },
-    onSuccess: () => {
-      Notification.Success({
-        msg: t("password_sent"),
-      });
+    onSuccess: (response) => {
+      if (response.res && response.res.ok) {
+        Notification.Success({
+          msg: t("password_sent"),
+        });
+      }
     },
     onError: (error: any) => {
-      setErrors(error);
+      Notification.Error({
+        msg: error.message || t("password_reset_failure"),
+      });
     },
   });
 

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -4,6 +4,7 @@ import { Link } from "raviger";
 import { useEffect, useState } from "react";
 import ReCaptcha from "react-google-recaptcha";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 
@@ -98,24 +99,10 @@ const Login = (props: { forgot?: boolean }) => {
   });
 
   // Forgot Password Mutation
-  const forgotPasswordMutation = useMutation({
-    mutationFn: async (data: { username: string }) => {
-      const response = await request(routes.forgotPassword, {
-        body: data,
-      });
-      return response;
-    },
-    onSuccess: (response) => {
-      if (response.res && response.res.ok) {
-        Notification.Success({
-          msg: t("password_sent"),
-        });
-      }
-    },
-    onError: (error: any) => {
-      Notification.Error({
-        msg: error.message || t("password_reset_failure"),
-      });
+  const { mutate: submitForgetPassword } = useMutation({
+    mutationFn: mutate(routes.forgotPassword),
+    onSuccess: () => {
+      toast.success(t("password_sent"));
     },
   });
 
@@ -296,7 +283,7 @@ const Login = (props: { forgot?: boolean }) => {
     const valid = validateForgetData();
     if (!valid) return;
 
-    forgotPasswordMutation.mutate(valid);
+    submitForgetPassword(valid);
   };
 
   const onCaptchaChange = (value: any) => {
@@ -326,10 +313,7 @@ const Login = (props: { forgot?: boolean }) => {
 
   // Loading state derived from mutations
   const isLoading =
-    staffLoginMutation.isPending ||
-    forgotPasswordMutation.isPending ||
-    sendOtpPending ||
-    verifyOtpPending;
+    staffLoginMutation.isPending || sendOtpPending || verifyOtpPending;
 
   const logos = [stateLogo, customLogo].filter(
     (logo) => logo?.light || logo?.dark,


### PR DESCRIPTION
## Proposed Changes

- Fixes #9686 
- Major Change: In the onSuccess function of your forgotPasswordMutation, I added a condition to check if the response from the server indicates a successful operation. This is done by checking if response.res exists and if response.res.ok is true, which means the HTTP response status is in the successful range (typically 200-299).


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


### Screenshot
![image](https://github.com/user-attachments/assets/89d38717-ff87-4610-a0bc-bd9052665841)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced user feedback during login and password reset processes with toast notifications.
	- Simplified loading state for the forgot password functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->