### PR TITLE
fix last selected geo-org not being sent in user create

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -285,6 +285,7 @@ export default function UserForm({
             ? data.c_password
             : undefined,
         profile_picture_url: "",
+        geo_organization: data.geo_organization || null,
       } as CreateUserModel);
     }
   };

--- a/src/pages/Organization/components/GovtOrganizationSelector.tsx
+++ b/src/pages/Organization/components/GovtOrganizationSelector.tsx
@@ -119,12 +119,7 @@ export default function GovtOrganizationSelector(
         newLevels.push(organization);
         return newLevels;
       });
-      if (!organization.has_children) {
-        onChange(organization.id);
-        // Else condition is necessary to reset the form value for pre-filled forms
-      } else {
-        onChange("");
-      }
+      onChange(organization.id);
     } else {
       onChange("");
       // Reset subsequent levels when clearing a selection


### PR DESCRIPTION
## Proposed Changes

- Fixes #11546

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The user registration process now accepts optional geographical organization information, enabling users to include location-related details during account creation for a more comprehensive profile setup.
  
- **Improvements**
  - Simplified logic in the organization selection process, ensuring smoother user interaction when filtering organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->