### PR TITLE
Fix: showing "-" in the emergency contact person field to represent the field is null

### DIFF
--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -89,7 +89,7 @@ export const Demography = (props: PatientProps) => {
             {t("emergency_contact_person_name")}
           </div>
           <div className="mt-1 text-sm font-semibold leading-5 text-gray-900">
-            {props.name || "-"}
+            -
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #10306 
- Change 1
- Change 2
- More?

![image](https://github.com/user-attachments/assets/f17566f9-5465-4f16-9c10-3495110d90df)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted emergency contact display in patient details to show a consistent placeholder

<!-- end of auto-generated comment: release notes by coderabbit.ai -->