### PR TITLE
Fixes certain users from being unable to view an encounter from organizations patients

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2374,6 +2374,7 @@
   "view_consultation_and_log_updates": "View Consultation / Log Updates",
   "view_dashboard": "View Dashboard",
   "view_details": "View Details",
+  "view_encounter": "View Encounter",
   "view_facility": "View Facility",
   "view_files": "View Files",
   "view_patient": "View Patient",

--- a/src/Routers/routes/ConsultationRoutes.tsx
+++ b/src/Routers/routes/ConsultationRoutes.tsx
@@ -19,6 +19,27 @@ const consultationRoutes: AppRoutes = {
     ({ facilityId, encounterId }) => (
       <TreatmentSummary facilityId={facilityId} encounterId={encounterId} />
     ),
+  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire":
+    ({ facilityId, encounterId, patientId }) => (
+      <EncounterQuestionnaire
+        facilityId={facilityId}
+        encounterId={encounterId}
+        patientId={patientId}
+      />
+    ),
+  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire/:slug":
+    ({ facilityId, encounterId, slug, patientId }) => (
+      <EncounterQuestionnaire
+        facilityId={facilityId}
+        encounterId={encounterId}
+        questionnaireSlug={slug}
+        patientId={patientId}
+      />
+    ),
+  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire_response/:id":
+    ({ patientId, id }) => (
+      <QuestionnaireResponseView responseId={id} patientId={patientId} />
+    ),
   "/facility/:facilityId/patient/:patientId/encounter/:encounterId/:tab": ({
     facilityId,
     patientId,
@@ -62,27 +83,6 @@ const consultationRoutes: AppRoutes = {
       subjectType="patient"
     />
   ),
-  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire":
-    ({ facilityId, encounterId, patientId }) => (
-      <EncounterQuestionnaire
-        facilityId={facilityId}
-        encounterId={encounterId}
-        patientId={patientId}
-      />
-    ),
-  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire/:slug":
-    ({ facilityId, encounterId, slug, patientId }) => (
-      <EncounterQuestionnaire
-        facilityId={facilityId}
-        encounterId={encounterId}
-        questionnaireSlug={slug}
-        patientId={patientId}
-      />
-    ),
-  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire_response/:id":
-    ({ patientId, id }) => (
-      <QuestionnaireResponseView responseId={id} patientId={patientId} />
-    ),
 };
 
 export default consultationRoutes;

--- a/src/Routers/routes/ConsultationRoutes.tsx
+++ b/src/Routers/routes/ConsultationRoutes.tsx
@@ -19,30 +19,29 @@ const consultationRoutes: AppRoutes = {
     ({ facilityId, encounterId }) => (
       <TreatmentSummary facilityId={facilityId} encounterId={encounterId} />
     ),
-  "/facility/:facilityId/encounter/:encounterId/:tab": ({
+  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/:tab": ({
     facilityId,
+    patientId,
     encounterId,
     tab,
   }) => (
     <EncounterShow
       facilityId={facilityId}
+      patientId={patientId}
       encounterId={encounterId}
       tab={tab}
     />
   ),
-  "/facility/:facilityId/encounter/:encounterId/:tab/:subPage": ({
-    facilityId,
-    encounterId,
-    tab,
-    subPage,
-  }) => (
-    <EncounterShow
-      facilityId={facilityId}
-      encounterId={encounterId}
-      tab={tab}
-      subPage={subPage}
-    />
-  ),
+  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/:tab/:subPage":
+    ({ facilityId, encounterId, patientId, tab, subPage }) => (
+      <EncounterShow
+        facilityId={facilityId}
+        patientId={patientId}
+        encounterId={encounterId}
+        tab={tab}
+        subPage={subPage}
+      />
+    ),
   "/facility/:facilityId/patient/:patientId/consultation": ({
     facilityId,
     patientId,

--- a/src/components/Encounter/CreateEncounterForm.tsx
+++ b/src/components/Encounter/CreateEncounterForm.tsx
@@ -154,7 +154,9 @@ export default function CreateEncounterForm({
       form.reset();
       queryClient.invalidateQueries({ queryKey: ["encounters", patientId] });
       onSuccess?.();
-      navigate(`/facility/${facilityId}/encounter/${data.id}/updates`);
+      navigate(
+        `/facility/${facilityId}/patient/${patientId}/encounter/${data.id}/updates`,
+      );
     },
     onError: (error) => {
       const errorData = error.cause as { errors: { msg: string[] } };

--- a/src/components/Facility/EncounterCard.tsx
+++ b/src/components/Facility/EncounterCard.tsx
@@ -92,7 +92,7 @@ export const EncounterCard = (props: EncounterCardProps) => {
         </div>
 
         <Link
-          href={`/facility/${encounter.facility.id}/encounter/${encounter.id}/updates`}
+          href={`/facility/${encounter.facility.id}/patient/${encounter.patient.id}/encounter/${encounter.id}/updates`}
           className={cn(
             buttonVariants({ variant: "secondary" }),
             "mt-2 shadow-none border border-secondary-300",
@@ -100,7 +100,7 @@ export const EncounterCard = (props: EncounterCardProps) => {
           )}
         >
           <CareIcon icon="l-plus-circle" />
-          {t("View Encounter")}
+          {t("view_encounter")}
         </Link>
       </div>
     </>

--- a/src/components/Files/FilesTab.tsx
+++ b/src/components/Files/FilesTab.tsx
@@ -655,7 +655,7 @@ export const FilesTab = (props: FilesTabProps) => {
           <TabsTrigger value="all" asChild>
             <Link
               className="text-gray-600"
-              href={`/facility/${encounter?.facility.id}/encounter/${encounter?.id}/files/all`}
+              href={`/facility/${encounter?.facility.id}/patient/${patientId}/encounter/${encounter?.id}/files/all`}
             >
               {t("all")}
             </Link>
@@ -663,7 +663,7 @@ export const FilesTab = (props: FilesTabProps) => {
           <TabsTrigger value="discharge_summary" asChild>
             <Link
               className="text-gray-600"
-              href={`/facility/${encounter?.facility.id}/encounter/${encounter?.id}/files/discharge_summary`}
+              href={`/facility/${encounter?.facility.id}/patient/${patientId}/encounter/${encounter?.id}/files/discharge_summary`}
             >
               {t("discharge_summary")}
             </Link>

--- a/src/components/Patient/EncounterQuestionnaire.tsx
+++ b/src/components/Patient/EncounterQuestionnaire.tsx
@@ -37,7 +37,7 @@ export default function EncounterQuestionnaire({
             onSubmit={() => {
               if (encounterId) {
                 navigate(
-                  `/facility/${facilityId}/encounter/${encounterId}/updates`,
+                  `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
                 );
               } else {
                 navigate(`/patient/${patientId}/updates`);

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -464,7 +464,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
                       <Link
-                        href={`/facility/${encounter.facility.id}/encounter/${encounter.id}/files/discharge_summary`}
+                        href={`/facility/${encounter.facility.id}/patient/${patient.id}/encounter/${encounter.id}/files/discharge_summary`}
                         className="cursor-pointer text-gray-800"
                       >
                         {t("discharge_summary")}

--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -721,7 +721,7 @@ export function EncounterList({
                       </div>
                       <Separator className="my-2" />
                       <Link
-                        href={`/facility/${facilityId}/encounter/${encounter.id}/updates`}
+                        href={`/facility/${facilityId}/patient/${encounter.patient.id}/encounter/${encounter.id}/updates`}
                         className="text-sm text-primary hover:underline text-right flex items-center justify-end group-hover:translate-x-1 transition-transform"
                       >
                         View Details

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -42,14 +42,15 @@ const defaultTabs = {
 } as Record<string, React.FC<EncounterTabProps>>;
 
 interface Props {
-  encounterId: string;
   facilityId: string;
+  patientId: string;
+  encounterId: string;
   tab?: string;
   subPage?: string;
 }
 
 export const EncounterShow = (props: Props) => {
-  const { facilityId, encounterId, subPage } = props;
+  const { facilityId, encounterId, patientId, subPage } = props;
   const { t } = useTranslation();
   const pluginTabs = useCareAppConsultationTabs();
 
@@ -64,6 +65,7 @@ export const EncounterShow = (props: Props) => {
       pathParams: { id: encounterId },
       queryParams: {
         facility: facilityId,
+        patient: patientId,
       },
     }),
     enabled: !!encounterId,
@@ -169,7 +171,7 @@ export const EncounterShow = (props: Props) => {
                   <Link
                     key={tab}
                     className={tabButtonClasses(props.tab === tab)}
-                    href={`/facility/${facilityId}/encounter/${encounterData.id}/${tab}`}
+                    href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterData.id}/${tab}`}
                   >
                     {t(`ENCOUNTER_TAB__${tab}`)}
                   </Link>

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -82,6 +82,8 @@ export const EncounterShow = (props: Props) => {
     facilityId,
   };
 
+  console.log(encounterTabProps);
+
   if (!props.tab) {
     return <ErrorPage />;
   }

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -82,8 +82,6 @@ export const EncounterShow = (props: Props) => {
     facilityId,
   };
 
-  console.log(encounterTabProps);
-
   if (!props.tab) {
     return <ErrorPage />;
   }


### PR DESCRIPTION


## Proposed Changes

- Fixes certain users unable to open encounter page through Organization > Patients > Encounter > View Encounter
- Update encounter routes to always be sub-route of patient
- Update related navigates to include patient ID

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new localization label for viewing encounters.
	- Enhanced navigation across the application by integrating patient identifiers into encounter-related URLs. This update refines the paths for viewing encounter details, discharge summaries, file tabs, and questionnaires, ensuring a more consistent and context-aware user experience.
- **Bug Fixes**
	- Improved routing logic for encounter-related navigation to include patient identifiers, ensuring accurate context in URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->