### PR TITLE
Fix: Issue with File Upload Validation for Uppercase File Extensions

### DIFF
--- a/src/hooks/useFileUpload.tsx
+++ b/src/hooks/useFileUpload.tsx
@@ -141,11 +141,11 @@ export default function useFileUpload(
         setError(t("file_error__file_size"));
         return false;
       }
-      const extension = file.name.split(".").pop();
+      const extension = file.name.split(".").pop()?.toLowerCase();
       if (
         "allowedExtensions" in options &&
         !options.allowedExtensions
-          ?.map((extension) => extension.replace(".", ""))
+          ?.map((extension) => extension.replace(".", "").toLowerCase())
           ?.includes(extension || "")
       ) {
         setError(


### PR DESCRIPTION
## Proposed Changes

Fixed #10059 

Fixed file upload validation case-insensitive, allowing file extensions in both uppercase and lowercase (e.g., .png, .PNG, .Png, etc.) to be accepted as valid. For example, a file saved as image.PNG should be processed without any errors.

## Screnshoot

Now its accepting, file extension with caps also.
![image](https://github.com/user-attachments/assets/dc9e303e-dffb-4719-95e7-936dc805d0c5)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file upload validation to handle file extensions in a case-insensitive manner
	- Enhanced file type checking to prevent potential rejection of valid file types due to case differences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->