### PR TITLE
Fix duplicate error message in Login

### DIFF
--- a/src/Utils/FiltersCache.tsx
+++ b/src/Utils/FiltersCache.tsx
@@ -58,7 +58,7 @@ const invalidate = (key?: string) => {
 /**
  * Removes all filters cache in the platform.
  */
-const invaldiateAll = () => {
+const invalidateAll = () => {
   for (const key in localStorage) {
     if (key.startsWith("filters--")) {
       invalidate(key);
@@ -70,7 +70,7 @@ export default {
   get,
   set,
   invalidate,
-  invaldiateAll,
+  invalidateAll,
   utils: {
     clean,
   },

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -106,10 +106,10 @@ const Login = (props: LoginProps) => {
   // Staff Login Mutation
   const staffLoginMutation = useMutation({
     mutationFn: async (data: LoginFormData) => {
-      FiltersCache.invaldiateAll();
-      return await signIn(data);
+      FiltersCache.invalidateAll();
+      signIn(data);
     },
-    onError: (error) => {
+    onError: (error: any) => {
       setCaptcha(error.status == 429);
     },
   });


### PR DESCRIPTION
## Proposed Changes

- Fixes #10453
- Fixed the duplicate login error.
- Corrected the typo in invalidateAll.
- Added `any` type to the error parameter (for consistency in codebase)

<img width="1120" alt="{2D9A2678-AD6B-4962-9C5E-1722091A6D1F}" src="https://github.com/user-attachments/assets/f1a1c38e-845d-4b0c-af9e-7704cc3b26cd" />

@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Corrected a typo in the cache clearing function to ensure filters are properly reset.
	- Adjusted the staff login process to improve asynchronous handling and error reporting.
- Refactor
	- Made minor formatting improvements for enhanced readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->