### PR TITLE
Minor enhancement: restrict lsgd filter to 2 levels

### DIFF
--- a/src/pages/Organization/components/OrganizationFilter.tsx
+++ b/src/pages/Organization/components/OrganizationFilter.tsx
@@ -28,7 +28,7 @@ interface OrganizationFilterProps {
   className?: string;
 }
 
-const DEFAULT_ORG_LEVELS = 3;
+const DEFAULT_ORG_LEVELS = 2;
 
 export default function OrganizationFilter(props: OrganizationFilterProps) {
   const { t } = useTranslation();

--- a/src/pages/Organization/components/OrganizationLevel.tsx
+++ b/src/pages/Organization/components/OrganizationLevel.tsx
@@ -43,7 +43,7 @@ export function OrganizationLevel({
   return (
     <Autocomplete
       popoverClassName={classNames(
-        "lg:border-0 lg:border-0 lg:shadow-none lg:rounded-none lg:max-w-56",
+        "lg:border-0 lg:border-0 lg:shadow-none lg:rounded-none lg:max-w-72",
         index !== 0 && "lg:border-l lg:border-secondary-500",
       )}
       key={`dropdown-${index}`}


### PR DESCRIPTION
## Proposed Changes

- Restrict filter to 2 levels (district, local body)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Reduced maximum number of organization levels from 3 to 2
	- Increased popover maximum width for organization level selection on large screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->