### PR TITLE
Compute availability from `slots_for_day` API in availability heatmap calendar if the date is today

### DIFF
--- a/src/pages/Appointments/utils.ts
+++ b/src/pages/Appointments/utils.ts
@@ -4,7 +4,7 @@ import {
   compareAsc,
   eachDayOfInterval,
   format,
-  isBefore,
+  isPast,
   max,
   startOfToday,
 } from "date-fns";
@@ -25,7 +25,7 @@ export const groupSlotsByAvailability = (slots: TokenSlot[]) => {
   }[] = [];
 
   for (const slot of slots) {
-    if (isBefore(slot.end_datetime, new Date())) {
+    if (isPast(slot.end_datetime)) {
       continue;
     }
     const availability = slot.availability;


### PR DESCRIPTION

## Proposed Changes

- Fixes #11551
- Compute slots from slots for day response in availability heatmap calendar if the date is today. 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced appointment slot availability on the booking page. Today's available appointments are now displayed with improved accuracy by prioritizing current-day slots and filtering out past time slots for a better booking experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->