### PR TITLE
Fix: OTP Sent Success Toast on Patient Appointment Booking

### DIFF
--- a/src/pages/PublicAppointments/auth/PatientLogin.tsx
+++ b/src/pages/PublicAppointments/auth/PatientLogin.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { isValidPhoneNumber } from "react-phone-number-input";
+import { toast } from "sonner";
 import { z } from "zod";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -77,6 +78,7 @@ export default function PatientLogin({
   const { mutate: sendOTP, isPending: isSendOTPLoading } = useMutation({
     mutationFn: mutate(routes.otp.sendOtp),
     onSuccess: () => {
+      toast.success(t("send_otp_success"));
       if (page === "send") {
         navigate(`/facility/${facilityId}/appointments/${staffId}/otp/verify`);
       }


### PR DESCRIPTION
## Proposed Changes

- Fixes: https://github.com/ohcnetwork/care_fe/issues/11454
- Now Success Toast is visible after requesting OTP on the Patient Appointment Screen

## Video:

https://github.com/user-attachments/assets/776569bb-b256-4cfb-abd4-1bea977c4645

@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a success notification that confirms to users when an OTP is sent, enhancing the feedback during the login process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->