### PR TITLE
Set theme color to white in vite PWA manifest

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -237,6 +237,7 @@ export default defineConfig(({ mode }) => {
           name: "Care",
           short_name: "Care",
           background_color: "#ffffff",
+          theme_color: "#ffffff",
           display: "standalone",
           icons: [
             {


### PR DESCRIPTION
fixes this warning

<img width="608" alt="image" src="https://github.com/user-attachments/assets/e5f0f7e0-c655-4afb-92f5-d24795baee7a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Progressive Web App (PWA) configuration by adding a theme color setting.
	- Set default theme color to white (#ffffff) for improved visual consistency across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->