### PR TITLE
Default to nurse user type in the create user form

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -119,7 +119,7 @@ export default function UserForm({
   const form = useForm<UserFormValues>({
     resolver: zodResolver(userFormSchema),
     defaultValues: {
-      user_type: "staff",
+      user_type: "nurse",
       username: "",
       password: "",
       c_password: "",


### PR DESCRIPTION
## Proposed Changes

- Fixes #issue_number
- Change 1
- Change 2
- More?

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default role selection in the user form so that new entries now preset to "nurse" instead of "staff," ensuring a more accurate initial option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->