### PR TITLE
Fix: Make Duplicate Patient Pop-up scrollable on mobile devices

### DIFF
--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -37,7 +37,7 @@ const DuplicatePatientDialog = (props: Props) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="[&>button:last-child]:hidden w-3/4 md:w-1/2"
+        className="[&>button:last-child]:hidden w-3/4 max-w-lg max-h-[90vh] overflow-y-auto sm:w-3/4 sm:max-w-xl"
         onInteractOutside={(e) => {
           e.preventDefault();
         }}
@@ -56,7 +56,7 @@ const DuplicatePatientDialog = (props: Props) => {
             </p>
           </div>
           <div>
-            <div className="max-h-[200px] overflow-auto ">
+            <div className="overflow-auto ">
               <Table>
                 <TableHeader>
                   <TableRow>

--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -56,7 +56,7 @@ const DuplicatePatientDialog = (props: Props) => {
             </p>
           </div>
           <div>
-            <div className="overflow-auto ">
+            <div className="overflow-auto">
               <Table>
                 <TableHeader>
                   <TableRow>

--- a/src/components/Facility/DuplicatePatientDialog.tsx
+++ b/src/components/Facility/DuplicatePatientDialog.tsx
@@ -37,7 +37,7 @@ const DuplicatePatientDialog = (props: Props) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="[&>button:last-child]:hidden w-3/4 max-w-lg max-h-[90vh] overflow-y-auto sm:w-3/4 sm:max-w-xl"
+        className="[&>button:last-child]:hidden w-3/4 md:w-1/2 max-h-[90vh] overflow-y-auto"
         onInteractOutside={(e) => {
           e.preventDefault();
         }}


### PR DESCRIPTION
## Proposed Changes

- Fixes #11514 
- Added max-h-[90vh] overflow-y-auto to DialogContent
- Ensures dialog scrolls properly on small screens
- Verified behavior on multiple breakpoints

@ohcnetwork/care-fe-code-reviewers
## Screenshot

![Screenshot 2025-03-26 220012](https://github.com/user-attachments/assets/2964536f-863d-47c7-8ba0-b4e763788643)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the dialog’s layout for improved responsiveness with refined dimensions and enhanced overflow handling.
  - Simplified the table container styling to allow content expansion without restrictive height limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->