### PR TITLE
Fix Multiple tabs marked active

### DIFF
--- a/src/components/ui/sidebar/app-sidebar.tsx
+++ b/src/components/ui/sidebar/app-sidebar.tsx
@@ -62,7 +62,7 @@ function generateFacilityLinks(
     { name: t("encounters"), url: `${baseUrl}/encounters`, icon: "d-patient" },
     // { name: t("assets"), url: `${baseUrl}/assets`, icon: "d-folder" },
     // { name: t("shifting"), url: "/shifting", icon: "d-ambulance" },
-    { name: t("resource"), url: "/resource", icon: "d-book-open" },
+    { name: t("resource"), url: "/resource/board", icon: "d-book-open" },
     { name: t("users"), url: `${baseUrl}/users`, icon: "d-people" },
     // { name: t("All users"), url: "/users", icon: "d-people" },
     {

--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -34,7 +34,6 @@ export function NavMain({
             >
               <ActiveLink
                 href={link.url}
-                activeClass="bg-white text-green-700 shadow"
                 exactActiveClass="bg-white text-green-700 shadow"
               >
                 {link.icon && <CareIcon icon={link.icon as IconName} />}


### PR DESCRIPTION
## Proposed Changes

- Fixes #9637 
- Removed activeClass prop from ActiveLink so that the menu item is highlighted only when the current url matches exactly with url of the menu item

## Video of Solution:
<video src="https://github.com/user-attachments/assets/a742ede9-bd20-47a2-ba13-0aaf45023bbe" controls></video>

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated navigation link styling by removing the `activeClass` prop from the `ActiveLink` component.
- **New Features**
	- Changed the URL for the "resource" navigation link from `"/resource"` to `"/resource/board"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->