### PR TITLE
Add count to resource and encounter page

### DIFF
--- a/src/components/Resource/ResourceList.tsx
+++ b/src/components/Resource/ResourceList.tsx
@@ -103,7 +103,21 @@ export default function ResourceList({ facilityId }: { facilityId: string }) {
   const resources = queryResources?.results || [];
 
   return (
-    <Page title={t("resource")}>
+    <Page
+      title={t("resource")}
+      componentRight={
+        <Badge
+          className="bg-purple-50 text-purple-700 ml-2 text-sm font-medium rounded-xl px-3 m-3 w-max"
+          variant="outline"
+        >
+          {isLoading
+            ? t("loading")
+            : t("entity_count_one", {
+                count: queryResources?.count ?? 0,
+              })}
+        </Badge>
+      }
+    >
       <div className="space-y-4 mt-2">
         <div className="rounded-lg border bg-card shadow-sm">
           <div className="flex flex-col">

--- a/src/components/Resource/ResourceList.tsx
+++ b/src/components/Resource/ResourceList.tsx
@@ -112,8 +112,9 @@ export default function ResourceList({ facilityId }: { facilityId: string }) {
         >
           {isLoading
             ? t("loading")
-            : t("entity_count_one", {
+            : t("entity_count", {
                 count: queryResources?.count ?? 0,
+                entity: "Resource",
               })}
         </Badge>
       }

--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -213,7 +213,21 @@ export function EncounterList({
   const { t } = useTranslation();
 
   return (
-    <Page title={t("encounters")}>
+    <Page
+      title={t("encounters")}
+      componentRight={
+        <Badge
+          className="bg-purple-50 text-purple-700 ml-2 text-sm font-medium rounded-xl px-3 m-3 w-max"
+          variant="outline"
+        >
+          {isLoading
+            ? t("loading")
+            : t("entity_count_one", {
+                count: queryEncounters?.count ?? 0,
+              })}
+        </Badge>
+      }
+    >
       <div className="space-y-4 mt-2 flex flex-col">
         <div className="rounded-lg border bg-card shadow-sm flex flex-col">
           <div className="flex flex-col">

--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -222,8 +222,9 @@ export function EncounterList({
         >
           {isLoading
             ? t("loading")
-            : t("entity_count_one", {
+            : t("entity_count", {
                 count: queryEncounters?.count ?? 0,
+                entity: "Encounter",
               })}
         </Badge>
       }


### PR DESCRIPTION
## Proposed Changes

- Fixes #10697 

![image](https://github.com/user-attachments/assets/b4521e99-7ca3-43fa-a146-73834826a323)

![image](https://github.com/user-attachments/assets/6f6b705a-513a-4b55-8053-5c0c4133269e)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced both resource and encounter pages with a dynamic badge that visibly indicates whether data is loading or shows the count of available items.
  - This improvement provides immediate, clear feedback during data retrieval, enriching the overall user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->