### PR TITLE
Adjust medication statement validation for end date

### DIFF
--- a/src/components/Patient/MedicationStatementList.tsx
+++ b/src/components/Patient/MedicationStatementList.tsx
@@ -69,7 +69,9 @@ function MedicationRow({ statement, isEnteredInError }: MedicationRowProps) {
       </TableCell>
       <TableCell>
         {[statement.effective_period?.start, statement.effective_period?.end]
-          .map((date) => formatDateTime(date))
+          .map((date, ind) =>
+            date ? formatDateTime(date) : ind === 1 ? t("ongoing") : "",
+          )
           .join(" - ")}
       </TableCell>
       <TableCell>{statement.reason}</TableCell>

--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -479,7 +479,13 @@ export default function TreatmentSummary({
                       medication.effective_period?.start,
                       medication.effective_period?.end,
                     ]
-                      .map((date) => formatDateTime(date))
+                      .map((date, ind) =>
+                        date
+                          ? formatDateTime(date)
+                          : ind === 1
+                            ? t("ongoing")
+                            : "",
+                      )
                       .join(" - "),
                     reason: medication.reason,
                     notes: medication.note,

--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -100,7 +100,7 @@ const MEDICATION_STATEMENT_FIELDS: FieldDefinitions = {
     required: true,
     validate: (value: unknown) => {
       const period = value as { start?: string; end?: string };
-      return !!period?.start && !!period?.end;
+      return !!period?.start;
     },
   },
 } as const;


### PR DESCRIPTION
## Proposed Changes

- Adjust validation to not include end date
   - So user can submit medication statement with only start date
  
@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated medication statement effective period validation to require only a start date, simplifying data entry when an end date is not available.
- **New Features**
	- Enhanced display of medication effective periods to show "ongoing" when the end date is not available, providing clearer information to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->