### PR TITLE
Replaced React Date & Time Picker with the device's default date and Time picker

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1030,6 +1030,7 @@
   "encounter_type": "Encounter Type",
   "encounters": "Encounters",
   "end_date": "End date",
+  "end_date_must_be_after_start_date": "End Date must be after Start Date",
   "end_datetime": "End Date/Time",
   "end_dose": "End Dose",
   "end_time": "End Time",

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -821,12 +821,12 @@ const MedicationRequestGridRow: React.FC<MedicationRequestGridRowProps> = ({
         <DateTimePicker
           value={
             medication.authored_on
-              ? new Date(medication.authored_on)
+              ? new Date(medication.authored_on).toISOString()
               : undefined
           }
           onChange={(date) => {
             if (!date) return;
-            onUpdate?.({ authored_on: date.toISOString() });
+            onUpdate?.({ authored_on: date.toString() });
           }}
           disabled={disabled || isReadOnly}
         />

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -819,11 +819,7 @@ const MedicationRequestGridRow: React.FC<MedicationRequestGridRowProps> = ({
           {t("authored_on")}
         </Label>
         <DateTimePicker
-          value={
-            medication.authored_on
-              ? new Date(medication.authored_on).toISOString()
-              : undefined
-          }
+          value={medication.authored_on}
           onChange={(date) => {
             if (!date) return;
             onUpdate?.({ authored_on: date.toString() });

--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -42,6 +42,7 @@ import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 import useBreakpoints from "@/hooks/useBreakpoints";
 
 import query from "@/Utils/request/query";
+import { dateQueryString } from "@/Utils/utils";
 import {
   MEDICATION_STATEMENT_STATUS,
   MedicationStatementInformationSourceType,
@@ -485,19 +486,20 @@ const MedicationStatementGridRow: React.FC<MedicationStatementGridRowProps> = ({
           {t("medication_taken_between")}
         </Label>
         <DateRangePicker
+          key={`${medication.effective_period}`}
           date={{
             from: medication.effective_period?.start
-              ? new Date(medication.effective_period?.start)
+              ? dateQueryString(new Date(medication.effective_period?.start))
               : undefined,
             to: medication.effective_period?.end
-              ? new Date(medication.effective_period?.end)
+              ? dateQueryString(new Date(medication.effective_period?.end))
               : undefined,
           }}
           onChange={(date) =>
             onUpdate?.({
               effective_period: {
-                start: date?.from?.toISOString(),
-                end: date?.to?.toISOString(),
+                start: date?.from?.toString(),
+                end: date?.to?.toString(),
               },
             })
           }

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,69 +1,32 @@
 import { format } from "date-fns";
-import { t } from "i18next";
 import { useState } from "react";
 
-import { cn } from "@/lib/utils";
-
-import CareIcon from "@/CAREUI/icons/CareIcon";
-
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { Input } from "@/components/ui/input";
 
 interface DatePickerProps {
   date?: Date;
   onChange?: (date?: Date) => void;
-  disabled?: (date: Date) => boolean;
+  disabled?: boolean;
 }
 
 export function DatePicker({ date, onChange, disabled }: DatePickerProps) {
-  const [open, setOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(
+    date ? format(date, "yyyy-MM-dd") : "",
+  );
+
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newDate = e.target.value ? new Date(e.target.value) : undefined;
+
+    setSelectedDate(e.target.value);
+    onChange?.(newDate);
+  };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          className={cn(
-            "w-full justify-start text-left font-normal",
-            !date && "text-gray-500",
-            "sm:w-auto",
-          )}
-        >
-          <CareIcon
-            icon="l-calender"
-            className="mr-0 sm:mr-2 h-4 w-4 flex-shrink-0"
-          />
-          <span className="truncate">
-            {date ? (
-              <>
-                <span className="block sm:hidden">
-                  {format(date, "MMM d, yyyy")}
-                </span>
-                <span className="hidden sm:block">{format(date, "PPP")}</span>
-              </>
-            ) : (
-              <span>{t("pick_a_date")}</span>
-            )}
-          </span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0 sm:w-64" align="start">
-        <Calendar
-          mode="single"
-          selected={date}
-          onSelect={(date) => {
-            onChange?.(date);
-            setOpen(false);
-          }}
-          initialFocus
-          disabled={disabled}
-        />
-      </PopoverContent>
-    </Popover>
+    <Input
+      type="date"
+      value={selectedDate}
+      onChange={handleDateChange}
+      disabled={disabled}
+    />
   );
 }

--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -1,26 +1,15 @@
-import { format } from "date-fns";
 import { t } from "i18next";
-import * as React from "react";
-import { DateRange } from "react-day-picker";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 
-import CareIcon from "@/CAREUI/icons/CareIcon";
+import { Input } from "./input";
+import { Label } from "./label";
 
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-
-type DateRangePickerProps = Omit<
-  React.HTMLAttributes<HTMLDivElement>,
-  "onChange"
-> & {
-  date?: DateRange;
-  onChange?: (date?: DateRange) => void;
+type DateRangePickerProps = {
+  date?: { from?: string; to?: string };
+  onChange?: (date?: { from?: string; to?: string }) => void;
   className?: string;
 };
 
@@ -29,44 +18,49 @@ export function DateRangePicker({
   onChange,
   className,
 }: DateRangePickerProps) {
+  const [startDate, setStartDate] = useState(date?.from || "");
+  const [endDate, setEndDate] = useState(date?.to || "");
+
+  const handleDateChange = (key: "from" | "to", value: string) => {
+    if (key === "from") {
+      if (endDate && value > endDate) {
+        setEndDate(value);
+      }
+      setStartDate(value);
+      onChange?.({ from: value, to: endDate });
+    } else {
+      if (value < startDate) {
+        toast.error(t("end_date_must_be_after_start_date"));
+        return;
+      }
+      setEndDate(value);
+      onChange?.({ from: startDate, to: value });
+    }
+  };
+
   return (
     <div className={cn("grid gap-2", className)}>
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            id="date"
-            variant={"outline"}
-            className={cn(
-              "justify-center text-left font-normal",
-              !date && "text-gray-500",
-            )}
-          >
-            <CareIcon icon="l-calender" className="mr-2 h-4 w-4" />
-            {date?.from ? (
-              date.to ? (
-                <>
-                  {format(date.from, "LLL dd, y")} -{" "}
-                  {format(date.to, "LLL dd, y")}
-                </>
-              ) : (
-                format(date.from, "LLL dd, y")
-              )
-            ) : (
-              <span>{t("pick_a_date")}</span>
-            )}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            initialFocus
-            mode="range"
-            defaultMonth={date?.from}
-            selected={date}
-            onSelect={onChange}
-            numberOfMonths={2}
-          />
-        </PopoverContent>
-      </Popover>
+      <div className="flex items-center gap-2">
+        <Label className="text-gray-700 font-medium">{t("start_date")}</Label>
+        <Input
+          type="date"
+          value={startDate}
+          onChange={(e) => handleDateChange("from", e.target.value)}
+          className="border px-3 py-2 rounded-md"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Label className="text-gray-700 font-medium">{t("end_date")}</Label>
+        <Input
+          type="date"
+          value={endDate}
+          onChange={(e) => handleDateChange("to", e.target.value)}
+          className={cn(
+            "border px-3 py-2 rounded-md",
+            endDate && endDate < startDate ? "border-red-500" : "",
+          )}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -38,6 +38,7 @@ export function DateTimePicker({
         value={formattedDateTime}
         disabled={disabled}
         onChange={handleChange}
+        className="px-0"
       />
     </div>
   );

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -26,11 +27,15 @@ export function DateTimePicker({
     onChange?.(newDateTime);
   };
 
+  const formattedDateTime = dateTime
+    ? format(new Date(dateTime), "yyyy-MM-dd'T'HH:mm")
+    : "";
+
   return (
     <div className={cn(className)}>
       <Input
         type="datetime-local"
-        value={dateTime}
+        value={formattedDateTime}
         disabled={disabled}
         onChange={handleChange}
       />

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -1,159 +1,39 @@
-"use client";
-
-import { CalendarIcon } from "@radix-ui/react-icons";
-import { format } from "date-fns";
-import * as React from "react";
+import { useState } from "react";
 
 import { cn } from "@/lib/utils";
 
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { Input } from "./input";
 
 interface DateTimePickerProps {
-  value?: Date;
-  onChange?: (date?: Date) => void;
+  value?: string;
+  onChange?: (date?: string) => void;
+  className?: string;
+
   disabled?: boolean;
 }
 
 export function DateTimePicker({
   value,
   onChange,
-  disabled,
+  className,
+  disabled = false,
 }: DateTimePickerProps) {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [dateTime, setDateTime] = useState(value || "");
 
-  const hours = Array.from({ length: 12 }, (_, i) => i + 1);
-  const handleDateSelect = (selectedDate: Date | undefined) => {
-    if (selectedDate) {
-      onChange?.(selectedDate);
-    }
-  };
-
-  const handleTimeChange = (
-    type: "hour" | "minute" | "ampm",
-    selectedValue: string,
-  ) => {
-    if (!value) return;
-    const newDate = new Date(value);
-
-    if (type === "hour") {
-      newDate.setHours(
-        (parseInt(selectedValue) % 12) + (newDate.getHours() >= 12 ? 12 : 0),
-      );
-    } else if (type === "minute") {
-      newDate.setMinutes(parseInt(selectedValue));
-    } else if (type === "ampm") {
-      const currentHours = newDate.getHours();
-      const isPM = selectedValue === "PM";
-      if (isPM && currentHours < 12) {
-        newDate.setHours(currentHours + 12);
-      } else if (!isPM && currentHours >= 12) {
-        newDate.setHours(currentHours - 12);
-      }
-    }
-    onChange?.(newDate);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newDateTime = e.target.value;
+    setDateTime(newDateTime);
+    onChange?.(newDateTime);
   };
 
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          disabled={disabled}
-          variant="outline"
-          className={cn(
-            "w-full justify-start text-left font-normal",
-            !value && "text-gray-500",
-          )}
-        >
-          <CalendarIcon className="mr-2 h-4 w-4" />
-          {value ? (
-            format(value, "dd/MM/yyyy hh:mm aa")
-          ) : (
-            <span>DD/MM/YYYY hh:mm aa</span>
-          )}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
-        <div className="sm:flex">
-          <Calendar
-            mode="single"
-            selected={value}
-            onSelect={handleDateSelect}
-            initialFocus
-          />
-          <div className="flex flex-col sm:flex-row sm:h-[300px] divide-y sm:divide-y-0 sm:divide-x">
-            <ScrollArea className="w-64 sm:w-auto">
-              <div className="flex sm:flex-col p-2">
-                {hours.reverse().map((hour) => (
-                  <Button
-                    key={hour}
-                    size="icon"
-                    variant={
-                      value && value.getHours() % 12 === hour % 12
-                        ? "default"
-                        : "ghost"
-                    }
-                    className="sm:w-full shrink-0 aspect-square"
-                    onClick={() => handleTimeChange("hour", hour.toString())}
-                  >
-                    {hour}
-                  </Button>
-                ))}
-              </div>
-              <ScrollBar orientation="horizontal" className="sm:hidden" />
-            </ScrollArea>
-            <ScrollArea className="w-64 sm:w-auto">
-              <div className="flex sm:flex-col p-2">
-                {Array.from({ length: 12 }, (_, i) => i * 5).map((minute) => (
-                  <Button
-                    key={minute}
-                    size="icon"
-                    variant={
-                      value && value.getMinutes() === minute
-                        ? "default"
-                        : "ghost"
-                    }
-                    className="sm:w-full shrink-0 aspect-square"
-                    onClick={() =>
-                      handleTimeChange("minute", minute.toString())
-                    }
-                  >
-                    {minute}
-                  </Button>
-                ))}
-              </div>
-              <ScrollBar orientation="horizontal" className="sm:hidden" />
-            </ScrollArea>
-            <ScrollArea className="">
-              <div className="flex sm:flex-col p-2">
-                {["AM", "PM"].map((ampm) => (
-                  <Button
-                    key={ampm}
-                    size="icon"
-                    variant={
-                      value &&
-                      ((ampm === "AM" && value.getHours() < 12) ||
-                        (ampm === "PM" && value.getHours() >= 12))
-                        ? "default"
-                        : "ghost"
-                    }
-                    className="sm:w-full shrink-0 aspect-square"
-                    onClick={() => handleTimeChange("ampm", ampm)}
-                  >
-                    {ampm}
-                  </Button>
-                ))}
-              </div>
-            </ScrollArea>
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <div className={cn(className)}>
+      <Input
+        type="datetime-local"
+        value={dateTime}
+        disabled={disabled}
+        onChange={handleChange}
+      />
+    </div>
   );
 }

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -552,12 +552,13 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
                     </div>
 
                     <DateRangePicker
+                      key={`${qParams.date_from}-${qParams.date_to}`}
                       date={{
                         from: qParams.date_from
-                          ? new Date(qParams.date_from)
+                          ? dateQueryString(new Date(qParams.date_from))
                           : undefined,
                         to: qParams.date_to
-                          ? new Date(qParams.date_to)
+                          ? dateQueryString(new Date(qParams.date_to))
                           : undefined,
                       }}
                       onChange={(date) =>

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -124,9 +124,6 @@ h6 {
     width: 10px;
     height: 8px;
 }
-::-webkit-calendar-picker-indicator{
-  margin-left: -20px;
-}
 
 ::-webkit-scrollbar-track {
     background: transparent;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -124,6 +124,9 @@ h6 {
     width: 10px;
     height: 8px;
 }
+::-webkit-calendar-picker-indicator{
+  margin-left: -20px;
+}
 
 ::-webkit-scrollbar-track {
     background: transparent;


### PR DESCRIPTION
## Proposed Changes

- Fixes #11099 
- [x] Modified DateRangePicker to have start and end date along with default date picker
- [x] Modified DateTimePicker to have default datetime picker 
- [x] Modified Date Picker to have default date picker 

@ohcnetwork/care-fe-code-reviewers
<img width="386" alt="Screenshot 2025-03-07 at 11 44 18 PM" src="https://github.com/user-attachments/assets/9e6c359e-eab9-4598-88c5-68329fc90456" />
<img width="386" alt="Screenshot 2025-03-08 at 12 11 54 AM" src="https://github.com/user-attachments/assets/2145053d-d999-471a-aaf9-5972ecbc4dd8" />

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a user validation message to ensure that the end date comes after the start date.
	- Simplified the date selection experience by replacing complex calendar menus with native input fields for dates, date ranges, and date-time.
	- Improved date display and handling across medication requests, medication statements, and appointment scheduling for a more intuitive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->