### PR TITLE
Fixed invalid nesting and DOM errors in Facility Location page

### DIFF
--- a/src/pages/Facility/settings/locations/LocationView.tsx
+++ b/src/pages/Facility/settings/locations/LocationView.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "raviger";
-import { useState } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -125,24 +125,27 @@ export default function LocationView({ id, facilityId }: Props) {
               <Link href={`/locations`}>{t("home")}</Link>
             </BreadcrumbLink>
           </BreadcrumbItem>
+          <BreadcrumbSeparator />
           {breadcrumbs.map((breadcrumb, index) => (
-            <BreadcrumbItem key={breadcrumb.id}>
-              {index === breadcrumbs.length - 1 ? (
-                <span className="font-semibold text-gray-900">
-                  {breadcrumb.name}
-                </span>
-              ) : (
-                <>
-                  <BreadcrumbLink
-                    asChild
-                    className="text-sm text-gray-900 hover:underline hover:underline-offset-2"
-                  >
-                    <Link href={`${breadcrumb.id}`}>{breadcrumb.name}</Link>
-                  </BreadcrumbLink>
-                  <BreadcrumbSeparator />
-                </>
-              )}
-            </BreadcrumbItem>
+            <React.Fragment key={breadcrumb.id}>
+              <BreadcrumbItem key={breadcrumb.id}>
+                {index === breadcrumbs.length - 1 ? (
+                  <span className="font-semibold text-gray-900">
+                    {breadcrumb.name}
+                  </span>
+                ) : (
+                  <>
+                    <BreadcrumbLink
+                      asChild
+                      className="text-sm text-gray-900 hover:underline hover:underline-offset-2"
+                    >
+                      <Link href={`${breadcrumb.id}`}>{breadcrumb.name}</Link>
+                    </BreadcrumbLink>
+                  </>
+                )}
+              </BreadcrumbItem>
+              {index != breadcrumbs.length - 1 && <BreadcrumbSeparator />}
+            </React.Fragment>
           ))}
         </BreadcrumbList>
       </Breadcrumb>

--- a/src/pages/Facility/settings/locations/LocationView.tsx
+++ b/src/pages/Facility/settings/locations/LocationView.tsx
@@ -128,7 +128,7 @@ export default function LocationView({ id, facilityId }: Props) {
           <BreadcrumbSeparator />
           {breadcrumbs.map((breadcrumb, index) => (
             <React.Fragment key={breadcrumb.id}>
-              <BreadcrumbItem key={breadcrumb.id}>
+              <BreadcrumbItem>
                 {index === breadcrumbs.length - 1 ? (
                   <span className="font-semibold text-gray-900">
                     {breadcrumb.name}


### PR DESCRIPTION
## Proposed Changes

- Fixes #11375 
- Fixed format of breadcrumb separators, this fixed invalid nesting of `<li>`
- Put the BreadcrumbItem and separator inside React.Fragment and added unique key prop to it, this prevents missing key value in `<li>`


https://github.com/user-attachments/assets/50922bf8-c31a-41b9-b708-46ae8747bac4


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the breadcrumb rendering logic to ensure that separators appear only between items when appropriate, enhancing the clarity and visual consistency of the navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->