### PR TITLE
Bugfix: Keep Cancel Button Visible After Removing All Questionnaires #10769

### DIFF
--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -462,7 +462,6 @@ export function QuestionnaireForm({
         ))}
 
         {/* Search and Add Questionnaire */}
-
         {encounterId !== "preview" && (
           <>
             <div
@@ -494,16 +493,19 @@ export function QuestionnaireForm({
             </div>
 
             {/* Submit and Cancel Buttons */}
-            {questionnaireForms.length > 0 && (
-              <div className="flex justify-end gap-4 mx-4 mt-4 max-w-4xl">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={onCancel}
-                  disabled={isPending}
-                >
-                  {t("cancel")}
-                </Button>
+            <div className="flex justify-end gap-4 mx-4 mt-4 max-w-4xl">
+              {/* Always visible Cancel button */}
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onCancel}
+                disabled={isPending}
+              >
+                {t("cancel")}
+              </Button>
+
+              {/* Conditionally visible Submit button */}
+              {questionnaireForms.length > 0 && (
                 <Button
                   type="submit"
                   onClick={handleSubmit}
@@ -521,8 +523,8 @@ export function QuestionnaireForm({
                     t("submit")
                   )}
                 </Button>
-              </div>
-            )}
+              )}
+            </div>
           </>
         )}
 


### PR DESCRIPTION

Related to #10769 

I moved the Cancel button outside the conditional rendering block so it is always visible, even after removing all questionnaires. 

![image](https://github.com/user-attachments/assets/e0c7f885-2539-4aee-afa5-f309f8e7a31e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The questionnaire interface now always shows the cancel button, ensuring it's consistently accessible.
	- The submit button appears only when applicable, resulting in a clearer and more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->