### PR TITLE
User Form: Pass in Org to GovtSelector only if Org is Govt

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -271,7 +271,7 @@ export default function UserForm({
 
   useEffect(() => {
     const levels: Organization[] = [];
-    if (org) levels.push(org);
+    if (org && org.org_type === "govt") levels.push(org);
     setSelectedLevels(levels);
   }, [org, organizationId]);
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #10515 
- Currently org is passed into govt selector to pre-fill the org selectors (i.e. if user opens up user addition from from Aluva Municipality in Ernakulam, it will fill in Kerala as State, Ernakulam as District and Aluva Municipality as Municipality).
- But we do not need to do so if org is of non-govt type. 


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced organization selection in the user form so that only organizations meeting specific criteria appear, ensuring a more relevant and streamlined display without impacting overall form functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->