### PR TITLE
Replace Date Inputs with Relative & Absolute Date Picker

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
@@ -9,9 +9,10 @@ import {
 } from "@radix-ui/react-icons";
 import { useQuery } from "@tanstack/react-query";
 import { t } from "i18next";
-import { useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -42,6 +43,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { CATEGORY_ICONS } from "@/components/Patient/allergy/list";
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
@@ -119,6 +121,9 @@ export function AllergyQuestion({
   const allergies =
     (questionnaireResponse.values?.[0]?.value as AllergyIntoleranceRequest[]) ||
     [];
+  const [activeTab, setActiveTab] = useState<"absolute" | "relative">(
+    "absolute",
+  );
 
   const { data: patientAllergies } = useQuery({
     queryKey: ["allergies", patientId],
@@ -232,6 +237,8 @@ export function AllergyQuestion({
                     disabled={disabled}
                     onUpdate={(updates) => handleUpdateAllergy(index, updates)}
                     onRemove={() => handleRemoveAllergy(index)}
+                    activeTab={activeTab}
+                    setActiveTab={setActiveTab}
                   />
                 ))}
               </TableBody>
@@ -412,11 +419,12 @@ export function AllergyQuestion({
                     <Label className="text-xs text-gray-500">
                       {t("occurrence")}
                     </Label>
+
                     <Popover>
                       <PopoverTrigger asChild>
                         <Button
                           variant="outline"
-                          className="h-8 w-full mt-1 justify-start font-normal"
+                          className="h-7 text-sm px-2 justify-start font-normal"
                           disabled={disabled}
                         >
                           {allergy.last_occurrence ? (
@@ -430,19 +438,51 @@ export function AllergyQuestion({
                           )}
                         </Button>
                       </PopoverTrigger>
-                      <PopoverContent className="p-0" align="start">
-                        <RelativeDatePicker
-                          value={
-                            allergy.last_occurrence
-                              ? new Date(allergy.last_occurrence)
-                              : undefined
+                      <PopoverContent className="p-0 w-auto" align="start">
+                        <Tabs
+                          value={activeTab}
+                          onValueChange={(v) =>
+                            setActiveTab(v as "absolute" | "relative")
                           }
-                          onDateChange={(date) =>
-                            handleUpdateAllergy(index, {
-                              last_occurrence: dateQueryString(date),
-                            })
-                          }
-                        />
+                        >
+                          <TabsList className="grid w-full grid-cols-2">
+                            <TabsTrigger value="absolute">
+                              {t("absolute_date")}
+                            </TabsTrigger>
+                            <TabsTrigger value="relative">
+                              {t("relative_date")}
+                            </TabsTrigger>
+                          </TabsList>
+                          <TabsContent value="absolute" className="p-0">
+                            <Calendar
+                              mode="single"
+                              selected={
+                                allergy.last_occurrence
+                                  ? new Date(allergy.last_occurrence)
+                                  : undefined
+                              }
+                              onSelect={(date: Date | undefined) => {
+                                handleUpdateAllergy(index, {
+                                  last_occurrence: dateQueryString(date),
+                                });
+                              }}
+                            />
+                          </TabsContent>
+                          <TabsContent value="relative" className="p-0">
+                            <RelativeDatePicker
+                              value={
+                                allergy.last_occurrence
+                                  ? new Date(allergy.last_occurrence)
+                                  : undefined
+                              }
+                              onDateChange={(date) =>
+                                handleUpdateAllergy(index, {
+                                  last_occurrence: dateQueryString(date),
+                                })
+                              }
+                            />
+                          </TabsContent>
+                        </Tabs>
                       </PopoverContent>
                     </Popover>
                   </div>
@@ -484,12 +524,16 @@ interface AllergyItemProps {
   disabled?: boolean;
   onUpdate?: (allergy: Partial<AllergyIntoleranceRequest>) => void;
   onRemove?: () => void;
+  activeTab: "absolute" | "relative";
+  setActiveTab: Dispatch<SetStateAction<"absolute" | "relative">>;
 }
 const AllergyTableRow = ({
   allergy,
   disabled,
   onUpdate,
   onRemove,
+  activeTab,
+  setActiveTab,
 }: AllergyItemProps) => {
   const [showNotes, setShowNotes] = useState(allergy.note !== undefined);
 
@@ -600,7 +644,7 @@ const AllergyTableRow = ({
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
-                className="h-7 text-sm w-[100px] px-1 justify-start font-normal"
+                className="h-7 text-sm px-2 justify-start font-normal"
                 disabled={disabled}
               >
                 {allergy.last_occurrence ? (
@@ -610,17 +654,47 @@ const AllergyTableRow = ({
                 )}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="p-0" align="start">
-              <RelativeDatePicker
-                value={
-                  allergy.last_occurrence
-                    ? new Date(allergy.last_occurrence)
-                    : undefined
+            <PopoverContent className="p-0 w-auto" align="start">
+              <Tabs
+                value={activeTab}
+                onValueChange={(v) =>
+                  setActiveTab(v as "absolute" | "relative")
                 }
-                onDateChange={(date) => {
-                  onUpdate?.({ last_occurrence: dateQueryString(date) });
-                }}
-              />
+              >
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="absolute">
+                    {t("absolute_date")}
+                  </TabsTrigger>
+                  <TabsTrigger value="relative">
+                    {t("relative_date")}
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent value="absolute" className="p-0">
+                  <Calendar
+                    mode="single"
+                    selected={
+                      allergy.last_occurrence
+                        ? new Date(allergy.last_occurrence)
+                        : undefined
+                    }
+                    onSelect={(date: Date | undefined) => {
+                      onUpdate?.({ last_occurrence: dateQueryString(date) });
+                    }}
+                  />
+                </TabsContent>
+                <TabsContent value="relative" className="p-0">
+                  <RelativeDatePicker
+                    value={
+                      allergy.last_occurrence
+                        ? new Date(allergy.last_occurrence)
+                        : undefined
+                    }
+                    onDateChange={(date) => {
+                      onUpdate?.({ last_occurrence: dateQueryString(date) });
+                    }}
+                  />
+                </TabsContent>
+              </Tabs>
             </PopoverContent>
           </Popover>
         </TableCell>

--- a/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
@@ -9,7 +9,7 @@ import {
 } from "@radix-ui/react-icons";
 import { useQuery } from "@tanstack/react-query";
 import { t } from "i18next";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -21,6 +21,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { RelativeDatePicker } from "@/components/ui/relative-date-picker";
 import {
   Select,
   SelectContent,
@@ -44,17 +50,17 @@ import query from "@/Utils/request/query";
 import { dateQueryString } from "@/Utils/utils";
 import {
   ALLERGY_VERIFICATION_STATUS,
-  AllergyIntolerance,
-  AllergyIntoleranceRequest,
-  AllergyVerificationStatus,
+  type AllergyIntolerance,
+  type AllergyIntoleranceRequest,
+  type AllergyVerificationStatus,
 } from "@/types/emr/allergyIntolerance/allergyIntolerance";
 import allergyIntoleranceApi from "@/types/emr/allergyIntolerance/allergyIntoleranceApi";
-import { Code } from "@/types/questionnaire/code";
-import {
+import type { Code } from "@/types/questionnaire/code";
+import type {
   QuestionnaireResponse,
   ResponseValue,
 } from "@/types/questionnaire/form";
-import { Question } from "@/types/questionnaire/question";
+import type { Question } from "@/types/questionnaire/question";
 
 interface AllergyQuestionProps {
   patientId: string;
@@ -406,17 +412,39 @@ export function AllergyQuestion({
                     <Label className="text-xs text-gray-500">
                       {t("occurrence")}
                     </Label>
-                    <Input
-                      type="date"
-                      value={allergy.last_occurrence || ""}
-                      onChange={(e) =>
-                        handleUpdateAllergy(index, {
-                          last_occurrence: e.target.value,
-                        })
-                      }
-                      disabled={disabled}
-                      className="h-8 mt-1"
-                    />
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          className="h-8 w-full mt-1 justify-start font-normal"
+                          disabled={disabled}
+                        >
+                          {allergy.last_occurrence ? (
+                            new Date(
+                              allergy.last_occurrence,
+                            ).toLocaleDateString()
+                          ) : (
+                            <span className="text-muted-foreground">
+                              Select date
+                            </span>
+                          )}
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="p-0" align="start">
+                        <RelativeDatePicker
+                          value={
+                            allergy.last_occurrence
+                              ? new Date(allergy.last_occurrence)
+                              : undefined
+                          }
+                          onDateChange={(date) =>
+                            handleUpdateAllergy(index, {
+                              last_occurrence: dateQueryString(date),
+                            })
+                          }
+                        />
+                      </PopoverContent>
+                    </Popover>
                   </div>
                 </div>
 
@@ -568,13 +596,33 @@ const AllergyTableRow = ({
           </Select>
         </TableCell>
         <TableCell className="min-w-[100px] py-1 px-1">
-          <Input
-            type="date"
-            value={allergy.last_occurrence}
-            onChange={(e) => onUpdate?.({ last_occurrence: e.target.value })}
-            disabled={disabled}
-            className="h-7 text-sm w-[100px] px-1"
-          />
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className="h-7 text-sm w-[100px] px-1 justify-start font-normal"
+                disabled={disabled}
+              >
+                {allergy.last_occurrence ? (
+                  new Date(allergy.last_occurrence).toLocaleDateString()
+                ) : (
+                  <span className="text-muted-foreground">Select date</span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="p-0" align="start">
+              <RelativeDatePicker
+                value={
+                  allergy.last_occurrence
+                    ? new Date(allergy.last_occurrence)
+                    : undefined
+                }
+                onDateChange={(date) => {
+                  onUpdate?.({ last_occurrence: dateQueryString(date) });
+                }}
+              />
+            </PopoverContent>
+          </Popover>
         </TableCell>
         <TableCell className="min-w-[35px] py-1 px-0">
           <DropdownMenu>

--- a/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
@@ -433,7 +433,7 @@ export function AllergyQuestion({
                             ).toLocaleDateString()
                           ) : (
                             <span className="text-muted-foreground">
-                              Select date
+                              {t("select_date")}
                             </span>
                           )}
                         </Button>
@@ -650,7 +650,9 @@ const AllergyTableRow = ({
                 {allergy.last_occurrence ? (
                   new Date(allergy.last_occurrence).toLocaleDateString()
                 ) : (
-                  <span className="text-muted-foreground">Select date</span>
+                  <span className="text-muted-foreground">
+                    {t("select_date")}
+                  </span>
                 )}
               </Button>
             </PopoverTrigger>

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -397,7 +397,9 @@ export function DiagnosisQuestion({
                         newDiagnosis.onset.onset_datetime,
                       ).toLocaleDateString()
                     ) : (
-                      <span className="text-muted-foreground">Select date</span>
+                      <span className="text-muted-foreground">
+                        {t("select_date")}
+                      </span>
                     )}
                   </Button>
                 </PopoverTrigger>
@@ -632,7 +634,9 @@ const DiagnosisItem: React.FC<DiagnosisItemProps> = ({
                       diagnosis.onset.onset_datetime,
                     ).toLocaleDateString()
                   ) : (
-                    <span className="text-muted-foreground">Select date</span>
+                    <span className="text-muted-foreground">
+                      {t("select_date")}
+                    </span>
                   )}
                 </Button>
               </PopoverTrigger>

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -6,12 +6,19 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { t } from "i18next";
-import React, { useEffect, useMemo, useState } from "react";
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,6 +41,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
@@ -114,6 +122,9 @@ export function DiagnosisQuestion({
     ...DIAGNOSIS_INITIAL_VALUE,
     onset: { onset_datetime: new Date().toISOString().split("T")[0] },
   });
+  const [activeTab, setActiveTab] = useState<"absolute" | "relative">(
+    "absolute",
+  );
 
   // Sort diagnoses: chronic conditions first, then by date
   const sortedDiagnoses = useMemo(() => {
@@ -306,6 +317,8 @@ export function DiagnosisQuestion({
                 disabled={disabled}
                 onUpdate={(updates) => handleUpdateDiagnosis(index, updates)}
                 onRemove={() => handleRemoveDiagnosis(index)}
+                activeTab={activeTab}
+                setActiveTab={setActiveTab}
               />
             ))}
           </div>
@@ -388,20 +401,53 @@ export function DiagnosisQuestion({
                     )}
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className="p-0" align="start">
-                  <RelativeDatePicker
-                    value={
-                      newDiagnosis.onset?.onset_datetime
-                        ? new Date(newDiagnosis.onset.onset_datetime)
-                        : undefined
+                <PopoverContent className="p-0 w-auto" align="start">
+                  <Tabs
+                    value={activeTab}
+                    onValueChange={(v) =>
+                      setActiveTab(v as "absolute" | "relative")
                     }
-                    onDateChange={(date) =>
-                      setNewDiagnosis((prev) => ({
-                        ...prev,
-                        onset: { onset_datetime: dateQueryString(date) },
-                      }))
-                    }
-                  />
+                  >
+                    <TabsList className="grid w-full grid-cols-2">
+                      <TabsTrigger value="absolute">
+                        {t("absolute_date")}
+                      </TabsTrigger>
+                      <TabsTrigger value="relative">
+                        {t("relative_date")}
+                      </TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="absolute" className="p-0">
+                      <Calendar
+                        mode="single"
+                        selected={
+                          newDiagnosis.onset?.onset_datetime
+                            ? new Date(newDiagnosis.onset.onset_datetime)
+                            : undefined
+                        }
+                        onSelect={(date: Date | undefined) => {
+                          setNewDiagnosis((prev) => ({
+                            ...prev,
+                            onset: { onset_datetime: dateQueryString(date) },
+                          }));
+                        }}
+                      />
+                    </TabsContent>
+                    <TabsContent value="relative" className="p-0">
+                      <RelativeDatePicker
+                        value={
+                          newDiagnosis.onset?.onset_datetime
+                            ? new Date(newDiagnosis.onset.onset_datetime)
+                            : undefined
+                        }
+                        onDateChange={(date) =>
+                          setNewDiagnosis((prev) => ({
+                            ...prev,
+                            onset: { onset_datetime: dateQueryString(date) },
+                          }))
+                        }
+                      />
+                    </TabsContent>
+                  </Tabs>
                 </PopoverContent>
               </Popover>
             </div>
@@ -498,6 +544,8 @@ interface DiagnosisItemProps {
   disabled?: boolean;
   onUpdate?: (diagnosis: Partial<DiagnosisRequest>) => void;
   onRemove?: () => void;
+  activeTab: "absolute" | "relative";
+  setActiveTab: Dispatch<SetStateAction<"absolute" | "relative">>;
 }
 
 const DiagnosisItem: React.FC<DiagnosisItemProps> = ({
@@ -505,6 +553,8 @@ const DiagnosisItem: React.FC<DiagnosisItemProps> = ({
   disabled,
   onUpdate,
   onRemove,
+  activeTab,
+  setActiveTab,
 }) => {
   const [showNotes, setShowNotes] = useState(Boolean(diagnosis.note));
 
@@ -586,19 +636,51 @@ const DiagnosisItem: React.FC<DiagnosisItemProps> = ({
                   )}
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="p-0" align="start">
-                <RelativeDatePicker
-                  value={
-                    diagnosis.onset?.onset_datetime
-                      ? new Date(diagnosis.onset.onset_datetime)
-                      : undefined
+              <PopoverContent className="p-0 w-auto" align="start">
+                <Tabs
+                  value={activeTab}
+                  onValueChange={(v) =>
+                    setActiveTab(v as "absolute" | "relative")
                   }
-                  onDateChange={(date) =>
-                    onUpdate?.({
-                      onset: { onset_datetime: dateQueryString(date) },
-                    })
-                  }
-                />
+                >
+                  <TabsList className="grid w-full grid-cols-2">
+                    <TabsTrigger value="absolute">
+                      {t("absolute_date")}
+                    </TabsTrigger>
+                    <TabsTrigger value="relative">
+                      {t("relative_date")}
+                    </TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="absolute" className="p-0">
+                    <Calendar
+                      mode="single"
+                      selected={
+                        diagnosis.onset?.onset_datetime
+                          ? new Date(diagnosis.onset.onset_datetime)
+                          : undefined
+                      }
+                      onSelect={(date: Date | undefined) => {
+                        onUpdate?.({
+                          onset: { onset_datetime: dateQueryString(date) },
+                        });
+                      }}
+                    />
+                  </TabsContent>
+                  <TabsContent value="relative" className="p-0">
+                    <RelativeDatePicker
+                      value={
+                        diagnosis.onset?.onset_datetime
+                          ? new Date(diagnosis.onset.onset_datetime)
+                          : undefined
+                      }
+                      onDateChange={(date) =>
+                        onUpdate?.({
+                          onset: { onset_datetime: dateQueryString(date) },
+                        })
+                      }
+                    />
+                  </TabsContent>
+                </Tabs>
               </PopoverContent>
             </Popover>
           </div>

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -22,6 +22,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { RelativeDatePicker } from "@/components/ui/relative-date-picker";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -32,6 +38,7 @@ import {
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
 import query from "@/Utils/request/query";
+import { dateQueryString } from "@/Utils/utils";
 import {
   ACTIVE_DIAGNOSIS_CLINICAL_STATUS,
   DIAGNOSIS_CATEGORY,
@@ -365,17 +372,38 @@ export function DiagnosisQuestion({
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="space-y-2">
               <Label className="text-sm">{t("date")}</Label>
-              <Input
-                type="date"
-                value={newDiagnosis.onset?.onset_datetime || ""}
-                onChange={(e) =>
-                  setNewDiagnosis((prev) => ({
-                    ...prev,
-                    onset: { onset_datetime: e.target.value },
-                  }))
-                }
-                className="h-9"
-              />
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="h-9 w-full justify-start font-normal"
+                    disabled={disabled}
+                  >
+                    {newDiagnosis.onset?.onset_datetime ? (
+                      new Date(
+                        newDiagnosis.onset.onset_datetime,
+                      ).toLocaleDateString()
+                    ) : (
+                      <span className="text-muted-foreground">Select date</span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="p-0" align="start">
+                  <RelativeDatePicker
+                    value={
+                      newDiagnosis.onset?.onset_datetime
+                        ? new Date(newDiagnosis.onset.onset_datetime)
+                        : undefined
+                    }
+                    onDateChange={(date) =>
+                      setNewDiagnosis((prev) => ({
+                        ...prev,
+                        onset: { onset_datetime: dateQueryString(date) },
+                      }))
+                    }
+                  />
+                </PopoverContent>
+              </Popover>
             </div>
             <div className="space-y-2">
               <Label className="text-sm">{t("status")}</Label>
@@ -542,17 +570,37 @@ const DiagnosisItem: React.FC<DiagnosisItemProps> = ({
             <Label className="text-xs text-gray-500 md:hidden">
               {t("date")}
             </Label>
-            <Input
-              type="date"
-              value={diagnosis.onset?.onset_datetime || ""}
-              onChange={(e) =>
-                onUpdate?.({
-                  onset: { onset_datetime: e.target.value },
-                })
-              }
-              disabled={disabled || !!diagnosis.id}
-              className="h-8 md:h-9"
-            />
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="h-8 md:h-9 w-full justify-start font-normal"
+                  disabled={disabled || !!diagnosis.id}
+                >
+                  {diagnosis.onset?.onset_datetime ? (
+                    new Date(
+                      diagnosis.onset.onset_datetime,
+                    ).toLocaleDateString()
+                  ) : (
+                    <span className="text-muted-foreground">Select date</span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="p-0" align="start">
+                <RelativeDatePicker
+                  value={
+                    diagnosis.onset?.onset_datetime
+                      ? new Date(diagnosis.onset.onset_datetime)
+                      : undefined
+                  }
+                  onDateChange={(date) =>
+                    onUpdate?.({
+                      onset: { onset_datetime: dateQueryString(date) },
+                    })
+                  }
+                />
+              </PopoverContent>
+            </Popover>
           </div>
           <div>
             <Label className="text-xs text-gray-500 md:hidden">

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -227,7 +227,9 @@ const SymptomRow = React.memo(function SymptomRow({
                 {symptom.onset?.onset_datetime ? (
                   new Date(symptom.onset.onset_datetime).toLocaleDateString()
                 ) : (
-                  <span className="text-muted-foreground">Select date</span>
+                  <span className="text-muted-foreground">
+                    {t("select_date")}
+                  </span>
                 )}
               </Button>
             </PopoverTrigger>

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +36,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
@@ -158,9 +160,12 @@ const SymptomRow = React.memo(function SymptomRow({
   onRemove,
 }: SymptomRowProps) {
   const [showNotes, setShowNotes] = useState(Boolean(symptom.note));
+  const [activeTab, setActiveTab] = useState<"absolute" | "relative">(
+    "absolute",
+  );
 
   const handleDateChange = useCallback(
-    (date: Date) =>
+    (date: Date | undefined) =>
       onUpdate(index, {
         onset: { onset_datetime: dateQueryString(date) },
       }),
@@ -226,15 +231,45 @@ const SymptomRow = React.memo(function SymptomRow({
                 )}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="p-0" align="start">
-              <RelativeDatePicker
-                value={
-                  symptom.onset?.onset_datetime
-                    ? new Date(symptom.onset.onset_datetime)
-                    : undefined
+            <PopoverContent className="p-0 w-auto" align="start">
+              <Tabs
+                value={activeTab}
+                onValueChange={(v) =>
+                  setActiveTab(v as "absolute" | "relative")
                 }
-                onDateChange={handleDateChange}
-              />
+              >
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="absolute">
+                    {t("absolute_date")}
+                  </TabsTrigger>
+                  <TabsTrigger value="relative">
+                    {t("relative_date")}
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent value="absolute" className="p-0">
+                  <Calendar
+                    mode="single"
+                    selected={
+                      symptom.onset?.onset_datetime
+                        ? new Date(symptom.onset.onset_datetime)
+                        : undefined
+                    }
+                    onSelect={(date: Date | undefined) => {
+                      handleDateChange(date);
+                    }}
+                  />
+                </TabsContent>
+                <TabsContent value="relative" className="p-0">
+                  <RelativeDatePicker
+                    value={
+                      symptom.onset?.onset_datetime
+                        ? new Date(symptom.onset.onset_datetime)
+                        : undefined
+                    }
+                    onDateChange={(date) => handleDateChange(date)}
+                  />
+                </TabsContent>
+              </Tabs>
             </PopoverContent>
           </Popover>
         </div>

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -23,6 +23,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { RelativeDatePicker } from "@/components/ui/relative-date-picker";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -33,6 +39,7 @@ import {
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
 import query from "@/Utils/request/query";
+import { dateQueryString } from "@/Utils/utils";
 import {
   SYMPTOM_CLINICAL_STATUS,
   SYMPTOM_SEVERITY,
@@ -153,9 +160,9 @@ const SymptomRow = React.memo(function SymptomRow({
   const [showNotes, setShowNotes] = useState(Boolean(symptom.note));
 
   const handleDateChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
+    (date: Date) =>
       onUpdate(index, {
-        onset: { onset_datetime: e.target.value },
+        onset: { onset_datetime: dateQueryString(date) },
       }),
     [index, onUpdate],
   );
@@ -205,13 +212,31 @@ const SymptomRow = React.memo(function SymptomRow({
           <div className="block text-sm font-medium text-gray-500 mb-1 md:hidden">
             {t("date")}
           </div>
-          <Input
-            type="date"
-            value={symptom.onset?.onset_datetime || ""}
-            onChange={handleDateChange}
-            disabled={disabled || !!symptom.id}
-            className="h-8 md:h-9"
-          />
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className="h-8 md:h-9 w-full justify-start font-normal"
+                disabled={disabled || !!symptom.id}
+              >
+                {symptom.onset?.onset_datetime ? (
+                  new Date(symptom.onset.onset_datetime).toLocaleDateString()
+                ) : (
+                  <span className="text-muted-foreground">Select date</span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="p-0" align="start">
+              <RelativeDatePicker
+                value={
+                  symptom.onset?.onset_datetime
+                    ? new Date(symptom.onset.onset_datetime)
+                    : undefined
+                }
+                onDateChange={handleDateChange}
+              />
+            </PopoverContent>
+          </Popover>
         </div>
         <div className="col-span-2">
           <div className="block text-sm font-medium text-gray-500 mb-1 md:hidden">


### PR DESCRIPTION
## Proposed Changes

- Fixes #11516 
- Replaced date inputs with RelativeDatePicker in Allergy, Symptom, and Diagnosis questions.
- Added Absolute Date Picker alongside the relative one for more flexibility.
- Tested both pickers to ensure correct functionality.

[Screencast from 2025-03-24 22-16-19.webm](https://github.com/user-attachments/assets/5715a362-953b-4048-985d-15ebc7460bd4)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users now experience an enhanced date selection interface in multiple questionnaire sections. The update replaces standard input fields with an interactive popover date picker that displays either the chosen date or a prompt to "Select date," streamlining the process and improving overall usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->