### PR TITLE
Add Support for Valueset Options in Choice Question & Quantity

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponseView.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponseView.tsx
@@ -89,9 +89,7 @@ export default function QuestionnaireResponseView({
                     );
                     if (!questionResponse) return null;
 
-                    const value =
-                      questionResponse.values[0]?.value ||
-                      questionResponse.values[0]?.value_quantity?.value;
+                    const value = questionResponse.values[0]?.value;
 
                     return (
                       <div key={question.id} className="grid grid-cols-2 gap-4">

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -77,8 +77,15 @@ function QuestionResponseValue({ question, response }: QuestionResponseProps) {
       <div className="text-xs text-gray-500">{question.text}</div>
       <div className="space-y-1">
         {response.values.map((valueObj, index) => {
-          const value = valueObj.value || valueObj.value_quantity?.value;
-          if (!value) return null;
+          const value = valueObj.value;
+
+          const coding = valueObj.coding;
+
+          const unit = valueObj.unit;
+
+          if (!value && !coding) return null;
+
+          const precedentUnit = unit ? unit : question.unit;
 
           return (
             <div
@@ -86,8 +93,13 @@ function QuestionResponseValue({ question, response }: QuestionResponseProps) {
               className="text-sm font-medium whitespace-pre-wrap"
             >
               {formatValue(value, question.type)}
-              {question.unit?.code && (
-                <span className="ml-1 text-xs">{question.unit.code}</span>
+              {precedentUnit && (
+                <span className="ml-1 text-xs">{precedentUnit.code}</span>
+              )}
+              {coding && (
+                <span className="ml-1 text-xs">
+                  {coding.display} ({coding.code})
+                </span>
               )}
               {index === response.values.length - 1 && response.note && (
                 <span className="ml-2 text-xs text-gray-500">

--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -94,17 +94,14 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
             <SelectValue placeholder="Select an option" />
           </SelectTrigger>
           <SelectContent>
-            {options
-              // TODO: Temporary fix to remove empty options
-              .filter((option) => option.value !== "")
-              .map((option: AnswerOption) => (
-                <SelectItem
-                  key={option.value.toString()}
-                  value={option.value.toString()}
-                >
-                  {properCase(option.display || option.value)}
-                </SelectItem>
-              ))}
+            {options.map((option: AnswerOption) => (
+              <SelectItem
+                key={option.value.toString()}
+                value={option.value.toString()}
+              >
+                {properCase(option.display || option.value)}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       )}

--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -8,7 +8,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
+
 import { properCase } from "@/Utils/utils";
+import { Code } from "@/types/questionnaire/code";
 import type {
   QuestionnaireResponse,
   ResponseValue,
@@ -39,7 +42,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
 }: ChoiceQuestionProps) {
   const options = question.answer_option || [];
   const currentValue = questionnaireResponse.values[index]?.value?.toString();
-
+  const currentCoding = questionnaireResponse.values[index]?.coding;
   const handleValueChange = (newValue: string) => {
     clearError();
     const newValues = [...questionnaireResponse.values];
@@ -55,25 +58,56 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
     );
   };
 
+  const handleCodingChange = (newValue: Code) => {
+    clearError();
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "quantity",
+      coding: {
+        code: newValue.code,
+        system: newValue.system,
+        display: newValue.display,
+      },
+    };
+
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
   return (
-    <Select
-      value={currentValue}
-      onValueChange={handleValueChange}
-      disabled={disabled}
-    >
-      <SelectTrigger className="w-full">
-        <SelectValue placeholder="Select an option" />
-      </SelectTrigger>
-      <SelectContent>
-        {options.map((option: AnswerOption) => (
-          <SelectItem
-            key={option.value.toString()}
-            value={option.value.toString()}
-          >
-            {properCase(option.display || option.value)}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <>
+      {question.answer_value_set ? (
+        <ValueSetSelect
+          system={question.answer_value_set}
+          value={currentCoding}
+          onSelect={handleCodingChange}
+        ></ValueSetSelect>
+      ) : (
+        <Select
+          value={currentValue}
+          onValueChange={handleValueChange}
+          disabled={disabled}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select an option" />
+          </SelectTrigger>
+          <SelectContent>
+            {options
+              // TODO: Temporary fix to remove empty options
+              .filter((option) => option.value !== "")
+              .map((option: AnswerOption) => (
+                <SelectItem
+                  key={option.value.toString()}
+                  value={option.value.toString()}
+                >
+                  {properCase(option.display || option.value)}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+      )}
+    </>
   );
 });

--- a/src/components/Questionnaire/QuestionTypes/QuantityQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuantityQuestion.tsx
@@ -1,0 +1,132 @@
+import { memo } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
+
+import { Code } from "@/types/questionnaire/code";
+import type {
+  QuestionnaireResponse,
+  ResponseValue,
+} from "@/types/questionnaire/form";
+import type { Question } from "@/types/questionnaire/question";
+
+interface QuantityQuestionProps {
+  question: Question;
+  questionnaireResponse: QuestionnaireResponse;
+  updateQuestionnaireResponseCB: (
+    values: ResponseValue[],
+    questionId: string,
+    note?: string,
+  ) => void;
+  disabled?: boolean;
+  clearError: () => void;
+  index?: number;
+}
+
+export const QuantityQuestion = memo(function QuantityQuestion({
+  question,
+  questionnaireResponse,
+  updateQuestionnaireResponseCB,
+  disabled = false,
+  clearError,
+  index = 0,
+}: QuantityQuestionProps) {
+  const currentValue = questionnaireResponse.values[index]?.value as
+    | number
+    | undefined;
+  const currentUnit = questionnaireResponse.values[index]?.unit;
+  const currentCoding = questionnaireResponse.values[index]?.coding;
+
+  const handleValueChange = (value: string) => {
+    clearError();
+    const numericValue = value === "" ? undefined : parseFloat(value);
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "quantity",
+      value: numericValue,
+      unit: currentUnit,
+      coding: currentCoding,
+    };
+
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
+
+  const handleUnitChange = (newUnit: Code) => {
+    clearError();
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "quantity",
+      value: currentValue,
+      unit: newUnit,
+      coding: currentCoding,
+    };
+
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
+
+  const handleCodingChange = (newCoding: Code) => {
+    clearError();
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "quantity",
+      value: currentValue,
+      unit: currentUnit,
+      coding: newCoding,
+    };
+
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
+
+  return (
+    <div className="flex gap-4">
+      {question.answer_value_set && (
+        <div className="space-y-2">
+          <Label htmlFor={`${question.id}-coding`}>Type</Label>
+          <div className="w-[200px]">
+            <ValueSetSelect
+              system={question.answer_value_set}
+              value={currentCoding}
+              onSelect={handleCodingChange}
+            />
+          </div>
+        </div>
+      )}
+      <div className="space-y-2">
+        <Label htmlFor={`${question.id}-value`}>Value</Label>
+        <Input
+          id={`${question.id}-value`}
+          type="number"
+          value={currentValue?.toString() || ""}
+          onChange={(e) => handleValueChange(e.target.value)}
+          step="0.01"
+          disabled={disabled}
+          className="w-[200px]"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={`${question.id}-unit`}>Unit</Label>
+        <div className="w-[200px]">
+          <ValueSetSelect
+            system="system-ucum-units"
+            value={currentUnit}
+            onSelect={handleUnitChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
@@ -26,6 +26,7 @@ import { MedicationRequestQuestion } from "./MedicationRequestQuestion";
 import { MedicationStatementQuestion } from "./MedicationStatementQuestion";
 import { NotesInput } from "./NotesInput";
 import { NumberQuestion } from "./NumberQuestion";
+import { QuantityQuestion } from "./QuantityQuestion";
 import { SymptomQuestion } from "./SymptomQuestion";
 import { TextQuestion } from "./TextQuestion";
 
@@ -105,6 +106,9 @@ export function QuestionInput({
       case "decimal":
       case "integer":
         return <NumberQuestion {...commonProps} />;
+
+      case "quantity":
+        return <QuantityQuestion {...commonProps} />;
 
       case "choice":
         return <ChoiceQuestion {...commonProps} />;

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1573,6 +1573,7 @@ function QuestionEditor({
                           updateField(
                             "answer_value_set",
                             val === "custom" ? undefined : "valueset",
+                            { answer_option: [] },
                           )
                         }
                       >
@@ -1626,9 +1627,7 @@ function QuestionEditor({
                                   ...opt,
                                   value: e.target.value,
                                 };
-                                updateField("answer_option", newOptions, {
-                                  answer_option: [],
-                                });
+                                updateField("answer_option", newOptions);
                               }}
                               placeholder="Option value"
                             />

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1441,6 +1441,21 @@ function QuestionEditor({
               </p>
               <div className="">
                 <div className="flex flex-wrap gap-4">
+                  {type === "group" && (
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        checked={question.is_component ?? false}
+                        onCheckedChange={(val) =>
+                          updateField("is_component", val)
+                        }
+                        id={`is_component-${getQuestionPath()}`}
+                      />
+                      <Label htmlFor={`is_component-${getQuestionPath()}`}>
+                        {t("is_component")}
+                      </Label>
+                    </div>
+                  )}
+
                   <div className="flex items-center gap-2">
                     <Switch
                       checked={question.collect_time ?? false}
@@ -1536,40 +1551,62 @@ function QuestionEditor({
             </div>
           )}
 
-          {type === "choice" && (
+          {(type === "choice" || type === "quantity") && (
             <div className="space-y-4">
               <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <div>
-                    <CardTitle className="text-base font-medium">
-                      Answer Options
-                    </CardTitle>
-                    <p className="text-sm text-gray-500">
-                      Define possible answers for this question
-                    </p>
-                  </div>
-                  <Select
-                    value={question.answer_value_set ? "valueset" : "custom"}
-                    onValueChange={(val: string) =>
-                      updateField(
-                        "answer_value_set",
-                        val === "custom" ? undefined : "valueset",
-                      )
-                    }
-                  >
-                    <SelectTrigger className="w-[200px]">
-                      <SelectValue placeholder={t("select_a_value_set")} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="custom">
-                        {t("custom_options")}
-                      </SelectItem>
-                      <SelectItem value="valueset">{t("value_set")}</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </CardHeader>
+                {question.type === "choice" && (
+                  <>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                      <div>
+                        <CardTitle className="text-base font-medium">
+                          Answer Options
+                        </CardTitle>
+                        <p className="text-sm text-gray-500">
+                          Define possible answers for this question
+                        </p>
+                      </div>
+                      <Select
+                        value={
+                          question.answer_value_set ? "valueset" : "custom"
+                        }
+                        onValueChange={(val: string) =>
+                          updateField(
+                            "answer_value_set",
+                            val === "custom" ? undefined : "valueset",
+                          )
+                        }
+                      >
+                        <SelectTrigger className="w-[200px]">
+                          <SelectValue placeholder={t("select_a_value_set")} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="custom">
+                            {t("custom_options")}
+                          </SelectItem>
+                          <SelectItem value="valueset">
+                            {t("value_set")}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </CardHeader>
+                  </>
+                )}
 
-                {!question.answer_value_set ? (
+                {question.type === "quantity" && (
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <div>
+                      <CardTitle className="text-base font-medium">
+                        Quantity
+                      </CardTitle>
+                      <p className="text-sm text-gray-500">
+                        Select the valueset of options for this quantity
+                        question
+                      </p>
+                    </div>
+                  </CardHeader>
+                )}
+
+                {question.type === "choice" && !question.answer_value_set ? (
                   <CardContent className="space-y-4">
                     {(answer_option || []).map((opt, idx) => (
                       <div
@@ -1589,7 +1626,9 @@ function QuestionEditor({
                                   ...opt,
                                   value: e.target.value,
                                 };
-                                updateField("answer_option", newOptions);
+                                updateField("answer_option", newOptions, {
+                                  answer_option: [],
+                                });
                               }}
                               placeholder="Option value"
                             />

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -555,13 +555,11 @@ export function QuestionnaireForm({
               (Array.isArray(v.value) ? v.value.length > 0 : true),
           );
 
-          const hasCoding = response?.values?.some(
-            (v) => v.coding !== undefined && v.coding !== null,
-          );
+          const hasProperty = (arr: any[] | undefined, prop: string) =>
+            Array.isArray(arr) && arr.some((item) => item?.[prop] != null);
 
-          const hasUnit = response?.values?.some(
-            (v) => v.unit !== undefined && v.unit !== null,
-          );
+          const hasCoding = hasProperty(response?.values, "coding");
+          const hasUnit = hasProperty(response?.values, "unit");
 
           if (!hasValue && !hasCoding && !hasUnit) {
             errors.push({

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -658,11 +658,15 @@ export function QuestionnaireForm({
                       value: value.value.toISOString(),
                     };
                   }
+                  if (value.unit) {
+                    return {
+                      value: value.value?.toString(),
+                      unit: value.unit,
+                      coding: value.coding,
+                    };
+                  }
                   if (value.coding) {
                     return { coding: value.coding };
-                  }
-                  if (value.unit) {
-                    return { unit: value.unit };
                   }
                   return { value: String(value.value) };
                 }),

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -555,7 +555,15 @@ export function QuestionnaireForm({
               (Array.isArray(v.value) ? v.value.length > 0 : true),
           );
 
-          if (!hasValue) {
+          const hasCoding = response?.values?.some(
+            (v) => v.coding !== undefined && v.coding !== null,
+          );
+
+          const hasUnit = response?.values?.some(
+            (v) => v.unit !== undefined && v.unit !== null,
+          );
+
+          if (!hasValue && !hasCoding && !hasUnit) {
             errors.push({
               question_id: q.id,
               error: t("field_required"),
@@ -650,8 +658,11 @@ export function QuestionnaireForm({
                       value: value.value.toISOString(),
                     };
                   }
-                  if (value.value_code) {
-                    return { value_code: value.value_code };
+                  if (value.coding) {
+                    return { coding: value.coding };
+                  }
+                  if (value.unit) {
+                    return { unit: value.unit };
                   }
                   return { value: String(value.value) };
                 }),

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -25,10 +25,10 @@ import useBreakpoints from "@/hooks/useBreakpoints";
 
 import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
-import { Code, ValueSetSystem } from "@/types/questionnaire/code";
+import { Code } from "@/types/questionnaire/code";
 
 interface Props {
-  system: ValueSetSystem;
+  system: string;
   value?: Code | null;
   onSelect: (value: Code) => void;
   placeholder?: string;

--- a/src/types/questionnaire/form.ts
+++ b/src/types/questionnaire/form.ts
@@ -5,7 +5,6 @@ import { MedicationRequest } from "@/types/emr/medicationRequest";
 import { MedicationStatementRequest } from "@/types/emr/medicationStatement";
 import { SymptomRequest } from "@/types/emr/symptom/symptom";
 import { Code } from "@/types/questionnaire/code";
-import { QuestionnaireQuantity } from "@/types/questionnaire/quantity";
 import { StructuredQuestionType } from "@/types/questionnaire/question";
 import { CreateAppointmentQuestion } from "@/types/scheduling/schedule";
 
@@ -38,7 +37,7 @@ export type ResponseValue =
   | RV<"number", number | undefined>
   | RV<"boolean", boolean | undefined>
   | RV<"dateTime", Date | undefined>
-  | RV<"quantity", QuestionnaireQuantity | undefined>
+  | RV<"quantity", number | undefined>
   | RV<"allergy_intolerance", AllergyIntoleranceRequest[]>
   | RV<"medication_request", MedicationRequest[]>
   | RV<"medication_statement", MedicationStatementRequest[]>

--- a/src/types/questionnaire/form.ts
+++ b/src/types/questionnaire/form.ts
@@ -5,7 +5,7 @@ import { MedicationRequest } from "@/types/emr/medicationRequest";
 import { MedicationStatementRequest } from "@/types/emr/medicationStatement";
 import { SymptomRequest } from "@/types/emr/symptom/symptom";
 import { Code } from "@/types/questionnaire/code";
-import { Quantity } from "@/types/questionnaire/quantity";
+import { QuestionnaireQuantity } from "@/types/questionnaire/quantity";
 import { StructuredQuestionType } from "@/types/questionnaire/question";
 import { CreateAppointmentQuestion } from "@/types/scheduling/schedule";
 
@@ -13,17 +13,32 @@ import { CreateAppointmentQuestion } from "@/types/scheduling/schedule";
  * A short hand for defining response value types
  */
 type RV<T extends string, V> = {
-  value_code?: Code;
-  value_quantity?: Quantity;
+  coding?: Code;
+  unit?: Code;
   type: T;
-  value: V;
+  value?: V;
 };
+
+// type RVValue<T extends string, V> = RVBase<T, V> & {
+//   value: V;
+// };
+
+// type RVCode<T extends string> = RVBase<T, Code> & {
+//   value: Code;
+// };
+
+// type RVQuantity<T extends string> = RVBase<T, QuestionnaireQuantity> & {
+//   value: QuestionnaireQuantity;
+// };
+
+// type RV<T extends string, V> = RVValue<T, V> | RVCode<T> | RVQuantity<T>;
 
 export type ResponseValue =
   | RV<"string", string | undefined>
   | RV<"number", number | undefined>
   | RV<"boolean", boolean | undefined>
   | RV<"dateTime", Date | undefined>
+  | RV<"quantity", QuestionnaireQuantity | undefined>
   | RV<"allergy_intolerance", AllergyIntoleranceRequest[]>
   | RV<"medication_request", MedicationRequest[]>
   | RV<"medication_statement", MedicationStatementRequest[]>

--- a/src/types/questionnaire/form.ts
+++ b/src/types/questionnaire/form.ts
@@ -18,20 +18,6 @@ type RV<T extends string, V> = {
   value?: V;
 };
 
-// type RVValue<T extends string, V> = RVBase<T, V> & {
-//   value: V;
-// };
-
-// type RVCode<T extends string> = RVBase<T, Code> & {
-//   value: Code;
-// };
-
-// type RVQuantity<T extends string> = RVBase<T, QuestionnaireQuantity> & {
-//   value: QuestionnaireQuantity;
-// };
-
-// type RV<T extends string, V> = RVValue<T, V> | RVCode<T> | RVQuantity<T>;
-
 export type ResponseValue =
   | RV<"string", string | undefined>
   | RV<"number", number | undefined>

--- a/src/types/questionnaire/quantity.ts
+++ b/src/types/questionnaire/quantity.ts
@@ -1,5 +1,3 @@
-import { Code } from "./code";
-
 export interface Quantity {
   value: number;
   unit: string;
@@ -7,10 +5,4 @@ export interface Quantity {
   code?: string;
   // TODO: Add support for meta parameter for quantity
   // meta?: {};
-}
-
-export interface QuestionnaireQuantity {
-  value: number;
-  unit: Code;
-  coding: Code;
 }

--- a/src/types/questionnaire/quantity.ts
+++ b/src/types/questionnaire/quantity.ts
@@ -1,3 +1,5 @@
+import { Code } from "./code";
+
 export interface Quantity {
   value: number;
   unit: string;
@@ -5,4 +7,10 @@ export interface Quantity {
   code?: string;
   // TODO: Add support for meta parameter for quantity
   // meta?: {};
+}
+
+export interface QuestionnaireQuantity {
+  value: number;
+  unit: Code;
+  coding: Code;
 }

--- a/src/types/questionnaire/question.ts
+++ b/src/types/questionnaire/question.ts
@@ -87,6 +87,7 @@ export interface Question {
     containerClasses?: string;
   };
   required?: boolean;
+  is_component?: boolean;
   collect_time?: boolean;
   collect_performer?: boolean;
   collect_body_site?: boolean;


### PR DESCRIPTION
## Proposed Changes
- Add Support for Valueset Options in Choice Question
- Add Support for Quantity Questions

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled quantity-type answer handling with dedicated numeric input and selection options.
  - Introduced a toggle to mark questions as components and conditional selection for coding versus value inputs.
  - Added a new `QuantityQuestion` component for handling quantity-type questions.
  - Enhanced display of coding information in response values.

- **Refactor**
  - Streamlined the extraction and display of response values, including improved handling of units and coding.
  - Enhanced form validation to ensure comprehensive checks on answer inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->