### PR TITLE
fix: Adjust ResourceList grid layout for better responsiveness

### DIFF
--- a/src/components/Resource/ResourceList.tsx
+++ b/src/components/Resource/ResourceList.tsx
@@ -279,7 +279,7 @@ export default function ResourceList({ facilityId }: { facilityId: string }) {
         </div>
 
         <div
-          className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
+          className="grid gap-4 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
           data-cy="resource-list-cards"
         >
           {isLoading ? (


### PR DESCRIPTION
## Proposed Changes

- Fixes #11182 
- Adjusted the grid

## Screenshot

<img width="1000" src="https://github.com/user-attachments/assets/7f1b3d0a-324c-411f-aa50-b86557443e8f" />
<img width="1000" src="https://github.com/user-attachments/assets/e5c04e62-60e2-4e76-b228-4a0057a0e4ee" />
<img width="1000" src="https://github.com/user-attachments/assets/04aaa1e4-777a-4073-bfd3-526063242f85" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the responsive layout for resource cards. On medium screens, resource cards now display in a single column, while on larger screens, the layout adjusts to show two columns and expands to three columns on extra-large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->