### PR TITLE
Fix: View Facility Redirection in public page is broken

### DIFF
--- a/src/pages/Facility/components/FacilityCard.tsx
+++ b/src/pages/Facility/components/FacilityCard.tsx
@@ -53,9 +53,7 @@ export function FacilityCard({ facility, className }: Props) {
         <div className="mt-auto border-t border-gray-100 bg-gray-50 p-4">
           <div className="flex justify-end">
             <Button variant="outline" asChild>
-              <Link href={`/facility/${facility.id}/overview`}>
-                View Facility
-              </Link>
+              <Link href={`/facility/${facility.id}`}>View Facility</Link>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #10315 
- Change 1
- Change 2
- More?

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Navigation Update**
  - Modified facility card link to direct users to the main facility page instead of the overview page
  - No changes to component's public interface or exported entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->