### PR TITLE
Fixed blinking issue while lazy loading plugin components

### DIFF
--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable i18next/no-literal-string */
 import React, { Suspense } from "react";
 
 import ErrorBoundary from "@/components/Common/ErrorBoundary";
@@ -52,7 +51,11 @@ export function PLUGIN_Component<K extends keyof SupportedPluginComponents>({
           return null;
         }
 
-        return <Component {...props} key={plugin.plugin} />;
+        return (
+          <React.Suspense key={plugin.plugin} fallback={<div>Loading...</div>}>
+            <Component {...props} />
+          </React.Suspense>
+        );
       })}
     </>
   );

--- a/src/hooks/useCareApps.tsx
+++ b/src/hooks/useCareApps.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext } from "react";
+import { Suspense, createContext, useContext } from "react";
 
+import { EncounterTabProps } from "@/pages/Encounters/EncounterShow";
 import { PluginManifest } from "@/pluginTypes";
 
 export const CareAppsContext = createContext<PluginManifest[]>([]);
@@ -22,11 +23,29 @@ export const useCareApps = () => {
 //   return navItems;
 // };
 
-export const useCareAppConsultationTabs = () => {
+const withSuspense = (Component: React.ComponentType<EncounterTabProps>) => {
+  // eslint-disable-next-line react/display-name
+  return (props: EncounterTabProps) => {
+    return (
+      <Suspense fallback={<div>Loading...</div>}>
+        <Component {...props} />
+      </Suspense>
+    );
+  };
+};
+
+export const useCareAppEncounterTabs = () => {
   const careApps = useCareApps();
 
   return careApps.reduce((acc, app) => {
-    return { ...acc, ...(app.encounterTabs ?? {}) };
+    const appTabs = Object.entries(app.encounterTabs ?? {}).reduce(
+      (acc, [key, Component]) => {
+        return { ...acc, [key]: withSuspense(Component) };
+      },
+      {},
+    );
+
+    return { ...acc, ...appTabs };
   }, {});
 };
 

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -8,7 +8,7 @@ import PageTitle from "@/components/Common/PageTitle";
 import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 import PatientInfoCard from "@/components/Patient/PatientInfoCard";
 
-import { useCareAppConsultationTabs } from "@/hooks/useCareApps";
+import { useCareAppEncounterTabs } from "@/hooks/useCareApps";
 
 import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
@@ -51,7 +51,7 @@ interface Props {
 export const EncounterShow = (props: Props) => {
   const { facilityId, encounterId, subPage } = props;
   const { t } = useTranslation();
-  const pluginTabs = useCareAppConsultationTabs();
+  const pluginTabs = useCareAppEncounterTabs();
 
   const tabs: Record<string, React.FC<EncounterTabProps>> = {
     ...defaultTabs,
@@ -62,9 +62,7 @@ export const EncounterShow = (props: Props) => {
     queryKey: ["encounter", encounterId],
     queryFn: query(routes.encounter.get, {
       pathParams: { id: encounterId },
-      queryParams: {
-        facility: facilityId,
-      },
+      queryParams: { facility: facilityId },
     }),
     enabled: !!encounterId,
   });


### PR DESCRIPTION
Wrapping the components with Suspense fixed the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the application’s loading experience by displaying a clear loading indicator while plugin components and encounter tabs are being loaded.
  - Updated the encounters view to now provide visual feedback during asynchronous loading, ensuring smoother and more responsive interactions for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->