### PR TITLE
fix(pagination): auto-reset page on organization change

### DIFF
--- a/src/Routers/routes/OrganizationRoutes.tsx
+++ b/src/Routers/routes/OrganizationRoutes.tsx
@@ -7,29 +7,61 @@ import OrganizationView from "@/pages/Organization/OrganizationView";
 
 const OrganizationRoutes: AppRoutes = {
   "/organization": () => <OrganizationIndex />,
-  "/organization/:id": ({ id }) => <OrganizationView id={id} />,
-  "/organization/:id/users": ({ id }) => <OrganizationUsers id={id} />,
-  "/organization/:id/patients": ({ id }) => <OrganizationPatients id={id} />,
-  "/organization/:id/facilities": ({ id }) => (
-    <OrganizationFacilities id={id} />
+  "/organization/:id/:page": ({ id, page }) => (
+    <OrganizationView id={id} page={Number(page || 1)} />
   ),
-  "/organization/:navOrganizationId/children/:id": ({
+  "/organization/:id/:page/users": ({ id, page }) => (
+    <OrganizationUsers id={id} page={Number(page || 1)} />
+  ),
+  "/organization/:id/:page/patients": ({ id, page }) => (
+    <OrganizationPatients id={id} page={Number(page || 1)} />
+  ),
+  "/organization/:id/:page/facilities": ({ id, page }) => (
+    <OrganizationFacilities id={id} page={Number(page || 1)} />
+  ),
+  "/organization/:navOrganizationId/children/:id/:page": ({
     navOrganizationId,
     id,
-  }) => <OrganizationView id={id} navOrganizationId={navOrganizationId} />,
-  "/organization/:navOrganizationId/children/:id/users": ({
-    navOrganizationId,
-    id,
-  }) => <OrganizationUsers id={id} navOrganizationId={navOrganizationId} />,
-  "/organization/:navOrganizationId/children/:id/patients": ({
-    navOrganizationId,
-    id,
-  }) => <OrganizationPatients id={id} navOrganizationId={navOrganizationId} />,
-  "/organization/:navOrganizationId/children/:id/facilities": ({
-    navOrganizationId,
-    id,
+    page,
   }) => (
-    <OrganizationFacilities id={id} navOrganizationId={navOrganizationId} />
+    <OrganizationView
+      navOrganizationId={navOrganizationId}
+      id={id}
+      page={Number(page || 1)}
+    />
+  ),
+  "/organization/:navOrganizationId/children/:id/:page/users": ({
+    navOrganizationId,
+    id,
+    page,
+  }) => (
+    <OrganizationUsers
+      id={id}
+      navOrganizationId={navOrganizationId}
+      page={Number(page || 1)}
+    />
+  ),
+  "/organization/:navOrganizationId/children/:id/:page/patients": ({
+    navOrganizationId,
+    id,
+    page,
+  }) => (
+    <OrganizationPatients
+      id={id}
+      navOrganizationId={navOrganizationId}
+      page={Number(page || 1)}
+    />
+  ),
+  "/organization/:navOrganizationId/children/:id/:page/facilities": ({
+    navOrganizationId,
+    id,
+    page,
+  }) => (
+    <OrganizationFacilities
+      id={id}
+      navOrganizationId={navOrganizationId}
+      page={Number(page || 1)}
+    />
   ),
 };
 

--- a/src/pages/Organization/OrganizationFacilities.tsx
+++ b/src/pages/Organization/OrganizationFacilities.tsx
@@ -25,11 +25,13 @@ import OrganizationLayout from "./components/OrganizationLayout";
 interface Props {
   id: string;
   navOrganizationId?: string;
+  page: number;
 }
 
 export default function OrganizationFacilities({
   id,
   navOrganizationId,
+  page,
 }: Props) {
   const { t } = useTranslation();
 
@@ -56,7 +58,11 @@ export default function OrganizationFacilities({
   }
 
   return (
-    <OrganizationLayout id={id} navOrganizationId={navOrganizationId}>
+    <OrganizationLayout
+      id={id}
+      navOrganizationId={navOrganizationId}
+      page={page}
+    >
       <div className="space-y-6">
         <div className="flex justify-between items-center">
           <div className="mt-1 flex flex-col justify-start space-y-2 md:flex-row md:justify-between md:space-y-0">

--- a/src/pages/Organization/OrganizationPatients.tsx
+++ b/src/pages/Organization/OrganizationPatients.tsx
@@ -26,9 +26,14 @@ import OrganizationLayout from "./components/OrganizationLayout";
 interface Props {
   id: string;
   navOrganizationId?: string;
+  page: number;
 }
 
-export default function OrganizationPatients({ id, navOrganizationId }: Props) {
+export default function OrganizationPatients({
+  id,
+  navOrganizationId,
+  page,
+}: Props) {
   const { t } = useTranslation();
 
   const { qParams, Pagination, advancedFilter, resultsPerPage, updateQuery } =
@@ -95,6 +100,7 @@ export default function OrganizationPatients({ id, navOrganizationId }: Props) {
       id={id}
       navOrganizationId={navOrganizationId}
       setOrganization={setOrganization}
+      page={page}
     >
       <div className="space-y-6">
         <div className="flex justify-between items-center">

--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -29,9 +29,14 @@ import OrganizationLayout from "./components/OrganizationLayout";
 interface Props {
   id: string;
   navOrganizationId?: string;
+  page: number;
 }
 
-export default function OrganizationUsers({ id, navOrganizationId }: Props) {
+export default function OrganizationUsers({
+  id,
+  navOrganizationId,
+  page,
+}: Props) {
   const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
     limit: 15,
     disableCache: true,
@@ -102,7 +107,11 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
   }
 
   return (
-    <OrganizationLayout id={id} navOrganizationId={navOrganizationId}>
+    <OrganizationLayout
+      id={id}
+      navOrganizationId={navOrganizationId}
+      page={page}
+    >
       <div className="space-y-6">
         <div className="justify-between items-center flex flex-wrap">
           <div className="mt-1 flex flex-col justify-start space-y-2 md:flex-row md:justify-between md:space-y-0">

--- a/src/pages/Organization/OrganizationView.tsx
+++ b/src/pages/Organization/OrganizationView.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "raviger";
-import { useEffect, useState } from "react";
+import { Link, navigate } from "raviger";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -25,12 +25,15 @@ import OrganizationLayout from "./components/OrganizationLayout";
 interface Props {
   id: string;
   navOrganizationId?: string;
+  page: number;
 }
 
-export default function OrganizationView({ id, navOrganizationId }: Props) {
+export default function OrganizationView({
+  id,
+  navOrganizationId,
+  page,
+}: Props) {
   const { t } = useTranslation();
-
-  const [page, setPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("");
 
   const { data: children, isFetching } = useQuery({
@@ -45,17 +48,17 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
     }),
   });
 
-  useEffect(() => {
-    setPage(1);
-  }, [id, searchQuery]);
-
   // Hack for the sidebar to work
   const baseUrl = navOrganizationId
-    ? `/organization/${navOrganizationId}`
+    ? `/organization/${id}`
     : `/organization/${id}`;
 
   return (
-    <OrganizationLayout id={id} navOrganizationId={navOrganizationId}>
+    <OrganizationLayout
+      id={id}
+      navOrganizationId={navOrganizationId}
+      page={page}
+    >
       <div className="space-y-6">
         <div className="flex flex-col justify-between items-start gap-4">
           <div className="mt-1 flex flex-col justify-start space-y-2 md:flex-row md:justify-between md:space-y-0">
@@ -71,8 +74,7 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
               placeholder="Search by name..."
               value={searchQuery}
               onChange={(e) => {
-                setSearchQuery(e.target.value);
-                setPage(1); // Reset to first page on search
+                setSearchQuery(e.target.value); // Reset to first page on search
               }}
               className="w-full"
             />
@@ -88,23 +90,27 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {children?.results?.length ? (
                 children.results.map((orgChild: Organization) => (
-                  <Card key={orgChild.id} className="flex flex-col h-full">
-                    <CardContent className="p-6 flex-grow">
-                      <div className="space-y-4 flex-grow">
-                        <div className="space-y-1 mb-2">
-                          <h3 className="text-lg font-semibold">
-                            {orgChild.name}
-                          </h3>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="outline">{orgChild.org_type}</Badge>
-                            {orgChild.metadata?.govt_org_type && (
+                  <Card key={orgChild.id}>
+                    <CardContent className="p-6">
+                      <div className="space-y-4">
+                        <div className="flex items-center justify-between flex-wrap">
+                          <div className="space-y-1 mb-2">
+                            <h3 className="text-lg font-semibold">
+                              {orgChild.name}
+                            </h3>
+                            <div className="flex items-center gap-2">
                               <Badge variant="outline">
-                                {getOrgLabel(
-                                  orgChild.org_type,
-                                  orgChild.metadata,
-                                )}
+                                {orgChild.org_type}
                               </Badge>
-                            )}
+                              {orgChild.metadata?.govt_org_type && (
+                                <Badge variant="outline">
+                                  {getOrgLabel(
+                                    orgChild.org_type,
+                                    orgChild.metadata,
+                                  )}
+                                </Badge>
+                              )}
+                            </div>
                           </div>
                         </div>
                         {orgChild.description && (
@@ -116,7 +122,7 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
                     </CardContent>
                     <div className="p-4 pt-0 mt-auto text-end">
                       <Button variant="link" asChild>
-                        <Link href={`${baseUrl}/children/${orgChild.id}`}>
+                        <Link href={`${baseUrl}/children/${orgChild.id}/1`}>
                           {t("view_details")}
                           <CareIcon icon="l-arrow-right" className="h-4 w-4" />
                         </Link>
@@ -138,7 +144,7 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
               <div className="flex justify-center">
                 <Pagination
                   data={{ totalCount: children.count }}
-                  onChange={(page, _) => setPage(page)}
+                  onChange={(page, _) => navigate(`${baseUrl}/${page}`)}
                   defaultPerPage={RESULTS_PER_PAGE_LIMIT}
                   cPage={page}
                 />

--- a/src/pages/Organization/components/OrganizationLayout.tsx
+++ b/src/pages/Organization/components/OrganizationLayout.tsx
@@ -23,6 +23,7 @@ interface Props {
   navOrganizationId?: string;
   id: string;
   children: React.ReactNode;
+  page: number;
   setOrganization?: (org: Organization) => void;
 }
 
@@ -36,6 +37,7 @@ interface NavItem {
 export default function OrganizationLayout({
   id,
   navOrganizationId,
+  page,
   children,
   setOrganization,
 }: Props) {
@@ -71,25 +73,25 @@ export default function OrganizationLayout({
 
   const navItems: NavItem[] = [
     {
-      path: `${baseUrl}/${id}`,
+      path: `${baseUrl}/${id}/${page}`,
       title: "Organizations",
       icon: "d-hospital",
       visibility: hasPermission("can_view_organization", org.permissions),
     },
     {
-      path: `${baseUrl}/${id}/users`,
+      path: `${baseUrl}/${id}/${page}/users`,
       title: "Users",
       icon: "d-people",
       visibility: hasPermission("can_list_organization_users", org.permissions),
     },
     {
-      path: `${baseUrl}/${id}/patients`,
+      path: `${baseUrl}/${id}/${page}/patients`,
       title: "Patients",
       icon: "d-patient",
       visibility: hasPermission("can_list_patients", org.permissions),
     },
     {
-      path: `${baseUrl}/${id}/facilities`,
+      path: `${baseUrl}/${id}/${page}/facilities`,
       title: "Facilities",
       icon: "d-hospital",
       visibility: hasPermission("can_read_facility", org.permissions),

--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -134,7 +134,7 @@ export default function UserDashboard() {
             data-cy="organization-list"
           >
             {organizations.map((org) => (
-              <Link key={org.id} href={`/organization/${org.id}`}>
+              <Link key={org.id} href={`/organization/${org.id}/1`}>
                 <Card className="transition-all hover:shadow-md hover:border-primary/20">
                   <CardContent className="flex items-center gap-3 p-3 md:p-4">
                     <Avatar


### PR DESCRIPTION
## Proposed Changes

- Fixes #10854 
- Ensures pagination resets to page 1 when the organization changes.-
- Reset the page state

https://github.com/user-attachments/assets/0a6d3fe6-1023-45e6-9d63-7bf257e7a955



@ohcnetwork/care-fe-code-reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user interaction with pagination by introducing a `page` parameter in the URL structure for organization-related views.
	- Updated navigation paths to reflect the current page in the `OrganizationLayout` component.
	- Simplified search functionality without resetting the page state.

- **Bug Fixes**
	- Corrected URL links in the `UserDashboard` to include the default page number for organization links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->