### PR TITLE
Fixes the typographer quote replacement issue

### DIFF
--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -9,7 +9,7 @@ const md = new MarkdownIt({
   breaks: true,
   linkify: true,
   typographer: true,
-  quotes: ['""', "''"],
+  quotes: "“”‘’",
 });
 
 export interface MarkdownProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
## Proposed Changes

- When a note is create a with a word wrapped within single quote, the app crashes, this PR fixes that

cc: @Jacobjeevan 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated markdown rendering to use refined typographic quotation marks, resulting in a more polished and visually appealing display of quoted text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->