### PR TITLE
Fix dev server configuration and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@eslint/compat": "^1.2.5",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
         "@julr/vite-plugin-validate-env": "^1.1.1",
@@ -3676,24 +3675,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.5.tgz",
-      "integrity": "sha512-5iuG/StT+7OfvhoBHPlmxkPA9om6aDUFgmD4+mWKAGsYt4vCe8rypneG03AuseyRHBmcCLXQtIH5S26tIoggLg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": "^9.10.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.2.5",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
     "@julr/vite-plugin-validate-env": "^1.1.1",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -211,6 +211,7 @@ export default defineConfig(({ mode }) => {
       checker({
         typescript: true,
         eslint: {
+          useFlatConfig: true,
           lintCommand: "eslint ./src",
           dev: {
             logLevel: ["error"],


### PR DESCRIPTION
Remove unnecessary ESLint compatibility dependency and update the ESLint configuration to use flat config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed `@eslint/compat` development dependency
	- Updated Vite configuration to use flat ESLint configuration format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->