### PR TITLE
fix: update gender validation to include required error message

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -91,7 +91,7 @@ export default function UserForm({
       last_name: z.string().min(1, t("field_required")),
       email: z.string().email(t("invalid_email_address")),
       phone_number: validators.phoneNumber.required,
-      gender: z.enum(GENDERS),
+      gender: z.enum(GENDERS, { required_error: t("gender_is_required") }),
       /* TODO: Userbase doesn't currently support these, neither does BE
       but we will probably need these */
       /* qualification: z.string().optional(),


### PR DESCRIPTION
## Proposed Changes

- Fixes #10461

Previous PR (#10462) fixed the gender validation error for the patient registration form but missed the user form. This update ensures the required error message is applied consistently.

@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the user form so that if no gender is selected, a clear, custom error message is displayed, helping users understand the required field more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->