### PR TITLE
Fix: Show feedback for 'Resend OTP' button

### DIFF
--- a/src/pages/PublicAppointments/auth/PatientLogin.tsx
+++ b/src/pages/PublicAppointments/auth/PatientLogin.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { isValidPhoneNumber } from "react-phone-number-input";
+import { toast } from "sonner";
 import { z } from "zod";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -73,10 +74,10 @@ export default function PatientLogin({
       `/facility/${facilityId}/appointments/${staffId}/book-appointment`,
     );
   }
-
   const { mutate: sendOTP, isPending: isSendOTPLoading } = useMutation({
     mutationFn: mutate(routes.otp.sendOtp),
     onSuccess: () => {
+      toast.success(t("send_otp_success"));
       if (page === "send") {
         navigate(`/facility/${facilityId}/appointments/${staffId}/otp/verify`);
       }
@@ -217,12 +218,18 @@ export default function PatientLogin({
                 t("verify_otp")
               )}
             </Button>
-            <a
-              className="w-full text-sm underline text-center cursor-pointer text-secondary-800"
-              onClick={() => sendOTP({ phone_number: phoneNumber })}
-            >
-              {t("didnt_receive_a_message")} {t("resend_otp")}
-            </a>
+            {isSendOTPLoading ? (
+              <div className="w-full flex justify-center">
+                <CircularProgress className="text-secondary-800" />
+              </div>
+            ) : (
+              <a
+                className="w-full text-sm underline text-center cursor-pointer text-secondary-800"
+                onClick={() => sendOTP({ phone_number: phoneNumber })}
+              >
+                {t("didnt_receive_a_message")} {t("resend_otp")}
+              </a>
+            )}
           </form>
         </Form>
       </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11562 
- Shows toast message when OTP succeeds.
- Disables the "Resend OTP" button while the request is in progress.
- Adds a loading indicator when the request is in progress.

@ohcnetwork/care-fe-code-reviewers



https://github.com/user-attachments/assets/49f6030f-a39d-4eaa-9230-ae0a5032cad4




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a success notification when an OTP is sent, providing immediate feedback.
  - Enhanced the resend OTP functionality to show a loading indicator during processing, ensuring users are aware of ongoing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->