### PR TITLE
Remove Questionnaire show usage

### DIFF
--- a/src/components/Questionnaire/CloneQuestionnaireSheet.tsx
+++ b/src/components/Questionnaire/CloneQuestionnaireSheet.tsx
@@ -65,7 +65,7 @@ export default function CloneQuestionnaireSheet({
       silent: true,
     }),
     onSuccess: async (data: QuestionnaireDetail) => {
-      navigate(`/admin/questionnaire/${data.slug}`);
+      navigate(`/admin/questionnaire/${data.slug}/edit`);
       setOpen(false);
     },
     onError: (error) => {

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -687,7 +687,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     onSuccess: (data: QuestionnaireDetail) => {
       toast.success("Questionnaire created successfully");
       queryClient.invalidateQueries({ queryKey: ["questionnaireDetail", id] });
-      navigate(`/admin/questionnaire/${data.slug}`);
+      navigate(`/admin/questionnaire/${data.slug}/edit`);
     },
     onError: (_error) => {
       toast.error("Failed to create questionnaire");
@@ -698,10 +698,9 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     mutationFn: mutate(questionnaireApi.update, {
       pathParams: { id: id! },
     }),
-    onSuccess: (data: QuestionnaireDetail) => {
+    onSuccess: () => {
       toast.success("Questionnaire updated successfully");
       queryClient.invalidateQueries({ queryKey: ["questionnaireDetail", id] });
-      navigate(`/admin/questionnaire/${data.slug}`);
     },
     onError: (_error) => {
       toast.error("Failed to update questionnaire");
@@ -775,7 +774,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
   };
 
   const handleCancel = () => {
-    navigate(id ? `/admin/questionnaire/${id}` : "/admin/questionnaire");
+    navigate("/admin/questionnaire");
   };
 
   const toggleQuestionExpanded = (questionId: string) => {


### PR DESCRIPTION
Remove existing usages of Questionnaire show screen that was recently removed

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - After cloning a questionnaire, users are now taken directly to the editing interface.
  - Newly created questionnaires open in edit mode for seamless modifications.
  - The update workflow has been adjusted to remove automatic redirection, while the cancel action now consistently returns to the questionnaire overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->