### PR TITLE
Added plug hook PatientInfoCardMarkAsComplete

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -48,6 +48,7 @@
   "DOMESTIC_HEALTHCARE_SUPPORT__NO_SUPPORT": "No support",
   "DOMESTIC_HEALTHCARE_SUPPORT__PAID_CAREGIVER": "Paid caregiver",
   "ENCOUNTER_TAB__abdm": "ABDM Records",
+  "ENCOUNTER_TAB__claims": "Insurance Claims",
   "ENCOUNTER_TAB__feed": "Feed",
   "ENCOUNTER_TAB__files": "Files",
   "ENCOUNTER_TAB__medicines": "Medicines",

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -481,6 +481,11 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                     </AlertDialogDescription>
                   </AlertDialogHeader>
 
+                  <PLUGIN_Component
+                    __name="PatientInfoCardMarkAsComplete"
+                    encounter={encounter}
+                  />
+
                   <AlertDialogFooter>
                     <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
 

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -31,6 +31,10 @@ export type PatientInfoCardActionsComponentType = React.FC<{
   className?: string;
 }>;
 
+export type PatientInfoCardMarkAsCompleteComponentType = React.FC<{
+  encounter: Encounter;
+}>;
+
 export type FacilityHomeActionsComponentType = React.FC<{
   facility: FacilityData;
   className?: string;
@@ -53,6 +57,7 @@ export type SupportedPluginComponents = {
   Scribe: ScribeComponentType;
   PatientHomeActions: PatientHomeActionsComponentType;
   PatientInfoCardActions: PatientInfoCardActionsComponentType;
+  PatientInfoCardMarkAsComplete: PatientInfoCardMarkAsCompleteComponentType;
   FacilityHomeActions: FacilityHomeActionsComponentType;
   PatientRegistrationForm: PatientRegistrationFormComponentType;
   PatientDetailsTabDemographyGeneralInfo: PatientDetailsTabDemographyGeneralInfoComponentType;


### PR DESCRIPTION
## Proposed Changes

- Added a plug hook in mark as complete alert dialog to show a warning message that HCX claims are not yet filled.

@ohcnetwork/care-fe-code-reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Insurance Claims" label for an additional tab in the encounter section.
	- Enhanced the encounter completion experience with an improved confirmation prompt for marking encounters as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->