### PR TITLE
fix ui breakout  of list view of user's in user tab

### DIFF
--- a/src/components/Facility/FacilityUsers.tsx
+++ b/src/components/Facility/FacilityUsers.tsx
@@ -114,7 +114,7 @@ export default function FacilityUsers(props: { facilityId: string }) {
           </TabsList>
         </Tabs>
       </div>
-      <div>{usersList}</div>
+      <div className="overflow-x-auto overflow-y-hidden">{usersList}</div>
     </Page>
   );
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes #11279 
 -add overflow-x-auto to enable horizontal scrolling when content overflow screen size and also add overflow-y-hidden because when enable horizontal scrolling by default one more vertical scrollbar was also  appearing  which is not need so to disappear that  overflow-y-hidden  is also added.


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the users list display for improved layout, enabling horizontal scrolling and hiding vertical overflow for a cleaner view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->