### PR TITLE
Fixes incorrect count in appointments column when search query is present

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1901,6 +1901,7 @@
   "show_patient_presets": "Show Patient Presets",
   "show_unread_notifications": "Show Unread",
   "showing_all_appointments": "Showing all appointments",
+  "showing_x_of_y": "Showing <strong>{{x}}</strong> of <strong>{{y}}</strong>",
   "sign_in": "Sign in",
   "sign_out": "Sign out",
   "site": "Site",

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -15,7 +15,7 @@ import {
 import { Edit3Icon } from "lucide-react";
 import { Link, navigate, useQueryParams } from "raviger";
 import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
 
@@ -694,12 +694,27 @@ function AppointmentColumn(props: {
         !data && "animate-pulse",
       )}
     >
-      <div className="flex px-3 items-center gap-3 mb-4">
+      <div className="flex px-3 items-center gap-2 mb-4">
         <h2 className="font-semibold capitalize text-base px-1">
           {t(props.status)}
         </h2>
-        <span className="bg-gray-200 px-2 py-1 rounded-md text-sm">
-          {data?.count ?? "..."}
+        <span className="bg-gray-200 px-2 py-1 rounded-md text-xs font-medium">
+          {data?.count == null ? (
+            "..."
+          ) : data.count === appointments.length ? (
+            data.count
+          ) : (
+            <Trans
+              i18nKey="showing_x_of_y"
+              values={{
+                x: appointments.length,
+                y: data.count,
+              }}
+              components={{
+                strong: <span className="font-bold" />,
+              }}
+            />
+          )}
         </span>
       </div>
       {appointments.length === 0 ? (


### PR DESCRIPTION


## Proposed Changes

- Fixes incorrect count in appointments column when search query is present
- Closes #10240

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
	- Added a new translation string for displaying item count with dynamic highlighting
	- Enhanced appointment count display with improved internationalization support

- **User Interface**
	- Improved readability of appointment count information
	- Updated visual styling for appointment count display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->