### PR TITLE
Fix Facility Name Display, Alignment Issues in Appointment Card & Removed Extra spans from Buttons

### DIFF
--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -186,7 +186,6 @@ function PatientIndex() {
           <span className="text-xl font-bold">{t("appointments")}</span>
           <Button variant="primary_gradient" className="sticky right-0" asChild>
             <Link href="/facilities">
-              <span className="bg-gradient-to-b from-white/15 to-transparent"></span>
               <span>{t("book_appointment")}</span>
             </Link>
           </Button>

--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -121,21 +121,22 @@ function PatientIndex() {
               setAppointmentDialogOpen(true);
             }}
           >
-            <span className="bg-gradient-to-b from-white/15 to-transparent"></span>
             <span>{t("view_details")}</span>
           </Button>
         </CardHeader>
         <CardContent className="mt-2 pt-2 px-6 pb-3">
-          <div className="flex flex-col md:flex-row gap-2 justify-between">
-            <div className="flex flex-row md:flex-col gap-2 md:gap-0">
+          <div className="flex flex-col md:flex-row gap-2 justify-between md:justify-start">
+            <div className="flex flex-row md:flex-col gap-2 md:gap-0 md:flex-grow md:mr-8">
               <span className="text-xs font-medium">{t("location")}: </span>
-              <span className="text-sm">{"Facility Location"}</span>
+              <span className="text-sm">
+                {appointment.facility?.name || "Unknown Facility"}
+              </span>
             </div>
-            <div className="flex flex-row md:flex-col gap-2 md:gap-0 items-center md:items-start">
+            <div className="flex flex-row md:flex-col gap-2 md:gap-0 items-center md:items-start md:flex-none md:w-[80px] md:mr-8">
               <span className="text-xs font-medium">{t("status")}: </span>
               <span>{getStatusChip(appointment.status)}</span>
             </div>
-            <div className="flex flex-row gap-3 justify-between">
+            <div className="flex flex-row gap-3 justify-between md:flex-none md:w-[170px]">
               <div className="flex flex-row md:flex-col gap-2 md:gap-0">
                 <span className="text-xs font-medium">{t("date")}: </span>
                 <span className="text-sm">{appointmentDate}</span>

--- a/src/pages/PublicAppointments/Schedule.tsx
+++ b/src/pages/PublicAppointments/Schedule.tsx
@@ -341,7 +341,6 @@ export function ScheduleAppointment(props: AppointmentsProps) {
                 }
               }}
             >
-              <span className="bg-gradient-to-b from-white/15 to-transparent"></span>
               {appointmentId ? t("reschedule_appointment") : t("continue")}
               <CareIcon icon="l-arrow-right" className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11179 
- Updated facility location to display the actual facility name.
- Removed extra <span> from buttons: " view details", "book appointment", "reschedule appointment->"
- Corrected alignment for location, status, and time sections on the appointment card for improved responsiveness on middle screen and larger devices.

Before:
![Screenshot 2025-03-10 131154](https://github.com/user-attachments/assets/c966abbf-c7b3-414f-afe9-77568e81c81a)

After:
![Screenshot 2025-03-13 191314](https://github.com/user-attachments/assets/54e5c1a1-c0fb-4cbe-bd43-d00fa301c8be)

@rithviknishad @Jacobjeevan made the changes for removing the extra span in this PR itself.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Appointment details now display facility names dynamically, defaulting to "Unknown Facility" when necessary.
- **Style**
	- Improved layout responsiveness for appointment details on medium and larger screens.
	- Refined the appearance of the scheduling button by removing the background gradient effect while maintaining functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->