### PR TITLE
Display year of birth when age is entered in public patient registration page

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1235,6 +1235,7 @@
   "intended": "Intended",
   "intent": "Intent",
   "international_mobile": "International Mobile",
+  "invalid_age": "Invalid age",
   "invalid_asset_id_msg": "Oops! The asset ID you entered does not appear to be valid.",
   "invalid_date_format": "Invalid date format, expected {{format}}",
   "invalid_email": "Please enter a valid email address",

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -562,7 +562,9 @@ export default function PatientRegistration(
                         {form.getValues("age") && (
                           <div className="text-sm font-bold">
                             {Number(form.getValues("age")) <= 0 ? (
-                              <span className="text-red-600">Invalid age</span>
+                              <span className="text-red-600">
+                                {t("invalid_age")}
+                              </span>
                             ) : (
                               <span className="text-violet-600">
                                 {t("year_of_birth")}:{" "}

--- a/src/pages/Patient/Utils.tsx
+++ b/src/pages/Patient/Utils.tsx
@@ -4,7 +4,7 @@ export type AppointmentPatientRegister = {
   phone_number: string;
   address: string;
   date_of_birth?: Date | string;
-  year_of_birth?: string;
+  age?: string;
   geo_organization?: string;
   pincode?: string;
 };

--- a/src/pages/PublicAppointments/PatientRegistration.tsx
+++ b/src/pages/PublicAppointments/PatientRegistration.tsx
@@ -362,6 +362,19 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                         <span className="text-xs text-gray-500">
                           {t("age_notice")}
                         </span>
+                        {form.getValues("year_of_birth") && (
+                          <div className="text-sm font-bold">
+                            {Number(form.getValues("year_of_birth")) <= 0 ? (
+                              <span className="text-red-600">Invalid age</span>
+                            ) : (
+                              <span className="text-violet-600">
+                                {t("year_of_birth")}:{" "}
+                                {new Date().getFullYear() -
+                                  Number(form.getValues("year_of_birth"))}
+                              </span>
+                            )}
+                          </div>
+                        )}
                       </FormItem>
                     )}
                   />

--- a/src/pages/PublicAppointments/PatientRegistration.tsx
+++ b/src/pages/PublicAppointments/PatientRegistration.tsx
@@ -40,21 +40,6 @@ import {
   TokenSlot,
 } from "@/types/scheduling/schedule";
 
-// const initialForm: Omit<AppointmentPatientRegister, "gender"> & {
-//   ageInputType: "age" | "date_of_birth";
-//   gender: "male" | "female" | "transgender" | "non_binary";
-// } = {
-//   name: "",
-//   gender: "male",
-//   ageInputType: "date_of_birth",
-//   year_of_birth: undefined,
-//   date_of_birth: undefined,
-//   phone_number: "",
-//   address: "",
-//   pincode: "",
-//   geo_organization: undefined,
-// };
-
 type PatientRegistrationProps = {
   facilityId: string;
   staffId: string;
@@ -84,7 +69,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
         .refine(validateName, t("min_char_length_error", { min_length: 3 })),
       gender: z.enum(GENDERS, { required_error: t("gender_is_required") }),
       address: z.string().min(1, t("field_required")),
-      year_of_birth: z.string().optional(),
+      age: z.string().optional(),
       date_of_birth: z.date().or(z.string()).optional(),
       pincode: z
         .string()
@@ -100,8 +85,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
       ageInputType: z.enum(["age", "date_of_birth"]),
     })
     .superRefine((data, ctx) => {
-      const field =
-        data.ageInputType === "age" ? "year_of_birth" : "date_of_birth";
+      const field = data.ageInputType === "age" ? "age" : "date_of_birth";
       if (!data[field]) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -110,17 +94,16 @@ export function PatientRegistration(props: PatientRegistrationProps) {
         });
         return;
       }
-      // yob corresponds to age till now, only converted to year after validation
       if (
-        field === "year_of_birth" &&
-        data.year_of_birth &&
-        !isNaN(Number(data.year_of_birth)) &&
-        Number(data.year_of_birth) < 0
+        field === "age" &&
+        data.age &&
+        !isNaN(Number(data.age)) &&
+        Number(data.age) < 0
       ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: t("age_less_than_0"),
-          path: ["year_of_birth"],
+          path: ["age"],
         });
       }
     });
@@ -133,7 +116,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
     defaultValues: {
       name: "",
       ageInputType: "date_of_birth",
-      year_of_birth: undefined,
+      age: undefined,
       date_of_birth: undefined,
       address: "",
       pincode: "",
@@ -196,7 +179,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
         data.ageInputType === "date_of_birth"
           ? dateQueryString(data.date_of_birth)
           : undefined,
-      age: data.ageInputType === "age" ? data.year_of_birth : undefined,
+      age: data.ageInputType === "age" ? data.age : undefined,
       pincode: data.pincode || undefined,
       geo_organization: data.geo_organization,
       is_active: true,
@@ -348,13 +331,13 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                 {form.watch("ageInputType") === "age" && (
                   <FormField
                     control={form.control}
-                    name="year_of_birth"
+                    name="age"
                     render={() => (
                       <FormItem className="flex flex-col">
                         <FormLabel required>{t("age")}</FormLabel>
                         <FormControl>
                           <Input
-                            {...form.register("year_of_birth")}
+                            {...form.register("age")}
                             placeholder={t("type_patient_age")}
                           />
                         </FormControl>
@@ -362,15 +345,15 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                         <span className="text-xs text-gray-500">
                           {t("age_notice")}
                         </span>
-                        {form.getValues("year_of_birth") && (
+                        {form.getValues("age") && (
                           <div className="text-sm font-bold">
-                            {Number(form.getValues("year_of_birth")) <= 0 ? (
+                            {Number(form.getValues("age")) <= 0 ? (
                               <span className="text-red-600">Invalid age</span>
                             ) : (
                               <span className="text-violet-600">
                                 {t("year_of_birth")}:{" "}
                                 {new Date().getFullYear() -
-                                  Number(form.getValues("year_of_birth"))}
+                                  Number(form.getValues("age"))}
                               </span>
                             )}
                           </div>

--- a/src/pages/PublicAppointments/PatientRegistration.tsx
+++ b/src/pages/PublicAppointments/PatientRegistration.tsx
@@ -348,7 +348,9 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                         {form.getValues("age") && (
                           <div className="text-sm font-bold">
                             {Number(form.getValues("age")) <= 0 ? (
-                              <span className="text-red-600">Invalid age</span>
+                              <span className="text-red-600">
+                                {t("invalid_age")}
+                              </span>
                             ) : (
                               <span className="text-violet-600">
                                 {t("year_of_birth")}:{" "}


### PR DESCRIPTION
Fixes #10807

Add year of birth display when age is entered in public patient registration page

* Add a new `div` element to display the year of birth when age is entered
* Update the `FormField` for age to include the year of birth display
* Calculate the year of birth based on the entered age and display it
* Display "Invalid age" message if the calculated year of birth is less than or equal to 0

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ohcnetwork/care_fe/pull/10808?shareId=474d253a-412d-489f-8929-7e75ba8d5ad4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the patient registration form by replacing the year of birth input with an age field. Users now receive immediate error alerts for invalid age entries, improving the registration process's interactivity and user-friendliness.
  - Added a localized error message for invalid age inputs, enhancing user experience across different languages.

- **Bug Fixes**
  - Updated the error message for invalid age inputs to be dynamically translated based on user language settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->