### PR TITLE
Trigger default filters apply logic only when there are no search params already applied

### DIFF
--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -262,12 +262,16 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
   );
 
   useEffect(() => {
+    // trigger this effect only when there are no query params already applied, and once the query is loaded
+    if (Object.keys(qParams).length !== 0 || schedulableUsersQuery.isLoading) {
+      return;
+    }
+
     const updates: Partial<QueryParams> = {};
 
     // Sets the practitioner filter to the current user if they are in the list of
     // schedulable users and no practitioner was selected.
     if (
-      !schedulableUsersQuery.isLoading &&
       !qParams.practitioner &&
       schedulableUsersQuery.data?.users.some(
         (r) => r.username === authUser.username,
@@ -301,7 +305,7 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
         ...updates,
       });
     }
-  }, [schedulableUsersQuery.isLoading]);
+  }, [schedulableUsersQuery.isLoading, qParams]);
 
   // Enabled only if filtered by a practitioner and a single day
   const slotsFilterEnabled =


### PR DESCRIPTION



## Proposed Changes

- Trigger default filters apply logic only when there are no search params already applied
- Fixes #9903

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved query parameter handling in the Appointments page to prevent unnecessary updates and enhance responsiveness during data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->