### PR TITLE
Fixes `year_of_birth` post patient registration success

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -171,10 +171,7 @@ export default function PatientRegistration(
       navigate(`/facility/${facilityId}/patients/verify`, {
         query: {
           phone_number: resp.phone_number,
-          year_of_birth:
-            form.getValues("age_or_dob") === "dob"
-              ? new Date(resp.date_of_birth!).getFullYear()
-              : new Date().getFullYear() - Number(resp.age!),
+          year_of_birth: resp.year_of_birth,
           partial_id: resp?.id?.slice(0, 5),
         },
       });


### PR DESCRIPTION
## Proposed Changes

- Fixes `year_of_birth` post patient registration success

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified patient registration year of birth calculation by directly using the response value
  - Streamlined navigation logic during patient registration process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->