### PR TITLE
Remove extra padding in appointment details page | Current status dropdown

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -219,8 +219,10 @@ const AppointmentDetails = ({
     <div className="container md:p-6 max-w-3xl space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>
-            <span className="mr-3">{t("schedule_information")}</span>
+          <CardTitle className="">
+            <span className="mr-3 inline-block mb-2">
+              {t("schedule_information")}
+            </span>
             <Badge
               variant={
                 (

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -161,13 +161,13 @@ export default function AppointmentDetail(props: Props) {
             facility={facilityQuery.data}
           />
           <div className="mt-3">
-            <div id="appointment-token-card" className="bg-gray-50 p-4">
+            <div id="appointment-token-card" className="bg-gray-50 md:p-4">
               <AppointmentTokenCard
                 appointment={appointmentQuery.data}
                 facility={facilityQuery.data}
               />
             </div>
-            <div className="flex gap-2 justify-end px-6">
+            <div className="flex gap-2 justify-end px-6 mt-4 md:mt-0">
               <Button
                 variant="outline"
                 onClick={() => printAppointment({ t, facility, appointment })}
@@ -190,7 +190,7 @@ export default function AppointmentDetail(props: Props) {
               </Button>
             </div>
             <Separator className="my-4" />
-            <div className="mx-6 mt-10">
+            <div className="md:mx-6 mt-10">
               <AppointmentActions
                 facilityId={props.facilityId}
                 appointment={appointment}
@@ -216,7 +216,7 @@ const AppointmentDetails = ({
   const { t } = useTranslation();
 
   return (
-    <div className="container p-6 max-w-3xl space-y-6">
+    <div className="container md:p-6 max-w-3xl space-y-6">
       <Card>
         <CardHeader>
           <CardTitle>

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -219,7 +219,7 @@ const AppointmentDetails = ({
     <div className="container md:p-6 max-w-3xl space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle className="">
+          <CardTitle>
             <span className="mr-3 inline-block mb-2">
               {t("schedule_information")}
             </span>

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -973,7 +973,7 @@ const AppointmentStatusDropdown = ({
   };
 
   return (
-    <div className="w-32">
+    <div className="w-32" onClick={(e) => e.stopPropagation()}>
       <Select
         value={currentStatus}
         onValueChange={(value) =>


### PR DESCRIPTION
## Proposed Changes

- Fixes #10422 
- Fixes #10424 

Remove extra padding in appointment details page in mobile view 

Previous:

![Image](https://github.com/user-attachments/assets/f9712ef1-9685-4ed3-9872-511ad896aa73)

Now:

![Image](https://github.com/user-attachments/assets/3d92538b-fc03-48e6-9609-9e3fd3a71084)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the appointment details view with enhanced spacing and responsiveness for better visual consistency across various screen sizes.
  - Updated button layout and margins for improved usability on different devices. 
- **Bug Fixes**
  - Added event handling to prevent unintended interactions with the dropdown component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->