### PR TITLE
Disabled the location form dropdown for edit form

### DIFF
--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -217,7 +217,11 @@ export default function LocationForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>{t("location_form")}</FormLabel>
-                <Select onValueChange={field.onChange} value={field.value}>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  disabled={!!locationId}
+                >
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue />


### PR DESCRIPTION
## Proposed Changes

- Fixes #10788 
- Disabled the location form dropdown in the edit form since the backend doesn't support them

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced behavior in the location management form: The dropdown selection now automatically becomes disabled when modifications are not permitted. This update streamlines the process, reducing the risk of accidental changes and ensuring users only adjust settings under the appropriate conditions for a more intuitive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->