### PR TITLE
Improved types for data fetching related utilities

### DIFF
--- a/src/CAREUI/misc/PaginatedList.tsx
+++ b/src/CAREUI/misc/PaginatedList.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonProps } from "@/components/ui/button";
 
 import Pagination from "@/components/Common/Pagination";
 
-import { PaginatedResponse, QueryRoute } from "@/Utils/request/types";
+import { ApiRoute, PaginatedResponse } from "@/Utils/request/types";
 import useTanStackQueryInstead, {
   QueryOptions,
 } from "@/Utils/request/useQuery";
@@ -35,7 +35,7 @@ function useContextualized<TItem>() {
 }
 
 interface Props<TItem> extends QueryOptions<PaginatedResponse<TItem>> {
-  route: QueryRoute<PaginatedResponse<TItem>>;
+  route: ApiRoute<PaginatedResponse<TItem>>;
   perPage?: number;
   initialPage?: number;
   onPageChange?: (page: number) => void;

--- a/src/Utils/request/handleResponse.ts
+++ b/src/Utils/request/handleResponse.ts
@@ -5,6 +5,9 @@ import { toast } from "sonner";
 import * as Notifications from "@/Utils/Notifications";
 import { RequestResult } from "@/Utils/request/types";
 
+/**
+ * @deprecated in favor of useQuery/useMutation/callApi
+ */
 export default function handleResponse(
   { res, error }: RequestResult<unknown>,
   silent?: boolean,

--- a/src/Utils/request/mutate.ts
+++ b/src/Utils/request/mutate.ts
@@ -1,5 +1,5 @@
 import { callApi } from "@/Utils/request/query";
-import { APICallOptions, Route } from "@/Utils/request/types";
+import { ApiCallOptions, ApiRoute } from "@/Utils/request/types";
 
 /**
  * Creates a TanStack Query compatible mutation function.
@@ -16,11 +16,11 @@ import { APICallOptions, Route } from "@/Utils/request/types";
  * });
  * ```
  */
-export default function mutate<TData, TBody>(
-  route: Route<TData, TBody>,
-  options?: APICallOptions<TBody>,
+export default function mutate<Route extends ApiRoute<unknown, unknown>>(
+  route: Route,
+  options?: ApiCallOptions<Route>,
 ) {
-  return (variables: TBody) => {
+  return (variables: Route["TBody"]) => {
     return callApi(route, { ...options, body: variables });
   };
 }

--- a/src/Utils/request/query.ts
+++ b/src/Utils/request/query.ts
@@ -1,14 +1,14 @@
 import careConfig from "@careConfig";
 
 import { getResponseBody } from "@/Utils/request/request";
-import { APICallOptions, HTTPError, Route } from "@/Utils/request/types";
+import { ApiCallOptions, ApiRoute, HTTPError } from "@/Utils/request/types";
 import { makeHeaders, makeUrl } from "@/Utils/request/utils";
 import { sleep } from "@/Utils/utils";
 
-export async function callApi<TData, TBody>(
-  { path, method, noAuth }: Route<TData, TBody>,
-  options?: APICallOptions<TBody>,
-): Promise<TData> {
+export async function callApi<Route extends ApiRoute<unknown, unknown>>(
+  { path, method, noAuth }: Route,
+  options?: ApiCallOptions<Route>,
+): Promise<Route["TRes"]> {
   const url = `${careConfig.apiUrl}${makeUrl(path, options?.queryParams, options?.pathParams)}`;
 
   const fetchOptions: RequestInit = {
@@ -29,7 +29,7 @@ export async function callApi<TData, TBody>(
     throw new Error("Network Error");
   }
 
-  const data = await getResponseBody<TData>(res);
+  const data = await getResponseBody<Route["TRes"]>(res);
 
   if (!res.ok) {
     throw new HTTPError({
@@ -60,9 +60,9 @@ export async function callApi<TData, TBody>(
  * });
  * ```
  */
-export default function query<TData, TBody>(
-  route: Route<TData, TBody>,
-  options?: APICallOptions<TBody>,
+export default function query<Route extends ApiRoute<unknown, unknown>>(
+  route: Route,
+  options?: ApiCallOptions<Route>,
 ) {
   return ({ signal }: { signal: AbortSignal }) => {
     return callApi(route, { ...options, signal });
@@ -98,9 +98,9 @@ export default function query<TData, TBody>(
  * - When aborted, both the `sleep` promise and the fetch request are cancelled automatically
  * - TanStack Query handles the abortion and cleanup of previous in-flight requests
  */
-const debouncedQuery = <TData, TBody>(
-  route: Route<TData, TBody>,
-  options?: APICallOptions<TBody> & { debounceInterval?: number },
+const debouncedQuery = <Route extends ApiRoute<unknown, unknown>>(
+  route: Route,
+  options?: ApiCallOptions<Route> & { debounceInterval?: number },
 ) => {
   return async ({ signal }: { signal: AbortSignal }) => {
     await sleep(options?.debounceInterval ?? 500);

--- a/src/Utils/request/request.ts
+++ b/src/Utils/request/request.ts
@@ -1,7 +1,7 @@
 import careConfig from "@careConfig";
 
 import handleResponse from "@/Utils/request/handleResponse";
-import { RequestOptions, RequestResult, Route } from "@/Utils/request/types";
+import { ApiRoute, RequestOptions, RequestResult } from "@/Utils/request/types";
 import { makeHeaders, makeUrl } from "@/Utils/request/utils";
 
 type Options<TData, TBody> = RequestOptions<TData, TBody> & {
@@ -12,7 +12,7 @@ type Options<TData, TBody> = RequestOptions<TData, TBody> & {
  * @deprecated use useQuery/useMutation/callApi instead
  */
 export default async function request<TData, TBody>(
-  { path, method, noAuth }: Route<TData, TBody>,
+  { path, method, noAuth }: ApiRoute<TData, TBody>,
   {
     query,
     body,

--- a/src/Utils/request/request.ts
+++ b/src/Utils/request/request.ts
@@ -10,6 +10,9 @@ type Options<TData, TBody> = RequestOptions<TData, TBody> & {
 
 /**
  * @deprecated use useQuery/useMutation/callApi instead
+ *
+ * This no longer ensures that the path params are provided correctly during runtime.
+ * Usages so far works as path params were passed correctly, but this should not be used anymore.
  */
 export default async function request<TData, TBody>(
   { path, method, noAuth }: ApiRoute<TData, TBody>,

--- a/src/Utils/request/types.ts
+++ b/src/Utils/request/types.ts
@@ -8,44 +8,47 @@ type QueryParamValue =
 
 export type QueryParams = Record<string, QueryParamValue>;
 
-interface RouteBase<TData> {
+export interface ApiRoute<TData, TBody = unknown> {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  TBody?: TBody;
   path: string;
   TRes: TData;
   noAuth?: boolean;
 }
 
-export interface QueryRoute<TData, TBody = unknown> extends RouteBase<TData> {
-  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-  TBody?: TBody;
-}
-
-export interface MutationRoute<TData, TBody> extends RouteBase<TData> {
-  method: "POST" | "PUT" | "PATCH" | "DELETE";
-  TBody?: TBody;
-}
-
-export type Route<TData, TBody> =
-  | QueryRoute<TData, TBody>
-  | MutationRoute<TData, TBody>;
-
+/**
+ * @deprecated in favor of useQuery/useMutation/callApi
+ */
 export interface RequestResult<TData> {
   res: Response | undefined;
   data: TData | undefined;
   error: undefined | Record<string, unknown>;
 }
 
+/**
+ * @deprecated in favor of ApiCallOptions used by useQuery/useMutation/callApi
+ */
 export interface RequestOptions<TData = unknown, TBody = unknown> {
   query?: QueryParams;
   body?: TBody;
-  pathParams?: Record<string, string | number>;
+  pathParams?: Record<string, string>;
   onResponse?: (res: RequestResult<TData>) => void;
   silent?: boolean;
 }
 
-export interface APICallOptions<TBody = unknown> {
-  pathParams?: Record<string, string | number>;
+type ExtractRouteParams<T extends string> =
+  T extends `${infer _Start}{${infer Param}}${infer Rest}`
+    ? Param | ExtractRouteParams<Rest>
+    : never;
+
+type PathParams<T extends string> = {
+  [K in ExtractRouteParams<T>]: string;
+};
+
+export interface ApiCallOptions<Route extends ApiRoute<unknown, unknown>> {
+  pathParams?: PathParams<Route["path"]>;
   queryParams?: QueryParams;
-  body?: TBody;
+  body?: Route["TBody"];
   silent?: boolean;
   signal?: AbortSignal;
   headers?: HeadersInit;

--- a/src/Utils/request/useQuery.ts
+++ b/src/Utils/request/useQuery.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo, useRef } from "react";
 
 import request from "@/Utils/request/request";
-import { QueryRoute, RequestOptions } from "@/Utils/request/types";
+import { ApiRoute, RequestOptions } from "@/Utils/request/types";
 
 import { mergeRequestOptions } from "./utils";
 
@@ -15,7 +15,7 @@ export interface QueryOptions<TData> extends RequestOptions<TData> {
  * @deprecated use `useQuery` from `@tanstack/react-query` instead.
  */
 export default function useTanStackQueryInstead<TData, TBody = unknown>(
-  route: QueryRoute<TData, TBody>,
+  route: ApiRoute<TData, TBody>,
   options?: QueryOptions<TData>,
 ) {
   const overridesRef = useRef<QueryOptions<TData>>();

--- a/src/Utils/request/utils.ts
+++ b/src/Utils/request/utils.ts
@@ -1,5 +1,4 @@
 import { Dispatch, SetStateAction } from "react";
-import { toast } from "sonner";
 
 import { LocalStorageKeys } from "@/common/constants";
 
@@ -16,8 +15,6 @@ export function makeUrl(
       path,
     );
   }
-
-  ensurePathNotMissingReplacements(path);
 
   if (query) {
     path += `?${makeQueryParams(query)}`;
@@ -41,22 +38,6 @@ const makeQueryParams = (query: QueryParams) => {
   });
 
   return qParams.toString();
-};
-
-/**
- * TODO: consider replacing this with inferring the types from the route and using a generic
- * to ensure that the path params are not missing.
- */
-const ensurePathNotMissingReplacements = (path: string) => {
-  const missingParams = path.match(/\{.*\}/g);
-
-  if (missingParams) {
-    const msg = `Missing path params: ${missingParams.join(
-      ", ",
-    )}. Path: ${path}`;
-    toast.error(msg);
-    throw new Error(msg);
-  }
 };
 
 export function makeHeaders(noAuth: boolean, additionalHeaders?: HeadersInit) {

--- a/src/components/Common/Export.tsx
+++ b/src/components/Common/Export.tsx
@@ -14,7 +14,7 @@ import DropdownMenu, {
 import useExport from "@/hooks/useExport";
 
 import request from "@/Utils/request/request";
-import { Route } from "@/Utils/request/types";
+import { ApiRoute } from "@/Utils/request/types";
 
 interface ExportItem {
   options?: DropdownItemProps;
@@ -23,7 +23,7 @@ interface ExportItem {
   label: string;
   parse?: (data: string) => string;
   action?: Parameters<ReturnType<typeof useExport>["exportFile"]>[0];
-  route?: Route<string | { results: object[] }, unknown>;
+  route?: ApiRoute<string | { results: object[] }, unknown>;
 }
 
 interface ExportMenuProps {
@@ -38,7 +38,7 @@ interface ExportButtonProps {
   tooltipClassName?: string;
   type?: "csv" | "json";
   action?: Parameters<ReturnType<typeof useExport>["exportFile"]>[0];
-  route?: Route<string | { results: object[] }, unknown>;
+  route?: ApiRoute<string | { results: object[] }, unknown>;
   parse?: (data: string) => string;
   filenamePrefix: string;
   className?: string;

--- a/src/components/Facility/FacilityUsers.tsx
+++ b/src/components/Facility/FacilityUsers.tsx
@@ -15,7 +15,7 @@ import useFilters from "@/hooks/useFilters";
 import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
 
-export default function FacilityUsers(props: { facilityId: number }) {
+export default function FacilityUsers(props: { facilityId: string }) {
   const { t } = useTranslation();
   const { qParams, updateQuery, Pagination } = useFilters({
     limit: 18,

--- a/src/components/Kanban/Board.tsx
+++ b/src/components/Kanban/Board.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { callApi } from "@/Utils/request/query";
-import { QueryRoute } from "@/Utils/request/types";
+import { ApiRoute } from "@/Utils/request/types";
 import { QueryOptions } from "@/Utils/request/useQuery";
 
 interface KanbanBoardProps<T extends { id: string }> {
@@ -24,7 +24,7 @@ interface KanbanBoardProps<T extends { id: string }> {
       id: string,
       ...args: unknown[]
     ) => {
-      route: QueryRoute<unknown>;
+      route: ApiRoute<unknown>;
       options?: QueryOptions<unknown>;
     };
   }[];

--- a/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
@@ -84,7 +84,9 @@ export function AppointmentQuestion({
     queryFn: query(scheduleApis.slots.getSlotsForDay, {
       pathParams: { facility_id: facilityId },
       body: {
-        user: resource?.id,
+        // voluntarily coalesce to empty string since we know query would be
+        // enabled only if resource and selectedDate are present
+        user: resource?.id ?? "",
         day: dateQueryString(selectedDate),
       },
     }),

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -293,8 +293,10 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
     queryFn: query(scheduleApis.slots.getSlotsForDay, {
       pathParams: { facility_id: facilityId },
       body: {
-        user: practitioner?.id,
-        day: qParams.date_from,
+        // voluntarily coalesce to empty string since we know query would be
+        // enabled only if practitioner and date_from are present
+        user: practitioner?.id ?? "",
+        day: qParams.date_from ?? "",
       },
     }),
     enabled: slotsFilterEnabled,

--- a/src/pages/Appointments/BookAppointment.tsx
+++ b/src/pages/Appointments/BookAppointment.tsx
@@ -78,7 +78,9 @@ export default function BookAppointment(props: Props) {
     queryFn: query(scheduleApis.slots.getSlotsForDay, {
       pathParams: { facility_id: props.facilityId },
       body: {
-        user: resourceId,
+        // voluntarily coalesce to empty string since we know query would be
+        // enabled only if resourceId and selectedDate are present
+        user: resourceId ?? "",
         day: dateQueryString(selectedDate),
       },
     }),

--- a/src/pages/Appointments/utils.ts
+++ b/src/pages/Appointments/utils.ts
@@ -79,7 +79,9 @@ export const useAvailabilityHeatmap = ({
   let queryFn = query(scheduleApis.slots.availabilityStats, {
     pathParams: { facility_id: facilityId },
     body: {
-      user: userId,
+      // voluntarily coalesce to empty string since we know query would be
+      // enabled only if userId is present
+      user: userId ?? "",
       from_date: fromDate,
       to_date: toDate,
     },

--- a/src/pages/FacilityOrganization/FacilityOrganizationView.tsx
+++ b/src/pages/FacilityOrganization/FacilityOrganizationView.tsx
@@ -41,7 +41,7 @@ export default function FacilityOrganizationView({ id, facilityId }: Props) {
       searchQuery,
     ],
     queryFn: query.debounced(routes.facilityOrganization.list, {
-      pathParams: { facilityId, organizationId: id },
+      pathParams: { facilityId },
       queryParams: {
         parent: id,
         offset: (page - 1) * limit,


### PR DESCRIPTION
## Proposed Changes

- Cleaned up types for data fetching related utilities
- Infer types for `pathParams` from the Route's path, drop useless runtime checks that toasts missing path params.

_Now catches the error during build time instead of runtime_

### Before - No type error

![image](https://github.com/user-attachments/assets/1020cb7c-305a-428d-b754-5ff0251d4800)


### After - Type Error

![image](https://github.com/user-attachments/assets/7174260a-7c96-4bf8-8193-f74a735e7c8e)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Type Changes**
	- Updated route and API call types across multiple components and utility files
	- Renamed `QueryRoute` and `Route` types to `ApiRoute`
	- Enhanced type safety for API request handling

- **Deprecation Notices**
	- Added deprecation warning for `handleResponse` function
	- Recommended transitioning to `useQuery`, `useMutation`, or `callApi`

- **Parameter Handling**
	- Improved handling of undefined parameters in various API calls
	- Added fallback to empty string for user and resource ID parameters

- **Minor Adjustments**
	- Removed path parameter validation in URL generation
	- Updated type references in components and utility functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->