### PR TITLE
Potential fix for code scanning alert no. 116: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -216,7 +216,11 @@ const AvatarEditModal = ({
                   <>
                     <div className="flex flex-1 items-center justify-center rounded-lg">
                       <img
-                        src={preview && preview.startsWith('blob:') ? preview : imageUrl}
+                        src={
+                          preview && preview.startsWith("blob:")
+                            ? preview
+                            : imageUrl
+                        }
                         alt="cover-photo"
                         className="h-full w-full object-cover"
                       />

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from "dompurify";
 import React, {
   ChangeEventHandler,
   useCallback,
@@ -218,7 +219,7 @@ const AvatarEditModal = ({
                       <img
                         src={
                           preview && preview.startsWith("blob:")
-                            ? preview
+                            ? DOMPurify.sanitize(preview)
                             : imageUrl
                         }
                         alt="cover-photo"

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -131,11 +131,12 @@ const AvatarEditModal = ({
       setSelectedFile(undefined);
       return;
     }
-    if (!isImageFile(e.target.files[0])) {
+    const file = e.target.files[0];
+    if (!isImageFile(file)) {
       toast.warning(t("please_upload_an_image_file"));
       return;
     }
-    setSelectedFile(e.target.files[0]);
+    setSelectedFile(file);
   };
 
   const uploadAvatar = async () => {
@@ -215,7 +216,7 @@ const AvatarEditModal = ({
                   <>
                     <div className="flex flex-1 items-center justify-center rounded-lg">
                       <img
-                        src={preview || imageUrl}
+                        src={preview && preview.startsWith('blob:') ? preview : imageUrl}
                         alt="cover-photo"
                         className="h-full w-full object-cover"
                       />


### PR DESCRIPTION
Potential fix for [https://github.com/ohcnetwork/care_fe/security/code-scanning/116](https://github.com/ohcnetwork/care_fe/security/code-scanning/116)

To fix the problem, we need to ensure that the content being used in the `src` attribute of the `img` tag is safe. One way to do this is to validate the file type and ensure it is an image before creating the object URL. Additionally, we can add a check to ensure that the `preview` variable contains a valid URL.

- Validate the file type to ensure it is an image before setting `selectedFile`.
- Add a check to ensure that the `preview` variable contains a valid URL before using it in the `src` attribute of the `img` tag.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the avatar editing experience to securely sanitize image previews, ensuring that only safe content is displayed.
  
- **Refactor**
  - Streamlined the file selection process for clearer and more reliable image preview handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->