### PR TITLE
fix: style error message when javascript is blocked

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,12 @@
         </p>
         <p style="margin-top: 10px;">
           🔧 <strong>How to Enable JavaScript:</strong>
+        </p>
           <ul style="text-align: left; display: inline-block; margin: 10px auto;">
             <li>Go to your browser settings.</li>
             <li>Find the "JavaScript" section.</li>
             <li>Enable JavaScript and refresh this page.</li>
           </ul>
-        </p>
         <p>If you are using a script blocker, allow scripts from this site.</p>
       </div>
     </noscript>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, interactive-widget=resizes-content"
-    />
+      content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, interactive-widget=resizes-content" />
     <title>%REACT_APP_TITLE%</title>
     <meta name="description" content="%REACT_APP_META_DESCRIPTION%" />
     <meta property="og:title" content="%REACT_APP_TITLE%" />
@@ -24,12 +23,40 @@
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link
       rel="apple-touch-icon"
-      href="/images/icons/apple-touch-icon-180x180.png"
-    />
+      href="/images/icons/apple-touch-icon-180x180.png" />
   </head>
 
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>
+      <div style="
+        font-family: sans-serif;
+        color: #d32f2f;
+        font-size: 16px;
+        text-align: center;
+        padding: 20px;
+        background-color: #ffebee;
+        border: 1px solid #d32f2f;
+        border-radius: 8px;
+        margin: 20px;
+        max-width: 500px;
+        margin: 40px auto;
+      ">
+        <h2 style="margin-bottom: 10px;">🚫 JavaScript is Disabled</h2>
+        <p>
+          This application requires JavaScript to function properly. It looks like JavaScript is either 
+          <strong>disabled</strong> or <strong>blocked</strong> in your browser.
+        </p>
+        <p style="margin-top: 10px;">
+          🔧 <strong>How to Enable JavaScript:</strong>
+          <ul style="text-align: left; display: inline-block; margin: 10px auto;">
+            <li>Go to your browser settings.</li>
+            <li>Find the "JavaScript" section.</li>
+            <li>Enable JavaScript and refresh this page.</li>
+          </ul>
+        </p>
+        <p>If you are using a script blocker, allow scripts from this site.</p>
+      </div>
+    </noscript>
     <div id="root">
       <style nonce="7e14cf80">
         .App-logo {


### PR DESCRIPTION
## Proposed Changes

- Fixes #11424
Earlier it was showing:

<img width="1438" alt="Screenshot 2025-03-20 at 1 54 38 PM" src="https://github.com/user-attachments/assets/3224132a-bc81-4470-8e5d-0e9050eec6bf" />



styled error message:


<img width="1440" alt="Screenshot 2025-03-20 at 1 46 07 PM" src="https://github.com/user-attachments/assets/55c5d78e-e3c2-45bf-9e36-7be994f27919" />



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced informational message for users with JavaScript disabled, including detailed guidance on enabling JavaScript.

- **Style**
  - Improved the formatting of key page metadata for better consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->