### PR TITLE
Fix: Encounter class and status on reseting on tab switch in Encounter lIst

### DIFF
--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -120,7 +120,13 @@ export function EncounterList({
 }: EncounterListProps) {
   const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
     limit: 15,
-    cacheBlacklist: ["name", "encounter_id", "external_identifier"],
+    cacheBlacklist: [
+      "name",
+      "encounter_id",
+      "external_identifier",
+      "status",
+      "encounter_class",
+    ],
   });
   const {
     status,


### PR DESCRIPTION
## Proposed Changes
- [x]  Cacheblacklist for encounter_class and status in EncounterList
- On tab switching, encounter_class tab ans encounter_status tab was not clearing up , needs to reset 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA
