### PR TITLE
Fix autofocus in input-otp's

### DIFF
--- a/src/components/Auth/Authenticate.tsx
+++ b/src/components/Auth/Authenticate.tsx
@@ -137,7 +137,7 @@ export const Authenticate = () => {
                                 value={field.value}
                                 onChange={field.onChange}
                                 autoComplete="one-time-code"
-                                autoFocus={true}
+                                autoFocus
                               >
                                 <InputOTPGroup>
                                   {[

--- a/src/components/Auth/Authenticate.tsx
+++ b/src/components/Auth/Authenticate.tsx
@@ -131,11 +131,13 @@ export const Authenticate = () => {
                           <FormControl>
                             <div className="flex justify-center">
                               <InputOTP
+                                key={`otp-input-${currentMethod}`}
                                 maxLength={currentMethod === "backup" ? 8 : 6}
                                 pattern={REGEXP_ONLY_DIGITS}
                                 value={field.value}
                                 onChange={field.onChange}
                                 autoComplete="one-time-code"
+                                autoFocus={true}
                               >
                                 <InputOTPGroup>
                                   {[

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -554,6 +554,7 @@ const Login = (props: LoginProps) => {
                               maxLength={5}
                               pattern={REGEXP_ONLY_DIGITS}
                               autoComplete="one-time-code"
+                              autoFocus
                               onChange={(value) => {
                                 setOtp(value);
                                 setOtpValidationError("");

--- a/src/components/Users/TOTPSetupDialog.tsx
+++ b/src/components/Users/TOTPSetupDialog.tsx
@@ -142,6 +142,7 @@ export function TOTPSetupDialog({
                 maxLength={6}
                 pattern={REGEXP_ONLY_DIGITS}
                 autoComplete="one-time-code"
+                autoFocus
               >
                 <InputOTPGroup>
                   {[...Array(6)].map((_, index) => (


### PR DESCRIPTION
## Proposed Changes

- Fixes #11410 

[fix_auto_focus_11410 video.webm](https://github.com/user-attachments/assets/f7cad11b-ec67-4600-b7b8-a9682290a1f5)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

~~- [ ] Add specs that demonstrate bug / test a new feature.~~
~~- [ ] Update [product documentation](https://docs.ohc.network).~~
~~- [ ] Ensure that UI text is kept in I18n files.~~
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- OTP input fields now automatically receive focus when displayed, allowing users to quickly start entering their one-time codes during authentication and setup processes. This seamless behavior enhances the overall user experience by eliminating the need for manual clicks, streamlining the login and security workflows across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->