### PR TITLE
fix: use formatDisplayName on UserDashboard

### DIFF
--- a/src/components/Users/UserAvatar.tsx
+++ b/src/components/Users/UserAvatar.tsx
@@ -103,8 +103,8 @@ export default function UserAvatar({ username }: { username: string }) {
         <div className="my-4 overflow-visible rounded-lg bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 flex justify-between">
           <div className="flex items-center">
             <Avatar
-              imageUrl={userData?.profile_picture_url}
               name={formatDisplayName(userData)}
+              imageUrl={userData?.profile_picture_url}
               className="h-20 w-20"
             />
             <div className="my-4 ml-4 flex flex-col gap-2">

--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -8,6 +8,7 @@ import { Avatar } from "@/components/Common/Avatar";
 
 import useAuthUser, { useAuthContext } from "@/hooks/useAuthUser";
 
+import { formatDisplayName } from "@/Utils/utils";
 import { getOrgLabel } from "@/types/organization/organization";
 
 export default function UserDashboard() {
@@ -22,7 +23,7 @@ export default function UserDashboard() {
       <div className="flex flex-col gap-4 bg-card p-4 md:p-6 rounded-lg border shadow-sm">
         <div className="flex flex-col sm:flex-row sm:items-center gap-4">
           <Avatar
-            name={user.first_name}
+            name={formatDisplayName(user)}
             imageUrl={user.read_profile_picture_url}
             className="h-14 w-14 md:h-16 md:w-16"
           />


### PR DESCRIPTION
## Proposed Changes

- Fixes #10588

Ensure consistent autogenerated avatar display by using formatDisplayName for the name prop in UserDashboard.

@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the avatar display for a consistent, defined size.
- **New Features**
  - Enhanced the user dashboard by formatting display names for improved readability.
- **Bug Fixes**
  - Improved error handling during avatar deletion to offer a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->