### PR TITLE
API queries: fail fast and retry only for network errors and HTTP 502/503/504s

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import AuthUserProvider from "@/Providers/AuthUserProvider";
 import HistoryAPIProvider from "@/Providers/HistoryAPIProvider";
 import Routers from "@/Routers";
 import { handleHttpError } from "@/Utils/request/errorHandler";
+import { HTTPError } from "@/Utils/request/types";
 
 import { PubSubProvider } from "./Utils/pubsubContext";
 
@@ -25,8 +26,14 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: (failureCount, error) => {
-        // Only retry network errors up to 3 times
-        return error.message === "Network Error" && failureCount < 3;
+        // Only retry network errors or server errors (502, 503, 504) up to 3 times
+        if (
+          error.message === "Network Error" ||
+          (error instanceof HTTPError && [502, 503, 504].includes(error.status))
+        ) {
+          return failureCount < 3;
+        }
+        return false;
       },
       refetchOnWindowFocus: false,
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,10 @@ import { PubSubProvider } from "./Utils/pubsubContext";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 2,
+      retry: (failureCount, error) => {
+        // Only retry network errors up to 3 times
+        return error.message === "Network Error" && failureCount < 3;
+      },
       refetchOnWindowFocus: false,
     },
   },


### PR DESCRIPTION
## Proposed Changes

- API queries: fail fast and retry only for network errors and HTTP 502/503/504s

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced network error handling by dynamically adjusting retry attempts (up to three) for connectivity issues, resulting in improved stability during network disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->