### PR TITLE
Patient Detail Tabs: Org List Access

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1452,6 +1452,7 @@
   "no_tests_taken": "No tests taken",
   "no_treating_physicians_available": "This facility does not have any home facility doctors. Please contact your admin.",
   "no_update_available": "No update available",
+  "no_updates_found": "No updates found",
   "no_user_assigned": "No User Assigned to this patient",
   "no_users_found": "No Users Found",
   "no_vitals_present": "No Vitals Monitor present in this location or facility",

--- a/src/Routers/routes/PatientRoutes.tsx
+++ b/src/Routers/routes/PatientRoutes.tsx
@@ -1,5 +1,8 @@
 import FileUploadPage from "@/components/Patient/FileUploadPage";
-import { patientTabs } from "@/components/Patient/PatientDetailsTab";
+import {
+  facilityPatientTabs,
+  patientTabs,
+} from "@/components/Patient/PatientDetailsTab";
 import { PatientHome } from "@/components/Patient/PatientHome";
 import PatientIndex from "@/components/Patient/PatientIndex";
 import PatientRegistration from "@/components/Patient/PatientRegistration";
@@ -19,13 +22,20 @@ const PatientRoutes: AppRoutes = {
     <VerifyPatient facilityId={facilityId} />
   ),
   "/patient/:id": ({ id }) => <PatientHome id={id} page="demography" />,
+  "/patient/:id/update": ({ id }) => <PatientRegistration patientId={id} />,
+  ...patientTabs.reduce((acc: AppRoutes, tab) => {
+    acc["/patient/:id/" + tab.route] = ({ id }) => (
+      <PatientHome id={id} page={tab.route} />
+    );
+    return acc;
+  }, {}),
   "/facility/:facilityId/patient/create": ({ facilityId }) => (
     <PatientRegistration facilityId={facilityId} />
   ),
   "/facility/:facilityId/patient/:id": ({ facilityId, id }) => (
     <PatientHome facilityId={facilityId} id={id} page="demography" />
   ),
