### PR TITLE
Fix autocomplete unable to pre-fill in certain usages; Adds utility fn. to merge autocomplete options; Fixes facility select in resource form edge case

### DIFF
--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -241,3 +241,12 @@ export const stringifyGeoOrganization = (org: Organization) => {
 
   return levels.join(", ");
 };
+
+export const mergeAutocompleteOptions = (
+  options: { label: string; value: string }[],
+  value?: { label: string; value: string },
+) => {
+  if (!value) return options;
+  if (options.find((o) => o.value === value.value)) return options;
+  return [value, ...options];
+};

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -48,6 +48,7 @@ import { RESOURCE_CATEGORY_CHOICES } from "@/common/constants";
 import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { mergeAutocompleteOptions } from "@/Utils/utils";
 import validators from "@/Utils/validators";
 import facilityApi from "@/types/facility/facilityApi";
 import { ResourceRequest } from "@/types/resourceRequest/resourceRequest";
@@ -274,17 +275,15 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                           </FormLabel>
                           <FormControl>
                             <Autocomplete
-                              options={
-                                field.value?.id
-                                  ? [
-                                      {
-                                        label: field.value.name,
-                                        value: field.value.id,
-                                      },
-                                      ...(facilityOptions ?? []),
-                                    ]
-                                  : (facilityOptions ?? [])
-                              }
+                              options={mergeAutocompleteOptions(
+                                facilityOptions ?? [],
+                                field.value
+                                  ? {
+                                      label: field.value.name,
+                                      value: field.value.id,
+                                    }
+                                  : undefined,
+                              )}
                               value={field.value?.id ?? ""}
                               placeholder={t("start_typing_to_search")}
                               onSearch={setFacilitySearch}

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -274,7 +274,17 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                           </FormLabel>
                           <FormControl>
                             <Autocomplete
-                              options={facilityOptions ?? []}
+                              options={
+                                field.value?.id
+                                  ? [
+                                      {
+                                        label: field.value.name,
+                                        value: field.value.id,
+                                      },
+                                      ...(facilityOptions ?? []),
+                                    ]
+                                  : (facilityOptions ?? [])
+                              }
                               value={field.value?.id ?? ""}
                               placeholder={t("start_typing_to_search")}
                               onSearch={setFacilitySearch}

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -69,10 +69,11 @@ export default function Autocomplete({
           {options.map((option) => (
             <CommandItem
               key={option.value}
-              value={option.value}
+              value={`${option.label} - ${option.value}`}
               onSelect={(v) => {
                 const currentValue =
-                  options.find((option) => option.value === v)?.value || "";
+                  options.find((o) => `${o.label} - ${o.value}` === v)?.value ||
+                  "";
                 onChange(currentValue);
                 setOpen(false);
               }}


### PR DESCRIPTION
## Proposed Changes

> Issue reported by @nihal467 

- Fixes autocomplete unable to pre-fill in certain usages due to it's default filtering behaviour based on `value`. Eg. all usages of Geo Organization Selector 
- Adds utility fn. to merge autocomplete options when used along with search / paginated APIs when elements are not present in first page during pre-fill / edit forms.
- Fixes the same for facility select in resource form

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced autocomplete suggestions for facility selection. Now, if a facility is chosen, it seamlessly appears within the options list without duplicates.
  - Updated the display format for suggestions to clearly show both descriptive labels and corresponding values, improving clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->