### PR TITLE
Fixed name overflow in user card

### DIFF
--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -9,6 +9,11 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 import { Avatar } from "@/components/Common/Avatar";
 import SearchByMultipleFields from "@/components/Common/SearchByMultipleFields";
@@ -154,88 +159,86 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {users?.results?.length === 0 ? (
-              <Card className="col-span-full">
-                <CardContent className="p-6 text-center text-gray-500">
-                  {t("no_users_found")}
-                </CardContent>
-              </Card>
-            ) : (
-              users?.results?.map((userRole) => (
-                <Card key={userRole.id} className="h-full">
-                  <CardContent className="p-4 sm:p-6 flex flex-col h-full justify-between">
-                    <div className="flex items-start gap-3">
-                      <Avatar
-                        name={`${userRole.user.first_name} ${userRole.user.last_name}`}
-                        imageUrl={userRole.user.profile_picture_url}
-                        className="h-12 w-12 sm:h-14 sm:w-14 text-xl sm:text-2xl flex-shrink-0"
-                      />
+            {users?.results?.map((userRole) => (
+              <Card key={userRole.id} className="h-full">
+                <CardContent className="p-4 sm:p-6 flex flex-col h-full justify-between">
+                  <div className="flex items-start gap-3">
+                    <Avatar
+                      name={`${userRole.user.first_name} ${userRole.user.last_name}`}
+                      imageUrl={userRole.user.profile_picture_url}
+                      className="h-12 w-12 sm:h-14 sm:w-14 text-xl sm:text-2xl flex-shrink-0"
+                    />
 
-                      <div className="flex flex-col min-w-0 flex-1">
-                        <div className="flex flex-col gap-1">
-                          <div className="flex items-start justify-between">
-                            <h1
-                              className="text-base font-bold pr-2 overflow-hidden text-ellipsis whitespace-nowrap max-w-48 sm:max-w-80 md:max-w-full"
-                              title={`${userRole.user.first_name} ${userRole.user.last_name}`}
-                            >
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <div className="flex flex-col gap-1">
+                        <div className="flex items-start justify-between">
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <h1 className="text-base font-bold pr-2 overflow-hidden text-ellipsis whitespace-nowrap max-w-48 sm:max-w-80 md:max-w-96 cursor-pointer">
+                                {userRole.user.first_name}{" "}
+                                {userRole.user.last_name}
+                              </h1>
+                            </TooltipTrigger>
+                            <TooltipContent className="break-words whitespace-normal max-w-60 sm:max-w-80 md:max-w-96">
                               {userRole.user.first_name}{" "}
                               {userRole.user.last_name}
-                            </h1>
-                            <span className="text-sm text-gray-500">
-                              <UserStatusIndicator user={userRole.user} />
-                            </span>
-                          </div>
-                          <span className="text-sm text-gray-500 mr-2 break-words">
-                            {userRole.user.username}
+                            </TooltipContent>
+                          </Tooltip>
+                          <span className="text-sm text-gray-500">
+                            <UserStatusIndicator user={userRole.user} />
                           </span>
                         </div>
-                        <div className="mt-4 -ml-12 sm:ml-0 grid grid-cols-2 gap-2 text-sm">
-                          <div>
-                            <div className="text-gray-500">{t("role")}</div>
-                            <div className="font-medium truncate">
-                              {userRole.role.name ?? "-"}
-                            </div>
+                        <span className="text-sm text-gray-500 mr-2 break-words">
+                          {userRole.user.username}
+                        </span>
+                      </div>
+
+                      <div className="mt-4 -ml-12 sm:ml-0 grid grid-cols-2 gap-2 text-sm">
+                        <div>
+                          <div className="text-gray-500">{t("role")}</div>
+                          <div className="font-medium truncate">
+                            {userRole.role.name ?? "-"}
                           </div>
-                          <div>
-                            <div className="text-gray-500">
-                              {t("phone_number")}
-                            </div>
-                            <div className="font-medium truncate">
-                              {userRole.user.phone_number
-                                ? formatPhoneNumberIntl(
-                                    userRole.user.phone_number,
-                                  )
-                                : "-"}
-                            </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-500">
+                            {t("phone_number")}
+                          </div>
+                          <div className="font-medium truncate">
+                            {userRole.user.phone_number
+                              ? formatPhoneNumberIntl(
+                                  userRole.user.phone_number,
+                                )
+                              : "-"}
                           </div>
                         </div>
                       </div>
                     </div>
+                  </div>
 
-                    <div className="mt-2 -mx-2 -mb-2 sm:-mx-4 sm:-mb-4 rounded-md py-4 px-4 bg-gray-50 flex justify-end gap-2">
-                      <EditUserRoleSheet
-                        organizationId={id}
-                        userRole={userRole}
-                        trigger={
-                          <Button variant="outline" size="sm">
-                            <span>{t("edit_role")}</span>
-                          </Button>
-                        }
-                      />
-                      <Button asChild variant="outline" size="sm">
-                        <Link href={`/users/${userRole.user.username}`}>
-                          <CareIcon
-                            icon="l-arrow-up-right"
-                            className="text-lg mr-1"
-                          />
-                          <span>{t("see_details")}</span>
-                        </Link>
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))
-            )}
+                  <div className="mt-2 -mx-2 -mb-2 sm:-mx-4 sm:-mb-4 rounded-md py-4 px-4 bg-gray-50 flex justify-end gap-2">
+                    <EditUserRoleSheet
+                      organizationId={id}
+                      userRole={userRole}
+                      trigger={
+                        <Button variant="outline" size="sm">
+                          <span>{t("edit_role")}</span>
+                        </Button>
+                      }
+                    />
+                    <Button asChild variant="outline" size="sm">
+                      <Link href={`/users/${userRole.user.username}`}>
+                        <CareIcon
+                          icon="l-arrow-up-right"
+                          className="text-lg mr-1"
+                        />
+                        <span>{t("see_details")}</span>
+                      </Link>
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         )}
         <Pagination totalCount={users?.count || 0} />

--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -174,7 +174,10 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
                       <div className="flex flex-col min-w-0 flex-1">
                         <div className="flex flex-col gap-1">
                           <div className="flex items-start justify-between">
-                            <h1 className="text-base font-bold break-words pr-2">
+                            <h1
+                              className="text-base font-bold pr-2 overflow-hidden text-ellipsis whitespace-nowrap max-w-48 sm:max-w-80 md:max-w-full"
+                              title={`${userRole.user.first_name} ${userRole.user.last_name}`}
+                            >
                               {userRole.user.first_name}{" "}
                               {userRole.user.last_name}
                             </h1>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11012 
- Fixed the overflowing of text in the users section by adding ellipsis in place of the long text. On hover, complete name of user is visible.

![image](https://github.com/user-attachments/assets/9761d1ef-9d93-4257-8f35-0b69f18d3158)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The user’s name now displays a full name tooltip on hover, enhancing user interaction.
- **Style**
  - Improved text handling to ensure names fit well within designated space without truncation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->