### PR TITLE
Added `autoFocus` Prop to Search Inputs

### DIFF
--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -397,6 +397,7 @@ const Login = (props: LoginProps) => {
                             data-cy="username"
                             value={form.username}
                             onChange={handleChange}
+                            autoFocus
                             className={cn(
                               errors.username &&
                                 "border-red-500 focus-visible:ring-red-500",

--- a/src/components/Facility/FacilityUsers.tsx
+++ b/src/components/Facility/FacilityUsers.tsx
@@ -92,6 +92,7 @@ export default function FacilityUsers(props: { facilityId: string }) {
           value={qParams.username}
           placeholder={t("search_by_username")}
           className="w-full max-w-sm"
+          autoFocus
         />
         <Tabs
           value={activeTab}

--- a/src/pages/Facility/locations/LocationContent.tsx
+++ b/src/pages/Facility/locations/LocationContent.tsx
@@ -265,6 +265,7 @@ export default function LocationContent({
               value={searchQuery}
               onChange={(e) => onSearchChange(e.target.value)}
               className="w-full"
+              autoFocus
             />
           </div>
         </div>

--- a/src/pages/Facility/settings/devices/DevicesList.tsx
+++ b/src/pages/Facility/settings/devices/DevicesList.tsx
@@ -144,6 +144,7 @@ export default function DevicesList({ facilityId }: Props) {
             value={qParams.search_text || ""}
             onChange={(e) => handleSearchChange(e.target.value)}
             className="pl-9"
+            autoFocus
           />
         </div>
         <Popover>

--- a/src/pages/Facility/settings/locations/LocationList.tsx
+++ b/src/pages/Facility/settings/locations/LocationList.tsx
@@ -264,6 +264,7 @@ export default function LocationList({ facilityId }: Props) {
               setSearchQuery(e.target.value);
             }}
             className="w-full text-xs lg:text-sm"
+            autoFocus
           />
           <Button
             variant="primary"

--- a/src/pages/Facility/settings/organizations/FacilityOrganizationView.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationView.tsx
@@ -120,6 +120,7 @@ export default function FacilityOrganizationView({
                   updateQuery({ search: e.target.value || undefined });
                 }}
                 className="w-full pl-8"
+                autoFocus
               />
             </div>
           </div>

--- a/src/pages/Organization/OrganizationFacilities.tsx
+++ b/src/pages/Organization/OrganizationFacilities.tsx
@@ -92,6 +92,7 @@ export default function OrganizationFacilities({
                 }
                 className="max-w-sm"
                 data-cy="search-facility"
+                autoFocus
               />
             </div>
 

--- a/src/pages/Organization/OrganizationPatients.tsx
+++ b/src/pages/Organization/OrganizationPatients.tsx
@@ -121,6 +121,7 @@ export default function OrganizationPatients({ id, navOrganizationId }: Props) {
               )}
               onSearch={handleSearch}
               onFieldChange={handleFieldChange}
+              autoFocus
             />
 
             <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">

--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -161,6 +161,7 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
                 onFieldChange={handleFieldChange}
                 className="w-full"
                 data-cy="search-user"
+                autoFocus
               />
             </div>
             {isFetchingUsers ? (

--- a/src/pages/Organization/OrganizationView.tsx
+++ b/src/pages/Organization/OrganizationView.tsx
@@ -72,6 +72,7 @@ export default function OrganizationView({ id, navOrganizationId }: Props) {
                     updateQuery({ name: e.target.value });
                   }}
                   className="w-full"
+                  autoFocus
                 />
               </div>
             </div>


### PR DESCRIPTION
## Proposed Changes

- Added `autoFocus` prop true to Input Searches to get input in focus state when user lands on that specific page

@ohcnetwork/care-fe-code-reviewers

Demo:

https://github.com/user-attachments/assets/13a45e72-f605-4964-9ad3-904a9d22418b



## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x]  Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Input and search fields across the application now automatically receive focus when pages load. This enhancement allows you to start typing immediately without needing to click into the form, streamlining interactions on login, facility, and organization screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->