### PR TITLE
Fix : Country Selection Additional Click

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -36,14 +36,8 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
   React.forwardRef<React.ElementRef<typeof RPNInput.default>, PhoneInputProps>(
     ({ className, onChange, ...props }, ref) => {
       const getCountryFromNumber = (phoneNumber: string) => {
-        try {
-          return (
-            RPNInput.parsePhoneNumber(phoneNumber)?.country ||
-            careConfig.defaultCountry
-          );
-        } catch {
-          return careConfig.defaultCountry;
-        }
+        const parsedNumber = RPNInput.parsePhoneNumber(phoneNumber);
+        return parsedNumber?.country || careConfig.defaultCountry;
       };
 
       const [selectedCountry, setSelectedCountry] =

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -32,25 +32,31 @@ type PhoneInputProps = Omit<
     onChange?: (value: RPNInput.Value) => void;
   };
 
+const getCountryFromNumber = (
+  phoneNumber: string | undefined,
+): RPNInput.Country => {
+  if (!phoneNumber) {
+    return careConfig.defaultCountry as RPNInput.Country;
+  }
+  const parsedNumber = RPNInput.parsePhoneNumber(phoneNumber);
+  return (
+    parsedNumber?.country || (careConfig.defaultCountry as RPNInput.Country)
+  );
+};
+
 const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
   React.forwardRef<React.ElementRef<typeof RPNInput.default>, PhoneInputProps>(
     ({ className, onChange, ...props }, ref) => {
-      const getCountryFromNumber = (phoneNumber: string) => {
-        const parsedNumber = RPNInput.parsePhoneNumber(phoneNumber);
-        return parsedNumber?.country || careConfig.defaultCountry;
-      };
-
       const [selectedCountry, setSelectedCountry] =
         React.useState<RPNInput.Country>(
-          props.value
-            ? (getCountryFromNumber(props.value as string) as RPNInput.Country)
-            : (careConfig.defaultCountry as RPNInput.Country),
+          getCountryFromNumber(props.value as string | undefined),
         );
+
       React.useEffect(() => {
         if (props.value) {
           const detectedCountry = getCountryFromNumber(props.value as string);
           if (detectedCountry && detectedCountry !== selectedCountry) {
-            setSelectedCountry(detectedCountry as RPNInput.Country);
+            setSelectedCountry(detectedCountry);
           }
         }
       }, [props.value]);

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -88,6 +88,15 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
           inputComponent={InputComponent}
           defaultCountry={careConfig.defaultCountry}
           smartCaret={true}
+          /**
+           * Handles the onChange event.
+           *
+           * react-phone-number-input might trigger the onChange event as undefined
+           * when a valid phone number is not entered. To prevent this,
+           * the value is coerced to an empty string.
+           *
+           * @param {E164Number | undefined} value - The entered value
+           */
           country={selectedCountry}
           onChange={(value) => onChange?.(value || ("" as RPNInput.Value))}
           {...props}

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -35,6 +35,37 @@ type PhoneInputProps = Omit<
 const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
   React.forwardRef<React.ElementRef<typeof RPNInput.default>, PhoneInputProps>(
     ({ className, onChange, ...props }, ref) => {
+      const getCountryFromNumber = (phoneNumber: string) => {
+        try {
+          return (
+            RPNInput.parsePhoneNumber(phoneNumber)?.country ||
+            careConfig.defaultCountry
+          );
+        } catch {
+          return careConfig.defaultCountry;
+        }
+      };
+
+      const [selectedCountry, setSelectedCountry] =
+        React.useState<RPNInput.Country>(
+          props.value
+            ? (getCountryFromNumber(props.value as string) as RPNInput.Country)
+            : (careConfig.defaultCountry as RPNInput.Country),
+        );
+      React.useEffect(() => {
+        if (props.value) {
+          const detectedCountry = getCountryFromNumber(props.value as string);
+          if (detectedCountry && detectedCountry !== selectedCountry) {
+            setSelectedCountry(detectedCountry as RPNInput.Country);
+          }
+        }
+      }, [props.value]);
+
+      const handleCountryChange = (country: RPNInput.Country) => {
+        setSelectedCountry(country);
+        onChange?.("" as RPNInput.Value);
+      };
+
       return (
         <RPNInput.default
           ref={ref}
@@ -47,19 +78,17 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
               : "ring-primary-700",
           )}
           flagComponent={FlagComponent}
-          countrySelectComponent={CountrySelect}
+          countrySelectComponent={(countrySelectProps) => (
+            <CountrySelect
+              {...countrySelectProps}
+              onChange={handleCountryChange}
+              value={selectedCountry}
+            />
+          )}
           inputComponent={InputComponent}
           defaultCountry={careConfig.defaultCountry}
           smartCaret={true}
-          /**
-           * Handles the onChange event.
-           *
-           * react-phone-number-input might trigger the onChange event as undefined
-           * when a valid phone number is not entered. To prevent this,
-           * the value is coerced to an empty string.
-           *
-           * @param {E164Number | undefined} value - The entered value
-           */
+          country={selectedCountry}
           onChange={(value) => onChange?.(value || ("" as RPNInput.Value))}
           {...props}
         />
@@ -136,13 +165,25 @@ const CountrySelect = ({
               <CommandGroup>
                 {countryList.map(({ value, label }) =>
                   value ? (
-                    <CountrySelectOption
+                    <CommandItem
                       key={value}
-                      country={value}
-                      countryName={label}
-                      selectedCountry={selectedCountry}
-                      onChange={onChange}
-                    />
+                      onSelect={() => onChange(value)}
+                      className="gap-2"
+                    >
+                      <FlagComponent country={value} countryName={label} />
+                      <span className="flex-1 text-sm">{label}</span>
+                      <span className="text-sm text-foreground/50">
+                        {`+${RPNInput.getCountryCallingCode(value)}`}
+                      </span>
+                      <CheckIcon
+                        className={cn(
+                          "ml-auto size-4",
+                          value === selectedCountry
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                    </CommandItem>
                   ) : null,
                 )}
               </CommandGroup>
@@ -151,29 +192,6 @@ const CountrySelect = ({
         </Command>
       </PopoverContent>
     </Popover>
-  );
-};
-
-interface CountrySelectOptionProps extends RPNInput.FlagProps {
-  selectedCountry: RPNInput.Country;
-  onChange: (country: RPNInput.Country) => void;
-}
-
-const CountrySelectOption = ({
-  country,
-  countryName,
-  selectedCountry,
-  onChange,
-}: CountrySelectOptionProps) => {
-  return (
-    <CommandItem className="gap-2" onSelect={() => onChange(country)}>
-      <FlagComponent country={country} countryName={countryName} />
-      <span className="flex-1 text-sm">{countryName}</span>
-      <span className="text-sm text-foreground/50">{`+${RPNInput.getCountryCallingCode(country)}`}</span>
-      <CheckIcon
-        className={`ml-auto size-4 ${country === selectedCountry ? "opacity-100" : "opacity-0"}`}
-      />
-    </CommandItem>
   );
 };
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #11265
* Reflect the country code without requiring additional Click.
* Clear the input field when switched to other country.
* Reflect the country code after Updating the role.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.

- [x] Completion of QA in Mobile Devices




https://github.com/user-attachments/assets/4be0f89c-ab69-4973-8ad0-b6c0ac32406d



- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the phone input component with automatic country detection, ensuring the displayed country adjusts in real-time based on the entered number.
  - Improved manual country selection, so user changes are quickly reflected in the input field.

- **Refactor**
  - Streamlined the country selection interface for a more cohesive and responsive user experience.
  - Simplified rendering of country options by integrating functionality directly into the selection component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->