### PR TITLE
Fixes: Resetting Input Field In Organisation Tab

### DIFF
--- a/src/pages/Organization/OrganizationView.tsx
+++ b/src/pages/Organization/OrganizationView.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link, useQueryParams } from "raviger";
-import { useState } from "react";
+import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -9,9 +8,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
-import Pagination from "@/components/Common/Pagination";
 import SearchByMultipleFields from "@/components/Common/SearchByMultipleFields";
 import { CardGridSkeleton } from "@/components/Common/SkeletonLoading";
+
+import useFilters from "@/hooks/useFilters";
 
 import query from "@/Utils/request/query";
 import { Organization, getOrgLabel } from "@/types/organization/organization";
@@ -27,10 +27,10 @@ interface Props {
 
 export default function OrganizationView({ id, navOrganizationId }: Props) {
   const { t } = useTranslation();
-
-  const [page, setPage] = useState(1);
-  const limit = 12; // 3x4 grid
-  const [qParams, setQParams] = useQueryParams();
+  const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
+    limit: 15,
+    disableCache: true,
+  });
 
   const searchOptions = [
     {
@@ -41,23 +41,13 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
     },
   ];
 
-  const handleSearch = (_key: string, value: string) => {
-    setPage(1);
-    setQParams({ name: value || null });
-  };
-
-  const handleFieldChange = () => {
-    setPage(1);
-    setQParams({ name: null });
-  };
-
   const { data: children, isFetching } = useQuery({
-    queryKey: ["organization", id, "children", page, limit, qParams.name],
+    queryKey: ["organization", id, "children", qParams, resultsPerPage],
     queryFn: query.debounced(organizationApi.list, {
       queryParams: {
         parent: id,
-        offset: (page - 1) * limit,
-        limit,
+        offset: (qParams.page - 1) * resultsPerPage,
+        limit: resultsPerPage,
         name: qParams.name || undefined,
       },
     }),
@@ -87,8 +77,7 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
               key={id}
               options={searchOptions}
               initialOptionIndex={0}
-              onSearch={handleSearch}
-              onFieldChange={handleFieldChange}
+              onSearch={(value) => updateQuery({ name: value || null })}
               className="w-full"
             />
           </div>
@@ -155,12 +144,7 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
               )}
             </div>
             <div className="flex justify-center">
-              <Pagination
-                data={{ totalCount: children?.count || 0 }}
-                onChange={(page) => setPage(page)}
-                defaultPerPage={limit}
-                cPage={page}
-              />
+              <Pagination totalCount={children?.count || 0} />
             </div>
           </div>
         )}

--- a/src/pages/Organization/OrganizationView.tsx
+++ b/src/pages/Organization/OrganizationView.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "raviger";
-import { useEffect, useState } from "react";
+import { Link, useQueryParams } from "raviger";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -8,12 +8,10 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 
 import Pagination from "@/components/Common/Pagination";
+import SearchByMultipleFields from "@/components/Common/SearchByMultipleFields";
 import { CardGridSkeleton } from "@/components/Common/SkeletonLoading";
-
-import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 
 import query from "@/Utils/request/query";
 import { Organization, getOrgLabel } from "@/types/organization/organization";
@@ -31,23 +29,40 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
   const { t } = useTranslation();
 
   const [page, setPage] = useState(1);
-  const [searchQuery, setSearchQuery] = useState("");
+  const limit = 12; // 3x4 grid
+  const [qParams, setQParams] = useQueryParams();
+
+  const searchOptions = [
+    {
+      key: "name",
+      type: "text" as const,
+      placeholder: t("search_by_name"),
+      value: qParams.name || "",
+    },
+  ];
+
+  const handleSearch = (_key: string, value: string) => {
+    setPage(1);
+    setQParams({ name: value || null });
+  };
+
+  const handleFieldChange = () => {
+    setPage(1);
+    setQParams({ name: null });
+  };
 
   const { data: children, isFetching } = useQuery({
-    queryKey: ["organization", id, "children", page, searchQuery],
+    queryKey: ["organization", id, "children", page, limit, qParams.name],
     queryFn: query.debounced(organizationApi.list, {
       queryParams: {
         parent: id,
-        offset: (page - 1) * RESULTS_PER_PAGE_LIMIT,
-        limit: RESULTS_PER_PAGE_LIMIT,
-        name: searchQuery || undefined,
+        offset: (page - 1) * limit,
+        limit,
+        name: qParams.name || undefined,
       },
     }),
+    enabled: !!id,
   });
-
-  useEffect(() => {
-    setPage(1);
-  }, [id, searchQuery]);
 
   // Hack for the sidebar to work
   const baseUrl = navOrganizationId
@@ -67,13 +82,13 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
             />
           </div>
           <div className="w-72">
-            <Input
-              placeholder="Search by name..."
-              value={searchQuery}
-              onChange={(e) => {
-                setSearchQuery(e.target.value);
-                setPage(1); // Reset to first page on search
-              }}
+            <SearchByMultipleFields
+              id="organization-search"
+              key={id}
+              options={searchOptions}
+              initialOptionIndex={0}
+              onSearch={handleSearch}
+              onFieldChange={handleFieldChange}
               className="w-full"
             />
           </div>
