### PR TITLE
displaying "-" when user type not defined

### DIFF
--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -110,7 +110,7 @@ const UserCard = ({ user }: { user: UserBase }) => {
             <div>
               <div className="text-gray-500">{t("role")}</div>
               <div className="font-medium truncate">
-                {user.user_type ?? "-"}
+              {user.user_type ? user.user_type : "-"}
               </div>
             </div>
             <div>


### PR DESCRIPTION
Returns `user.user_type` if it is truthy. Otherwise, it returns "-"

- Fixes #10150



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user type display logic to handle empty or falsy values consistently, ensuring a hyphen ("-") is shown when no user type is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->