### PR TITLE
SIssues/#10936/filter toggle not resetting

### DIFF
--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -503,7 +503,7 @@ export function EncounterList({
                           if (status === "planned") {
                             updateQuery({
                               ...{ encounter_class: encounterClass, priority },
-                              status: "all",
+                              status: undefined,
                             });
                           } else {
                             updateQuery({
@@ -523,7 +523,7 @@ export function EncounterList({
                           if (status === "in_progress") {
                             updateQuery({
                               ...{ encounter_class: encounterClass, priority },
-                              status: "all",
+                              status: undefined,
                             });
                           } else {
                             updateQuery({
@@ -543,7 +543,7 @@ export function EncounterList({
                           if (status === "discharged") {
                             updateQuery({
                               ...{ encounter_class: encounterClass, priority },
-                              status: "all",
+                              status: undefined,
                             });
                           } else {
                             updateQuery({
@@ -563,7 +563,7 @@ export function EncounterList({
                           if (status === "completed") {
                             updateQuery({
                               ...{ encounter_class: encounterClass, priority },
-                              status: "all",
+                              status: undefined,
                             });
                           } else {
                             updateQuery({
@@ -583,7 +583,7 @@ export function EncounterList({
                           if (status === "cancelled") {
                             updateQuery({
                               ...{ encounter_class: encounterClass, priority },
-                              status: "all",
+                              status: undefined,
                             });
                           } else {
                             updateQuery({

--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -499,12 +499,19 @@ export function EncounterList({
                       <TabsTrigger
                         value="planned"
                         className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                        onClick={() =>
-                          updateQuery({
-                            ...{ encounter_class: encounterClass, priority },
-                            status: "planned",
-                          })
-                        }
+                        onClick={() => {
+                          if (status === "planned") {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "all",
+                            });
+                          } else {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "planned",
+                            });
+                          }
+                        }}
                       >
                         <CareIcon icon="l-calender" className="mr-2 h-4 w-4" />
                         {t("encounter_status__planned")}
@@ -512,12 +519,19 @@ export function EncounterList({
                       <TabsTrigger
                         value="in_progress"
                         className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                        onClick={() =>
-                          updateQuery({
-                            ...{ encounter_class: encounterClass, priority },
-                            status: "in_progress",
-                          })
-                        }
+                        onClick={() => {
+                          if (status === "in_progress") {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "all",
+                            });
+                          } else {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "in_progress",
+                            });
+                          }
+                        }}
                       >
                         <CareIcon icon="l-spinner" className="mr-2 h-4 w-4" />
                         {t("encounter_class__in_progress")}
@@ -525,12 +539,19 @@ export function EncounterList({
                       <TabsTrigger
                         value="discharged"
                         className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                        onClick={() =>
-                          updateQuery({
-                            ...{ encounter_class: encounterClass, priority },
-                            status: "discharged",
-                          })
-                        }
+                        onClick={() => {
+                          if (status === "discharged") {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "all",
+                            });
+                          } else {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "discharged",
+                            });
+                          }
+                        }}
                       >
                         <CareIcon icon="l-home" className="mr-2 h-4 w-4" />
                         {t("discharge")}
@@ -538,12 +559,19 @@ export function EncounterList({
                       <TabsTrigger
                         value="completed"
                         className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                        onClick={() =>
-                          updateQuery({
-                            ...{ encounter_class: encounterClass, priority },
-                            status: "completed",
-                          })
-                        }
+                        onClick={() => {
+                          if (status === "completed") {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "all",
+                            });
+                          } else {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "completed",
+                            });
+                          }
+                        }}
                       >
                         <CareIcon icon="l-check" className="mr-2 h-4 w-4" />
                         {t("completed")}
@@ -551,12 +579,19 @@ export function EncounterList({
                       <TabsTrigger
                         value="cancelled"
                         className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                        onClick={() =>
-                          updateQuery({
-                            ...{ encounter_class: encounterClass, priority },
-                            status: "cancelled",
-                          })
-                        }
+                        onClick={() => {
+                          if (status === "cancelled") {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "all",
+                            });
+                          } else {
+                            updateQuery({
+                              ...{ encounter_class: encounterClass, priority },
+                              status: "cancelled",
+                            });
+                          }
+                        }}
                       >
                         <CareIcon icon="l-x" className="mr-2 h-4 w-4" />
                         {t("cancelled")}


### PR DESCRIPTION
## Proposed Changes

- Fixes #10936
- Clicking the same status filter twice now resets the encounters list to display all statuses.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA

https://github.com/user-attachments/assets/e8c9c47e-f7c1-42d7-b853-aa1d8e3e240e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved filtering on encounter lists by enabling users to toggle status selections on and off for a more intuitive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->