### PR TITLE
Hide ongoing slots and fix practitioners avatar not being shown in public appointment booking

### DIFF
--- a/src/Routers/routes/ScheduleRoutes.tsx
+++ b/src/Routers/routes/ScheduleRoutes.tsx
@@ -1,22 +1,9 @@
-import { Redirect } from "raviger";
-
-import useAuthUser from "@/hooks/useAuthUser";
-
 import { AppRoutes } from "@/Routers/AppRouter";
 import AppointmentDetail from "@/pages/Appointments/AppointmentDetail";
 import AppointmentsPage from "@/pages/Appointments/AppointmentsPage";
 import BookAppointment from "@/pages/Appointments/BookAppointment";
 
-const HomeFacilityRedirect = ({ suffix }: { suffix: string }) => {
-  const authUser = useAuthUser();
-  const facilityId = authUser.home_facility!;
-
-  return <Redirect to={`/facility/${facilityId}${suffix}`} />;
-};
-
 const ScheduleRoutes: AppRoutes = {
-  // Appointments
-  "/appointments": () => <HomeFacilityRedirect suffix="/appointments" />,
   "/facility/:facilityId/appointments": ({ facilityId }) => (
     <AppointmentsPage facilityId={facilityId} />
   ),

--- a/src/Utils/request/api.tsx
+++ b/src/Utils/request/api.tsx
@@ -8,11 +8,7 @@ import {
   CreateFileResponse,
   FileUploadModel,
 } from "@/components/Patient/models";
-import {
-  UpdatePasswordForm,
-  UserAssignedModel,
-  UserModel,
-} from "@/components/Users/models";
+import { UpdatePasswordForm, UserModel } from "@/components/Users/models";
 
 import { PaginatedResponse } from "@/Utils/request/types";
 import { AppointmentPatientRegister } from "@/pages/Patient/Utils";
@@ -198,7 +194,7 @@ const routes = {
 
   getScheduleAbleFacilityUsers: {
     path: "/api/v1/facility/{facility_id}/schedulable_users/",
-    TRes: Type<PaginatedResponse<UserAssignedModel>>(),
+    TRes: Type<PaginatedResponse<UserBase>>(),
   },
 
   // Download Api

--- a/src/Utils/request/api.tsx
+++ b/src/Utils/request/api.tsx
@@ -8,7 +8,7 @@ import {
   CreateFileResponse,
   FileUploadModel,
 } from "@/components/Patient/models";
-import { UpdatePasswordForm, UserModel } from "@/components/Users/models";
+import { AuthUserModel, UpdatePasswordForm } from "@/components/Users/models";
 
 import { PaginatedResponse } from "@/Utils/request/types";
 import { AppointmentPatientRegister } from "@/pages/Patient/Utils";
@@ -144,13 +144,13 @@ const routes = {
   // User Endpoints
   currentUser: {
     path: "/api/v1/users/getcurrentuser/",
-    TRes: Type<UserModel>(),
+    TRes: Type<AuthUserModel>(),
   },
 
   deleteProfilePicture: {
     path: "/api/v1/users/{username}/profile_picture/",
     method: "DELETE",
-    TRes: Type<UserModel>(),
+    TRes: Type<AuthUserModel>(),
     TBody: Type<void>(),
   },
 

--- a/src/components/Users/models.tsx
+++ b/src/components/Users/models.tsx
@@ -1,7 +1,5 @@
 import { Gender, UserType } from "@/components/Users/UserFormValidations";
 
-import { GENDER_TYPES } from "@/common/constants";
-
 import { Organization } from "@/types/organization/organization";
 
 export type UpdatePasswordForm = {
@@ -39,28 +37,8 @@ export type UserModel = UserBareMinimum & {
   date_of_birth: Date | null | string;
   is_superuser?: boolean;
   verified?: boolean;
-  home_facility?: string;
-  qualification?: string;
-  doctor_experience_commenced_on?: string;
-  doctor_medical_council_registration?: string;
-  weekly_working_hours?: string | null;
   facilities?: UserFacilityModel[];
   organizations?: Organization[];
   permissions: string[];
   mfa_enabled?: boolean;
 };
-
-export interface UserAssignedModel extends UserBareMinimum {
-  phone_number?: string;
-  alt_phone_number?: string;
-  video_connect_link: string;
-  gender?: (typeof GENDER_TYPES)[number]["id"];
-  date_of_birth: Date | null;
-  is_superuser?: boolean;
-  verified?: boolean;
-  home_facility?: string;
-  qualification?: string;
-  doctor_experience_commenced_on?: Date;
-  doctor_medical_council_registration?: string;
-  weekly_working_hours?: string;
-}

--- a/src/components/Users/models.tsx
+++ b/src/components/Users/models.tsx
@@ -27,13 +27,11 @@ export type UserFacilityModel = {
   name: string;
 };
 
-export type UserModel = UserBareMinimum & {
+export type AuthUserModel = UserBareMinimum & {
   external_id: string;
-  video_connect_link: string;
   phone_number?: string;
   alt_phone_number?: string;
   gender?: Gender;
-  read_profile_picture_url?: string;
   date_of_birth: Date | null | string;
   is_superuser?: boolean;
   verified?: boolean;

--- a/src/components/ui/sidebar/app-sidebar.tsx
+++ b/src/components/ui/sidebar/app-sidebar.tsx
@@ -25,10 +25,10 @@ import { OrgNav } from "@/components/ui/sidebar/org-nav";
 import { OrganizationSwitcher } from "@/components/ui/sidebar/organization-switcher";
 import { PatientNav } from "@/components/ui/sidebar/patient-nav";
 
-import { UserFacilityModel, UserModel } from "@/components/Users/models";
+import { AuthUserModel, UserFacilityModel } from "@/components/Users/models";
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
-  user?: UserModel;
+  user?: AuthUserModel;
   facilitySidebar?: boolean;
   sidebarFor?: SidebarFor;
 }

--- a/src/hooks/useAuthUser.ts
+++ b/src/hooks/useAuthUser.ts
@@ -1,12 +1,12 @@
 import { createContext, useContext } from "react";
 
-import { UserModel } from "@/components/Users/models";
+import { AuthUserModel } from "@/components/Users/models";
 
 import { LoginCredentials, LoginResponse } from "@/Utils/request/api";
 import { MFALoginRequest, TokenData } from "@/types/auth/otp";
 
 interface AuthContextType {
-  user: UserModel | undefined;
+  user: AuthUserModel | undefined;
   signIn: (creds: LoginCredentials) => Promise<LoginResponse>;
   verifyMFA: (data: MFALoginRequest) => Promise<LoginResponse>;
   isAuthenticating: boolean;

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -237,14 +237,16 @@ function DateRangeDisplay({ dateFrom, dateTo }: DateRangeDisplayProps) {
   );
 }
 
-export default function AppointmentsPage(props: { facilityId?: string }) {
+export default function AppointmentsPage({
+  facilityId,
+}: {
+  facilityId: string;
+}) {
   const { t } = useTranslation();
   const authUser = useAuthUser();
   const { qParams, updateQuery, resultsPerPage, Pagination } = useFilters({
     limit: 15,
   });
-
-  const facilityId = props.facilityId ?? authUser.home_facility!;
 
   const [activeTab, setActiveTab] = useView("appointments", "board");
 

--- a/src/pages/Appointments/components/AppointmentSlotPicker.tsx
+++ b/src/pages/Appointments/components/AppointmentSlotPicker.tsx
@@ -258,7 +258,6 @@ export function AppointmentSlotPicker({
                                   : slot.id,
                               );
                             }}
-                            allowOngoingSlots={true}
                           />
                         ))}
                       </div>
@@ -279,13 +278,11 @@ export const TokenSlotButton = ({
   availability,
   selectedSlotId,
   onClick,
-  allowOngoingSlots = false,
 }: {
   slot: Omit<TokenSlot, "availability">;
   availability: TokenSlot["availability"];
   selectedSlotId: string | undefined;
   onClick: () => void;
-  allowOngoingSlots: boolean;
 }) => {
   const { t } = useTranslation();
 
@@ -295,10 +292,6 @@ export const TokenSlotButton = ({
     start: slot.start_datetime,
     end: slot.end_datetime,
   });
-
-  if (!allowOngoingSlots && isOngoingSlot) {
-    return null;
-  }
 
   return (
     <Button

--- a/src/pages/Facility/FacilityDetailsPage.tsx
+++ b/src/pages/Facility/FacilityDetailsPage.tsx
@@ -12,14 +12,12 @@ import { Avatar } from "@/components/Common/Avatar";
 import { LoginHeader } from "@/components/Common/LoginHeader";
 import { FacilityMapsLink } from "@/components/Facility/FacilityMapLink";
 import { FacilityModel } from "@/components/Facility/models";
-import { UserAssignedModel } from "@/components/Users/models";
 
 import useAppHistory from "@/hooks/useAppHistory";
 import useFilters from "@/hooks/useFilters";
 
 import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
-import { PaginatedResponse } from "@/Utils/request/types";
 
 import { FeatureBadge } from "./Utils";
 import { UserCard } from "./components/UserCard";
@@ -42,9 +40,7 @@ export function FacilityDetailsPage({ id }: Props) {
     limit: 18,
   });
 
-  const { data: docResponse, error: docError } = useQuery<
-    PaginatedResponse<UserAssignedModel>
-  >({
+  const { data: docResponse, error: docError } = useQuery({
     queryKey: [routes.getScheduleAbleFacilityUsers, id],
     queryFn: query(routes.getScheduleAbleFacilityUsers, {
       pathParams: { facility_id: id },

--- a/src/pages/Facility/components/UserCard.tsx
+++ b/src/pages/Facility/components/UserCard.tsx
@@ -9,14 +9,14 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
 import { Avatar } from "@/components/Common/Avatar";
-import { UserAssignedModel } from "@/components/Users/models";
 
 import { useAuthContext } from "@/hooks/useAuthUser";
 
 import { formatName } from "@/Utils/utils";
+import { UserBase } from "@/types/user/user";
 
 interface Props {
-  user: UserAssignedModel;
+  user: UserBase;
   className?: string;
   facilityId: string;
 }
@@ -41,7 +41,7 @@ export function UserCard({ user, className, facilityId }: Props) {
         <div className="p-6">
           <div className="flex flex-col sm:flex-row gap-4">
             <Avatar
-              imageUrl={user.read_profile_picture_url}
+              imageUrl={user.profile_picture_url}
               name={formatName(user, true)}
               className="size-32 rounded-lg"
             />
@@ -51,13 +51,6 @@ export function UserCard({ user, className, facilityId }: Props) {
                 {formatName(user)}
               </h3>
               <p className="text-sm text-gray-500">{user.user_type}</p>
-
-              {user.qualification && (
-                <>
-                  <p className="text-xs mt-3">{t("education")}: </p>
-                  <p className="text-sm text-gray-500">{user.qualification}</p>
-                </>
-              )}
             </div>
           </div>
         </div>

--- a/src/pages/PublicAppointments/Success.tsx
+++ b/src/pages/PublicAppointments/Success.tsx
@@ -6,13 +6,13 @@ import { toast } from "sonner";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import Loading from "@/components/Common/Loading";
-import { UserModel } from "@/components/Users/models";
 
 import { usePatientContext } from "@/hooks/usePatientUser";
 
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
 import PublicAppointmentApi from "@/types/scheduling/PublicAppointmentApi";
+import { UserBase } from "@/types/user/user";
 
 export function AppointmentSuccess(props: { appointmentId: string }) {
   const { appointmentId } = props;
@@ -21,7 +21,7 @@ export function AppointmentSuccess(props: { appointmentId: string }) {
   const patientUserContext = usePatientContext();
   const tokenData = patientUserContext?.tokenData;
 
-  const userData: UserModel = JSON.parse(localStorage.getItem("user") ?? "{}");
+  const userData: UserBase = JSON.parse(localStorage.getItem("user") ?? "{}");
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["appointment", tokenData.phoneNumber],

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -1,12 +1,11 @@
 import { LazyExoticComponent } from "react";
 import { UseFormReturn } from "react-hook-form";
 
-import { UserAssignedModel } from "@/components/Users/models";
-
 import { EncounterTabProps } from "@/pages/Encounters/EncounterShow";
 import { DeviceDetail } from "@/types/device/device";
 import { Encounter } from "@/types/emr/encounter";
 import { Patient } from "@/types/emr/newPatient";
+import { UserBase } from "@/types/user/user";
 
 import { AppRoutes } from "./Routers/AppRouter";
 import { QuestionnaireFormState } from "./components/Questionnaire/QuestionnaireForm";
@@ -14,7 +13,7 @@ import { pluginMap } from "./pluginMap";
 import { FacilityData } from "./types/facility/facility";
 
 export type DoctorConnectButtonComponentType = React.FC<{
-  user: UserAssignedModel;
+  user: UserBase;
 }>;
 
 export type ScribeComponentType = React.FC<{


### PR DESCRIPTION
## Proposed Changes

- Fixes #11654
- Fixes #11675
- Cleaned up incorrect types and removed unused routes

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in i18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the facility scheduling data to use a simpler, consistent user representation.
  - Adjusted the appointment slot display so that only upcoming slots are shown.
  - Updated user cards by removing qualification details and refining how profile pictures are presented.
  - Simplified the handling of `facilityId` in the AppointmentsPage to require it as a mandatory field.
  - Removed unnecessary props and conditional rendering in the appointment slot selection component. 
  - Updated sidebar component to use a new user model for authentication-related properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->