### PR TITLE
Removed the unwanted padding in the bottom of the patient details page

### DIFF
--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -154,7 +154,7 @@ export const PatientHome = (props: {
             </div>
           </div>
         </div>
-        <div className="h-full lg:flex">
+        <div className="lg:flex">
           <div className="h-full lg:mr-7 lg:basis-5/6">
             {Tab && (
               <Tab


### PR DESCRIPTION
## Proposed Changes

- Fixes #10889 
- Removed the unwanted space from the bottom of the patient details page

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ba8622c0-6021-4028-842c-fcbbba94a981" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The patient home page layout has been refined, resulting in updated vertical spacing and element alignment. End users may notice a refreshed visual structure offering a more balanced presentation of content on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->