### PR TITLE
use html-to-image instead of html2canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "echarts-for-react": "^3.0.2",
         "events": "^3.3.0",
         "hi-profiles": "^1.1.0",
-        "html2canvas": "^1.4.1",
+        "html-to-image": "^1.11.11",
         "i18next": "^24.2.1",
         "i18next-browser-languagedetector": "^8.0.2",
         "i18next-http-backend": "^3.0.1",
@@ -145,8 +145,8 @@
         "node": ">=22.8.0"
       },
       "optionalDependencies": {
-        "@esbuild/linux-arm64": "*",
-        "@esbuild/linux-x64": "*",
+        "@esbuild/linux-arm64": "latest",
+        "@esbuild/linux-x64": "latest",
         "@rollup/rollup-linux-arm64-gnu": "4.30.1",
         "@rollup/rollup-linux-x64-gnu": "4.30.1"
       }
@@ -7757,15 +7757,6 @@
         "zxing-wasm": "1.3.4"
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -8644,15 +8635,6 @@
       "license": "MIT",
       "dependencies": {
         "tiny-invariant": "^1.0.6"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -11677,18 +11659,11 @@
         "void-elements": "3.1.0"
       }
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==",
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -19586,15 +19561,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -20599,15 +20565,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "node_modules/uuid": {
       "version": "11.0.3",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "echarts-for-react": "^3.0.2",
     "events": "^3.3.0",
     "hi-profiles": "^1.1.0",
-    "html2canvas": "^1.4.1",
+    "html-to-image": "^1.11.11",
     "i18next": "^24.2.1",
     "i18next-browser-languagedetector": "^8.0.2",
     "i18next-http-backend": "^3.0.1",

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -1,5 +1,5 @@
 import { differenceInMinutes, format } from "date-fns";
-import html2canvas from "html2canvas";
+import { toPng } from "html-to-image";
 import { toast } from "sonner";
 
 import { AREACODES, IN_LANDLINE_AREA_CODES } from "@/common/constants";
@@ -393,12 +393,18 @@ export const saveElementAsImage = async (id: string, filename: string) => {
   const element = document.getElementById(id);
   if (!element) return;
 
-  const canvas = await html2canvas(element);
+  try {
+    const dataUrl = await toPng(element, {
+      quality: 1.0,
+    });
 
-  const link = document.createElement("a");
-  link.download = filename;
-  link.href = canvas.toDataURL("image/png", 1);
-  link.click();
+    const link = document.createElement("a");
+    link.download = filename;
+    link.href = dataUrl;
+    link.click();
+  } catch (error) {
+    console.error("Failed to save element as image:", error);
+  }
 };
 
 export const conditionalAttribute = <T>(


### PR DESCRIPTION
Fixes #10070

Replaces `html2canvas` with `html-to-image` -- `html-to-image` is lighter than `html2canvas` and is maintained actively

<img width="694" alt="Image" src="https://github.com/user-attachments/assets/83e81514-ee19-430f-bd6b-ad74b9e30448" />