### PR TITLE
fix: rename dosage field to frequency in ongoing medication form

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -736,6 +736,7 @@
   "domestic_international_travel": "Domestic/international Travel (within last 28 days)",
   "done": "Done",
   "dosage": "Dosage",
+  "dosage_instructions": "Dosage Instructions",
   "down": "Down",
   "download": "Download",
   "download_discharge_summary": "Download discharge summary",

--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -243,7 +243,7 @@ const MedicationStatementItem: React.FC<{
           </div>
           <div className="flex-[2]">
             <Label className="mb-1 block text-sm font-medium">
-              {t("dosage")}
+              {t("dosage_instructions")}
             </Label>
             <Input
               value={medication.dosage_text}


### PR DESCRIPTION
Fixes #9808 - Renamed 'Dosage' field to 'Frequency' in the Ongoing Medication Form to better reflect its purpose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added new localization key `dosage_instructions` for enhanced clarity in medication dosage instructions

- **UI Update**
  - Updated medication dosage input label to use more descriptive terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->