### PR TITLE
Add Edit and See Details buttons for Location Sub-Groups (Close #10894)

### DIFF
--- a/src/pages/Facility/settings/locations/LocationList.tsx
+++ b/src/pages/Facility/settings/locations/LocationList.tsx
@@ -154,11 +154,6 @@ export default function LocationList({ facilityId }: Props) {
   };
 
   useEffect(() => {
-    if (!searchQuery) {
-      setExpandedRows((prevExpandedRows) => ({ ...prevExpandedRows }));
-      return;
-    }
-
     const allLocations = data?.results || [];
     const matchesSearch = createSearchMatcher(searchQuery);
 

--- a/src/pages/Facility/settings/locations/LocationList.tsx
+++ b/src/pages/Facility/settings/locations/LocationList.tsx
@@ -155,7 +155,7 @@ export default function LocationList({ facilityId }: Props) {
 
   useEffect(() => {
     if (!searchQuery) {
-      setExpandedRows({});
+      setExpandedRows((prevExpandedRows) => ({ ...prevExpandedRows }));
       return;
     }
 

--- a/src/pages/Facility/settings/locations/components/LocationListView.tsx
+++ b/src/pages/Facility/settings/locations/components/LocationListView.tsx
@@ -108,49 +108,48 @@ function LocationRow({
             )}
             {location.name}
           </div>
-          {isTopLevel && (
-            <div className="flex justify-between items-center gap-2">
-              <div className="flex-1">
-                {children.length > 0 && displayExpandAll && (
-                  <Button
-                    variant="white"
-                    size={isMobile ? "xs" : "sm"}
-                    onClick={toggleAllChildren}
-                    className="gap-2"
-                  >
-                    <CareIcon
-                      icon={allExpanded ? "l-minus" : "l-plus"}
-                      className="h-4 w-4"
-                    />
-                    <span className="hidden lg:inline">
-                      {t(allExpanded ? "collapse_all" : "expand_all")}
-                    </span>
-                  </Button>
-                )}
-              </div>
 
-              <div className="flex items-center gap-2 ml-auto">
+          <div className="flex justify-between items-center gap-2">
+            <div className="flex-1">
+              {children.length > 0 && displayExpandAll && (
                 <Button
                   variant="white"
                   size={isMobile ? "xs" : "sm"}
-                  onClick={() => onEdit(location)}
+                  onClick={toggleAllChildren}
+                  className="gap-2"
                 >
-                  <PenLine className="h-4 w-4" />
-                  <span className="hidden lg:inline">{t("edit")}</span>
+                  <CareIcon
+                    icon={allExpanded ? "l-minus" : "l-plus"}
+                    className="h-4 w-4"
+                  />
+                  <span className="hidden lg:inline">
+                    {t(allExpanded ? "collapse_all" : "expand_all")}
+                  </span>
                 </Button>
-
-                <Button variant="white" size={isMobile ? "xs" : "sm"} asChild>
-                  <Link
-                    href={`/location/${location.id}`}
-                    className="text-gray-900 flex items-center"
-                  >
-                    <CareIcon icon="l-arrow-up-right" className="h-4 w-4" />
-                    <span className="hidden lg:inline">{t("see_details")}</span>
-                  </Link>
-                </Button>
-              </div>
+              )}
             </div>
-          )}
+
+            <div className="flex items-center gap-2 ml-auto">
+              <Button
+                variant="white"
+                size={isMobile ? "xs" : "sm"}
+                onClick={() => onEdit(location)}
+              >
+                <PenLine className="h-4 w-4" />
+                <span className="hidden lg:inline">{t("edit")}</span>
+              </Button>
+
+              <Button variant="white" size={isMobile ? "xs" : "sm"} asChild>
+                <Link
+                  href={`/location/${location.id}`}
+                  className="text-gray-900 flex items-center"
+                >
+                  <CareIcon icon="l-arrow-up-right" className="h-4 w-4" />
+                  <span className="hidden lg:inline">{t("see_details")}</span>
+                </Link>
+              </Button>
+            </div>
+          </div>
         </TableCell>
         <TableCell className="hidden sm:table-cell border-l bg-white font-semibold text-gray-900">
           {t(`location_form__${location.form}`)}


### PR DESCRIPTION
## Proposed Changes

- Fixes #10874
- Remove the condition that restricts these buttons to top-level locations.
- Apply minor code formatting updates as per ESLint/Prettier guidelines.

![Screenshot 2025-03-01 082432](https://github.com/user-attachments/assets/46a2e34d-ed68-40a8-9eea-9e9701e1bce3)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the layout for the locations display to offer a more uniform and cohesive interface.
  - Enhanced button functionality so the expansion button now toggles the visibility of all child locations, providing a more intuitive experience.
  - Maintained distinct options for editing and viewing location details, ensuring clear and consistent interactions for users.
  - Improved state management to preserve expanded rows when the search query is cleared, enhancing user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->