### PR TITLE
hide the view button when facility id is not present

### DIFF
--- a/src/components/Patient/PatientDetailsTab/Appointments.tsx
+++ b/src/components/Patient/PatientDetailsTab/Appointments.tsx
@@ -92,7 +92,9 @@ export const Appointments = (props: PatientProps) => {
               <TableHead>{t("date_and_time")}</TableHead>
               <TableHead>{t("booked_by")}</TableHead>
               <TableHead>{t("status")}</TableHead>
-              <TableHead className="text-right">{t("actions")}</TableHead>
+              {facilityId && (
+                <TableHead className="text-right">{t("actions")}</TableHead>
+              )}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -126,8 +128,8 @@ export const Appointments = (props: PatientProps) => {
                     )}
                   </TableCell>
                   <TableCell>{getStatusBadge(appointment.status)}</TableCell>
-                  <TableCell className="text-right">
-                    {facilityId && (
+                  {facilityId && (
+                    <TableCell className="text-right">
                       <Button variant="outline" size="sm" asChild>
                         <Link
                           href={`/facility/${facilityId}/patient/${patientData.id}/appointments/${appointment.id}`}
@@ -136,8 +138,8 @@ export const Appointments = (props: PatientProps) => {
                           {t("view")}
                         </Link>
                       </Button>
-                    )}
-                  </TableCell>
+                    </TableCell>
+                  )}
                 </TableRow>
               ))
             ) : (

--- a/src/components/Patient/PatientDetailsTab/Appointments.tsx
+++ b/src/components/Patient/PatientDetailsTab/Appointments.tsx
@@ -127,14 +127,16 @@ export const Appointments = (props: PatientProps) => {
                   </TableCell>
                   <TableCell>{getStatusBadge(appointment.status)}</TableCell>
                   <TableCell className="text-right">
-                    <Button variant="outline" size="sm" asChild>
-                      <Link
-                        href={`/facility/${facilityId}/patient/${patientData.id}/appointments/${appointment.id}`}
-                      >
-                        <CareIcon icon="l-eye" className="mr-1" />
-                        {t("view")}
-                      </Link>
-                    </Button>
+                    {facilityId && (
+                      <Button variant="outline" size="sm" asChild>
+                        <Link
+                          href={`/facility/${facilityId}/patient/${patientData.id}/appointments/${appointment.id}`}
+                        >
+                          <CareIcon icon="l-eye" className="mr-1" />
+                          {t("view")}
+                        </Link>
+                      </Button>
+                    )}
                   </TableCell>
                 </TableRow>
               ))


### PR DESCRIPTION
## Proposed Changes

- Fixes #11266 
- checking facility id to show view button or not

facility id present:
![image](https://github.com/user-attachments/assets/59e043cb-bb95-49cd-840a-e565ef4d1e34)

facility id is not present:
![image](https://github.com/user-attachments/assets/bfc255ed-0975-400d-a88b-d6494a3e4efe)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [X] Completion of QA in Mobile Devices
- [X] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the Patient Details view by conditionally displaying the appointment details button and "actions" header based on the availability of valid facility information, enhancing the user interface's reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->