### PR TITLE
Difficulty Selecting Past months in the Date Range Filter, Especially…

### DIFF
--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -1,19 +1,8 @@
 import { format } from "date-fns";
-import { t } from "i18next";
 import * as React from "react";
 import { DateRange } from "react-day-picker";
 
 import { cn } from "@/lib/utils";
-
-import CareIcon from "@/CAREUI/icons/CareIcon";
-
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 
 type DateRangePickerProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
@@ -29,44 +18,57 @@ export function DateRangePicker({
   onChange,
   className,
 }: DateRangePickerProps) {
+  const inputClasses =
+    "border border-gray-200 bg-white shadow-sm rounded-md px-3 py-2 w-full hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50 focus:outline-none ";
+
+  const handleChange =
+    (field: "from" | "to") => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selectedDate = e.target.value
+        ? new Date(e.target.value)
+        : undefined;
+      onChange?.(
+        field === "from"
+          ? { from: selectedDate, to: date?.to }
+          : { from: date?.from, to: selectedDate },
+      );
+    };
   return (
     <div className={cn("grid gap-2", className)}>
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            id="date"
-            variant={"outline"}
-            className={cn(
-              "justify-center text-left font-normal",
-              !date && "text-gray-500",
-            )}
+      <div className="flex space-x-2">
+        <div className="flex flex-col w-full">
+          <label
+            htmlFor="from-date"
+            className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
           >
-            <CareIcon icon="l-calender" className="mr-2 h-4 w-4" />
-            {date?.from ? (
-              date.to ? (
-                <>
-                  {format(date.from, "LLL dd, y")} -{" "}
-                  {format(date.to, "LLL dd, y")}
-                </>
-              ) : (
-                format(date.from, "LLL dd, y")
-              )
-            ) : (
-              <span>{t("pick_a_date")}</span>
-            )}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            initialFocus
-            mode="range"
-            defaultMonth={date?.from}
-            selected={date}
-            onSelect={onChange}
-            numberOfMonths={2}
+            From Date
+          </label>
+          <input
+            id="from-date"
+            type="date"
+            className={inputClasses}
+            value={date?.from ? format(date.from, "yyyy-MM-dd") : ""}
+            max={date?.to ? format(date.to, "yyyy-MM-dd") : undefined}
+            onChange={handleChange("from")}
           />
-        </PopoverContent>
-      </Popover>
+        </div>
+
+        <div className="flex flex-col w-full">
+          <label
+            htmlFor="to-date"
+            className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            To Date
+          </label>
+          <input
+            type="date"
+            placeholder="To Date"
+            className={inputClasses}
+            value={date?.to ? format(date.to, "yyyy-MM-dd") : ""}
+            min={date?.from ? format(date.from, "yyyy-MM-dd") : undefined}
+            onChange={handleChange("to")}
+          />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
… on Mobile #11113

## Proposed Changes

- Fixes #11113
- Replaced `Calendar` component with native **HTML `<input type="date">`** for better mobile support.  
- Ensured **past months are easily selectable** on mobile devices.  
- Added **`min` and `max` constraints** to enforce a valid date range.  


![WhatsApp Image 2025-03-18 at 16 05 21_4b58d053](https://github.com/user-attachments/assets/8c0f39a8-fb4e-4a58-824b-c8e671fdf33e)
![WhatsApp Image 2025-03-18 at 16 05 20_e1720b14](https://github.com/user-attachments/assets/d3eb8db9-a506-425d-aac0-f0e448310f2e)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The date selection interface now offers two direct input fields for "From Date" and "To Date," providing a streamlined and intuitive experience with built-in constraints to ensure logical date ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->