### PR TITLE
Remove unnecessary sticky positioning from ResourceForm footer for improved layout

### DIFF
--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -557,7 +557,7 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                   </div>
                 </div>
 
-                <div className="sticky bottom-0 flex justify-end gap-4 border-t border-gray-200 pt-4">
+                <div className="flex justify-end gap-4 border-t border-gray-200 pt-4">
                   <Button
                     type="button"
                     variant="outline"


### PR DESCRIPTION


## Proposed Changes

- Remove unnecessary sticky positioning from ResourceForm footer for improved layout

reported by @nihal467 

@ohcnetwork/care-fe-code-reviewers




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the layout of the form's action buttons so that they now scroll normally with the page instead of staying fixed at the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->