### PR TITLE
bugfix:fix Overapping greenindicator and scrollbar in Patient Details

### DIFF
--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -108,34 +108,35 @@ export const PatientHome = (props: {
         </div>
 
         <div
-          className="sticky top-0 z-10 mt-4 w-full overflow-x-auto border-b bg-gray-50"
+          className="sticky top-0 z-10 mt-4 w-full border-b bg-gray-50"
           role="navigation"
         >
-          <div className="flex flex-row" role="tablist">
-            {tabs.map((tab) => (
-              <Link
-                key={tab.route}
-                data-cy={`tab-${tab.route}`}
-                href={
-                  facilityId
-                    ? `/facility/${facilityId}/patient/${id}/${tab.route}`
-                    : `/patient/${id}/${tab.route}`
-                }
-                className={`whitespace-nowrap px-4 py-2 text-sm font-medium ${
-                  page === tab.route
-                    ? "border-b-4 border-green-800 text-green-800 md:border-b-2"
-                    : "rounded-t-lg text-gray-600 hover:bg-gray-100"
-                }`}
-                role="tab"
-                aria-selected={page === tab.route}
-                aria-controls={`${tab.route}-panel`}
-              >
-                {t(tab.route)}
-              </Link>
-            ))}
+          <div className="overflow-x-auto pb-3">
+            <div className="flex flex-row" role="tablist">
+              {tabs.map((tab) => (
+                <Link
+                  key={tab.route}
+                  data-cy={`tab-${tab.route}`}
+                  href={
+                    facilityId
+                      ? `/facility/${facilityId}/patient/${id}/${tab.route}`
+                      : `/patient/${id}/${tab.route}`
+                  }
+                  className={`whitespace-nowrap px-4 py-2 text-sm font-medium ${
+                    page === tab.route
+                      ? "border-b-4 border-green-800 text-green-800 md:border-b-2"
+                      : "rounded-t-lg text-gray-600 hover:bg-gray-100"
+                  }`}
+                  role="tab"
+                  aria-selected={page === tab.route}
+                  aria-controls={`${tab.route}-panel`}
+                >
+                  {t(tab.route)}
+                </Link>
+              ))}
+            </div>
           </div>
         </div>
-
         <div className="h-full lg:flex">
           <div className="h-full lg:mr-7 lg:basis-5/6">
             {Tab && (


### PR DESCRIPTION
## Proposed Changes

- Fixes #10707'
- Fixed the overlap of the green bar indicator and the scrollbar in the patient details screen.

@ohcnetwork/care-fe-code-reviewers

![image](https://github.com/user-attachments/assets/46094f4a-f089-4da6-92d3-2121b87cfbc6)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the layout and visual presentation of the Patient home page's navigation tabs to improve alignment and spacing, ensuring a cleaner and more consistent look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->