### PR TITLE
Dob/Age and Lat/Log Override

### DIFF
--- a/src/components/Facility/FacilityForm.tsx
+++ b/src/components/Facility/FacilityForm.tsx
@@ -140,7 +140,11 @@ export default function FacilityForm(props: FacilityProps) {
     data: FacilityFormValues,
   ) => {
     if (facilityId) {
-      updateFacility(data);
+      updateFacility({
+        ...data,
+        latitude: data.latitude ?? 0,
+        longitude: data.longitude ?? 0,
+      });
     } else {
       createFacility(data);
     }
@@ -224,8 +228,12 @@ export default function FacilityForm(props: FacilityProps) {
         )?.id,
         address: facilityData.address,
         phone_number: facilityData.phone_number,
-        latitude: Number(facilityData.latitude),
-        longitude: Number(facilityData.longitude),
+        latitude: facilityData.latitude
+          ? Number(facilityData.latitude)
+          : undefined,
+        longitude: facilityData.longitude
+          ? Number(facilityData.longitude)
+          : undefined,
         is_public: facilityData.is_public,
       });
     }
@@ -466,7 +474,10 @@ export default function FacilityForm(props: FacilityProps) {
                       {...field}
                       type="number"
                       onChange={(e) => {
-                        form.setValue("latitude", Number(e.target.value));
+                        form.setValue(
+                          "latitude",
+                          e.target.value ? Number(e.target.value) : undefined,
+                        );
                       }}
                       data-cy="facility-latitude"
                       placeholder="Enter latitude"
@@ -490,7 +501,10 @@ export default function FacilityForm(props: FacilityProps) {
                       {...field}
                       type="number"
                       onChange={(e) => {
-                        form.setValue("longitude", Number(e.target.value));
+                        form.setValue(
+                          "longitude",
+                          e.target.value ? Number(e.target.value) : undefined,
+                        );
                       }}
                       data-cy="facility-longitude"
                       placeholder="Enter longitude"

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -215,7 +215,13 @@ export default function PatientRegistration(
 
   function onSubmit(values: z.infer<typeof formSchema>) {
     if (patientId) {
-      updatePatient({ ...values, ward_old: undefined });
+      updatePatient({
+        ...values,
+        ward_old: undefined,
+        age: values.age_or_dob === "age" ? values.age : undefined,
+        date_of_birth:
+          values.age_or_dob === "dob" ? values.date_of_birth : undefined,
+      });
       return;
     }
 

--- a/src/components/ui/sidebar/nav-user.tsx
+++ b/src/components/ui/sidebar/nav-user.tsx
@@ -191,15 +191,6 @@ export function PatientNavUser() {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              {patient && (
-                <DropdownMenuItem>
-                  <BadgeCheck />
-                  {t("profile")}
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
             <DropdownMenuItem onClick={signOut}>
               <LogOut />
               {t("logout")}


### PR DESCRIPTION
## Proposed Changes

- Fixes #10263 
- Override DoB/Age if user chooses to update one (assuming other is present)
- For Lat/Log, user can clear the existing data, however on update, it will just be updated to 0/0
   - User will see 0/0 afterwards
- Fixes #10258 
  - Just removed profile link, (2) is fine as is
- [BE PR](https://github.com/ohcnetwork/care/pull/2792)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of latitude and longitude values in facility form
  - Enhanced patient update logic for age and date of birth selection
  - Removed patient profile dropdown menu option

- **Refactor**
  - Updated form submission and data loading logic for more flexible input handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->