### PR TITLE
Enhance CreateScheduleTemplateSheet: Add auto-fill slot duration

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -463,6 +463,7 @@
   "auth_method_unsupported": "This authentication method is not supported, please try a different method",
   "authored_on": "Authored On",
   "authorize_shift_delete": "Authorize shift delete",
+  "auto_fill_slot_duration": "Auto-fill slot duration",
   "auto_generated_for_care": "Auto Generated for Care",
   "autofilled_fields": "Autofilled Fields",
   "availabilities": "Availabilities",

--- a/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
@@ -240,7 +240,8 @@ export function AppointmentQuestion({
                           >
                             <div className="flex items-center justify-between">
                               <span>
-                                {format(slot.start_datetime, "HH:mm")}
+                                {format(slot.start_datetime, "HH:mm")} -{" "}
+                                {format(slot.end_datetime, "HH:mm")}
                               </span>
                               <span className="pl-1 text-xs text-gray-500">
                                 {availability.tokens_per_slot - slot.allocated}{" "}


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the scheduling component, primarily focusing on the auto-fill slot duration functionality. The changes include updates to the `CreateScheduleTemplateSheet` component, as well as minor improvements to the `AppointmentQuestion` component and localization files.

New feature implementation:

* [`src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx`](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfL3-R3): Added `auto_fill_duration` field to the form schema and default values. Implemented functions to calculate and update slot duration based on start and end times. Integrated a switch to enable or disable auto-fill duration, and updated form controls to handle this new feature. [[1]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfL3-R3) [[2]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfR28) [[3]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfR39) [[4]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfR111) [[5]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfR164) [[6]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfR242-R262) [[7]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfL448-R480) [[8]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfL462-R501) [[9]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfR513-R542) [[10]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfL492-R566) [[11]](diffhunk://#diff-818f3afdde29bfeca4e031d9144655a50e17eac43a8d964274d92e5f6d4a1abfR652)

Minor improvements:

* [`src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx`](diffhunk://#diff-af9013146aef5904f0301622179b97f5056cb3e42b87bb78a639ec2ff1f63fa9L243-R244): Updated the time format to display both start and end times for appointment slots.
* [`public/locale/en.json`](diffhunk://#diff-d120f97dc8f2f2c516a2ea69a046e008947dbbc26e5a77467a102837c665f923R466): Added a new localization string for "Auto-fill slot duration".
## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Appointment time selections now display both start and end times.
	- A new auto-fill duration option automatically calculates appointment slot lengths, streamlining scheduling.
	- Expanded localization includes an updated label for the auto-fill feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->