### PR TITLE
Fixed: Long Usernames Overflow in User Cards #11133

### DIFF
--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -75,7 +75,7 @@ const UserCard = ({ user }: { user: UserBase }) => {
           <div className="flex flex-col min-w-0 flex-1">
             <div className="flex flex-col gap-1">
               <div className="flex items-start justify-between">
-                <h1 className="text-base font-bold break-words pr-2 w-[50%] text-wrap">
+                <h1 className="text-base font-bold break-words pr-2 w-[50%] text-wrap truncate">
                   {user.first_name} {user.last_name}
                 </h1>
                 <span className="text-sm text-gray-500">

--- a/src/pages/Facility/settings/organizations/FacilityOrganizationUsers.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationUsers.tsx
@@ -130,7 +130,7 @@ export default function FacilityOrganizationUsers({ id, facilityId }: Props) {
                         <div className="flex flex-col min-w-0 flex-1">
                           <div className="flex flex-col gap-1">
                             <div className="flex items-start justify-between">
-                              <h1 className="text-base font-bold break-words pr-2">
+                              <h1 className="text-base font-bold break-words pr-2 truncate">
                                 {userRole.user.first_name}{" "}
                                 {userRole.user.last_name}
                               </h1>

--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -174,7 +174,7 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
                       <div className="flex flex-col min-w-0 flex-1">
                         <div className="flex flex-col gap-1">
                           <div className="flex items-start justify-between">
-                            <h1 className="text-base font-bold break-words pr-2">
+                            <h1 className="text-base font-bold break-words pr-2 truncate">
                               {userRole.user.first_name}{" "}
                               {userRole.user.last_name}
                             </h1>


### PR DESCRIPTION
## Proposed Changes
Fixes #11133
Add truncation or word wrapping for long usernames in user cards to prevent overflow and UI breakage.
Implement truncation with ellipsis or wrapping, based on the solution selected.
@ohcnetwork/care-fe-code-reviewers
## Before : 
<img width="1800" alt="Screenshot 2025-03-08 at 11 44 44 PM" src="https://github.com/user-attachments/assets/1adba2f4-6ed9-4595-83d0-16f729e807df" />

## After :
<img width="1800" alt="Screenshot 2025-03-09 at 12 07 34 AM" src="https://github.com/user-attachments/assets/060c3f68-f212-4752-9d56-42f33d6bae1d" />

## Merge Checklist
 Add specs that demonstrate bug / test a new feature.
 Update [product documentation](https://docs.ohc.network/).
 Ensure that UI text is kept in I18n files.
 Prep screenshot or demo video for changelog entry, and attach it to issue.
 Request for Peer Reviews
 Completion of QA in Mobile Devices
 Completion of QA in Desktop Devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted text display across the application to use truncation for long text, ensuring that overflow is handled gracefully with an ellipsis.
  - These improvements provide a cleaner, more consistent layout and improved readability in various sections of the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->