### PR TITLE
Make autocompletes mobile friendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
+      content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, interactive-widget=resizes-content"
     />
     <title>%REACT_APP_TITLE%</title>
     <meta name="description" content="%REACT_APP_META_DESCRIPTION%" />

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -1,3 +1,4 @@
+import { CaretSortIcon } from "@radix-ui/react-icons";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -7,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Command,
+  CommandDialog,
   CommandEmpty,
   CommandGroup,
   CommandInput,
@@ -18,6 +20,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+
+import useBreakpoints from "@/hooks/useBreakpoints";
 
 import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
@@ -51,6 +55,7 @@ export default function ValueSetSelect({
   const { t } = useTranslation();
   const [internalOpen, setInternalOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const isMobile = useBreakpoints({ default: true, sm: false });
 
   const searchQuery = useQuery({
     queryKey: ["valueset", system, "expand", count, search],
@@ -103,6 +108,33 @@ export default function ValueSetSelect({
       </CommandList>
     </Command>
   );
+
+  if (isMobile && !hideTrigger) {
+    return (
+      <>
+        <Button
+          variant="outline"
+          role="combobox"
+          onClick={() => setInternalOpen(true)}
+          className={cn(
+            "w-full justify-between",
+            wrapTextForSmallScreen
+              ? "h-auto md:h-9 whitespace-normal text-left md:truncate"
+              : "truncate",
+            !value?.display && "text-gray-400",
+          )}
+          disabled={disabled}
+        >
+          <span>{value?.display || placeholder}</span>
+          <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+        <CommandDialog open={internalOpen} onOpenChange={setInternalOpen}>
+          {content}
+        </CommandDialog>
+      </>
+    );
+  }
+
   return (
     <Popover
       open={controlledOpen || internalOpen}
@@ -121,7 +153,8 @@ export default function ValueSetSelect({
               !value?.display && "text-gray-400",
             )}
           >
-            {value?.display || placeholder}
+            <span>{value?.display || placeholder}</span>
+            <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
       )}

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Command,
+  CommandDialog,
   CommandEmpty,
   CommandGroup,
   CommandInput,
@@ -17,6 +18,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+
+import useBreakpoints from "@/hooks/useBreakpoints";
 
 interface AutoCompleteOption {
   label: string;
@@ -49,6 +52,77 @@ export default function Autocomplete({
   "data-cy": dataCy,
 }: AutocompleteProps) {
   const [open, setOpen] = React.useState(false);
+  const isMobile = useBreakpoints({ default: true, sm: false });
+
+  const commandContent = (
+    <>
+      <CommandInput
+        placeholder="Search option..."
+        disabled={disabled}
+        onValueChange={onSearch}
+        className="outline-none border-none ring-0 shadow-none"
+      />
+      <CommandList>
+        <CommandEmpty>{noOptionsMessage}</CommandEmpty>
+        <CommandGroup>
+          {options.map((option) => (
+            <CommandItem
+              key={option.value}
+              value={option.label}
+              onSelect={(v) => {
+                const currentValue =
+                  options.find(
+                    (option) => option.label.toLowerCase() === v.toLowerCase(),
+                  )?.value || "";
+                onChange(currentValue === value ? "" : currentValue);
+                setOpen(false);
+              }}
+            >
+              <CheckIcon
+                className={cn(
+                  "mr-2 h-4 w-4",
+                  value === option.value ? "opacity-100" : "opacity-0",
+                )}
+              />
+              {option.label}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        <Button
+          title={
+            value
+              ? options.find((option) => option.value === value)?.label
+              : undefined
+          }
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between"
+          disabled={disabled}
+          data-cy={dataCy}
+          type="button"
+          onClick={() => setOpen(true)}
+        >
+          <span className="overflow-hidden">
+            {value
+              ? options.find((option) => option.value === value)?.label
+              : placeholder}
+          </span>
+          <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+        <CommandDialog open={open} onOpenChange={setOpen}>
+          {commandContent}
+        </CommandDialog>
+      </>
+    );
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen} modal={true}>
@@ -78,42 +152,7 @@ export default function Autocomplete({
         className="sm:w-full p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]"
         align={align}
       >
-        <Command>
-          <CommandInput
-            placeholder="Search option..."
-            disabled={disabled}
-            onValueChange={onSearch}
-            className="outline-none border-none ring-0 shadow-none"
-          />
-          <CommandList>
-            <CommandEmpty>{noOptionsMessage}</CommandEmpty>
-            <CommandGroup>
-              {options.map((option) => (
-                <CommandItem
-                  key={option.value}
-                  value={option.label}
-                  onSelect={(v) => {
-                    const currentValue =
-                      options.find(
-                        (option) =>
-                          option.label.toLowerCase() === v.toLowerCase(),
-                      )?.value || "";
-                    onChange(currentValue === value ? "" : currentValue);
-                    setOpen(false);
-                  }}
-                >
-                  <CheckIcon
-                    className={cn(
-                      "mr-2 h-4 w-4",
-                      value === option.value ? "opacity-100" : "opacity-0",
-                    )}
-                  />
-                  {option.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        <Command>{commandContent}</Command>
       </PopoverContent>
     </Popover>
   );

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -31,12 +31,9 @@
 
 html {
     @apply w-full h-full;
-    min-height: -webkit-fill-available;
 }
 
 body {
-    min-height: 100vh;
-    min-height: -webkit-fill-available;
     font-family: "Figtree", sans-serif;
     color: #453c52;
     @apply font-sans text-secondary-900 w-full h-full antialiased;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -31,9 +31,12 @@
 
 html {
     @apply w-full h-full;
+    min-height: -webkit-fill-available;
 }
 
 body {
+    min-height: 100vh;
+    min-height: -webkit-fill-available;
     font-family: "Figtree", sans-serif;
     color: #453c52;
     @apply font-sans text-secondary-900 w-full h-full antialiased;


### PR DESCRIPTION
## Proposed Changes

- Make autocompletes mobile friendly

### Mobile

![image](https://github.com/user-attachments/assets/773e13cf-7869-41e1-b0fb-4fbd592a0c69)


### Desktop

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/7229962b-1e91-445d-8fd2-520c00dcfd55" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced mobile responsiveness for select and autocomplete components
  - Added support for interactive widget resizing in viewport settings

- **Improvements**
  - Implemented mobile-specific UI for search and selection interactions
  - Optimized component rendering across different screen sizes

- **Technical Updates**
  - Introduced `CommandDialog` for mobile search functionality
  - Added `useBreakpoints` hook to detect mobile device view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->