### PR TITLE
Enhance feature tag hover contrast in the facility editor.

### DIFF
--- a/src/pages/Facility/Utils.tsx
+++ b/src/pages/Facility/Utils.tsx
@@ -12,14 +12,14 @@ export const FeatureBadge = ({ featureId }: { featureId: number }) => {
     return <></>;
   }
   const variantStyles = {
-    blue: "bg-blue-100 text-blue-800",
-    orange: "bg-orange-100 text-orange-800",
-    teal: "bg-teal-100 text-teal-800",
-    yellow: "bg-yellow-100 text-yellow-800",
-    pink: "bg-pink-100 text-pink-800",
-    red: "bg-red-100 text-red-800",
-    indigo: "bg-indigo-100 text-indigo-800",
-    purple: "bg-purple-100 text-purple-800",
+    blue: "bg-blue-100 text-blue-800 hover:bg-blue-200",
+    orange: "bg-orange-100 text-orange-800 hover:bg-orange-200",
+    teal: "bg-teal-100 text-teal-800 hover:bg-teal-200",
+    yellow: "bg-yellow-100 text-yellow-800 hover:bg-yellow-200",
+    pink: "bg-pink-100 text-pink-800 hover:bg-pink-200",
+    red: "bg-red-100 text-red-800 hover:bg-red-200",
+    indigo: "bg-indigo-100 text-indigo-800 hover:bg-indigo-200",
+    purple: "bg-purple-100 text-purple-800 hover:bg-purple-200",
   };
 
   return (


### PR DESCRIPTION
Fixes #11635

Enhance feature tag hover contrast in the facility editor.

* Modify `src/pages/Facility/Utils.tsx` to add hover styles to the `FeatureBadge` component.
* Update the `variantStyles` object to include hover background color changes for each feature tag color.
  * Blue: `hover:bg-blue-200`
  * Orange: `hover:bg-orange-200`
  * Teal: `hover:bg-teal-200`
  * Yellow: `hover:bg-yellow-200`
  * Pink: `hover:bg-pink-200`
  * Red: `hover:bg-red-200`
  * Indigo: `hover:bg-indigo-200`
  * Purple: `hover:bg-purple-200`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ohcnetwork/care_fe/pull/11636?shareId=ec8130f9-f803-4bab-a1f0-dd543fe9d349).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced interactive badge styling with updated hover effects that provide a lighter background on mouse-over, offering improved visual feedback for a more engaging user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->