### PR TITLE
Removed close button and fixed clicking outside issues in Duplicate Warning Message

### DIFF
--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -37,7 +37,7 @@ const DuplicatePatientDialog = (props: Props) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="[&>button:last-child]:hidden w-3/4 md:w-1/"
+        className="[&>button:last-child]:hidden w-3/4 md:w-1/2"
         onInteractOutside={(e) => {
           e.preventDefault();
         }}

--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -41,6 +41,9 @@ const DuplicatePatientDialog = (props: Props) => {
         onInteractOutside={(e) => {
           e.preventDefault();
         }}
+        onEscapeKeyDown={(e) => {
+          e.preventDefault();
+        }}
       >
         <DialogHeader>
           <DialogTitle>{t("patient_records_found")}</DialogTitle>

--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -33,25 +33,13 @@ const DuplicatePatientDialog = (props: Props) => {
   const { t } = useTranslation();
   const { open, onOpenChange, patientList, handleOk } = props;
   const [action, setAction] = useState("");
-  const [isOutside, setIsOutside] = useState(false);
-  const dialogRef = useRef<HTMLDivElement | null>(null);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        ref={dialogRef}
-        className={`[&>button:last-child]:hidden w-3/4 md:w-1/2 ${isOutside ? "border-4 border-red-500" : "border-none"}`}
+        className="[&>button:last-child]:hidden w-3/4 md:w-1/"
         onInteractOutside={(e) => {
           e.preventDefault();
-          setIsOutside(true);
-        }}
-        onClick={(e) => {
-          if (
-            dialogRef.current &&
-            dialogRef.current.contains(e.target as Node)
-          ) {
-            setIsOutside(false);
-          }
         }}
       >
         <DialogHeader>

--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -35,7 +35,11 @@ const DuplicatePatientDialog = (props: Props) => {
   const [action, setAction] = useState("");
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(open) => open && onOpenChange(open)}
+      modal
+    >
       <DialogContent className="w-3/4 md:w-1/2">
         <DialogHeader>
           <DialogTitle>{t("patient_records_found")}</DialogTitle>
@@ -119,14 +123,6 @@ const DuplicatePatientDialog = (props: Props) => {
         </div>
         <DialogFooter>
           <div className="mt-4 flex flex-col justify-between sm:flex-row gap-2">
-            <Button
-              onClick={() => onOpenChange(false)}
-              className="gap-1"
-              variant={"secondary"}
-            >
-              <CareIcon icon="l-times" className="text-lg" />
-              {t("close")}
-            </Button>
             <Button
               onClick={() => handleOk(action)}
               disabled={!action}

--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -33,14 +33,27 @@ const DuplicatePatientDialog = (props: Props) => {
   const { t } = useTranslation();
   const { open, onOpenChange, patientList, handleOk } = props;
   const [action, setAction] = useState("");
+  const [isOutside, setIsOutside] = useState(false);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(open) => open && onOpenChange(open)}
-      modal
-    >
-      <DialogContent className="w-3/4 md:w-1/2">
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        ref={dialogRef}
+        className={`[&>button:last-child]:hidden w-3/4 md:w-1/2 ${isOutside ? "border-4 border-red-500" : "border-none"}`}
+        onInteractOutside={(e) => {
+          e.preventDefault();
+          setIsOutside(true);
+        }}
+        onClick={(e) => {
+          if (
+            dialogRef.current &&
+            dialogRef.current.contains(e.target as Node)
+          ) {
+            setIsOutside(false);
+          }
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{t("patient_records_found")}</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11417 
- Removed the close button
- Made the Dialog into a modal, so that it doesn't close when user clicks outside

## Video showing changes

https://github.com/user-attachments/assets/05d7cc76-ae68-457c-a3b1-87cb73e10299


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The duplicate patient alert dialog now behaves as a modal, requiring users to explicitly confirm their actions.

- **Refactor**
  - Enhanced interaction handling for the dialog by managing outside interactions and removing the direct close option, leading to a more controlled user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->