### PR TITLE
Confirm Alert for Patient Registration

### DIFF
--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { navigate } from "raviger";
+import { navigate, useQueryParams } from "raviger";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -39,7 +39,8 @@ import { parsePhoneNumber } from "@/Utils/utils";
 import { PartialPatientModel } from "@/types/emr/newPatient";
 
 export default function PatientIndex({ facilityId }: { facilityId: string }) {
-  const [phoneNumber, setPhoneNumber] = useState("");
+  const [{ phone_number }] = useQueryParams();
+  const [phoneNumber, setPhoneNumber] = useState(phone_number || "");
   const [yearOfBirth, setYearOfBirth] = useState("");
   const [selectedPatient, setSelectedPatient] =
     useState<PartialPatientModel | null>(null);

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -39,8 +39,8 @@ import { parsePhoneNumber } from "@/Utils/utils";
 import { PartialPatientModel } from "@/types/emr/newPatient";
 
 export default function PatientIndex({ facilityId }: { facilityId: string }) {
-  const [{ phone_number }] = useQueryParams();
-  const [phoneNumber, setPhoneNumber] = useState(phone_number || "");
+  const [{ phone_number: phoneNumber = "" }, setPhoneNumberQuery] =
+    useQueryParams();
   const [yearOfBirth, setYearOfBirth] = useState("");
   const [selectedPatient, setSelectedPatient] =
     useState<PartialPatientModel | null>(null);
@@ -92,7 +92,9 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
 
   const handleSearch = useCallback((key: string, value: string) => {
     if (key === "phone_number") {
-      setPhoneNumber(value.length >= 13 || value === "" ? value : "");
+      setPhoneNumberQuery({
+        phone_number: value.length >= 13 || value === "" ? value : "",
+      });
     }
   }, []);
 

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { navigate, useQueryParams } from "raviger";
+import { navigate, useNavigationPrompt, useQueryParams } from "raviger";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -299,6 +299,22 @@ export default function PatientRegistration(
       } as unknown as z.infer<typeof formSchema>);
     }
   }, [patientQuery.data]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const showDuplicate =
+    !patientPhoneSearch.isLoading &&
+    !!duplicatePatients?.length &&
+    !!parsePhoneNumber(form.watch("phone_number") || "") &&
+    !suppressDuplicateWarning;
+
+  // TODO: Use useBlocker hook after switching to tanstack router
+  // https://tanstack.com/router/latest/docs/framework/react/guide/navigation-blocking#how-do-i-use-navigation-blocking
+  useNavigationPrompt(
+    form.formState.isDirty &&
+      !isCreatingPatient &&
+      !isUpdatingPatient &&
+      !showDuplicate,
+    t("unsaved_changes"),
+  );
 
   if (patientId && patientQuery.isLoading) {
     return <Loading />;
@@ -675,7 +691,7 @@ export default function PatientRegistration(
                 )}
               />
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4">
                 <FormField
                   control={form.control}
                   name="nationality"
@@ -699,6 +715,9 @@ export default function PatientRegistration(
                     </FormItem>
                   )}
                 />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
                 {form.watch("nationality") === "India" && (
                   <FormField
                     control={form.control}
@@ -743,18 +762,15 @@ export default function PatientRegistration(
           </form>
         </Form>
       </div>
-      {!patientPhoneSearch.isLoading &&
-        !!duplicatePatients?.length &&
-        !!parsePhoneNumber(form.watch("phone_number") || "") &&
-        !suppressDuplicateWarning && (
-          <DuplicatePatientDialog
-            patientList={duplicatePatients}
-            handleOk={handleDialogClose}
-            handleCancel={() => {
-              handleDialogClose("close");
-            }}
-          />
-        )}
+      {showDuplicate && (
+        <DuplicatePatientDialog
+          patientList={duplicatePatients}
+          handleOk={handleDialogClose}
+          handleCancel={() => {
+            handleDialogClose("close");
+          }}
+        />
+      )}
     </Page>
   );
 }

--- a/src/pages/PublicAppointments/PatientRegistration.tsx
+++ b/src/pages/PublicAppointments/PatientRegistration.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { navigate } from "raviger";
+import { navigate, useNavigationPrompt } from "raviger";
 import { Fragment } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -165,7 +165,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
     },
   });
 
-  const { mutate: createPatient } = useMutation({
+  const { mutate: createPatient, isPending: isCreatingPatient } = useMutation({
     mutationFn: (body: Partial<AppointmentPatientRegister>) =>
       mutate(routes.otp.createPatient, {
         body: { ...body, phone_number: tokenData.phoneNumber },
@@ -210,6 +210,13 @@ export function PatientRegistration(props: PatientRegistrationProps) {
     };
     createPatient(formattedData);
   });
+
+  // TODO: Use useBlocker hook after switching to tanstack router
+  // https://tanstack.com/router/latest/docs/framework/react/guide/navigation-blocking#how-do-i-use-navigation-blocking
+  useNavigationPrompt(
+    form.formState.isDirty && !isCreatingPatient,
+    t("unsaved_changes"),
+  );
 
   // const [showAutoFilledPincode, setShowAutoFilledPincode] = useState(false);
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #10203 
    - Show alert is form is dirty and user navigates away (except for submit buttons) for patient registration in both logged in and otp flows
    - Also exception for duplicate patient flow
- Fix for duplicate flow: Duplicate dialog is triggered if user goes to the registration form with existing number. If user then confirms duplicate record, they are redirected back to PatientIndex, however currently phone number isn't auto entered into the field

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added navigation prompt to alert users about unsaved changes in patient registration forms.
  - Implemented query parameter handling for managing phone number in patient search functionality.

- **Improvements**
  - Enhanced patient registration form layout for better organization.
  - Refined logic for displaying duplicate patient alerts.

- **Technical Updates**
  - Updated patient registration mutation to track creation status.

The changes focus on improving user experience and form interaction in patient-related workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->