### PR TITLE
📝 Add patient login OTP information for staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Authenticate to staging API with any of the following credentials
   role: Doctor
 ```
 
+#### 📱 Patient Login in Staging
+
+For patient login via phone number:
+
+- In production, an actual SMS with OTP is sent to the provided phone number
+- In staging environment, to save costs, SMS messages are not actually sent
+- For testing purposes in staging, use the hardcoded OTP: `45612`
+
 #### Contributing to CARE
 
 - Create a branch with branch name of the format `issues/{issue#}/{short-name}` (example `issues/7001/edit-prescriptions`) from the latest [`develop`](https://github.com/ohcnetwork/care_fe/tree/develop) branch when starting to work on an issue.


### PR DESCRIPTION
## Description

This PR adds information to the README about patient login OTP behavior in the staging environment:
- Explains that real SMS messages are sent in production
- Clarifies that SMS messages are not sent in staging to save costs
- Provides the hardcoded OTP value (45612) for testing in staging

## Changes

- Added a new section '📱 Patient Login in Staging' to the README
- Placed this section right after the 'Staging API Credentials' section for logical grouping

## Testing

- Verified the formatting and placement of the new section in the README


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced patient login instructions to clearly differentiate behavior between live and testing environments.
  - Specified that live login sends an OTP via SMS, while the testing environment utilizes a preset OTP for user convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->