### PR TITLE
DRAFT : Make Layout for resource section and fix missing Breadcrumb

### DIFF
--- a/src/CAREUI/misc/PrintPreview.tsx
+++ b/src/CAREUI/misc/PrintPreview.tsx
@@ -21,6 +21,8 @@ type Props = {
   disabled?: boolean;
   className?: string;
   title: string;
+  resName?: string;
+  id?: string;
 };
 
 export default function PrintPreview(props: Props) {
@@ -28,7 +30,12 @@ export default function PrintPreview(props: Props) {
   const { t } = useTranslation();
 
   return (
-    <Page title={props.title}>
+    <Page
+      title={props.title}
+      crumbsReplacements={
+        props.id ? { [props.id]: { name: props.resName } } : {}
+      }
+    >
       <div className="mx-auto my-8 xl:w-[50rem] border rounded-xl border-gray-200 shadow-2xl overflow-hidden">
         <div className="top-0 z-20 flex gap-2 bg-secondary-100 px-2 py-4 xl:absolute xl:right-6 xl:top-8 xl:justify-end">
           <Button variant="primary" disabled={props.disabled} onClick={print}>

--- a/src/Routers/routes/ResourceRoutes.tsx
+++ b/src/Routers/routes/ResourceRoutes.tsx
@@ -1,22 +1,10 @@
-import PrintResourceLetter from "@/components/Resource/PrintResourceLetter";
-import ResourceDetails from "@/components/Resource/ResourceDetails";
-import { ResourceDetailsUpdate } from "@/components/Resource/ResourceDetailsUpdate";
-import ResourceList from "@/components/Resource/ResourceList";
+import ResourceLayout from "@/components/Resource/ResourceLayout";
 
 import { AppRoutes } from "@/Routers/AppRouter";
 
 const ResourceRoutes: AppRoutes = {
-  "/facility/:facilityId/resource": ({ facilityId }) => (
-    <ResourceList facilityId={facilityId} />
-  ),
-  "/facility/:facilityId/resource/:id": ({ facilityId, id }) => (
-    <ResourceDetails facilityId={facilityId} id={id} />
-  ),
-  "/facility/:facilityId/resource/:id/update": ({ facilityId, id }) => (
-    <ResourceDetailsUpdate facilityId={facilityId} id={id} />
-  ),
-  "/facility/:facilityId/resource/:id/print": ({ id }) => (
-    <PrintResourceLetter id={id} />
+  "/facility/:facilityId/resource*": ({ facilityId }) => (
+    <ResourceLayout facilityId={facilityId} />
   ),
 };
 

--- a/src/components/Resource/PrintResourceLetter.tsx
+++ b/src/components/Resource/PrintResourceLetter.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
 import PrintPreview from "@/CAREUI/misc/PrintPreview";
@@ -7,25 +6,20 @@ import Loading from "@/components/Common/Loading";
 
 import { RESOURCE_CATEGORY_CHOICES } from "@/common/constants";
 
-import routes from "@/Utils/request/api";
-import query from "@/Utils/request/query";
 import { formatDateTime, formatName } from "@/Utils/utils";
+import { useBreadcrumbs } from "@/context/BreadcrumbsContext";
 
-export default function PrintResourceLetter({ id }: { id: string }) {
+export default function PrintResourceLetter() {
   const { t } = useTranslation();
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["resource_request_letter", id],
-    queryFn: query(routes.getResourceDetails, {
-      pathParams: { id: id },
-    }),
-  });
+  const { resourceDetails, isLoading } = useBreadcrumbs();
+  const data = resourceDetails;
 
   if (isLoading || !data) {
     return <Loading />;
   }
   return (
-    <PrintPreview title={t("request_letter")}>
+    <PrintPreview title={t("request_letter")} resName={data.title} id={data.id}>
       <div className="min-h-screen bg-white">
         <div className="mx-4 p-4 lg:mx-20">
           {/* Header */}

--- a/src/components/Resource/ResourceDetails.tsx
+++ b/src/components/Resource/ResourceDetails.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { navigate } from "raviger";
 import { useTranslation } from "react-i18next";
 
@@ -16,9 +15,8 @@ import CommentSection from "@/components/Resource/ResourceCommentSection";
 
 import { RESOURCE_CATEGORY_CHOICES } from "@/common/constants";
 
-import routes from "@/Utils/request/api";
-import query from "@/Utils/request/query";
 import { formatDateTime, formatName } from "@/Utils/utils";
+import { useBreadcrumbs } from "@/context/BreadcrumbsContext";
 import { PatientModel } from "@/types/emr/patient";
 
 function PatientCard({ patient }: { patient: PatientModel }) {
@@ -102,30 +100,17 @@ function FacilityCard({
   );
 }
 
-export default function ResourceDetails({
-  id,
-  facilityId,
-}: {
-  id: string;
-  facilityId: string;
-}) {
+export default function ResourceDetails() {
   const { t } = useTranslation();
-
-  const { data, isLoading } = useQuery({
-    queryKey: ["resource_request", id],
-    queryFn: query(routes.getResourceDetails, {
-      pathParams: { id },
-    }),
-  });
-
+  const { facilityId, id, resourceDetails, isLoading } = useBreadcrumbs();
+  const data = resourceDetails;
   if (isLoading || !data) {
     return <Loading />;
   }
-
   return (
     <Page
       title="Request Details"
-      crumbsReplacements={{ [id]: { name: data.title } }}
+      crumbsReplacements={{ [id]: { name: data.title } }} // was already passing breadcrumb name here before :(
       backUrl={`/facility/${facilityId}/resource`}
     >
       <div className="mx-auto max-w-7xl space-y-6 p-4 md:p-6">

--- a/src/components/Resource/ResourceDetailsUpdate.tsx
+++ b/src/components/Resource/ResourceDetailsUpdate.tsx
@@ -30,6 +30,7 @@ import { RESOURCE_STATUS_CHOICES } from "@/common/constants";
 import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { useBreadcrumbs } from "@/context/BreadcrumbsContext";
 import { UpdateResourceRequest } from "@/types/resourceRequest/resourceRequest";
 
 interface resourceProps {
@@ -129,12 +130,7 @@ export const ResourceDetailsUpdate = (props: resourceProps) => {
     form[name] = selected;
     dispatch({ type: "set_form", form });
   };
-  const { data: resourceDetails } = useQuery({
-    queryKey: ["resource", props.facilityId, props.id],
-    queryFn: query(routes.getResourceDetails, {
-      pathParams: { id: props.id },
-    }),
-  });
+  const { resourceDetails } = useBreadcrumbs();
   useEffect(() => {
     if (resourceDetails) {
       dispatch({

--- a/src/components/Resource/ResourceLayout.tsx
+++ b/src/components/Resource/ResourceLayout.tsx
@@ -1,0 +1,44 @@
+import { usePath, useRoutes } from "raviger";
+
+import PrintResourceLetter from "@/components/Resource/PrintResourceLetter";
+import ResourceDetails from "@/components/Resource/ResourceDetails";
+import { ResourceDetailsUpdate } from "@/components/Resource/ResourceDetailsUpdate";
+import ResourceList from "@/components/Resource/ResourceList";
+
+import { BreadcrumbsProvider } from "@/context/BreadcrumbsContext";
+
+const getRoutes = (facilityId: string) => {
+  return {
+    [`/facility/${facilityId}/resource`]: () => (
+      <ResourceList facilityId={facilityId} />
+    ),
+    [`/facility/${facilityId}/resource/:id`]: () => {
+      return <ResourceDetails />;
+    },
+    [`/facility/${facilityId}/resource/:id/update`]: ({
+      id = "",
+    }: {
+      id?: string;
+    }) => {
+      return <ResourceDetailsUpdate facilityId={facilityId} id={id} />;
+    },
+    [`/facility/${facilityId}/resource/:id/print`]: () => {
+      return <PrintResourceLetter />;
+    },
+  };
+};
+
+const ResourceLayout = ({ facilityId }: { facilityId: string }) => {
+  const routeResult = useRoutes(getRoutes(facilityId));
+  const path = usePath(); // Get the current route path
+  const resourceIdMatch = path?.match(/\/facility\/[^/]+\/resource\/([^/]+)/);
+  const resourceId = resourceIdMatch ? resourceIdMatch[1] : "";
+
+  return (
+    <BreadcrumbsProvider facilityId={facilityId} id={resourceId}>
+      <div>{routeResult}</div>
+    </BreadcrumbsProvider>
+  );
+};
+
+export default ResourceLayout;

--- a/src/context/BreadcrumbsContext.tsx
+++ b/src/context/BreadcrumbsContext.tsx
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import { createContext, useContext } from "react";
+import { ReactNode } from "react";
+
+import routes from "@/Utils/request/api";
+import query from "@/Utils/request/query";
+
+export const BreadcrumbsContext = createContext<{
+  facilityId: string;
+  id: string;
+  resourceDetails: any | null | undefined;
+  isLoading: boolean;
+}>({
+  facilityId: "",
+  id: "",
+  resourceDetails: null,
+  isLoading: false,
+});
+
+interface BreadcrumbsProviderProps {
+  facilityId: string;
+  id: string;
+  children: ReactNode;
+}
+
+export const BreadcrumbsProvider = ({
+  facilityId,
+  id,
+  children,
+}: BreadcrumbsProviderProps) => {
+  const { data: resourceDetails, isLoading } = useQuery({
+    queryKey: ["resource_request", facilityId, id],
+    queryFn: query(routes.getResourceDetails, {
+      pathParams: { id },
+    }),
+  });
+  return (
+    <BreadcrumbsContext.Provider
+      value={{ facilityId, id, resourceDetails, isLoading }}
+    >
+      {children}
+    </BreadcrumbsContext.Provider>
+  );
+};
+
+export const useBreadcrumbs = () => {
+  const context = useContext(BreadcrumbsContext);
+  if (!context) {
+    throw new Error("useBreadcrumbs must be used within a BreadcrumbsProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
## Proposed Changes

- Draft For #9822 
- Introduce a common layout for Resource section
- Fetch resource data only once and reuse it 
 

@rithviknishad 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced breadcrumb support with optional identifiers, enabling dynamic navigation displays.
	- Consolidated multiple resource routes into a unified layout for streamlined access.
	- Introduced a centralized breadcrumb management system for consistent resource detail presentation.
  
- **Refactor**
	- Simplified resource detail, update, and printing components by replacing individual data queries with a context-based approach for efficient data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->