### PR TITLE
Fix Enable Clickable Appointments to Access Facility Details Directly from Appointments Tab #11181

### DIFF
--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -109,7 +109,7 @@ function PatientIndex() {
     }
     return (
       <Card key={appointment.id} className="shadow overflow-hidden">
-        <CardHeader className="px-6 pb-4 bg-secondary-200 flex flex-col md:flex-row justify-between">
+        <CardHeader className="px-6 pb-3 bg-secondary-200 flex flex-col md:flex-row justify-between">
           <CardTitle>
             <div className="flex flex-col">
               <span className="text-xs font-medium">{t("practitioner")}: </span>

--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -121,7 +121,7 @@ function PatientIndex() {
             </div>
           </CardTitle>
           <div className="flex flex-row space-x-4">
-            <a href={`/nearby_facilities/?${queryParams.toString()}`}>
+            <a href={`/facilities/?${queryParams.toString()}`}>
               <Button
                 variant="secondary"
                 className="border border-secondary-400"

--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -100,9 +100,16 @@ function PatientIndex() {
     const appointmentTime = dayjs(appointment.token_slot.start_datetime);
     const appointmentDate = appointmentTime.format("DD MMMM YYYY");
     const appointmentTimeSlot = appointmentTime.format("hh:mm a");
+    const queryParams = new URLSearchParams();
+    if (selectedPatient?.geo_organization?.parent) {
+      queryParams.set(
+        "organization",
+        String(selectedPatient.geo_organization.parent.id),
+      );
+    }
     return (
       <Card key={appointment.id} className="shadow overflow-hidden">
-        <CardHeader className="px-6 pb-3 bg-secondary-200 flex flex-col md:flex-row justify-between">
+        <CardHeader className="px-6 pb-4 bg-secondary-200 flex flex-col md:flex-row justify-between">
           <CardTitle>
             <div className="flex flex-col">
               <span className="text-xs font-medium">{t("practitioner")}: </span>
@@ -113,17 +120,29 @@ function PatientIndex() {
               </span>
             </div>
           </CardTitle>
-          <Button
-            variant="secondary"
-            className="border border-secondary-400"
-            onClick={() => {
-              setSelectedAppointment(appointment);
-              setAppointmentDialogOpen(true);
-            }}
-          >
-            <span className="bg-gradient-to-b from-white/15 to-transparent"></span>
-            <span>{t("view_details")}</span>
-          </Button>
+          <div className="flex flex-row space-x-4">
+            <a href={`/nearby_facilities/?${queryParams.toString()}`}>
+              <Button
+                variant="secondary"
+                className="border border-secondary-400"
+                // style={{ transform: " translatex(15cm)" }}
+              >
+                <span className="bg-gradient-to-b from-white/15 to-transparent"></span>
+                <span>{t("View Facilities")}</span>
+              </Button>
+            </a>
+            <Button
+              variant="secondary"
+              className="border border-secondary-400"
+              onClick={() => {
+                setSelectedAppointment(appointment);
+                setAppointmentDialogOpen(true);
+              }}
+            >
+              <span className="bg-gradient-to-b from-white/15 to-transparent"></span>
+              <span>{t("view_details")}</span>
+            </Button>
+          </div>
         </CardHeader>
         <CardContent className="mt-2 pt-2 px-6 pb-3">
           <div className="flex flex-col md:flex-row gap-2 justify-between">

--- a/src/pages/Patient/index.tsx
+++ b/src/pages/Patient/index.tsx
@@ -125,7 +125,6 @@ function PatientIndex() {
               <Button
                 variant="secondary"
                 className="border border-secondary-400"
-                // style={{ transform: " translatex(15cm)" }}
               >
                 <span className="bg-gradient-to-b from-white/15 to-transparent"></span>
                 <span>{t("View Facilities")}</span>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11181 
- Add a new button in appointments tab
- Now can access facility details directly from appointments tab by clicking View Facilities


@ohcnetwork/care-fe-code-reviewers




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new button that directs users to a facilities page with context-based navigation.
  - Retained the original appointment details button, ensuring continued access to appointment information while offering enhanced navigation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->