### PR TITLE
Improve autocomplete experience ✨ on iOS mobiles 📱

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no, interactive-widget=resizes-content"
     />
     <title>%REACT_APP_TITLE%</title>
     <meta name="description" content="%REACT_APP_META_DESCRIPTION%" />

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no, interactive-widget=resizes-content"
+      content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, interactive-widget=resizes-content"
     />
     <title>%REACT_APP_TITLE%</title>
     <meta name="description" content="%REACT_APP_META_DESCRIPTION%" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.1.3",
         "@radix-ui/react-collapsible": "^1.1.2",
-        "@radix-ui/react-dialog": "^1.1.4",
+        "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.1",
@@ -81,6 +81,7 @@
         "tailwind-merge": "^3.0.0",
         "tailwindcss-animate": "^1.0.7",
         "use-keyboard-shortcut": "^1.1.6",
+        "vaul": "^1.1.2",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -18993,6 +18994,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/verror": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-collapsible": "^1.1.2",
-    "@radix-ui/react-dialog": "^1.1.4",
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.1",
@@ -121,6 +121,7 @@
     "tailwind-merge": "^3.0.0",
     "tailwindcss-animate": "^1.0.7",
     "use-keyboard-shortcut": "^1.1.6",
+    "vaul": "^1.1.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Command,
-  CommandDialog,
+  CommandDrawer,
   CommandEmpty,
   CommandGroup,
   CommandInput,
@@ -77,6 +77,7 @@ export default function ValueSetSelect({
         placeholder={placeholder}
         className="outline-none border-none ring-0 shadow-none"
         onValueChange={setSearch}
+        autoFocus
       />
       <CommandList>
         <CommandEmpty>
@@ -128,9 +129,9 @@ export default function ValueSetSelect({
           <span>{value?.display || placeholder}</span>
           <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
         </Button>
-        <CommandDialog open={internalOpen} onOpenChange={setInternalOpen}>
+        <CommandDrawer open={internalOpen} onOpenChange={setInternalOpen}>
           {content}
-        </CommandDialog>
+        </CommandDrawer>
       </>
     );
   }

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Command,
-  CommandDialog,
+  CommandDrawer,
   CommandEmpty,
   CommandGroup,
   CommandInput,
@@ -62,6 +62,7 @@ export default function Autocomplete({
         disabled={disabled}
         onValueChange={onSearch}
         className="outline-none border-none ring-0 shadow-none"
+        autoFocus
       />
       <CommandList>
         <CommandEmpty>{noOptionsMessage}</CommandEmpty>
@@ -117,9 +118,9 @@ export default function Autocomplete({
           </span>
           <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
         </Button>
-        <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandDrawer open={open} onOpenChange={setOpen}>
           {commandContent}
-        </CommandDialog>
+        </CommandDrawer>
       </>
     );
   }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -31,6 +32,21 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
         </Command>
       </DialogContent>
     </Dialog>
+  );
+};
+
+const CommandDrawer = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof Drawer>) => {
+  return (
+    <Drawer {...props}>
+      <DrawerContent className="max-h-[85vh] mx-2 rounded-md">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-gray-500 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 dark:[&_[cmdk-group-heading]]:text-gray-400">
+          {children}
+        </Command>
+      </DrawerContent>
+    </Drawer>
   );
 };
 
@@ -143,6 +159,7 @@ CommandShortcut.displayName = "CommandShortcut";
 export {
   Command,
   CommandDialog,
+  CommandDrawer,
   CommandInput,
   CommandList,
   CommandEmpty,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -60,7 +60,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-10 w-full focus:border-none rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-gray-400",
+        "flex h-10 w-full focus:border-none rounded-md bg-transparent py-3 text-base sm:text-sm outline-none placeholder:text-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-gray-400",
         className,
       )}
       {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -41,7 +41,7 @@ const CommandDrawer = ({
 }: React.ComponentProps<typeof Drawer>) => {
   return (
     <Drawer {...props}>
-      <DrawerContent className="max-h-[85vh] mx-2 rounded-md">
+      <DrawerContent className="max-h-[85vh] mx-2 rounded-t-md">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-gray-500 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 dark:[&_[cmdk-group-heading]]:text-gray-400">
           {children}
         </Command>

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+);
+Drawer.displayName = "Drawer";
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+        className,
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-gray-100 dark:bg-gray-800" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+);
+DrawerHeader.displayName = "DrawerHeader";
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-gray-500 dark:text-gray-400", className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};


### PR DESCRIPTION
## Proposed Changes

- For autocompletes on mobile displays, used shadcn's CommandDrawer instead of CommandDialog.
- This fixes the issue on iOS devices where the previous CommandDialog would have it's options behind the keyboard when keyboard is opened up.
- Prevent iOS from automatically zooming due to font-size below 16px on command's input (Refer: https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone)
- Closes #11215

https://github.com/user-attachments/assets/07b5ee3a-ac97-4b99-838b-f262425da1b0


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced interactive elements now slide in as panels for streamlined selection and autocomplete interactions.
	- Input fields automatically gain focus upon activation for a smoother user experience.
	- Introduced new components for a Drawer UI element, enhancing the overall interface.
- **Chores**
	- Updated and added underlying dependencies to enhance performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->