### PR TITLE
Add new subsection for Drawings in File tab

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2333,6 +2333,7 @@
   "search_encounters": "Search Encounters",
   "search_existing_consent": "Search existing consent",
   "search_facilities": "Search for available facilities to book an appointment <strong>(for new patients)</strong>",
+  "search_files": "Search files",
   "search_for_a_user": "Search for a user",
   "search_for_allergies_to_add": "Search for allergies to add",
   "search_for_diagnoses_to_add": "Search for diagnoses to add",

--- a/src/Routers/routes/PatientRoutes.tsx
+++ b/src/Routers/routes/PatientRoutes.tsx
@@ -1,9 +1,9 @@
 import { Redirect } from "raviger";
 import { Suspense, lazy } from "react";
 
+import { DrawingTab } from "@/components/Common/Drawings/DrawingTab";
 import Loading from "@/components/Common/Loading";
 import { patientTabs } from "@/components/Patient/PatientDetailsTab";
-import { PatientDrawingTab } from "@/components/Patient/PatientDetailsTab/PatientDrawingsTab";
 import { PatientHome } from "@/components/Patient/PatientHome";
 import PatientIndex from "@/components/Patient/PatientIndex";
 import PatientRegistration from "@/components/Patient/PatientRegistration";
@@ -85,9 +85,7 @@ const PatientRoutes: AppRoutes = {
       />
     </Suspense>
   ),
