### PR TITLE
Remove cancel button and add scrolling and responsiveness in Manage Consent sheet

### DIFF
--- a/src/components/Common/FilePreviewDialog.tsx
+++ b/src/components/Common/FilePreviewDialog.tsx
@@ -301,7 +301,7 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
 
   return (
     <Dialog open={show} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="h-full w-full max-w-5xl flex-col gap-4 bg-white rounded-lg p-4 shadow-xl md:p-6">
+      <DialogContent className="h-full w-full max-w-5xl flex-col gap-4 rounded-lg p-4 shadow-xl md:p-6 overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-sm text-gray-600">
             {t("file_preview")}
@@ -343,14 +343,6 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
                     </a>
                   </Button>
                 )}
-                <Button
-                  variant="outline"
-                  type="button"
-                  onClick={handleClose}
-                  data-cy="file-preview-close"
-                >
-                  {t("close")}
-                </Button>
               </div>
             </div>
             <div className="flex flex-1 items-center justify-center">
@@ -483,18 +475,20 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
                         key={index}
                         onClick={button[2] as () => void}
                         className={cn(
-                          "z-50 rounded bg-white/60 px-4 py-2 text-black backdrop-blur-sm transition hover:bg-white/70",
+                          "z-50 rounded bg-white/60 text-black backdrop-blur-sm transition hover:bg-white/70",
                           index > 2 ? "max-md:col-span-3" : "max-md:col-span-2",
                         )}
                         disabled={button[3] as boolean}
                       >
-                        {button[1] && (
-                          <CareIcon
-                            icon={button[1] as IconName}
-                            className="mr-2 text-lg"
-                          />
-                        )}
-                        {button[0] as string}
+                        <div>
+                          {button[1] && (
+                            <CareIcon
+                              icon={button[1] as IconName}
+                              className="text-lg"
+                            />
+                          )}
+                          <div>{button[0] as string}</div>
+                        </div>
                       </Button>
                     ))}
                   </>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11630
- Remove cancel button because Dialog component already has a close option(icon)
- Improve responsiveness and add scrolling

Before Update:

https://github.com/user-attachments/assets/4421c617-7646-4db6-9341-29bfcc2b472e

After Update: 


https://github.com/user-attachments/assets/2840e5fa-0ce5-4f9b-b651-2a0ba7aa2cc3



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated a file preview dialog layout to support vertical scrolling for lengthy content.
  - Adjusted the button layout and removed a close button, changing how users dismiss the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->