### PR TITLE
Add datetime to Appointment Cards in Appointments Page

### DIFF
--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -67,6 +67,7 @@ import query from "@/Utils/request/query";
 import { useView } from "@/Utils/useView";
 import {
   dateQueryString,
+  formatDateTime,
   formatDisplayName,
   formatPatientAge,
 } from "@/Utils/utils";
@@ -663,6 +664,12 @@ function AppointmentCard({ appointment }: { appointment: Appointment }) {
             {formatPatientAge(patient as any, true)},{" "}
             {t(`GENDER__${patient.gender}`)}
           </p>
+          <p className="text-xs text-gray-500 mt-1">
+            {formatDateTime(
+              appointment.token_slot.start_datetime,
+              "ddd, DD MMM YYYY, HH:mm",
+            )}
+          </p>
         </div>
 
         <div className="bg-gray-100 px-2 py-1 rounded text-center">
@@ -676,6 +683,7 @@ function AppointmentCard({ appointment }: { appointment: Appointment }) {
     </div>
   );
 }
+
 function AppointmentRow(props: {
   facilityId: string;
   page: number | null;


### PR DESCRIPTION
## Proposed Changes

- Add datetime to Appointment Cards in Appointments Page

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced appointment cards by adding a clearly styled display of the appointment’s start date and time, ensuring users can easily see when appointments are scheduled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->