### PR TITLE
fix: Add min-width to user cards for responsiveness #11272

### DIFF
--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -2,8 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "raviger";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { formatPhoneNumberIntl } from "react-phone-number-input";
-import { isValidPhoneNumber } from "react-phone-number-input";
+import {
+  formatPhoneNumberIntl,
+  isValidPhoneNumber,
+} from "react-phone-number-input";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
@@ -53,18 +55,19 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
     },
   ];
 
-  const handleSearch = useCallback((key: string, value: string) => {
-    const searchParams = {
-      name: key === "username" ? value : "",
-      phone_number:
-        key === "phone_number"
-          ? isValidPhoneNumber(value)
+  const handleSearch = useCallback(
+    (key: string, value: string) => {
+      const searchParams = {
+        name: key === "username" ? value : "",
+        phone_number:
+          key === "phone_number" && isValidPhoneNumber(value)
             ? value
-            : undefined
-          : undefined,
-    };
-    updateQuery(searchParams);
-  }, []);
+            : undefined,
+      };
+      updateQuery(searchParams);
+    },
+    [updateQuery],
+  );
 
   const handleFieldChange = () => {
     updateQuery({
@@ -104,56 +107,50 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
   return (
     <OrganizationLayout id={id} navOrganizationId={navOrganizationId}>
       <div className="space-y-6">
-        <div className="justify-between items-center flex flex-wrap">
-          <div className="mt-1 flex flex-col justify-start space-y-2 md:flex-row md:justify-between md:space-y-0">
-            <EntityBadge
-              title={t("users")}
-              count={users?.count}
-              isFetching={isFetchingUsers}
-              translationParams={{ entity: "User" }}
-            />
-          </div>
-          <div className="gap-2 flex flex-wrap mt-2">
+        <div className="flex flex-col justify-between items-start gap-4 md:flex-row md:items-center">
+          <EntityBadge
+            title={t("users")}
+            count={users?.count}
+            isFetching={isFetchingUsers}
+            translationParams={{ entity: "User" }}
+          />
+          <div className="flex gap-2 w-full md:w-auto">
             <AddUserSheet
               open={openAddUserSheet}
-              setOpen={(open) => {
-                updateQuery({ sheet: open ? "add" : "" });
-              }}
-              onUserCreated={(user) => {
-                updateQuery({ sheet: "link", username: user.username });
-              }}
+              setOpen={(open) => updateQuery({ sheet: open ? "add" : "" })}
+              onUserCreated={(user) =>
+                updateQuery({ sheet: "link", username: user.username })
+              }
               organizationId={id}
             />
             <LinkUserSheet
               organizationId={id}
               open={openLinkUserSheet}
-              setOpen={(open) => {
-                updateQuery({ sheet: open ? "link" : "", username: "" });
-              }}
+              setOpen={(open) =>
+                updateQuery({ sheet: open ? "link" : "", username: "" })
+              }
               preSelectedUsername={qParams.username}
             />
           </div>
         </div>
-        <div className="flex gap-2">
-          <SearchByMultipleFields
-            id="user-search"
-            options={searchOptions}
-            initialOptionIndex={Math.max(
-              searchOptions.findIndex((option) => option.value !== ""),
-              0,
-            )}
-            onSearch={handleSearch}
-            onFieldChange={handleFieldChange}
-            className="w-full"
-            data-cy="search-user"
-          />
-        </div>
+        <SearchByMultipleFields
+          id="user-search"
+          options={searchOptions}
+          initialOptionIndex={Math.max(
+            searchOptions.findIndex((option) => option.value !== ""),
+            0,
+          )}
+          onSearch={handleSearch}
+          onFieldChange={handleFieldChange}
+          className="w-full"
+          data-cy="search-user"
+        />
         {isFetchingUsers ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             <CardGridSkeleton count={6} />
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {users?.results?.length === 0 ? (
               <Card className="col-span-full">
                 <CardContent className="p-6 text-center text-gray-500">
@@ -162,34 +159,36 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
               </Card>
             ) : (
               users?.results?.map((userRole) => (
-                <Card key={userRole.id} className="h-full">
-                  <CardContent className="p-4 sm:p-6 flex flex-col h-full justify-between">
-                    <div className="flex items-start gap-3">
+                <Card
+                  key={userRole.id}
+                  className="flex flex-col max-w-full overflow-hidden"
+                >
+                  <CardContent className="p-3 flex flex-col gap-3 flex-grow sm:p-4">
+                    <div className="flex items-start gap-2">
                       <Avatar
                         name={`${userRole.user.first_name} ${userRole.user.last_name}`}
                         imageUrl={userRole.user.profile_picture_url}
-                        className="h-12 w-12 sm:h-14 sm:w-14 text-xl sm:text-2xl flex-shrink-0"
+                        className="h-10 w-10 flex-shrink-0 sm:h-12 sm:w-12 lg:h-14 lg:w-14 text-lg sm:text-xl lg:text-2xl"
                       />
-
-                      <div className="flex flex-col min-w-0 flex-1">
+                      <div className="flex flex-col flex-1 min-w-0">
                         <div className="flex flex-col gap-1">
-                          <div className="flex items-start justify-between">
-                            <h1 className="text-base font-bold break-words pr-2">
+                          <div className="flex items-start justify-between gap-2">
+                            <h1 className="text-base font-bold leading-tight truncate">
                               {userRole.user.first_name}{" "}
                               {userRole.user.last_name}
                             </h1>
-                            <span className="text-sm text-gray-500">
+                            <span className="text-sm text-gray-500 flex-shrink-0">
                               <UserStatusIndicator user={userRole.user} />
                             </span>
                           </div>
-                          <span className="text-sm text-gray-500 mr-2 break-words">
+                          <span className="text-sm text-gray-500 truncate">
                             {userRole.user.username}
                           </span>
                         </div>
-                        <div className="mt-4 -ml-12 sm:ml-0 grid grid-cols-2 gap-2 text-sm">
+                        <div className="mt-2 grid grid-cols-1 gap-2 text-sm">
                           <div>
                             <div className="text-gray-500">{t("role")}</div>
-                            <div className="font-medium truncate">
+                            <div className="font-medium break-words">
                               {userRole.role.name ?? "-"}
                             </div>
                           </div>
@@ -197,7 +196,7 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
                             <div className="text-gray-500">
                               {t("phone_number")}
                             </div>
-                            <div className="font-medium truncate">
+                            <div className="font-medium break-words">
                               {userRole.user.phone_number
                                 ? formatPhoneNumberIntl(
                                     userRole.user.phone_number,
@@ -208,24 +207,32 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
                         </div>
                       </div>
                     </div>
-
-                    <div className="mt-2 -mx-2 -mb-2 sm:-mx-4 sm:-mb-4 rounded-md py-4 px-4 bg-gray-50 flex justify-end gap-2">
+                    <div className="mt-auto flex flex-col gap-2 sm:flex-row sm:justify-end">
                       <EditUserRoleSheet
                         organizationId={id}
                         userRole={userRole}
                         trigger={
-                          <Button variant="outline" size="sm">
-                            <span>{t("edit_role")}</span>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="w-full sm:w-auto"
+                          >
+                            {t("edit_role")}
                           </Button>
                         }
                       />
-                      <Button asChild variant="outline" size="sm">
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm"
+                        className="w-full sm:w-auto"
+                      >
                         <Link href={`/users/${userRole.user.username}`}>
                           <CareIcon
                             icon="l-arrow-up-right"
                             className="text-lg mr-1"
                           />
-                          <span>{t("see_details")}</span>
+                          {t("see_details")}
                         </Link>
                       </Button>
                     </div>


### PR DESCRIPTION
Closes #11272 
- Fixed overlap on tiny screens (<400px) by constraining widths.  
- Shrunk avatar, text, and padding for small screens, scales up smoothly.  
- Tested across all breakpoints—no overlap, functionality intact.  

https://drive.google.com/file/d/1jyk18p8OpJYxPtMTAd3s81SqI0OHZOk6/view?usp=sharing

@Jacobjeevan Plz Review it once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved phone number filtering in search results to ensure only valid entries influence the results.

- **Style**
  - Enhanced the overall layout with refined alignment and spacing for a cleaner interface.
  - Reorganized the display of user details and badges for improved responsiveness and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->