### PR TITLE
fixed search bar and drop-down in questionnar/create page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "care_fe",
-  "version": "2.13.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "care_fe",
-      "version": "2.13.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Building, Check, Loader2, X } from "lucide-react";
 import { useNavigate } from "raviger";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -89,6 +89,30 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
   );
   const [selectedOrgIds, setSelectedOrgIds] = useState<string[]>([]);
   const [orgSearchQuery, setOrgSearchQuery] = useState("");
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false); // state variable used to toggle drop-down
+  const searchDropdownRef = useRef<HTMLDivElement>(null);
+
+  // function that toggles the dropdown
+  const toggleSearchDropdown = () => {
+    setIsDropdownOpen(!isDropdownOpen);
+  };
+
+  useEffect(() => {
+    // this closes the drop-down if clicked outside of the search bar
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        searchDropdownRef.current &&
+        !searchDropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsDropdownOpen(false); // Close the dropdown if clicked outside
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
 
   const {
     data: initialQuestionnaire,
@@ -441,12 +465,19 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                           )}
                         </div>
 
-                        <Command className="rounded-lg border shadow-md">
-                          <CommandInput
-                            placeholder="Search organizations..."
-                            onValueChange={setOrgSearchQuery}
-                          />
-                          <CommandList>
+                        <Command
+                          className="rounded-lg border shadow-md"
+                          ref={searchDropdownRef}
+                        >
+                          <div onClick={toggleSearchDropdown}>
+                            <CommandInput
+                              placeholder="Search organizations..."
+                              onValueChange={setOrgSearchQuery}
+                            />
+                          </div>
+                          <CommandList
+                            className={`${isDropdownOpen ? "" : "hidden"}`}
+                          >
                             <CommandEmpty>No organizations found.</CommandEmpty>
                             <CommandGroup>
                               {isLoadingOrganizations ? (


### PR DESCRIPTION
## Proposed Changes

- Fixes #10541 
- The Drop down only displays when the user clicks on the search bar
- When the user click somewhere out of the search bar the drop down closes

@ohcnetwork/care-fe-code-reviewers

The issue stated the search bar is displaying options without clicking on it. I have fixed this Issue.

Here's a video of how it looks:

https://github.com/user-attachments/assets/afa80f4e-6c62-4c83-a346-1b36de22e2d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the organization search in the questionnaire editor with a dynamic dropdown.
  - Improved user interaction by enabling intuitive toggling and automatic closing when clicking outside.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->