### PR TITLE
Add silent for useQuery in useQuestionnaireOptions

### DIFF
--- a/src/Utils/request/query.ts
+++ b/src/Utils/request/query.ts
@@ -32,10 +32,15 @@ export async function callApi<Route extends ApiRoute<unknown, unknown>>(
   const data = await getResponseBody<Route["TRes"]>(res);
 
   if (!res.ok) {
+    const isSilent =
+      typeof options?.silent === "function"
+        ? options.silent(res)
+        : (options?.silent ?? false);
+
     throw new HTTPError({
       message: "Request Failed",
       status: res.status,
-      silent: options?.silent ?? false,
+      silent: isSilent,
       cause: data as unknown as Record<string, unknown>,
     });
   }

--- a/src/Utils/request/types.ts
+++ b/src/Utils/request/types.ts
@@ -49,7 +49,7 @@ export interface ApiCallOptions<Route extends ApiRoute<unknown, unknown>> {
   pathParams?: PathParams<Route["path"]>;
   queryParams?: QueryParams;
   body?: Route["TBody"];
-  silent?: boolean;
+  silent?: boolean | ((response: Response) => boolean);
   signal?: AbortSignal;
   headers?: HeadersInit;
 }

--- a/src/hooks/useQuestionnaireOptions.ts
+++ b/src/hooks/useQuestionnaireOptions.ts
@@ -22,6 +22,7 @@ export default function useQuestionnaireOptions(slug: string) {
       queryParams: {
         tag_slug: slug,
       },
+      silent: true,
     }),
   });
 

--- a/src/hooks/useQuestionnaireOptions.ts
+++ b/src/hooks/useQuestionnaireOptions.ts
@@ -22,7 +22,7 @@ export default function useQuestionnaireOptions(slug: string) {
       queryParams: {
         tag_slug: slug,
       },
-      silent: true,
+      silent: (res) => res.status === 404,
     }),
   });
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #9965 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data fetching behavior by adding a silent mode to query options, allowing for suppression of notifications or errors specifically for 404 responses. 
	- Enhanced flexibility of the silent option, which can now be a function that dynamically determines its value based on the response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->