### PR TITLE
Encounter Page Layout Fix for Smaller Screens

### DIFF
--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -164,7 +164,7 @@ export const EncounterShow = (props: Props) => {
           <div className="overflow-x-auto sm:flex sm:items-baseline">
             <div className="mt-4 sm:mt-0">
               <nav
-                className="flex space-x-6 overflow-x-auto pb-2 pl-2"
+                className="flex gap-3 flex-wrap pb-2 pl-2"
                 id="encounter_tab_nav"
               >
                 {keysOf(tabs).map((tab) => (

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -180,7 +180,16 @@ export const EncounterShow = (props: Props) => {
             </div>
           </div>
         </div>
-        <div className="mt-4">
+        {/* 
+          want to do this: 
+          
+          const {open: isSidebarOpen} = useSidebar();
+          <div className= { `mt-4 ${ isSidebarOpen && "max-w-[calc(96vw-var(--sidebar-width))] overflow-x-auto"}
+          
+          where isSidebarOpen would be the open state on sidebar, 
+          but it's only accessible through useSidebar (needs to be in SidebarProvider)
+         */}
+        <div className="mt-4 max-w-[calc(96vw-var(--sidebar-width))] overflow-x-auto">
           <PageHeadTitle title={t(`ENCOUNTER_TAB__${props.tab}`)} />
           <SelectedTab {...encounterTabProps} />
         </div>


### PR DESCRIPTION
## The bug
User needs to scroll to see the whole page in desktop view.
## Expected behavior 
There should be no horizontal scrolling present in all views. It should be same as mobile view.

## Proposed Changes

- Trying to fix #11268 
- Added `flex-wrap` and removed `overflow-x-auto`  on encounter tabs
- Found that the encounter page stretches based on content of selected tab, so tried to set a `max-width` 
  of `96vw - var(--sidebar-width)` on the tab, this way on tablets, we won't need to scroll

## Problem :
- This currently breaks the view when sidebar is collapsed, would be great if there was a way to access the `open` state of sidebar from outside a SidebarProvider, this could fix other similar layout issues too, I think.

Please see screencast and comment in my commit:
[Screencast from 2025-03-14 22-38-10.webm](https://github.com/user-attachments/assets/00dad890-2faf-45b9-a8f2-75b21b862a38)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices
