### PR TITLE
fix(ci): update Node.js version in Cypress workflow

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0-13265982013"
+          node-version: "22.14.0"
 
       - name: Install dependencies 📦
         run: npm ci

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.11.0"
+          node-version: "22.14.0"
 
       - name: Install dependencies 📦
         run: npm ci

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "22.11.0"
 
       - name: Install dependencies 📦
         run: npm ci


### PR DESCRIPTION
**Signed-off-by:** Areeb Ahmed [areebshariff@acm.org](mailto:areenshariff@acm.org)

## Summary of Changes
**Fixes:** #11242

- Fixed invalid Node.js version for arm64 runners (ubuntu-24.04-arm)
- Previous [Renovate bot commit](https://github.com/ohcnetwork/care_fe/commit/38b38583a88dfac791ac0732c1d680b56112345b) broke the Cypress workflow  

**NOTE**: Apparently, the LTS version of Node (22.14.0) is causing issues too. Reverting to 22.11.0 since that was originally working. (Error on [patient_creation.cy.ts](https://github.com/ohcnetwork/care_fe/actions/runs/13800571545))

Screenshot:

<img width="847" alt="{63E8935B-18DD-4AF8-8072-9DF68A8E80BB}" src="https://github.com/user-attachments/assets/0e08ddc2-c5fe-4f88-ac92-659c30a6b2f0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Refined the automation setup by updating the Node.js version for improved consistency in testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->