### PR TITLE
Empty sections in Treatment Summary are hidden

### DIFF
--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -164,12 +164,6 @@ export default function TreatmentSummary({
     medicationsLoading ||
     medicationStatementLoading;
 
-  console.log("Allergies:", allergies);
-  console.log("Symptoms:", symptoms);
-  console.log("Diagnoses:", diagnoses);
-  console.log("Medications:", medications);
-  console.log("Medication Statements:", medicationStatement);
-
   if (isLoading) {
     return (
       <PrintPreview

--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -55,13 +55,6 @@ const SectionLayout = ({
   );
 };
 
-const EmptyState = ({ message }: { message: string }) => {
-  return (
-    <CardContent className="px-2 pb-3 pt-2">
-      <p className="text-gray-500">{message}</p>
-    </CardContent>
-  );
-};
 export default function TreatmentSummary({
   facilityId,
   encounterId,
@@ -170,6 +163,12 @@ export default function TreatmentSummary({
     symptomsLoading ||
     medicationsLoading ||
     medicationStatementLoading;
+
+  console.log("Allergies:", allergies);
+  console.log("Symptoms:", symptoms);
+  console.log("Diagnoses:", diagnoses);
+  console.log("Medications:", medications);
+  console.log("Medication Statements:", medicationStatement);
 
   if (isLoading) {
     return (
@@ -338,8 +337,8 @@ export default function TreatmentSummary({
           {/* Medical Information */}
           <div className="space-y-6">
             {/* Allergies */}
-            <SectionLayout title={t("allergies")}>
-              {allergies?.count ? (
+            {allergies?.count != 0 && (
+              <SectionLayout title={t("allergies")}>
                 <PrintTable
                   headers={[
                     { key: "allergen" },
@@ -358,15 +357,12 @@ export default function TreatmentSummary({
                     logged_by: formatName(allergy.created_by),
                   }))}
                 />
-              ) : (
-                <EmptyState message={t("no_allergies_recorded")} />
-              )}
-            </SectionLayout>
+              </SectionLayout>
+            )}
 
             {/* Symptoms */}
-
-            <SectionLayout title={t("symptoms")}>
-              {symptoms?.count ? (
+            {symptoms?.count != 0 && (
+              <SectionLayout title={t("symptoms")}>
                 <PrintTable
                   headers={[
                     { key: "symptom" },
@@ -391,14 +387,12 @@ export default function TreatmentSummary({
                     logged_by: formatName(symptom.created_by),
                   }))}
                 />
-              ) : (
-                <EmptyState message={t("no_symptoms_recorded")} />
-              )}
-            </SectionLayout>
+              </SectionLayout>
+            )}
 
             {/* Diagnoses */}
-            <SectionLayout title={t("diagnoses")}>
-              {diagnoses?.count ? (
+            {diagnoses?.count != 0 && (
+              <SectionLayout title={t("diagnoses")}>
                 <PrintTable
                   headers={[
                     { key: "diagnosis" },
@@ -421,14 +415,12 @@ export default function TreatmentSummary({
                     logged_by: formatName(diagnosis.created_by),
                   }))}
                 />
-              ) : (
-                <EmptyState message={t("no_diagnoses_recorded")} />
-              )}
-            </SectionLayout>
+              </SectionLayout>
+            )}
 
             {/* Medications */}
-            <SectionLayout title={t("medications")}>
-              {medications?.results.length ? (
+            {medications?.count != 0 && (
+              <SectionLayout title={t("medications")}>
                 <PrintTable
                   headers={[
                     { key: "medicine" },
@@ -463,14 +455,12 @@ export default function TreatmentSummary({
                     };
                   })}
                 />
-              ) : (
-                <EmptyState message={t("no_medication_recorded")} />
-              )}
-            </SectionLayout>
+              </SectionLayout>
+            )}
 
             {/* Medication Statements */}
-            <SectionLayout title={t("ongoing_medications")}>
-              {medicationStatement?.results.length ? (
+            {medicationStatement?.count != 0 && (
+              <SectionLayout title={t("ongoing_medications")}>
                 <PrintTable
                   headers={[
                     { key: "medication" },
@@ -500,10 +490,8 @@ export default function TreatmentSummary({
                     logged_by: formatName(medication.created_by),
                   }))}
                 />
-              ) : (
-                <EmptyState message={t("no_ongoing_medications")} />
-              )}
-            </SectionLayout>
+              </SectionLayout>
+            )}
           </div>
 
           {/* Questionnaire Responses Section */}


### PR DESCRIPTION
## Proposed Changes

- Fixes #11505 
- Respective SectionLayouts are only displayed when there is data in the fields.
- Changed checking conditions of sections from `allergies?.count` to `allergies?.count != 0`. In the first condition a "0" was being printed on the screen when data was empty.
- Removed EmptyState, as it was no longer needed

## Video

https://github.com/user-attachments/assets/7562d5b7-2e17-47fe-b0f6-5ba3388147b7

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the presentation of patient treatment summaries by updating display logic. Now, sections such as allergies, symptoms, diagnoses, and medications are shown only when relevant data is available.
  - Removed the fallback placeholder for empty records, resulting in a cleaner, more focused view of treatment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->