### PR TITLE
Fix :  Alignment of Country List in Phone Number Search

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -120,7 +120,11 @@ const CountrySelect = ({
           />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[300px] p-0" align="start" sideOffset={5}>
+      <PopoverContent
+        className="w-[90vw] sm:w-[300px] p-2 sm:p-0"
+        align="start"
+        sideOffset={5}
+      >
         <Command>
           <CommandInput
             placeholder={t("search_country")}

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -121,8 +121,7 @@ const CountrySelect = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="p-2 sm:p-0"
-        style={{ width: "var(--radix-popover-trigger-width)" }}
+        className="p-2 sm:p-0 w-[var(--radix-popover-trigger-width)] min-w-[250px]"
         align="start"
         sideOffset={5}
       >

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -121,7 +121,7 @@ const CountrySelect = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="p-2 sm:p-0 w-[var(--radix-popover-trigger-width)] min-w-[250px]"
+        className="p-2 sm:p-0 w-[var(--radix-popover-trigger-width)] min-w-64"
         align="start"
         sideOffset={5}
       >

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -120,7 +120,7 @@ const CountrySelect = ({
           />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[300px] p-0">
+      <PopoverContent className="w-[300px] p-0" align="start" sideOffset={5}>
         <Command>
           <CommandInput
             placeholder={t("search_country")}

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -121,7 +121,8 @@ const CountrySelect = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[90vw] sm:w-[300px] p-2 sm:p-0"
+        className="p-2 sm:p-0"
+        style={{ width: "var(--radix-popover-trigger-width)" }}
         align="start"
         sideOffset={5}
       >


### PR DESCRIPTION
## Proposed Changes

- Fixes #10733
- Used align="start" sideOffset={5}
![p2](https://github.com/user-attachments/assets/693e0944-45ba-46f0-8744-8c16862d65a4)

![p1](https://github.com/user-attachments/assets/b6914866-a59e-46ec-bf4a-4c0f59dc4ef3)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the layout and positioning of the popover display within the country selection component. The responsive design improves usability on smaller screens, ensuring a polished and intuitive experience when interacting with the selection field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->