### PR TITLE
Fix :  Hover color for active button

### DIFF
--- a/src/components/Questionnaire/index.tsx
+++ b/src/components/Questionnaire/index.tsx
@@ -74,7 +74,7 @@ export function QuestionnaireList() {
                   <Badge
                     className={
                       questionnaire.status === "active"
-                        ? "bg-green-200 text-green-900 hover:bg-green-300"
+                        ? "bg-green-100 text-green-800 hover:bg-green-200"
                         : ""
                     }
                   >

--- a/src/components/Questionnaire/index.tsx
+++ b/src/components/Questionnaire/index.tsx
@@ -74,7 +74,7 @@ export function QuestionnaireList() {
                   <Badge
                     className={
                       questionnaire.status === "active"
-                        ? "bg-green-100 text-green-800"
+                        ? "bg-green-200 text-green-900 hover:bg-green-300"
                         : ""
                     }
                   >

--- a/src/components/Questionnaire/show.tsx
+++ b/src/components/Questionnaire/show.tsx
@@ -254,7 +254,7 @@ export function QuestionnaireShow({ id }: QuestionnaireShowProps) {
                       <Badge
                         className={
                           questionnaire.status === "active"
-                            ? "bg-green-200 text-green-900 hover:bg-green-300"
+                            ? "bg-green-100 text-green-800 hover:bg-green-200"
                             : ""
                         }
                       >

--- a/src/components/Questionnaire/show.tsx
+++ b/src/components/Questionnaire/show.tsx
@@ -254,7 +254,7 @@ export function QuestionnaireShow({ id }: QuestionnaireShowProps) {
                       <Badge
                         className={
                           questionnaire.status === "active"
-                            ? "bg-green-100 text-green-800"
+                            ? "bg-green-200 text-green-900 hover:bg-green-300"
                             : ""
                         }
                       >


### PR DESCRIPTION
## Proposed Changes

- Fixes #10457
- bg-green-100 text-green-800 -> bg-green-200 text-green-900 hover:bg-green-300
- Changed in index.tsx and show.tsx
When we click status button, the issue is also present in that page. 





https://github.com/user-attachments/assets/ae6c9e53-d3b4-4a08-adb2-50fed2539346




@ohcnetwork/care-fe-code-reviewers




## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Enhanced the visual appearance of questionnaire status badges with updated color schemes and a new hover effect for a more interactive experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->