### PR TITLE
"Updates edit icons and link styling" #10812

### DIFF
--- a/src/components/Facility/FacilityHome.tsx
+++ b/src/components/Facility/FacilityHome.tsx
@@ -269,7 +269,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
                     aria-label={t("edit_cover_photo")}
                   >
                     <CareIcon
-                      icon="l-edit"
+                      icon="l-pen"
                       className="text-white"
                       aria-hidden="true"
                     />
@@ -290,7 +290,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
                       className="cursor-pointer mt-2 [@media(max-width:25rem)]:mt-12 [@media(max-width:25rem)]:w-full"
                       variant="outline"
                     >
-                      <CareIcon icon="l-edit" />
+                      <CareIcon icon="l-pen" />
                       {t("edit_facility_details")}
                     </Button>
                   }

--- a/src/components/Patient/allergy/list.tsx
+++ b/src/components/Patient/allergy/list.tsx
@@ -301,7 +301,7 @@ const AllergyListLayout = ({
         {facilityId && encounterId && (
           <Link
             href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/allergy_intolerance`}
-            className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950 underline"
+            className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950"
           >
             <CareIcon icon="l-pen" className="w-4 h-4" />
             {t("edit")}

--- a/src/components/Patient/allergy/list.tsx
+++ b/src/components/Patient/allergy/list.tsx
@@ -303,7 +303,7 @@ const AllergyListLayout = ({
             href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/allergy_intolerance`}
             className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950 underline"
           >
-            <CareIcon icon="l-edit" className="w-4 h-4" />
+            <CareIcon icon="l-pen" className="w-4 h-4" />
             {t("edit")}
           </Link>
         )}

--- a/src/components/Patient/diagnosis/list.tsx
+++ b/src/components/Patient/diagnosis/list.tsx
@@ -144,7 +144,7 @@ const DiagnosisListLayout = ({
         {facilityId && encounterId && (
           <Link
             href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/diagnosis`}
-            className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950 underline"
+            className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950"
           >
             <CareIcon icon="l-pen" className="w-4 h-4" />
             {t("edit")}

--- a/src/components/Patient/diagnosis/list.tsx
+++ b/src/components/Patient/diagnosis/list.tsx
@@ -146,7 +146,7 @@ const DiagnosisListLayout = ({
             href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/diagnosis`}
             className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950 underline"
           >
-            <CareIcon icon="l-edit" className="w-4 h-4" />
+            <CareIcon icon="l-pen" className="w-4 h-4" />
             {t("edit")}
           </Link>
         )}

--- a/src/components/Patient/symptoms/list.tsx
+++ b/src/components/Patient/symptoms/list.tsx
@@ -135,7 +135,7 @@ const SymptomListLayout = ({
         {facilityId && encounterId && (
           <Link
             href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/symptom`}
-            className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950 underline"
+            className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950"
           >
             <CareIcon icon="l-pen" className="w-4 h-4" />
             {t("edit")}

--- a/src/components/Patient/symptoms/list.tsx
+++ b/src/components/Patient/symptoms/list.tsx
@@ -137,7 +137,7 @@ const SymptomListLayout = ({
             href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/symptom`}
             className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950 underline"
           >
-            <CareIcon icon="l-edit" className="w-4 h-4" />
+            <CareIcon icon="l-pen" className="w-4 h-4" />
             {t("edit")}
           </Link>
         )}

--- a/src/components/Questionnaire/show.tsx
+++ b/src/components/Questionnaire/show.tsx
@@ -158,7 +158,7 @@ export function QuestionnaireShow({ id }: QuestionnaireShowProps) {
             Back to List
           </Button>
           <Button onClick={() => navigate(`/admin/questionnaire/${id}/edit`)}>
-            <CareIcon icon="l-edit" className="mr-2 h-4 w-4" />
+            <CareIcon icon="l-pen" className="mr-2 h-4 w-4" />
             Edit
           </Button>
           <DropdownMenu>

--- a/src/components/Resource/ResourceDetails.tsx
+++ b/src/components/Resource/ResourceDetails.tsx
@@ -144,7 +144,7 @@ export default function ResourceDetails({
                 navigate(`/facility/${facilityId}/resource/${id}/update`)
               }
             >
-              <CareIcon icon="l-edit" className="mr-2 h-4 w-4" />
+              <CareIcon icon="l-pen" className="mr-2 h-4 w-4" />
               {t("update_status")}
             </Button>
           </div>

--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -101,7 +101,7 @@ export default function UserResetPassword({
             variant="primary"
           >
             <CareIcon
-              icon={isEditing ? "l-times" : "l-edit"}
+              icon={isEditing ? "l-times" : "l-pen"}
               className="h-4 w-4"
             />
             {t("update_password")}

--- a/src/pages/Organization/OrganizationFacilities.tsx
+++ b/src/pages/Organization/OrganizationFacilities.tsx
@@ -142,7 +142,7 @@ export default function OrganizationFacilities({
                           size="icon"
                           className="text-primary"
                         >
-                          <CareIcon icon="l-edit" className="h-4 w-4" />
+                          <CareIcon icon="l-pen" className="h-4 w-4" />
                           <span className="">{t("edit_facility")}</span>
                         </Button>
                       }


### PR DESCRIPTION
Closes #10812

Changes:
- Replaces `l-edit` with `l-pen` icon for better visual clarity
- Removes underline decoration from edit links in:
  - Allergy list
  - Diagnosis list  
  - Symptoms list

Screenshots:

before
![image](https://github.com/user-attachments/assets/fbe2938b-2cfc-4788-8fcb-d658bf94718a)

after:
![image](https://github.com/user-attachments/assets/ae762256-950e-45c1-a80b-ee03b24cdb24)


@ohcnetwork/care-fe-code-reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refreshed the edit action icons across various parts of the application for a more modern look.
	- Updated link styling by removing underlines for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->