### PR TITLE
Update organization navigation

### DIFF
--- a/src/pages/Facility/settings/organizations/FacilityOrganizationIndex.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationIndex.tsx
@@ -227,7 +227,7 @@ export default function FacilityOrganizationIndex({
                         asChild
                       >
                         <Link
-                          href={`/departments/${org.id}`}
+                          href={`/departments/${org.id}/users`}
                           className="text-gray-900 flex items-center"
                         >
                           <CareIcon

--- a/src/pages/Facility/settings/organizations/FacilityOrganizationView.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationView.tsx
@@ -50,7 +50,9 @@ function OrganizationCard({
               </div>
             </div>
             <Button variant="white" size="sm" className="font-semibold" asChild>
-              <Link href={`/departments/${org.id}`}>{t("see_details")}</Link>
+              <Link href={`/departments/${org.id}/users`}>
+                {t("see_details")}
+              </Link>
             </Button>
           </div>
         </div>

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationLayout.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationLayout.tsx
@@ -45,19 +45,19 @@ export default function FacilityOrganizationLayout({
 
   const navItems: NavItem[] = [
     {
-      path: `/departments/${id}`,
-      title: t("departments_or_teams"),
-      value: "departments",
-    },
-    {
       path: `/departments/${id}/users`,
       title: t("users"),
       value: "users",
     },
+    {
+      path: `/departments/${id}`,
+      title: t("departments_or_teams"),
+      value: "departments",
+    },
   ];
 
   const currentTab =
-    navItems.find((item) => item.path === path)?.value || "departments";
+    navItems.find((item) => item.path === path)?.value || "users";
 
   const { data: org, isLoading } = useQuery<FacilityOrganization>({
     queryKey: ["facilityOrganization", id],


### PR DESCRIPTION
## Proposed Changes

Update organization navigation to default to users tab
- Modify links in FacilityOrganizationIndex and FacilityOrganizationView to point to `/departments/${org.id}/users`
- Reorder and update default tab in FacilityOrganizationLayout to prioritize users tab
- Ensure consistent routing for organization-related pages


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Navigation links now direct department pages to a dedicated user section, offering a more targeted experience.
  - The default view opens with the "users" tab, streamlining access to user information.
  - These valuable enhancements improve navigation clarity, simplify user management workflows, and contribute to a more intuitive interface for organization insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->