### PR TITLE
Fix appointment slot computation to include end time and improve exception handling logic

### DIFF
--- a/src/pages/Scheduling/utils.ts
+++ b/src/pages/Scheduling/utils.ts
@@ -68,44 +68,38 @@ export function computeAppointmentSlots(
   const slots: VirtualSlot[] = [];
 
   let time = startTime;
-  while (time <= endTime) {
+  while (time < endTime) {
     const slotEndTime = addMinutes(time, slotSizeInMinutes);
-    if (slotEndTime > endTime) {
-      break;
-    }
-    slots.push({
-      start_time: format(time, "HH:mm") as Time,
-      end_time: format(slotEndTime, "HH:mm") as Time,
-      isAvailable: true,
-      exceptions: [],
-    });
-    time = slotEndTime;
-  }
 
-  for (const exception of exceptions) {
-    const exceptionTime = parse(
-      exception.start_time,
-      "HH:mm:ss",
-      referenceDate,
-    );
-    const exceptionEndTime = parse(
-      exception.end_time,
-      "HH:mm:ss",
-      referenceDate,
-    );
+    let conflicting = false;
+    for (const exception of exceptions) {
+      const exceptionStartTime = parse(
+        exception.start_time,
+        "HH:mm:ss",
+        referenceDate,
+      );
+      const exceptionEndTime = parse(
+        exception.end_time,
+        "HH:mm:ss",
+        referenceDate,
+      );
 
-    slots.forEach((slot) => {
-      const slotStart = parse(slot.start_time, "HH:mm", referenceDate);
-      const slotEnd = parse(slot.end_time, "HH:mm", referenceDate);
-      if (
-        (slotStart >= exceptionTime && slotStart < exceptionEndTime) ||
-        (slotEnd > exceptionTime && slotEnd <= exceptionEndTime) ||
-        (slotStart <= exceptionTime && slotEnd >= exceptionEndTime)
-      ) {
-        slot.isAvailable = false;
-        slot.exceptions.push(exception);
+      if (exceptionStartTime < slotEndTime && exceptionEndTime > time) {
+        conflicting = true;
+        break;
       }
-    });
+    }
+
+    if (!conflicting) {
+      slots.push({
+        start_time: format(time, "HH:mm") as Time,
+        end_time: format(slotEndTime, "HH:mm") as Time,
+        isAvailable: true,
+        exceptions: [],
+      });
+    }
+
+    time = slotEndTime;
   }
 
   return slots;

--- a/src/pages/Scheduling/utils.ts
+++ b/src/pages/Scheduling/utils.ts
@@ -68,7 +68,7 @@ export function computeAppointmentSlots(
   const slots: VirtualSlot[] = [];
 
   let time = startTime;
-  while (time < endTime) {
+  while (time <= endTime) {
     const slotEndTime = addMinutes(time, slotSizeInMinutes);
     if (slotEndTime > endTime) {
       break;
@@ -98,14 +98,9 @@ export function computeAppointmentSlots(
       const slotStart = parse(slot.start_time, "HH:mm", referenceDate);
       const slotEnd = parse(slot.end_time, "HH:mm", referenceDate);
       if (
-        isWithinInterval(slotStart, {
-          start: exceptionTime,
-          end: exceptionEndTime,
-        }) ||
-        isWithinInterval(slotEnd, {
-          start: exceptionTime,
-          end: exceptionEndTime,
-        })
+        (slotStart >= exceptionTime && slotStart < exceptionEndTime) ||
+        (slotEnd > exceptionTime && slotEnd <= exceptionEndTime) ||
+        (slotStart <= exceptionTime && slotEnd >= exceptionEndTime)
       ) {
         slot.isAvailable = false;
         slot.exceptions.push(exception);


### PR DESCRIPTION
## Proposed Changes

1. Changed the while loop condition from time `< endTime` to time `<= endTime` to include the end time in the calculation.
2. Updated the exception overlap checking logic to handle all possible overlap scenarios:
   - When the slot starts during an exception
   - When the slot ends during an exception 
   - When the exception is completely within the slot

This should now correctly return all available slots, that might have been missed due to the strict comparison. 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved appointment slot availability calculation
	- Enhanced precision of slot scheduling logic
	- Updated handling of time-based exceptions for appointment slots
	- Streamlined logic for computing appointment slots, reducing iterations and checks for conflicts with exceptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->