### PR TITLE
fix:Search is not working in facility departmental section #10887

### DIFF
--- a/src/pages/Facility/settings/organizations/FacilityOrganizationIndex.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationIndex.tsx
@@ -43,6 +43,7 @@ export default function FacilityOrganizationIndex({
   facilityId: string;
 }) {
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
+  const [searchTerm, setSearchTerm] = useState("");
   const { t } = useTranslation();
   const { data, isLoading } = useQuery({
     queryKey: ["facilityOrganization", "list", facilityId],
@@ -52,6 +53,11 @@ export default function FacilityOrganizationIndex({
     enabled: !!facilityId,
   });
   const tableData = data?.results || [];
+  const filteredTableData = tableData.filter(
+    (org) =>
+      org.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      org.org_type.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
   const isMobile = useBreakpoints({ default: true, sm: false });
   if (isLoading) {
     return (
@@ -274,6 +280,10 @@ export default function FacilityOrganizationIndex({
           <Input
             className="px-2 placeholder:text-xs placeholder:text-gray-500"
             placeholder={t("filter_by_department_or_team_name")}
+            value={searchTerm}
+            onChange={(e) => {
+              setSearchTerm(e.target.value);
+            }}
           ></Input>
         </div>
         <div className="flex lg:justify-end w-full">
@@ -330,7 +340,7 @@ export default function FacilityOrganizationIndex({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {tableData
+          {filteredTableData
             .filter(
               (org) => !org.parent || Object.keys(org.parent).length === 0,
             ) // Parent rows only


### PR DESCRIPTION
## Proposed Changes
When we initiate search in the facility department section, the data are not filtering

- Fixes [Search is not working in facility departmental section #10887
](https://github.com/ohcnetwork/care_fe/issues/10887)

We had to use a state variable and when there is a change in the input text apply it on the table and filter them accordingly

https://github.com/user-attachments/assets/046167a1-c734-495f-8907-b48eb3a0f4c7



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a real-time search functionality on the organizations page, allowing users to quickly filter the list based on organization name or type with case-insensitive matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->