### PR TITLE
Fixed Per Page card limit in Encounter list, organisation (Facility, Patients )

### DIFF
--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -150,7 +150,7 @@ export function EncounterList({
 }: EncounterListProps) {
   const { qParams, updateQuery, Pagination, clearSearch, resultsPerPage } =
     useFilters({
-      limit: 14,
+      limit: 15,
       cacheBlacklist: ["name", "encounter_id", "external_identifier"],
     });
   const {

--- a/src/pages/Organization/OrganizationFacilities.tsx
+++ b/src/pages/Organization/OrganizationFacilities.tsx
@@ -31,7 +31,7 @@ export default function OrganizationFacilities({
   const { t } = useTranslation();
 
   const { qParams, Pagination, advancedFilter, resultsPerPage, updateQuery } =
-    useFilters({ limit: 14, cacheBlacklist: ["facility"] });
+    useFilters({ limit: 15, cacheBlacklist: ["facility"] });
 
   const { data: facilities, isLoading } = useQuery({
     queryKey: ["organizationFacilities", id, qParams],

--- a/src/pages/Organization/OrganizationPatients.tsx
+++ b/src/pages/Organization/OrganizationPatients.tsx
@@ -29,7 +29,7 @@ interface Props {
 export default function OrganizationPatients({ id, navOrganizationId }: Props) {
   const { t } = useTranslation();
   const { qParams, Pagination, advancedFilter, resultsPerPage, updateQuery } =
-    useFilters({ limit: 14, cacheBlacklist: ["patient"] });
+    useFilters({ limit: 15, cacheBlacklist: ["patient"] });
   const [organization, setOrganization] = useState<Organization | null>(null);
 
   const { data: patients, isLoading } = useQuery({


### PR DESCRIPTION
## Proposed Changes

- Fixes #issue_number
- Change 1
- Change 2
- More?

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Increased pagination limit from 14 to 15 in multiple components:
		- Encounters list
		- Organization facilities
		- Organization patients

This change allows for displaying one additional item per page across different sections of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->