### PR TITLE
Fix: Facility Creation Form: Pincode Autofill Overwrites Pre-filled Geographic Data & Added Similar Approach in User Creation Form

### DIFF
--- a/src/components/Facility/FacilityForm.tsx
+++ b/src/components/Facility/FacilityForm.tsx
@@ -55,6 +55,15 @@ interface FacilityProps {
   onSubmitSuccess?: () => void;
 }
 
+function extractHierarchyLevels(org: Organization | undefined): Organization[] {
+  const levels: Organization[] = [];
+  while (org && org.level_cache >= 0) {
+    levels.unshift(org as Organization);
+    org = org.parent as Organization | undefined;
+  }
+  return levels;
+}
+
 export default function FacilityForm(props: FacilityProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -193,7 +202,11 @@ export default function FacilityForm(props: FacilityProps) {
 
   useEffect(() => {
     if (facilityId) return;
+    const orgLevels = extractHierarchyLevels(org);
+    const districtMatch =
+      districtOrg && orgLevels.some((level) => level.name === districtOrg.name);
     const levels: Organization[] = [];
+    if (districtMatch) return;
     if (stateOrg) levels.push(stateOrg);
     if (districtOrg) levels.push(districtOrg);
     if (!stateOrg && !districtOrg && org) levels.push(org);

--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -36,18 +36,26 @@ import { GENDERS } from "@/common/constants";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import GovtOrganizationSelector from "@/pages/Organization/components/GovtOrganizationSelector";
+import { Organization } from "@/types/organization/organization";
+import organizationApi from "@/types/organization/organizationApi";
 import { CreateUserModel, UpdateUserModel, UserBase } from "@/types/user/user";
 import userApi from "@/types/user/userApi";
 
 interface Props {
   onSubmitSuccess?: (user: UserBase) => void;
   existingUsername?: string;
+  organizationId?: string;
 }
 
-export default function UserForm({ onSubmitSuccess, existingUsername }: Props) {
+export default function UserForm({
+  onSubmitSuccess,
+  existingUsername,
+  organizationId,
+}: Props) {
   const { t } = useTranslation();
   const isEditMode = !!existingUsername;
   const queryClient = useQueryClient();
+  const [selectedLevels, setSelectedLevels] = useState<Organization[]>([]);
 
   const userFormSchema = z
     .object({
@@ -262,6 +270,20 @@ export default function UserForm({ onSubmitSuccess, existingUsername }: Props) {
       } as CreateUserModel);
     }
   };
+
+  const { data: org } = useQuery({
+    queryKey: ["organization", organizationId],
+    queryFn: query(organizationApi.get, {
+      pathParams: { id: organizationId },
+    }),
+    enabled: !!organizationId,
+  });
+
+  useEffect(() => {
+    const levels: Organization[] = [];
+    if (org) levels.push(org);
+    setSelectedLevels(levels);
+  }, [org, organizationId]);
 
   return (
     <Form {...form}>
@@ -585,8 +607,12 @@ export default function UserForm({ onSubmitSuccess, existingUsername }: Props) {
               <FormItem>
                 <FormControl>
                   <GovtOrganizationSelector
-                    value={field.value}
-                    onChange={field.onChange}
+                    {...field}
+                    value={form.watch("geo_organization")}
+                    selected={selectedLevels}
+                    onChange={(value) =>
+                      form.setValue("geo_organization", value)
+                    }
                     required={!isEditMode}
                   />
                 </FormControl>

--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -67,6 +67,7 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
               onUserCreated={(user) => {
                 updateQuery({ sheet: "link", username: user.username });
               }}
+              organizationId={id}
             />
             <LinkUserSheet
               organizationId={id}

--- a/src/pages/Organization/components/AddUserSheet.tsx
+++ b/src/pages/Organization/components/AddUserSheet.tsx
@@ -20,12 +20,14 @@ interface AddUserSheetProps {
   open: boolean;
   setOpen: (open: boolean) => void;
   onUserCreated?: (user: UserBase) => void;
+  organizationId?: string;
 }
 
 export default function AddUserSheet({
   open,
   setOpen,
   onUserCreated,
+  organizationId,
 }: AddUserSheetProps) {
   const { t } = useTranslation();
   return (
@@ -50,6 +52,7 @@ export default function AddUserSheet({
               setOpen(false);
               onUserCreated?.(user);
             }}
+            organizationId={organizationId}
           />
         </div>
       </SheetContent>


### PR DESCRIPTION
## Proposed Changes

- Fixes #10145 
- Pincode autofill matches the existing state and district data, the dropdown fields should not be reset.
- The user creation form prefill geographic details (similar to the facility creation form) based on the current page’s context

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced organization hierarchy handling in facility and user forms
  - Added support for organization-specific user creation and management

- **Improvements**
  - Refined organization level selection logic
  - Improved form integration with organization data
  - Added organization context to user creation process

- **Technical Updates**
  - Introduced new prop `organizationId` across multiple components to support more granular organization-level interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->