### PR TITLE
Fix: Align loading skeleton with user cards layout

### DIFF
--- a/src/components/Facility/FacilityUsers.tsx
+++ b/src/components/Facility/FacilityUsers.tsx
@@ -48,7 +48,7 @@ export default function FacilityUsers(props: { facilityId: string }) {
   if (userListFetching || !userListData) {
     usersList =
       activeTab === "card" ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
           <CardGridSkeleton count={6} />
         </div>
       ) : (


### PR DESCRIPTION
## Proposed Changes

- Fixes #11183 
- Adjusted the skeleton structure to align with user card dimensions.
- Ensured consistent spacing and layout across different screen sizes.


[Screencast from 2025-03-10 15-20-35.webm](https://github.com/user-attachments/assets/241e1c33-206b-4bce-b4d0-1870012c69a3)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the responsiveness of the loading indicator, ensuring a smoother display on different screen sizes during data fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->