### PR TITLE
pop up after appointment got cancelled #11475

### DIFF
--- a/src/pages/Patient/components/AppointmentDialog.tsx
+++ b/src/pages/Patient/components/AppointmentDialog.tsx
@@ -56,6 +56,7 @@ function AppointmentDialog({
         queryKey: ["appointment", tokenData?.phoneNumber],
       });
       toast.success(t("appointment_cancelled"));
+      alert("Appointment has been successfully cancelled.");
       setAppointmentDialogOpen(false);
     },
   });


### PR DESCRIPTION
There will be a pop message on top after appointment got cancelled 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced user notifications: Users now receive an additional immediate browser alert confirming the successful cancellation of an appointment, supplementing the existing toast notification. This new alert provides instant feedback, improving the clarity of actions taken and enhancing the overall user experience during appointment management. These improvements help users quickly confirm their actions and reduce uncertainty about appointment cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->