### PR TITLE
Revert "Ensure page scrolls to the top when mounted;"

### DIFF
--- a/src/components/Common/Page.tsx
+++ b/src/components/Common/Page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { RefObject } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -9,25 +9,35 @@ interface PageProps extends PageTitleProps {
   options?: React.ReactNode | React.ReactNode[];
   changePageMetadata?: boolean;
   className?: string;
+  ref?: RefObject<HTMLDivElement>;
+  /**
+   * If true, the sidebar will be collapsed when mounted, and restored to original state when unmounted.
+   * @default false
+   **/
+  collapseSidebar?: boolean;
   hideTitleOnPage?: boolean;
 }
 
 export default function Page(props: PageProps) {
-  const ref = useRef<HTMLDivElement>(null);
+  // const sidebar = useContext(SidebarShrinkContext);
 
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.scrollIntoView({ behavior: "smooth" });
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (!props.collapseSidebar) return;
+
+  //   sidebar.setShrinked(true);
+  //   return () => {
+  //     sidebar.setShrinked(sidebar.shrinked);
+  //   };
+  // }, [props.collapseSidebar]);
 
   return (
-    <div className={cn("md:px-6 py-0 grid", props.className)} ref={ref}>
+    <div className={cn("md:px-6 py-0 grid", props.className)} ref={props.ref}>
       <div className="flex flex-col justify-between gap-2 px-3 md:flex-row md:items-center md:gap-6 md:px-0">
         <PageTitle
           changePageMetadata={props.changePageMetadata}
           title={props.title}
           componentRight={props.componentRight}
+          focusOnLoad={props.focusOnLoad}
           isInsidePage={true}
           hideTitleOnPage={props.hideTitleOnPage}
         />

--- a/src/components/Common/PageTitle.tsx
+++ b/src/components/Common/PageTitle.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -8,6 +8,7 @@ export interface PageTitleProps {
   title: string;
   className?: string;
   componentRight?: ReactNode;
+  focusOnLoad?: boolean;
   isInsidePage?: boolean;
   changePageMetadata?: boolean;
   hideTitleOnPage?: boolean;
@@ -17,12 +18,24 @@ export default function PageTitle({
   title,
   className = "",
   componentRight = <></>,
+  focusOnLoad = false,
   isInsidePage = false,
   changePageMetadata = true,
   hideTitleOnPage,
 }: PageTitleProps) {
+  const divRef = useRef<any>();
+
+  useEffect(() => {
+    if (divRef.current && focusOnLoad) {
+      divRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [divRef, focusOnLoad]);
+
   return (
-    <div className={cn(!isInsidePage && "mb-2 md:mb-4", className)}>
+    <div
+      ref={divRef}
+      className={cn(!isInsidePage && "mb-2 md:mb-4", className)}
+    >
       {changePageMetadata && <PageHeadTitle title={title} />}
 
       <div

--- a/src/components/Users/UserHome.tsx
+++ b/src/components/Users/UserHome.tsx
@@ -106,6 +106,7 @@ export default function UserHome(props: UserHomeProps) {
     <>
       <Page
         title={formatName(userData) || userData.username || t("manage_user")}
+        focusOnLoad={true}
         hideTitleOnPage
       >
         {


### PR DESCRIPTION
Reverts ohcnetwork/care_fe#11604


This PR is reverted as we are having a UX bug in autocompletes in iphones (randomly in androids too).

cc: @nihal467 @rithviknishad 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an auto-scroll behavior on page load so that key content and titles are brought into view, enhancing navigation.
  - Added options to dynamically adjust the sidebar's visibility during page transitions for a more flexible layout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->