### PR TITLE
Fix: Unwanted Horizontal Scroll on Facility Settings Page

### DIFF
--- a/src/pages/Facility/settings/layout.tsx
+++ b/src/pages/Facility/settings/layout.tsx
@@ -90,12 +90,12 @@ export function SettingsLayout({ facilityId }: SettingsLayoutProps) {
   return (
     <div className="container mx-auto p-4">
       <Tabs defaultValue={currentTab} className="w-full" value={currentTab}>
-        <TabsList className="w-full justify-start border-b bg-transparent p-0 h-auto">
+        <TabsList className="w-full justify-evenly sm:justify-start border-b bg-transparent p-0 h-auto">
           {settingsTabs.map((tab) => (
             <Link key={tab.value} href={tab.href}>
               <TabsTrigger
                 value={tab.value}
-                className="border-b-2 border-transparent px-4 py-2 text-gray-600 hover:text-gray-900 data-[state=active]:border-primary-500 data-[state=active]:bg-transparent data-[state=active]:shadow-none rounded-none"
+                className="border-b-2 border-transparent px-2 sm:px-4 py-2 text-gray-600 hover:text-gray-900 data-[state=active]:border-primary-500 data-[state=active]:bg-transparent data-[state=active]:shadow-none rounded-none"
               >
                 {tab.label}
               </TabsTrigger>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11043
- Change: Just adjusted the padding and justification for mobile.

**Screenshot**

Before  - >  After
<img width="300" alt="Screenshot 2025-03-05 at 5 30 12 PM" src="https://github.com/user-attachments/assets/6b2caca2-379e-4da0-8c2d-ef31c313364d" /> <img width="300" alt="Screenshot 2025-03-05 at 5 31 02 PM" src="https://github.com/user-attachments/assets/5340836d-dfb3-4f2c-b9f8-1635838b10d0" />

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the appearance of the settings page by refining the tab alignment and spacing.
  - Enhanced responsiveness by adjusting element padding for a more balanced layout on both small and large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->