### PR TITLE
Add retries for fetching SBOM data

### DIFF
--- a/scripts/generate-sbom-data.ts
+++ b/scripts/generate-sbom-data.ts
@@ -6,22 +6,43 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const sbomFolderPath = path.join(__dirname, "..", "public", "sbom");
 
-const fetchSbomData = async (repo: `${string}/${string}`) => {
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const fetchSbomData = async (repo: `${string}/${string}`, retries = 3) => {
   const url = `https://api.github.com/repos/${repo}/dependency-graph/sbom`;
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
 
-  if (!response.ok) {
-    throw new Error(
-      `Error fetching SBOM data from ${url}: ${response.statusText}`,
-    );
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      });
+
+      if (response.ok) {
+        return await response.json();
+      }
+
+      if (attempt === retries) {
+        throw new Error(
+          `Error fetching SBOM data from ${url}: ${response.statusText}`,
+        );
+      }
+
+      // Wait before retrying (exponential backoff)
+      await delay(Math.pow(2, attempt) * 1000);
+    } catch (error) {
+      if (attempt === retries) {
+        throw error;
+      }
+
+      // Wait before retrying (exponential backoff)
+      await delay(Math.pow(2, attempt) * 1000);
+    }
   }
-
-  return await response.json();
 };
 
 async function main() {


### PR DESCRIPTION
## Issue

GitHub's APIs (SBOM), may throw internal 500 error, or network request could randomly fail due to unpredictable reasons which could be one-off exceptions.

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/eeffdfda-986a-4e6d-94f7-30d9d492ca8e" />


## Proposed Changes

- Add retries for fetching SBOM data

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SBOM data fetching with retry mechanism
	- Added configurable retry attempts for GitHub repository data retrieval

- **Bug Fixes**
	- Improved error handling for data fetching operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->