### PR TITLE
disable dependabot updates in favour of renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,24 @@
 version: 2
 updates:
-  - package-ecosystem: "yarn"
+  - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
     allow:
       - dependency-name: "*"
         dependency-type: "production"
     assignees:
       - "tomahawk_pilot"
     labels:
-      - "yarn"
       - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-        assignees:
+    open-pull-requests-limit: 0
+    assignees:
       - "tomahawk_pilot"
     labels:
       - "ci"


### PR DESCRIPTION
## Proposed Changes

- disable dependabot updates in favour of renovate

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dependabot configuration to use npm instead of yarn
	- Limited the number of open dependency update pull requests to zero for npm and GitHub Actions ecosystems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->