-  "/patient/:patientId/drawings": ({ patientId }) => (
-    <PatientDrawingTab patientId={patientId} />
-  ),
+  "/patient/:patientId/drawings": () => <DrawingTab type="patient" />,
 
   "/patient/:patientId/drawings/new": ({ patientId }) => {
     return (

--- a/src/components/Common/Drawings/DrawingTab.tsx
+++ b/src/components/Common/Drawings/DrawingTab.tsx
@@ -108,6 +108,7 @@ const ExcalidrawPreview = memo(({ elements }: ExcalidrawPreviewProps) => {
         </div>
       ) : (
         <div
+          key={JSON.stringify(elements)}
           ref={svgContainerRef}
           className="h-full w-full flex items-center justify-center p-2"
         />
@@ -119,21 +120,22 @@ const ExcalidrawPreview = memo(({ elements }: ExcalidrawPreviewProps) => {
 ExcalidrawPreview.displayName = "ExcalidrawPreview";
 
 export const DrawingTab = (props: DrawingsTabProps) => {
-  const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
+  const { qParams, Pagination, resultsPerPage } = useFilters({
     limit: 15,
     cacheBlacklist: ["name"],
   });
+  const [drawingName, setDrawingName] = useState("");
 
   const associatingId =
     props.type === "encounter" ? props.encounter?.id : props.patientId;
 
   const { data, isLoading } = useQuery({
-    queryKey: ["drawings", associatingId, qParams, resultsPerPage],
+    queryKey: ["drawings", associatingId, qParams, resultsPerPage, drawingName],
     queryFn: query.debounced(metaArtifactApi.list, {
       queryParams: {
         object_type: "drawing",
         associating_type: props.type,
-        name: qParams.name,
+        name: drawingName,
         associating_id: associatingId,
         limit: resultsPerPage,
         offset: (qParams.page - 1) * resultsPerPage,
@@ -148,8 +150,8 @@ export const DrawingTab = (props: DrawingsTabProps) => {
           id="search-by-name"
           name="name"
           placeholder={t("search_drawings")}
-          value={qParams.name}
-          onChange={(e) => updateQuery({ name: e.target.value })}
+          value={drawingName}
+          onChange={(e) => setDrawingName(e.target.value)}
           className="w-full sm:w-1/3"
         />
         <Button variant="white" onClick={() => navigate("drawings/new")}>

--- a/src/components/Common/Drawings/ExcalidrawEditor.tsx
+++ b/src/components/Common/Drawings/ExcalidrawEditor.tsx
@@ -59,7 +59,7 @@ export default function ExcalidrawEditor({
       queryClient.invalidateQueries({
         queryKey: ["drawing", drawingId, associatingId],
       });
-      navigate("../drawings");
+      navigate("../files");
     },
   });
 
@@ -111,7 +111,7 @@ export default function ExcalidrawEditor({
     if (isDirty) {
       setIsAlertOpen(true);
     } else {
-      navigate("../drawings");
+      navigate("../files");
     }
   };
 
@@ -140,7 +140,7 @@ export default function ExcalidrawEditor({
               className="bg-red-500 text-gray-50 shadow-sm hover:bg-red-500/90"
               onClick={() => {
                 setIsAlertOpen(false);
-                navigate("../drawings");
+                navigate("../files");
               }}
             >
               {t("discard_changes")}

--- a/src/components/Files/FilesTab.tsx
+++ b/src/components/Files/FilesTab.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Table,
@@ -29,6 +30,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TooltipComponent } from "@/components/ui/tooltip";
 
+import { DrawingTab } from "@/components/Common/Drawings/DrawingTab";
 import Loading from "@/components/Common/Loading";
 import ArchivedFileDialog from "@/components/Files/ArchivedFileDialog";
 import AudioPlayerDialog from "@/components/Files/AudioPlayerDialog";
@@ -68,6 +70,7 @@ export const FilesTab = (props: FilesTabProps) => {
   const [selectedAudioFile, setSelectedAudioFile] =
     useState<FileUploadModel | null>(null);
   const [openAudioPlayerDialog, setOpenAudioPlayerDialog] = useState(false);
+  const [fileName, setFileName] = useState("");
   const { hasPermission } = usePermissions();
   const {
     canViewClinicalData,
@@ -124,11 +127,12 @@ export const FilesTab = (props: FilesTabProps) => {
     isLoading: filesLoading,
     refetch,
   } = useQuery({
-    queryKey: ["files", type, associatingId, qParams],
+    queryKey: ["files", type, associatingId, qParams, fileName],
     queryFn: query(routes.viewUpload, {
       queryParams: {
         file_type: type,
         associating_id: associatingId,
+        name: fileName,
         limit: resultsPerPage,
         offset: ((qParams.page || 1) - 1) * resultsPerPage,
         ...(qParams.is_archived !== undefined && {
@@ -141,6 +145,8 @@ export const FilesTab = (props: FilesTabProps) => {
     }),
     enabled: canAccess,
   });
+
+  console.log("name:", fileName);
 
   const fileManager = useFileManager({
     type: type,
@@ -618,7 +624,6 @@ export const FilesTab = (props: FilesTabProps) => {
       </Table>
     </div>
   );
-
   return (
     <div className="space-y-4">
       <div className="z-40">
@@ -708,12 +713,29 @@ export const FilesTab = (props: FilesTabProps) => {
             </>
           )}
           <FileUploadButtons />
+          <Input
+            id="search-by-filename"
+            name="name"
+            placeholder={t("search_files")}
+            value={fileName}
+            onChange={(e) => {
+              setFileName(e.target.value);
+            }}
+            className="w-full pl-8"
+          />
         </div>
         <FilterBadges />
         {fileCategories.map((category) => (
           <TabsContent key={category.value} value={category.value}>
             <RenderTable />
             <RenderCard />
+            <span className="text-lg font-bold">{t("drawings")}</span>
+            <DrawingTab
+              type={props.type}
+              {...(props.type === "patient"
+                ? { patientId: props.patient?.id }
+                : { encounter: props.encounter })}
+            />
           </TabsContent>
         ))}
       </Tabs>

--- a/src/components/Patient/PatientDetailsTab/index.tsx
+++ b/src/components/Patient/PatientDetailsTab/index.tsx
@@ -7,7 +7,6 @@ import { HasPermissionFn, getPermissions } from "@/common/Permissions";
 import { Patient } from "@/types/emr/newPatient";
 
 import { Appointments } from "./Appointments";
-import { PatientDrawingTab } from "./PatientDrawingsTab";
 import { PatientFilesTab } from "./PatientFiles";
 import { PatientUsers } from "./PatientUsers";
 import { ResourceRequests } from "./ResourceRequests";
@@ -61,10 +60,6 @@ export const BASE_PATIENT_TABS: Tab[] = [
   {
     route: "files",
     component: PatientFilesTab,
-  },
-  {
-    route: "drawings",
-    component: PatientDrawingTab,
   },
 ];
 

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -24,7 +24,6 @@ import { EncounterPlotsTab } from "@/pages/Encounters/tabs/EncounterPlotsTab";
 import { Encounter, inactiveEncounterStatus } from "@/types/emr/encounter";
 import { Patient } from "@/types/emr/newPatient";
 
-import { EncounterDrawingsTab } from "./tabs/EncounterDrawingsTab";
 import { EncounterNotesTab } from "./tabs/EncounterNotesTab";
 
 export interface EncounterTabProps {
@@ -39,7 +38,6 @@ const defaultTabs = {
   files: EncounterFilesTab,
   notes: EncounterNotesTab,
   devices: EncounterDevicesTab,
-  drawings: EncounterDrawingsTab,
   // nursing: EncounterNursingTab,
   // neurological_monitoring: EncounterNeurologicalMonitoringTab,
   // pressure_sore: EncounterPressureSoreTab,


### PR DESCRIPTION
## Add new subsection for Drawings in File tab

- Fixes #11284
- Added a new subsection for Drawings in the FileTab section.
- Added a search feature in the Files section for name-based searching.
- A backend PR is required to complete file filtering by name [PR](https://github.com/ohcnetwork/care/pull/2958)

Implementation screenshot
![image](https://github.com/user-attachments/assets/fc0bdd98-1b9d-4613-a0c8-6d868ebbb796)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices
