### PR TITLE
remove appVersion null condition

### DIFF
--- a/src/components/Common/UpdatableApp.tsx
+++ b/src/components/Common/UpdatableApp.tsx
@@ -36,11 +36,6 @@ export const checkForUpdate = async () => {
 
   const meta = await res.json();
 
-  if (appVersion === null) {
-    // Skip updating since the app potentially is the latest version.
-    localStorage.setItem(APP_VERSION_KEY, meta.version);
-  }
-
   if (appVersion !== meta.version) {
     // Trigger an update if key: 'app-version' not present in localStorage
     // or does not match with metaVersion.


### PR DESCRIPTION
## Removed appVersion equals null Condition in checkForUpdate method in Updatable.tsx

- Fixes #9872
- removed (appVersion === null) condition

## Reason
During software update process for user, we click Check For Update button on profile page, internally we call checkForUpdate method twice, once from UserSoftwareUpdate component and second time from UpdatableApp component, during the first call there is no key app-version in local storage, so app goes inside (appVersion === null) and sets app-version in local storage to latest software version and because of this during the second run inside checkForUpdate method, first if statement is skipped because appVersion exists and second if statement is also skipped because appVersion is equal to latest version and method then does not return, as a result newVersion state in UpdatableApp is assigned to undefined, and we do not get expected pop up

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined version checking mechanism to improve update detection logic
	- Updated application version tracking to prevent unnecessary version overwrites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->