### PR TITLE
Make ComboboxQuantityInput reactive to parent state change

### DIFF
--- a/src/components/Common/ComboboxQuantityInput.tsx
+++ b/src/components/Common/ComboboxQuantityInput.tsx
@@ -92,6 +92,14 @@ export function ComboboxQuantityInput({
     }
   };
 
+  React.useEffect(() => {
+    setInputValue(quantity?.value.toString() || "");
+  }, [quantity?.value]);
+
+  React.useEffect(() => {
+    setSelectedUnit(quantity?.unit);
+  }, [quantity?.unit]);
+
   return (
     <div className="relative flex w-full lg:max-w-[200px] flex-col gap-1">
       <Popover open={open && showDropdown} onOpenChange={setOpen}>


### PR DESCRIPTION
## Proposed Changes

- This fix is required for Scribe to work properly

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved synchronization of input value and unit of measurement in the quantity input component.
	- Ensured input reflects current quantity and unit when props change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->