### PR TITLE
Remove slot type selection from schedule template forms

### DIFF
--- a/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
@@ -27,13 +27,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetClose,
   SheetContent,
@@ -380,7 +373,7 @@ export default function CreateScheduleTemplateSheet({
                         control={form.control}
                         name={`availabilities.${index}.name`}
                         render={({ field }) => (
-                          <FormItem className="col-span-2 md:col-span-1">
+                          <FormItem className="col-span-2">
                             <FormLabel required>{t("session_title")}</FormLabel>
                             <FormControl>
                               <Input
@@ -393,7 +386,7 @@ export default function CreateScheduleTemplateSheet({
                         )}
                       />
 
-                      <FormField
+                      {/* <FormField
                         control={form.control}
                         name={`availabilities.${index}.slot_type`}
                         render={({ field }) => (
@@ -436,7 +429,7 @@ export default function CreateScheduleTemplateSheet({
                             <FormMessage />
                           </FormItem>
                         )}
-                      />
+                      /> */}
 
                       <div className="flex items-center gap-4 col-span-2 md:col-span-1">
                         <FormField

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -27,13 +27,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetHeader,
@@ -627,7 +620,7 @@ const NewAvailabilityCard = ({
             )}
           />
 
-          <FormField
+          {/* <FormField
             control={form.control}
             name="slot_type"
             render={({ field }) => (
@@ -658,7 +651,7 @@ const NewAvailabilityCard = ({
                 <FormMessage />
               </FormItem>
             )}
-          />
+          /> */}
 
           <div className="flex items-center gap-4">
             <FormField


### PR DESCRIPTION


## Proposed Changes

- Fixes #10235

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
	- Removed the ability to select slot type (appointment, open, closed) from schedule template creation and editing forms
	- Disabled `slot_type` selection functionality in both `CreateScheduleTemplateSheet` and `EditScheduleTemplateSheet` components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->