### PR TITLE
Fixes login errors being shown twice due to nested `useMutation`

### DIFF
--- a/src/Utils/FiltersCache.tsx
+++ b/src/Utils/FiltersCache.tsx
@@ -58,7 +58,7 @@ const invalidate = (key?: string) => {
 /**
  * Removes all filters cache in the platform.
  */
-const invaldiateAll = () => {
+const invalidateAll = () => {
   for (const key in localStorage) {
     if (key.startsWith("filters--")) {
       invalidate(key);
@@ -70,7 +70,7 @@ export default {
   get,
   set,
   invalidate,
-  invaldiateAll,
+  invalidateAll,
   utils: {
     clean,
   },

--- a/src/Utils/request/query.ts
+++ b/src/Utils/request/query.ts
@@ -31,15 +31,6 @@ export async function callApi<Route extends ApiRoute<unknown, unknown>>(
 
   const data = await getResponseBody<Route["TRes"]>(res);
 
-  if (url.includes("/login/")) {
-    throw new HTTPError({
-      message: "Request Failed",
-      status: 429,
-      silent: true,
-      cause: data as unknown as Record<string, unknown>,
-    });
-  }
-
   if (!res.ok) {
     const isSilent =
       typeof options?.silent === "function"

--- a/src/Utils/request/query.ts
+++ b/src/Utils/request/query.ts
@@ -31,6 +31,15 @@ export async function callApi<Route extends ApiRoute<unknown, unknown>>(
 
   const data = await getResponseBody<Route["TRes"]>(res);
 
+  if (url.includes("/login/")) {
+    throw new HTTPError({
+      message: "Request Failed",
+      status: 429,
+      silent: true,
+      cause: data as unknown as Record<string, unknown>,
+    });
+  }
+
   if (!res.ok) {
     const isSilent =
       typeof options?.silent === "function"

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -37,12 +37,8 @@ import FiltersCache from "@/Utils/FiltersCache";
 import ViewCache from "@/Utils/ViewCache";
 import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
+import { HTTPError } from "@/Utils/request/types";
 import { TokenData } from "@/types/auth/otpToken";
-
-interface LoginFormData {
-  username: string;
-  password: string;
-}
 
 interface OtpLoginData {
   phone_number: string;
@@ -102,17 +98,6 @@ const Login = (props: LoginProps) => {
   useEffect(() => {
     localStorage.setItem(LocalStorageKeys.loginPreference, loginMode);
   }, [loginMode]);
-
-  // Staff Login Mutation
-  const staffLoginMutation = useMutation({
-    mutationFn: async (data: LoginFormData) => {
-      FiltersCache.invaldiateAll();
-      return await signIn(data);
-    },
-    onError: (error) => {
-      setCaptcha(error.status == 429);
-    },
-  });
 
   // Send OTP Mutation
   const { mutate: sendOtp, isPending: sendOtpPending } = useMutation({
@@ -233,7 +218,14 @@ const Login = (props: LoginProps) => {
     const validated = validateData();
     if (!validated) return;
 
-    staffLoginMutation.mutate(validated);
+    FiltersCache.invalidateAll();
+    try {
+      await signIn(validated);
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        setCaptcha(error.status == 429);
+      }
+    }
   };
 
   const validateForgetData = () => {

--- a/src/pages/Appointments/components/AppointmentTokenCard.tsx
+++ b/src/pages/Appointments/components/AppointmentTokenCard.tsx
@@ -52,7 +52,7 @@ const AppointmentTokenCard = ({ id, appointment, facility }: Props) => {
             <Label>{t("name")}</Label>
             <p className="font-semibold">{patient.name}</p>
             <p className="text-sm text-gray-600 font-medium">
-              {formatPatientAge(patient as any, true)},{" "}
+              {formatPatientAge(patient, true)},{" "}
               {t(`GENDER__${patient.gender}`)}
             </p>
           </div>


### PR DESCRIPTION


## Proposed Changes

- Fixes #10453

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
   • Improved login error management to better handle rate-limiting issues, which now automatically adjusts captcha requirements.
   • Made a minor adjustment to appointment display for smoother data handling.

- Refactor
   • Streamlined the staff login process by replacing outdated mutation logic with a direct sign-in approach.
   • Applied internal corrections for more consistent filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->