### PR TITLE
Scroll restoration at top of page in mobile view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { Toaster } from "@/components/ui/toaster";
 
 import Loading from "@/components/Common/Loading";
+import { ScrollRestoration } from "@/components/Common/ScrollRestoration";
 
 import Integrations from "@/Integrations";
 import PluginEngine from "@/PluginEngine";
@@ -54,6 +55,7 @@ const App = () => {
           <PubSubProvider>
             <PluginEngine>
               <HistoryAPIProvider>
+                <ScrollRestoration />
                 <AuthUserProvider
                   unauthorized={<Routers.PublicRouter />}
                   otpAuthorized={<Routers.PatientRouter />}

--- a/src/components/Common/ScrollRestoration.tsx
+++ b/src/components/Common/ScrollRestoration.tsx
@@ -5,25 +5,12 @@ export function ScrollRestoration() {
   const pathname = usePath();
 
   useEffect(() => {
-    const scrollToTop = () => {
+    requestAnimationFrame(() => {
       window.scrollTo(0, 0);
 
-      // Try scrolling the main container if it exists
-      const mainContent = document.getElementById("pages");
-      if (mainContent) {
-        mainContent.scrollTo(0, 0);
-      }
-    };
-
-    requestAnimationFrame(scrollToTop);
-
-    // Optional: Fallback after load event if content loading is delayed
-    const onLoad = () => scrollToTop();
-    window.addEventListener("load", onLoad);
-
-    return () => {
-      window.removeEventListener("load", onLoad);
-    };
+      // scroll to top of the container if exists
+      document.getElementById("pages")?.scrollTo(0, 0);
+    });
   }, [pathname]);
 
   return null;

--- a/src/components/Common/ScrollRestoration.tsx
+++ b/src/components/Common/ScrollRestoration.tsx
@@ -1,0 +1,30 @@
+import { usePath } from "raviger";
+import { useEffect } from "react";
+
+export function ScrollRestoration() {
+  const pathname = usePath();
+
+  useEffect(() => {
+    const scrollToTop = () => {
+      window.scrollTo(0, 0);
+
+      // Try scrolling the main container if it exists
+      const mainContent = document.getElementById("pages");
+      if (mainContent) {
+        mainContent.scrollTo(0, 0);
+      }
+    };
+
+    requestAnimationFrame(scrollToTop);
+
+    // Optional: Fallback after load event if content loading is delayed
+    const onLoad = () => scrollToTop();
+    window.addEventListener("load", onLoad);
+
+    return () => {
+      window.removeEventListener("load", onLoad);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -67,6 +67,9 @@ export const BLOOD_GROUPS = BLOOD_GROUP_CHOICES.map((bg) => bg.id) as [
   (typeof BLOOD_GROUP_CHOICES)[number]["id"],
 ];
 
+const FORM_STORAGE_KEY = "patient_registration_form_data";
+const AUTO_SAVE_INTERVAL = 5000; // Save every 5 seconds
+
 export default function PatientRegistration(
   props: PatientRegistrationPageProps,
 ) {
@@ -146,6 +149,50 @@ export default function PatientRegistration(
     [], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
+  const saveFormToStorage = (data: any) => {
+    try {
+      localStorage.setItem(
+        `${FORM_STORAGE_KEY}_${facilityId}`,
+        JSON.stringify({
+          timestamp: new Date().getTime(),
+          data: data,
+          facilityId: facilityId,
+        }),
+      );
+    } catch (error) {
+      console.error("Error saving form data to localStorage:", error);
+    }
+  };
+
+  const restoreFormFromStorage = () => {
+    try {
+      const stored = localStorage.getItem(`${FORM_STORAGE_KEY}_${facilityId}`);
+      if (stored) {
+        const {
+          timestamp,
+          data,
+          facilityId: storedFacilityId,
+        } = JSON.parse(stored);
+        const isValid = new Date().getTime() - timestamp < 24 * 60 * 60 * 1000;
+        const isSameFacility = storedFacilityId === facilityId;
+        if (isValid && isSameFacility && !patientId) {
+          return data;
+        }
+      }
+    } catch (error) {
+      console.error("Error restoring form data from localStorage:", error);
+    }
+    return null;
+  };
+
+  const clearStoredFormData = () => {
+    try {
+      localStorage.removeItem(`${FORM_STORAGE_KEY}_${facilityId}`);
+    } catch (error) {
+      console.error("Error clearing form data from localStorage:", error);
+    }
+  };
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -155,13 +202,27 @@ export default function PatientRegistration(
       age_or_dob: "dob",
       same_phone_number: false,
       same_address: true,
+      ...restoreFormFromStorage(),
     },
   });
+
+  useEffect(() => {
+    if (patientId) return;
+    const autoSaveInterval = setInterval(() => {
+      const formData = form.getValues();
+      if (form.formState.isDirty) {
+        saveFormToStorage(formData);
+      }
+    }, AUTO_SAVE_INTERVAL);
+
+    return () => clearInterval(autoSaveInterval);
+  }, [form, patientId]);
 
   const { mutate: createPatient, isPending: isCreatingPatient } = useMutation({
     mutationKey: ["create_patient"],
     mutationFn: mutate(routes.addPatient),
     onSuccess: (resp: PatientModel) => {
+      clearStoredFormData();
       toast.success(t("patient_registration_success"));
       // Lets navigate the user to the verify page as the patient is not accessible to the user yet
       navigate(`/facility/${facilityId}/patients/verify`, {


### PR DESCRIPTION

Fixes #11212 

Approach :
Scroll behavior or restoration can be handled using DOM APIs and specifically **window** object in it.

Implementation :

(1) Added ScrollRestoration.tsx file contains smooth scroll to the top of the view function
(2) uses window object to set the coordinate of viewport to top (0, 0)
(3) this should happen when page loads or url changes detected by usePath() hook in 'raviger' module

woking demo :
https://github.com/user-attachments/assets/4dcec867-266b-4a29-be5e-ade66e86d3c1


@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced auto-save and data restoration in the patient registration form, ensuring user entries are not lost during interruptions.
  - Enabled scroll restoration across the application, improving navigation experience.

- **Refactor**
  - Streamlined the scroll restoration logic for a cleaner and more efficient behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->