### PR TITLE
fix : validateDOMNesting Error in Location page

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -80,14 +80,14 @@ const BreadcrumbSeparator = ({
   className,
   ...props
 }: React.ComponentProps<"li">) => (
-  <li
+  <span
     role="presentation"
     aria-hidden="true"
     className={cn("[&>svg]:w-3.5 [&>svg]:h-3.5", className)}
     {...props}
   >
     {children ?? <ChevronRightIcon />}
-  </li>
+  </span>
 );
 BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #11375 
- Change `BreadcrumbSeparator` from an `<li>` element to a `<span>` element: Update the component props type from `React.ComponentProps<"li">` to `React.ComponentProps<"span">`


https://github.com/user-attachments/assets/86997f5c-10cf-4024-b9db-24b46a0b0756


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised the breadcrumb navigation separator for improved semantic structure. The change preserves existing accessibility features while refining its presentation. End-users may notice subtle adjustments in styling and screen reader interpretation without affecting overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->