### PR TITLE
Perms: add loading as dependent param for redirect

### DIFF
--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -79,12 +79,12 @@ export default function TreatmentSummary({
   const canAccess = canViewEncounter || canViewClinicalData;
 
   useEffect(() => {
-    if (!canAccess) {
+    if (!canAccess && !encounterLoading) {
       toast.error(t("no_permission_to_view_page"));
       goBack();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canAccess]);
+  }, [canAccess, encounterLoading]);
   const { data: allergies, isLoading: allergiesLoading } = useQuery({
     queryKey: ["allergies", patientId, encounterId],
     queryFn: query.paginated(allergyIntoleranceApi.getAllergy, {

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -83,7 +83,7 @@ export default function AppointmentDetail(props: Props) {
   const { hasPermission } = usePermissions();
   const { goBack } = useAppHistory();
 
-  const { data: facilityData } = useQuery({
+  const { data: facilityData, isLoading: isFacilityLoading } = useQuery({
     queryKey: ["facility", props.facilityId],
     queryFn: query(routes.getPermittedFacility, {
       pathParams: {
@@ -95,7 +95,7 @@ export default function AppointmentDetail(props: Props) {
   const { canViewAppointments, canUpdateAppointment, canCreateAppointment } =
     getPermissions(hasPermission, facilityData?.permissions ?? []);
 
-  const appointmentQuery = useQuery({
+  const { data: appointment } = useQuery({
     queryKey: ["appointment", props.appointmentId],
     queryFn: query(scheduleApis.appointments.retrieve, {
       pathParams: {
@@ -117,12 +117,12 @@ export default function AppointmentDetail(props: Props) {
   };
 
   useEffect(() => {
-    if (!canViewAppointments) {
+    if (!canViewAppointments && !isFacilityLoading) {
       toast.error(t("no_permission_to_view_page"));
       goBack(`/facility/${props.facilityId}/overview`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canViewAppointments]);
+  }, [canViewAppointments, isFacilityLoading]);
 
   const { mutate: updateAppointment, isPending } = useMutation<
     Appointment,
@@ -145,8 +145,6 @@ export default function AppointmentDetail(props: Props) {
     },
   });
 
-  const appointment = appointmentQuery.data;
-
   if (!facilityData || !appointment) {
     return <Loading />;
   }
@@ -163,14 +161,14 @@ export default function AppointmentDetail(props: Props) {
           )}
         >
           <AppointmentDetails
-            appointment={appointmentQuery.data}
+            appointment={appointment}
             facility={facilityData}
           />
           <div className="mt-3">
             <div id="section-to-print" className="print:w-[400px] print:pt-4">
               <div id="appointment-token-card" className="bg-gray-50 md:p-4">
                 <AppointmentTokenCard
-                  appointment={appointmentQuery.data}
+                  appointment={appointment}
                   facility={facilityData}
                 />
               </div>

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -251,7 +251,7 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
   const { hasPermission } = usePermissions();
   const { goBack } = useAppHistory();
 
-  const { data: facilityData } = useQuery({
+  const { data: facilityData, isLoading: isFacilityLoading } = useQuery({
     queryKey: ["facility", facilityId],
     queryFn: query(routes.getPermittedFacility, {
       pathParams: { id: facilityId },
@@ -342,11 +342,12 @@ export default function AppointmentsPage(props: { facilityId?: string }) {
   const slot = slots?.find((s) => s.id === qParams.slot);
 
   useEffect(() => {
-    if (!canViewAppointments) {
+    if (!canViewAppointments && !isFacilityLoading) {
       toast.error(t("no_permission_to_view_page"));
       goBack("/");
     }
-  }, [canViewAppointments]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canViewAppointments, isFacilityLoading]);
 
   if (schedulableUsersQuery.isLoading) {
     return <Loading />;


### PR DESCRIPTION
## Proposed Changes

- Fixes #11464
 - For some pages, useEffect (related to permissions) was triggering and redirecting early (on page reload).
 - Added isLoading as a dependency, since perms are dependent on the query finishing successfully.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted error notifications so they now trigger only after all relevant data has finished loading, preventing premature alerts.
	- Enhanced permission and loading checks in patient and appointment views to ensure smoother navigation and a more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->