### PR TITLE
Fix DateTimeQuestion response update logic from creating duplicates

### DIFF
--- a/src/components/Facility/ConsultationDetails/ObservationsList.tsx
+++ b/src/components/Facility/ConsultationDetails/ObservationsList.tsx
@@ -7,6 +7,8 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Card } from "@/components/ui/card";
 
+import { formatValue } from "@/components/Facility/ConsultationDetails/QuestionnaireResponsesList";
+
 import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
 import { HTTPError } from "@/Utils/request/types";
@@ -96,7 +98,7 @@ export default function ObservationsList(props: Props) {
               )}
               {item.value.value && (
                 <div className="mt-1 font-medium whitespace-pre-wrap">
-                  {item.value.value}
+                  {formatValue(item.value.value, item.value_type)}
                 </div>
               )}
               {item.note && (
@@ -108,7 +110,7 @@ export default function ObservationsList(props: Props) {
         {hasNextPage && (
           <div ref={ref} className="flex justify-center p-4">
             <div className="text-sm text-gray-500">
-              {isFetchingNextPage ? t("loading_more") : t("load_more")}
+              {isFetchingNextPage ? t("loading") : t("load_more")}
             </div>
           </div>
         )}

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -53,7 +53,10 @@ interface QuestionResponseProps {
   };
 }
 
-function formatValue(value: ResponseValueType["value"], type: string): string {
+export function formatValue(
+  value: ResponseValueType["value"],
+  type: string,
+): string {
   if (!value) return "";
 
   // Handle complex objects

--- a/src/components/Questionnaire/QuestionTypes/DateTimeQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DateTimeQuestion.tsx
@@ -72,7 +72,6 @@ export function DateTimeQuestion({
 
     updateQuestionnaireResponseCB(
       [
-        ...questionnaireResponse.values,
         {
           type: "dateTime",
           value: date.toISOString(),


### PR DESCRIPTION
## Proposed Changes

- Fix DateTimeQuestion response update logic from creating duplicates

Issue reported by @nihal467 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Revised how the questionnaire processes time inputs. Now, when a new time is selected, it replaces any previously stored value with the current one, ensuring that only the latest entry is maintained. This update streamlines the date/time response handling, resulting in a clearer and more intuitive experience.
  
- **New Features**
	- Enhanced observation value display by formatting values based on their type for improved clarity.
  
- **User Interface**
	- Updated loading message for fetching observations to provide better user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->