### PR TITLE
fix: update merge conflict label to "Merge Conflict" in GitHub workflow

### DIFF
--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: prince-chrismc/label-merge-conflicts-action@v3
         with:
-          conflict_label_name: "merge conflict"
+          conflict_label_name: "Merge Conflict"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           max_retries: 5
           wait_ms: 15000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the display of merge conflict notifications by updating the label to a capitalized format for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->