### PR TITLE
hide ongoing slot for public patients slot picker

### DIFF
--- a/src/pages/Appointments/components/AppointmentSlotPicker.tsx
+++ b/src/pages/Appointments/components/AppointmentSlotPicker.tsx
@@ -279,7 +279,7 @@ export const TokenSlotButton = ({
   availability,
   selectedSlotId,
   onClick,
-  allowOngoingSlots,
+  allowOngoingSlots = false,
 }: {
   slot: Omit<TokenSlot, "availability">;
   availability: TokenSlot["availability"];
@@ -296,16 +296,17 @@ export const TokenSlotButton = ({
     end: slot.end_datetime,
   });
 
+  if (!allowOngoingSlots && isOngoingSlot) {
+    return null;
+  }
+
   return (
     <Button
       key={slot.id}
       size="lg"
       variant={selectedSlotId === slot.id ? "primary" : "outline"}
       onClick={onClick}
-      disabled={
-        slot.allocated === availability.tokens_per_slot ||
-        (!allowOngoingSlots && isOngoingSlot)
-      }
+      disabled={slot.allocated === availability.tokens_per_slot}
       className="flex flex-col items-center group gap-0 w-24 relative"
     >
       <span className="font-semibold">


### PR DESCRIPTION
## Proposed Changes

- fixes #11631

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Appointment slot selection now hides ongoing slots by default, ensuring users see only upcoming available slots unless explicitly enabled.
  - The slot button behavior has been streamlined, so it now disables solely based on slot availability, providing clearer interaction feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->