### PR TITLE
Fix: Query Parameters Not Reset on Department Page Upon Performing Search

### DIFF
--- a/src/pages/Facility/settings/organizations/FacilityOrganizationView.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationView.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "raviger";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -62,11 +61,10 @@ function OrganizationCard({
 
 export default function FacilityOrganizationView({ id, facilityId }: Props) {
   const { t } = useTranslation();
-  const { qParams, Pagination, resultsPerPage } = useFilters({
+  const { qParams, Pagination, resultsPerPage, updateQuery } = useFilters({
     limit: 12,
     cacheBlacklist: ["username"],
   });
-  const [searchQuery, setSearchQuery] = useState("");
 
   const { data: children, isLoading } = useQuery({
     queryKey: [
@@ -76,7 +74,7 @@ export default function FacilityOrganizationView({ id, facilityId }: Props) {
       id,
       qParams.page,
       resultsPerPage,
-      searchQuery,
+      qParams.search,
     ],
     queryFn: query.debounced(routes.facilityOrganization.list, {
       pathParams: { facilityId },
@@ -84,7 +82,7 @@ export default function FacilityOrganizationView({ id, facilityId }: Props) {
         parent: id,
         offset: ((qParams.page || 1) - 1) * resultsPerPage,
         limit: resultsPerPage,
-        name: searchQuery || undefined,
+        name: qParams.search || undefined,
       },
     }),
   });
@@ -102,9 +100,9 @@ export default function FacilityOrganizationView({ id, facilityId }: Props) {
                 />
                 <Input
                   placeholder={t("search_by_department_team_name")}
-                  value={searchQuery}
+                  value={qParams.search || ""}
                   onChange={(e) => {
-                    setSearchQuery(e.target.value);
+                    updateQuery({ search: e.target.value || undefined });
                   }}
                   className="w-full pl-8"
                 />


### PR DESCRIPTION
## Proposed Changes

- Fixes #10716 
- Change : I replaced searchQuery with qParams.search from useFilters, added updateQuery to handle search updates, and updated the query key, queryFn, and Input component.

These changes will ensure that:
- The page number resets to 1 when performing a search
- The URL query parameters are properly updated
- The search state is maintained when navigating back/forward in the browser

Screen Recording
https://github.com/user-attachments/assets/53a2ca49-8e78-4481-ae3c-9745c79d334b

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the search functionality on the facility organization page by updating how the search query is managed, ensuring the input value remains in sync with the displayed filters for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->