@@ -88,24 +103,37 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {children?.results?.length ? (
                 children.results.map((orgChild: Organization) => (
-                  <Card key={orgChild.id} className="flex flex-col h-full">
-                    <CardContent className="p-6 flex-grow">
-                      <div className="space-y-4 flex-grow">
-                        <div className="space-y-1 mb-2">
-                          <h3 className="text-lg font-semibold">
-                            {orgChild.name}
-                          </h3>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="outline">{orgChild.org_type}</Badge>
-                            {orgChild.metadata?.govt_org_type && (
+                  <Card key={orgChild.id}>
+                    <CardContent className="p-6">
+                      <div className="space-y-4">
+                        <div className="flex items-center justify-between flex-wrap">
+                          <div className="space-y-1 mb-2">
+                            <h3 className="text-lg font-semibold">
+                              {orgChild.name}
+                            </h3>
+                            <div className="flex items-center gap-2">
                               <Badge variant="outline">
-                                {getOrgLabel(
-                                  orgChild.org_type,
-                                  orgChild.metadata,
-                                )}
+                                {orgChild.org_type}
                               </Badge>
-                            )}
+                              {orgChild.metadata?.govt_org_type && (
+                                <Badge variant="outline">
+                                  {getOrgLabel(
+                                    orgChild.org_type,
+                                    orgChild.metadata,
+                                  )}
+                                </Badge>
+                              )}
+                            </div>
                           </div>
+                          <Button variant="link" asChild>
+                            <Link href={`${baseUrl}/children/${orgChild.id}`}>
+                              {t("view_details")}
+                              <CareIcon
+                                icon="l-arrow-right"
+                                className="h-4 w-4"
+                              />
+                            </Link>
+                          </Button>
                         </div>
                         {orgChild.description && (
                           <p className="text-sm text-gray-500 line-clamp-2">
@@ -114,36 +142,26 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
                         )}
                       </div>
                     </CardContent>
-                    <div className="p-4 pt-0 mt-auto text-end">
-                      <Button variant="link" asChild>
-                        <Link href={`${baseUrl}/children/${orgChild.id}`}>
-                          {t("view_details")}
-                          <CareIcon icon="l-arrow-right" className="h-4 w-4" />
-                        </Link>
-                      </Button>
-                    </div>
                   </Card>
                 ))
               ) : (
                 <Card className="col-span-full">
                   <CardContent className="p-6 text-center text-gray-500">
-                    {searchQuery
+                    {qParams.name
                       ? t("no_organizations_found")
                       : t("no_sub_organizations_found")}
                   </CardContent>
                 </Card>
               )}
             </div>
-            {children && children.count > RESULTS_PER_PAGE_LIMIT && (
-              <div className="flex justify-center">
-                <Pagination
-                  data={{ totalCount: children.count }}
-                  onChange={(page, _) => setPage(page)}
-                  defaultPerPage={RESULTS_PER_PAGE_LIMIT}
-                  cPage={page}
-                />
-              </div>
-            )}
+            <div className="flex justify-center">
+              <Pagination
+                data={{ totalCount: children?.count || 0 }}
+                onChange={(page) => setPage(page)}
+                defaultPerPage={limit}
+                cPage={page}
+              />
+            </div>
           </div>
         )}
       </div>

--- a/src/pages/Organization/OrganizationView.tsx
+++ b/src/pages/Organization/OrganizationView.tsx
@@ -62,7 +62,7 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
   return (
     <OrganizationLayout id={id} navOrganizationId={navOrganizationId}>
       <div className="space-y-6">
-        <div className="flex flex-col justify-between items-start gap-4">
+        <div className="justify-between items-center flex flex-wrap">
           <div className="mt-1 flex flex-col justify-start space-y-2 md:flex-row md:justify-between md:space-y-0">
             <EntityBadge
               title={t("organizations")}
@@ -71,16 +71,16 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
               translationParams={{ entity: "Organization" }}
             />
           </div>
-          <div className="w-72">
-            <SearchByMultipleFields
-              id="organization-search"
-              key={id}
-              options={searchOptions}
-              initialOptionIndex={0}
-              onSearch={(value) => updateQuery({ name: value || null })}
-              className="w-full"
-            />
-          </div>
+        </div>
+        <div className="flex gap-2">
+          <SearchByMultipleFields
+            id="organization-search"
+            key={id}
+            options={searchOptions}
+            initialOptionIndex={0}
+            onSearch={(value) => updateQuery({ name: value || null })}
+            className="w-full"
+          />
         </div>
 
         {isFetching ? (


### PR DESCRIPTION
## Proposed Changes

- Fixes #10783 
- Added SearchByMultipleFields

@ohcnetwork/care-fe-code-reviewers

https://github.com/user-attachments/assets/417cb944-3fa3-4269-9a94-9c7884e442a0


## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality in the Organization view, now utilizing a more efficient query management system.
	- Pagination limit set to 15, improving the browsing experience.
- **Refactor**
	- Simplified the logic for search and pagination, resulting in improved clarity and efficiency in the Organization view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->