### PR TITLE
Fix : DOM nesting Warning in BreadcrumbSeparator

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -79,15 +79,15 @@ const BreadcrumbSeparator = ({
   children,
   className,
   ...props
-}: React.ComponentProps<"li">) => (
-  <li
+}: React.ComponentProps<"span">) => (
+  <span
     role="presentation"
     aria-hidden="true"
     className={cn("[&>svg]:w-3.5 [&>svg]:h-3.5", className)}
     {...props}
   >
     {children ?? <ChevronRightIcon />}
-  </li>
+  </span>
 );
 BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
 


### PR DESCRIPTION
### Proposed Changes : 

- Fixes #9936 
- Changed the (li) component to (span) component as it violates the descendant rules.

### Screenshots : 
![image](https://github.com/user-attachments/assets/aa84100b-8453-4033-9913-ee912c9bb0bd)


Plz review : @ohcnetwork/care-fe-code-reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Updated Breadcrumb Separator component to use `<span>` instead of `<li>`
	- Fixed display name typo for BreadcrumbEllipsis component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->