### PR TITLE
Fix: Crash on Appointment Selection in questionnaire Preview

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1963,6 +1963,7 @@
   "quantity_requested": "Quantity Requested",
   "quantity_required": "Quantity Required",
   "question": "Question",
+  "questionnaire_appointment_no_encounter": "Appointment cannot be recorded without an active encounter",
   "questionnaire_diagnosis_no_encounter": "Diagnosis cannot be recorded without an active encounter",
   "questionnaire_error_loading": "Error loading questionnaire",
   "questionnaire_medication_request_no_encounter": "Medication requests cannot be recorded without an active encounter",

--- a/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
@@ -16,8 +16,6 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
-import useSlug from "@/hooks/useSlug";
-
 import query from "@/Utils/request/query";
 import { dateQueryString } from "@/Utils/utils";
 import { PractitionerSelector } from "@/pages/Appointments/components/PractitionerSelector";
@@ -49,6 +47,7 @@ interface FollowUpVisitQuestionProps {
   ) => void;
   disabled?: boolean;
   errors: QuestionValidationError[];
+  facilityId: string;
 }
 
 const APPOINTMENT_FIELDS: FieldDefinitions = {
@@ -79,11 +78,11 @@ export function AppointmentQuestion({
   updateQuestionnaireResponseCB,
   disabled,
   errors,
+  facilityId,
 }: FollowUpVisitQuestionProps) {
   const { t } = useTranslation();
   const [resource, setResource] = useState<UserBase>();
   const [selectedDate, setSelectedDate] = useState<Date>();
-  const facilityId = useSlug("facility");
   const { hasError } = useFieldError(question.id, errors);
 
   const values =

--- a/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
@@ -165,7 +165,12 @@ export function QuestionInput({
             }
             return <span>{t("questionnaire_diagnosis_no_encounter")}</span>;
           case "appointment":
-            return <AppointmentQuestion {...commonProps} />;
+            if (facilityId) {
+              return (
+                <AppointmentQuestion {...commonProps} facilityId={facilityId} />
+              );
+            }
+            return <span>{t("questionnaire_appointment_no_encounter")}</span>;
           case "encounter":
             if (encounterId && facilityId) {
               return (


### PR DESCRIPTION
## Proposed Changes

- Fixes #11308 
### demo video

https://github.com/user-attachments/assets/bdb1bbbd-e870-45d4-aa90-4c8eb9b0fcee


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced appointment scheduling: Users now receive a clear message—"Appointment cannot be recorded without an active encounter"—when an appointment is attempted without the necessary encounter.
  - Improved display logic: The appointment section now conditionally renders content based on the availability of required information, providing a fallback message when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->