### PR TITLE
Show device type filter only if there are types registered in care

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ HEADERS="/*\n  Strict-Transport-Security: max-age=63072000; includeSubDomains; p
 REACT_RECAPTCHA_SITE_KEY=6LcedK8qAAAAAM2PpuqlqhZUxQpmIqHqluL74dDs
 
 # Care API URL without the /api prefix
-REACT_CARE_API_URL=https://develop-api.ohc.network
+REACT_CARE_API_URL=https://careapi.ohc.network
 REACT_SBOM_BASE_URL=https://sbom.ohc.network
 
 # Dev envs
@@ -21,4 +21,4 @@ REACT_ALLOWED_LOCALES="en,hi,ta,ml,mr,kn"
 # Localhost : ohcnetwork/care_scribe_fe@localhost:4173
 # Remote URL : ohcnetwork/care_scribe_fe@https://care-scribe-fe.pages.dev
 # Repo/Github Pages : ohcnetwork/care_scribe_fe
-REACT_ENABLED_APPS="ohcnetwork/care_teleicu_devices_fe@https://care-teleicu-devices-fe.pages.dev"
+REACT_ENABLED_APPS=""

--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ HEADERS="/*\n  Strict-Transport-Security: max-age=63072000; includeSubDomains; p
 REACT_RECAPTCHA_SITE_KEY=6LcedK8qAAAAAM2PpuqlqhZUxQpmIqHqluL74dDs
 
 # Care API URL without the /api prefix
-REACT_CARE_API_URL=https://careapi.ohc.network
+REACT_CARE_API_URL=https://develop-api.ohc.network
 REACT_SBOM_BASE_URL=https://sbom.ohc.network
 
 # Dev envs
@@ -21,4 +21,4 @@ REACT_ALLOWED_LOCALES="en,hi,ta,ml,mr,kn"
 # Localhost : ohcnetwork/care_scribe_fe@localhost:4173
 # Remote URL : ohcnetwork/care_scribe_fe@https://care-scribe-fe.pages.dev
 # Repo/Github Pages : ohcnetwork/care_scribe_fe
-REACT_ENABLED_APPS=""
+REACT_ENABLED_APPS="ohcnetwork/care_teleicu_devices_fe@https://care-teleicu-devices-fe.pages.dev"

--- a/src/pages/Facility/settings/devices/DevicesList.tsx
+++ b/src/pages/Facility/settings/devices/DevicesList.tsx
@@ -96,13 +96,16 @@ export default function DevicesList({ facilityId }: Props) {
 
         {pluginDevices.length > 0 ? (
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+            <DropdownMenuTrigger asChild className="lg:w-1/5 w-full">
               <Button variant="white" className="flex items-center gap-2">
                 {t("add_device")}
                 <CareIcon icon="l-angle-down" className="size-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent
+              align="end"
+              className="w-[var(--radix-dropdown-menu-trigger-width)]"
+            >
               {pluginDevices.map((pluginDevice) => {
                 const DeviceIcon = pluginDevice.icon || CubeIcon;
                 return (
@@ -161,7 +164,10 @@ export default function DevicesList({ facilityId }: Props) {
                 <CaretSortIcon className="ml-2 size-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-[200px] p-2">
+            <PopoverContent
+              className="min-w-[var(--radix-popover-trigger-width)] max-w-[200px] p-2"
+              align="end"
+            >
               <div className="space-y-2">
                 <Button
                   variant="ghost"

--- a/src/pages/Facility/settings/devices/DevicesList.tsx
+++ b/src/pages/Facility/settings/devices/DevicesList.tsx
@@ -146,47 +146,49 @@ export default function DevicesList({ facilityId }: Props) {
             className="pl-9"
           />
         </div>
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button
-              variant="outline"
-              className="flex items-center gap-2 w-full sm:w-auto"
-            >
-              {qParams.care_type ? (
-                <span className="capitalize">{qParams.care_type}</span>
-              ) : (
-                t("filter_by_type")
-              )}
-              <CaretSortIcon className="ml-2 size-4" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[200px] p-2">
-            <div className="space-y-2">
+        {pluginDevices.length > 0 && (
+          <Popover>
+            <PopoverTrigger asChild>
               <Button
-                variant="ghost"
-                className="w-full justify-start font-normal"
-                onClick={() => handleCareTypeChange(null)}
+                variant="outline"
+                className="flex items-center gap-2 w-full sm:w-auto"
               >
-                {t("all_types")}
+                {qParams.care_type ? (
+                  <span className="capitalize">{qParams.care_type}</span>
+                ) : (
+                  t("filter_by_type")
+                )}
+                <CaretSortIcon className="ml-2 size-4" />
               </Button>
-              <Separator />
-              {pluginDevices.map((device) => {
-                const DeviceIcon = device.icon || CubeIcon;
-                return (
-                  <Button
-                    key={device.type}
-                    variant="ghost"
-                    className="w-full capitalize justify-start font-normal"
-                    onClick={() => handleCareTypeChange(device.type)}
-                  >
-                    <DeviceIcon className="mr-2 size-4" />
-                    {device.type}
-                  </Button>
-                );
-              })}
-            </div>
-          </PopoverContent>
-        </Popover>
+            </PopoverTrigger>
+            <PopoverContent className="w-[200px] p-2">
+              <div className="space-y-2">
+                <Button
+                  variant="ghost"
+                  className="w-full justify-start font-normal"
+                  onClick={() => handleCareTypeChange(null)}
+                >
+                  {t("all_types")}
+                </Button>
+                <Separator />
+                {pluginDevices.map((device) => {
+                  const DeviceIcon = device.icon || CubeIcon;
+                  return (
+                    <Button
+                      key={device.type}
+                      variant="ghost"
+                      className="w-full capitalize justify-start font-normal"
+                      onClick={() => handleCareTypeChange(device.type)}
+                    >
+                      <DeviceIcon className="mr-2 size-4" />
+                      {device.type}
+                    </Button>
+                  );
+                })}
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
## Proposed Changes

- Show device type filter only if there are types registered in care
- Reported by @nihal467 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced device settings interface to display options conditionally based on availability.
- **Refactor**
	- Improved rendering efficiency by preventing unnecessary display of components when no devices are present.
	- Reorganized layout for a more intuitive user experience.
- **Style**
	- Updated button appearance for clearer visual distinction within the settings menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->