### PR TITLE
Update password field info to clarify optional behavior

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1793,6 +1793,7 @@
   "password_lowercase_validation": "Include at least <strong>one lowercase letter</strong> (a-z)",
   "password_mismatch": "Passwords do not match",
   "password_number_validation": "Include at least <strong>one number</strong> (0-9)",
+  "password_optional_info": "Leave blank to receive an email to set your password.",
   "password_required": "Password is required",
   "password_reset_failure": "Password Reset Failed",
   "password_reset_success": "Password Reset successfully",

--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -80,15 +80,8 @@ export default function UserForm({
               (val) => !val.match(/(?:[._-]{2,})/),
               t("username_not_valid"),
             ),
-      password: isEditMode
-        ? z.string().optional()
-        : z
-            .string()
-            .min(8, t("field_required"))
-            .regex(/[a-z]/, t("new_password_validation"))
-            .regex(/[A-Z]/, t("new_password_validation"))
-            .regex(/[0-9]/, t("new_password_validation")),
-      c_password: isEditMode ? z.string().optional() : z.string(),
+      password: z.string().optional(),
+      c_password: z.string().optional(),
       first_name: z.string().min(1, t("field_required")),
       last_name: z.string().min(1, t("field_required")),
       email: z.string().email(t("invalid_email_address")),
@@ -103,7 +96,7 @@ export default function UserForm({
     })
     .refine(
       (data) => {
-        if (!isEditMode) {
+        if (data.password) {
           return data.password === data.c_password;
         }
         return true;
@@ -425,7 +418,7 @@ export default function UserForm({
                 name="password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel required>{t("password")}</FormLabel>
+                    <FormLabel>{t("password")}</FormLabel>
                     <FormControl>
                       <PasswordInput
                         data-cy="password-input"
@@ -435,7 +428,7 @@ export default function UserForm({
                         onBlur={() => setIsPasswordFieldFocused(false)}
                       />
                     </FormControl>
-                    {isPasswordFieldFocused ? (
+                    {isPasswordFieldFocused && (
                       <div
                         className="text-small mt-2 pl-2 text-secondary-500"
                         aria-live="polite"
@@ -463,8 +456,11 @@ export default function UserForm({
                           ]}
                         />
                       </div>
-                    ) : (
-                      <FormMessage />
+                    )}
+                    {!isEditMode && (
+                      <p className="text-sm text-gray-500">
+                        {t("password_optional_info")}
+                      </p>
                     )}
                   </FormItem>
                 )}
@@ -475,7 +471,7 @@ export default function UserForm({
                 name="c_password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel required>{t("confirm_password")}</FormLabel>
+                    <FormLabel>{t("confirm_password")}</FormLabel>
                     <FormControl>
                       <PasswordInput
                         data-cy="confirm-password-input"


### PR DESCRIPTION
## Proposed Changes

- Fixes #11381 
- Made password and confirm password fields optional.
- Updated password_optional_info text to clarify that the password is optional and an email will be sent to set it if left blank.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced user guidance indicating that if the password field is left blank, an email will be sent to set up a password.

- **Refactor**
  - Updated the password entry form by making the password fields optional and streamlining the validation process, including removing the required field indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->