### PR TITLE
Fix: Address and Map icon alignment

### DIFF
--- a/src/components/Facility/FacilityHome.tsx
+++ b/src/components/Facility/FacilityHome.tsx
@@ -82,20 +82,22 @@ const renderGeoOrganizations = (geoOrg: Organization) => {
     };
   });
 
-  return parentDetails
+  const filteredDetails = parentDetails
     .reverse()
     .concat({
       label: getOrgLevelLabel(geoOrg.org_type, geoOrg.level_cache),
       value: geoOrg.name,
     })
-    .map((org, index) => (
-      <span key={org.value}>
-        <span className="text-muted-foreground">{org.value}</span>
-        {index < parentDetails.length - 1 && (
-          <span className="mx-2 text-muted-foreground/50">→</span>
-        )}
-      </span>
-    ));
+    .slice(-2);
+
+  return filteredDetails.map((org, index) => (
+    <span key={org.value} className="flex items-center flex-wrap">
+      <span className="text-muted-foreground">{org.value}</span>
+      {index < filteredDetails.length - 1 && (
+        <span className="mx-2">&nbsp;</span>
+      )}
+    </span>
+  ));
 };
 
 export const FacilityHome = ({ facilityId }: Props) => {
@@ -286,7 +288,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
                 <CardContent>
                   <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-12 mt-4">
                     <div className="flex items-start gap-3">
-                      <MapPin className="mt-1 h-5 w-5 flex-shrink-0 text-muted-foreground" />
+                      <MapPin className="mt-3 h-5 w-5 flex-shrink-0 text-muted-foreground" />
                       <div>
                         {facilityData?.geo_organization && (
                           <div className="mt-2 text-sm">


### PR DESCRIPTION
## Proposed Changes

**Visual Changes Explanation (User Interface Side)**

When the changes were made to the renderGeoOrganizations function, the following updates were reflected on the UI (User Interface) side:

✅ Before Changes:

    Full Hierarchy Shown: The entire organizational hierarchy was displayed.
    Arrow Separators (→): Arrows were used between every level to show a clear parent-child relationship.
    Example Display:
        Region A → Region B → Region C

![image](https://github.com/user-attachments/assets/ed08011c-3ee5-44f7-8a31-28626db85006)



✅ After Changes (New UI Behavior):

    Only Last Two Items Displayed: Now, only the last two elements in the organizational hierarchy are shown instead of the full hierarchy.
    Arrow Removed: The arrow (→) separators have been completely removed for a cleaner look.
    Space Between Items: A small space (&nbsp;) has been added between the last two items for better readability.
    Example Display Now:
        Region B Region C (Only the last two with a space, no arrow)

![image](https://github.com/user-attachments/assets/0131258e-2bce-463b-8770-99f01d7e40c5)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted layout and spacing of organization details and MapPin icon
	- Improved visual presentation of facility home component

- **Refactor**
	- Modified rendering logic for organization details
	- Optimized display of organization information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->