### PR TITLE
Remove patient query parameter from encounter fetch

### DIFF
--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -65,7 +65,6 @@ export const EncounterShow = (props: Props) => {
       pathParams: { id: encounterId },
       queryParams: {
         facility: facilityId,
-        patient: patientId,
       },
     }),
     enabled: !!encounterId,


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/Encounters/EncounterShow.tsx` file. The change removes the unnecessary `patient` query parameter from the `queryParams` object.

* [`src/pages/Encounters/EncounterShow.tsx`](diffhunk://#diff-97f06e623bc23db99abc00fc38e0a0d355c8bd6f99906bb1040af2a361ebedd8L68): Removed the `patient` query parameter from the `queryParams` object in the `EncounterShow` component.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices
