### PR TITLE
Restore-mechanism added in Patient registration #11220

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -67,6 +67,9 @@ export const BLOOD_GROUPS = BLOOD_GROUP_CHOICES.map((bg) => bg.id) as [
   (typeof BLOOD_GROUP_CHOICES)[number]["id"],
 ];
 
+const FORM_STORAGE_KEY = "patient_registration_form_data";
+const AUTO_SAVE_INTERVAL = 5000; // Save every 5 seconds
+
 export default function PatientRegistration(
   props: PatientRegistrationPageProps,
 ) {
@@ -146,6 +149,50 @@ export default function PatientRegistration(
     [], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
+  const saveFormToStorage = (data: any) => {
+    try {
+      localStorage.setItem(
+        `${FORM_STORAGE_KEY}_${facilityId}`,
+        JSON.stringify({
+          timestamp: new Date().getTime(),
+          data: data,
+          facilityId: facilityId,
+        }),
+      );
+    } catch (error) {
+      console.error("Error saving form data to localStorage:", error);
+    }
+  };
+
+  const restoreFormFromStorage = () => {
+    try {
+      const stored = localStorage.getItem(`${FORM_STORAGE_KEY}_${facilityId}`);
+      if (stored) {
+        const {
+          timestamp,
+          data,
+          facilityId: storedFacilityId,
+        } = JSON.parse(stored);
+        const isValid = new Date().getTime() - timestamp < 24 * 60 * 60 * 1000;
+        const isSameFacility = storedFacilityId === facilityId;
+        if (isValid && isSameFacility && !patientId) {
+          return data;
+        }
+      }
+    } catch (error) {
+      console.error("Error restoring form data from localStorage:", error);
+    }
+    return null;
+  };
+
+  const clearStoredFormData = () => {
+    try {
+      localStorage.removeItem(`${FORM_STORAGE_KEY}_${facilityId}`);
+    } catch (error) {
+      console.error("Error clearing form data from localStorage:", error);
+    }
+  };
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -155,13 +202,27 @@ export default function PatientRegistration(
       age_or_dob: "dob",
       same_phone_number: false,
       same_address: true,
+      ...restoreFormFromStorage(),
     },
   });
+
+  useEffect(() => {
+    if (patientId) return;
+    const autoSaveInterval = setInterval(() => {
+      const formData = form.getValues();
+      if (form.formState.isDirty) {
+        saveFormToStorage(formData);
+      }
+    }, AUTO_SAVE_INTERVAL);
+
+    return () => clearInterval(autoSaveInterval);
+  }, [form, patientId]);
 
   const { mutate: createPatient, isPending: isCreatingPatient } = useMutation({
     mutationKey: ["create_patient"],
     mutationFn: mutate(routes.addPatient),
     onSuccess: (resp: PatientModel) => {
+      clearStoredFormData();
       toast.success(t("patient_registration_success"));
       // Lets navigate the user to the verify page as the patient is not accessible to the user yet
       navigate(`/facility/${facilityId}/patients/verify`, {


### PR DESCRIPTION
Fixes #11220 

Approach :
As per the problem, for storing or persisting data in browser local storage API can be used.

Implementation :

After some seconds (currently 5), the data will be automatically stored inside localstorage with facility-specific key to prevent data mixing between facilities

On page reload, the data will be fetched from localstorage using that facility-key and rendered in form inputs.

if data becomes older than 24 hours, then it will not render on form

Video :
This is the working video of it (not able to attach here due to space limitation)
[demo video](https://drive.google.com/file/d/1snqIcssJoOk5oGynWXuNOqzhx8UAWNQi/view?usp=sharing)

@ohcnetwork/care-fe-code-reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an auto-save functionality for the patient registration form that periodically preserves your input data in your browser.
  - Enabled form data restoration if you return with unsaved changes, ensuring a smooth and reliable registration experience.
  - Auto-saved data is cleared once a patient registration is successfully completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->