-  ...patientTabs.reduce((acc: AppRoutes, tab) => {
+  ...facilityPatientTabs.reduce((acc: AppRoutes, tab) => {
     acc["/facility/:facilityId/patient/:id/" + tab.route] = ({
       facilityId,
       id,

--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -37,9 +37,13 @@ export const Demography = (props: PatientProps) => {
   };
 
   const handleEditClick = (sectionId: string) => {
-    navigate(
-      `/facility/${facilityId}/patient/${id}/update?section=${sectionId}`,
-    );
+    if (facilityId) {
+      navigate(
+        `/facility/${facilityId}/patient/${id}/update?section=${sectionId}`,
+      );
+    } else {
+      navigate(`/patient/${id}/update?section=${sectionId}`);
+    }
   };
 
   const hasEditPermission = () => {

--- a/src/components/Patient/PatientDetailsTab/index.tsx
+++ b/src/components/Patient/PatientDetailsTab/index.tsx
@@ -16,14 +16,10 @@ export interface PatientProps {
   patientData: Patient;
 }
 
-export const patientTabs = [
+const commonTabs = [
   {
     route: "demography",
     component: Demography,
-  },
-  {
-    route: "appointments",
-    component: Appointments,
   },
   {
     route: "encounters",
@@ -50,3 +46,14 @@ export const patientTabs = [
     component: PatientFilesTab,
   },
 ];
+
+export const facilityPatientTabs = [
+  commonTabs[0],
+  {
+    route: "appointments",
+    component: Appointments,
+  },
+  ...commonTabs.slice(1),
+];
+
+export const patientTabs = [...commonTabs];

--- a/src/components/Patient/PatientDetailsTab/index.tsx
+++ b/src/components/Patient/PatientDetailsTab/index.tsx
@@ -16,7 +16,7 @@ export interface PatientProps {
   patientData: Patient;
 }
 
-const commonTabs = [
+export const patientTabs = [
   {
     route: "demography",
     component: Demography,
@@ -48,12 +48,36 @@ const commonTabs = [
 ];
 
 export const facilityPatientTabs = [
-  commonTabs[0],
+  {
+    route: "demography",
+    component: Demography,
+  },
   {
     route: "appointments",
     component: Appointments,
   },
-  ...commonTabs.slice(1),
+  {
+    route: "encounters",
+    component: EncounterHistory,
+  },
+  {
+    route: "health-profile",
+    component: HealthProfileSummary,
+  },
+  {
+    route: "updates",
+    component: Updates,
+  },
+  {
+    route: "resource_requests",
+    component: ResourceRequests,
+  },
+  {
+    route: "users",
+    component: PatientUsers,
+  },
+  {
+    route: "files",
+    component: PatientFilesTab,
+  },
 ];
-
-export const patientTabs = [...commonTabs];

--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -9,7 +9,10 @@ import { Button } from "@/components/ui/button";
 import { Avatar } from "@/components/Common/Avatar";
 import Loading from "@/components/Common/Loading";
 import Page from "@/components/Common/Page";
-import { patientTabs } from "@/components/Patient/PatientDetailsTab";
+import {
+  facilityPatientTabs,
+  patientTabs,
+} from "@/components/Patient/PatientDetailsTab";
 
 import { PLUGIN_Component } from "@/PluginEngine";
 import routes from "@/Utils/request/api";
@@ -20,7 +23,7 @@ import { Patient } from "@/types/emr/newPatient";
 export const PatientHome = (props: {
   facilityId?: string;
   id: string;
-  page: (typeof patientTabs)[0]["route"];
+  page: (typeof patientTabs | typeof facilityPatientTabs)[0]["route"];
 }) => {
   const { facilityId, id, page } = props;
 
@@ -40,7 +43,9 @@ export const PatientHome = (props: {
     return <Loading />;
   }
 
-  const Tab = patientTabs.find((t) => t.route === page)?.component;
+  const tabs = facilityId ? facilityPatientTabs : patientTabs;
+
+  const Tab = tabs.find((t) => t.route === page)?.component;
 
   if (!patientData) {
     return <div>{t("patient_not_found")}</div>;
@@ -51,13 +56,15 @@ export const PatientHome = (props: {
       title={t("patient_details")}
       options={
         <>
-          <Button asChild variant="primary">
-            <Link
-              href={`/facility/${facilityId}/patient/${id}/book-appointment`}
-            >
-              {t("schedule_appointment")}
-            </Link>
-          </Button>
+          {facilityId && (
+            <Button asChild variant="primary">
+              <Link
+                href={`/facility/${facilityId}/patient/${id}/book-appointment`}
+              >
+                {t("schedule_appointment")}
+              </Link>
+            </Button>
+          )}
         </>
       }
     >
@@ -99,10 +106,14 @@ export const PatientHome = (props: {
           role="navigation"
         >
           <div className="flex flex-row" role="tablist">
-            {patientTabs.map((tab) => (
+            {tabs.map((tab) => (
               <Link
                 key={tab.route}
-                href={`/facility/${facilityId}/patient/${id}/${tab.route}`}
+                href={
+                  facilityId
+                    ? `/facility/${facilityId}/patient/${id}/${tab.route}`
+                    : `/patient/${id}/${tab.route}`
+                }
                 className={`whitespace-nowrap px-4 py-2 text-sm font-medium ${
                   page === tab.route
                     ? "border-b-4 border-green-800 text-green-800 md:border-b-2"

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -60,7 +60,7 @@ import { PatientModel } from "@/types/emr/patient";
 import { Organization } from "@/types/organization/organization";
 
 interface PatientRegistrationPageProps {
-  facilityId: string;
+  facilityId?: string;
   patientId?: string;
 }
 
@@ -224,11 +224,13 @@ export default function PatientRegistration(
       return;
     }
 
-    createPatient({
-      ...values,
-      facility: facilityId,
-      ward_old: undefined,
-    });
+    if (facilityId) {
+      createPatient({
+        ...values,
+        facility: facilityId,
+        ward_old: undefined,
+      });
+    }
   }
 
   const sidebarItems = [


### PR DESCRIPTION
## Proposed Changes

- Fixes #10109 
   - Use a sep list to render tabs for patient page when accessed directly (i.e. without related facility Id, from an org listing page, i.e.: url would be patient/id rather than facility/facilityId/patient/id).
   -  Allowing patient detail edit on above access (i.e. edit button on patient details page used to be facility specific).
   - Hides appointments tab for direct patient listing (appointments are facility specific).
   - All the other tabs are not facility exclusive, so keeping them but let me know if I missed something.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new route for patient updates.
  - Enhanced patient tab navigation with facility-specific routing.

- **Improvements**
  - Updated patient registration process to handle optional facility ID.
  - Improved localization with a new "No updates found" message.
  - Refined patient home and details tab navigation logic.

- **Bug Fixes**
  - Resolved routing inconsistencies in patient-related components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->