### PR TITLE
add Zod validation to Prevent entry of Death Date Before Birth Date

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -787,6 +787,7 @@
   "date_of_birth_age": "Date of Birth/Age",
   "date_of_birth_format": "Date of birth must be in YYYY-MM-DD format",
   "date_of_birth_must_be_present": "Date of birth must be present",
+  "death_date_must_be_after_dob": "Death date must be after date of birth",
   "date_of_birth_or_age": "Date of Birth or Age",
   "date_of_positive_covid_19_swab": "Date of Positive Covid 19 Swab",
   "date_of_result": "Covid confirmation date",

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -154,12 +154,16 @@ export default function PatientRegistration(
               ? dayjs(data.date_of_birth)
               : dayjs().subtract(data.age || 0, "years");
 
-            return dob.isValid() && dob.isBefore(deathDate);
+            return data.date_of_birth
+              ? dob.isBefore(deathDate)
+              : dob.year() < deathDate.year();
           },
-          {
-            message: t("death_date_must_be_after_dob"),
+          (data) => ({
+            message: dayjs(data.death_datetime).isValid()
+              ? t("death_date_must_be_after_dob")
+              : t("invalid_date_format", { format: "DD-MM-YYYY HH:mm" }),
             path: ["death_datetime"],
-          },
+          }),
         ),
 
     [], // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -142,7 +142,26 @@ export default function PatientRegistration(
             message: t("geo_organization_required"),
             path: ["geo_organization"],
           },
+        )
+        .refine(
+          (data) => {
+            if (!data.death_datetime) return true;
+
+            const deathDate = dayjs(data.death_datetime);
+            if (!deathDate.isValid()) return false;
+
+            const dob = data.date_of_birth
+              ? dayjs(data.date_of_birth)
+              : dayjs().subtract(data.age || 0, "years");
+
+            return dob.isValid() && dob.isBefore(deathDate);
+          },
+          {
+            message: t("death_date_must_be_after_dob"),
+            path: ["death_datetime"],
+          },
         ),
+
     [], // eslint-disable-line react-hooks/exhaustive-deps
   );
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #11389 
- add Zod validation to prevent invalid date entry  of dob and death date

screenshot:
![image](https://github.com/user-attachments/assets/87041357-ef47-43e1-9dff-28b98818d30c)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [X] Completion of QA in Mobile Devices
- [X] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced patient registration form validations to ensure submitted dates are consistent. Users will now receive a clear error message when the death date is entered earlier than the date of birth (or the computed date based on age).
	- Added a new validation message for death date requirements in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->