### PR TITLE
fix: Hide 'Scheduled Appointment' button in Appointment tab of Patient Details page

### DIFF
--- a/src/components/Patient/PatientDetailsTab/Appointments.tsx
+++ b/src/components/Patient/PatientDetailsTab/Appointments.tsx
@@ -93,7 +93,7 @@ export const Appointments = (props: PatientProps) => {
         <h2 className="text-2xl font-semibold leading-tight text-center sm:text-left">
           {t("appointments")}
         </h2>
-        {canCreateAppointment && (
+        {canCreateAppointment && facilityId && (
           <Button variant="outline_primary" asChild>
             <Link
               href={`/facility/${facilityId}/patient/${patientId}/book-appointment`}


### PR DESCRIPTION
## Proposed Changes

- Fixes #11742
Hide 'Scheduled Appointment' button in Appointment tab of Patient Details page when there is no facility. It was redirecting to error page earlier.

<img width="777" alt="Screenshot 2025-04-06 at 10 33 00 AM" src="https://github.com/user-attachments/assets/7e2ae4cc-09fb-4cb5-9ac5-022084b70544" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the appointment creation button’s visibility so it now appears only when you have the appropriate permissions and you’re associated with a valid facility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->