### PR TITLE
Fix: Ensure structured_type is set for structured questions

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2490,7 +2490,6 @@
   "select_site": "Select site",
   "select_skills": "Select and add some skills",
   "select_status": "Select status",
-  "select_structure_type": "Please select a structured type for this question.",
   "select_sub_department": "Select sub-department",
   "select_subject_type": "Select Subject Type",
   "select_symptom": "Select Symptom",

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2490,6 +2490,7 @@
   "select_site": "Select site",
   "select_skills": "Select and add some skills",
   "select_status": "Select status",
+  "select_structure_type": "Please select a structured type for this question.",
   "select_sub_department": "Select sub-department",
   "select_subject_type": "Select Subject Type",
   "select_symptom": "Select Symptom",

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -889,7 +889,15 @@ function QuestionEditor({
     value: Question[K],
     additionalFields?: Partial<Question>,
   ) => {
-    onChange({ ...question, [field]: value, ...additionalFields });
+    const updateQuestion = { ...question, [field]: value, ...additionalFields };
+    if (
+      field === "type" &&
+      value === "structured" &&
+      !updateQuestion.structured_type
+    ) {
+      updateQuestion.structured_type = "allergy_intolerance";
+    }
+    onChange(updateQuestion);
   };
 
   const toggleSubQuestionExpanded = (questionId: string) => {

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -396,7 +396,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
 
     questionnaire.questions.forEach((q) => {
       if (q.type === "structured" && !q.structured_type) {
-        updatedErrors[q.id] = t("select_structure_type");
+        updatedErrors[q.id] = t("field_required");
         hasError = true;
       } else {
         updatedErrors[q.id] = undefined;
@@ -927,8 +927,7 @@ function QuestionEditor({
     value: Question[K],
     additionalFields?: Partial<Question>,
   ) => {
-    const updateQuestion = { ...question, [field]: value, ...additionalFields };
-    onChange(updateQuestion);
+    onChange({ ...question, [field]: value, ...additionalFields });
   };
 
   const toggleSubQuestionExpanded = (questionId: string) => {

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -403,10 +403,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
       }
     });
 
-    setStructuredTypeErrors((prev) => ({
-      ...prev,
-      ...updatedErrors,
-    }));
+    setStructuredTypeErrors(updatedErrors);
 
     return !hasError;
   };

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -195,6 +195,9 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
   const [tagSearchQuery, setTagSearchQuery] = useState("");
   const [orgError, setOrgError] = useState<string | undefined>();
   const queryClient = useQueryClient();
+  const [structuredTypeErrors, setStructuredTypeErrors] = useState<
+    Record<string, string | undefined>
+  >({});
 
   const {
     data: initialQuestionnaire,
@@ -387,11 +390,34 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     return true;
   };
 
+  const validateStructuredType = (): boolean => {
+    let hasError = false;
+    const updatedErrors: Record<string, string | undefined> = {};
+
+    questionnaire.questions.forEach((q) => {
+      if (q.type === "structured" && !q.structured_type) {
+        updatedErrors[q.id] =
+          "Please select a structured type for this question.";
+        hasError = true;
+      } else {
+        updatedErrors[q.id] = undefined;
+      }
+    });
+
+    setStructuredTypeErrors((prev) => ({
+      ...prev,
+      ...updatedErrors,
+    }));
+
+    return !hasError;
+  };
+
   const handleSave = async () => {
     const isValid = await form.trigger();
     const hasOrganizations = validateOrganizations();
+    const hasValidStructuredType = validateStructuredType();
 
-    if (!isValid || !hasOrganizations) {
+    if (!isValid || !hasOrganizations || !hasValidStructuredType) {
       return;
     }
 
@@ -763,6 +789,15 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                           }}
                           isFirst={index === 0}
                           isLast={index === questionnaire.questions.length - 1}
+                          structuredTypeError={
+                            structuredTypeErrors[question.id]
+                          }
+                          setStructuredTypeError={(error) => {
+                            setStructuredTypeErrors((prev) => ({
+                              ...prev,
+                              [question.id]: error,
+                            }));
+                          }}
                         />
                       </div>
                     ))}
@@ -840,6 +875,8 @@ interface QuestionEditorProps {
   onMoveDown?: () => void;
   isFirst?: boolean;
   isLast?: boolean;
+  structuredTypeError?: string;
+  setStructuredTypeError?: (error: string | undefined) => void;
 }
 
 function QuestionEditor({
@@ -855,6 +892,8 @@ function QuestionEditor({
   isFirst,
   isLast,
   index,
+  structuredTypeError,
+  setStructuredTypeError,
 }: QuestionEditorProps) {
   const { t } = useTranslation();
   const {
@@ -890,13 +929,6 @@ function QuestionEditor({
     additionalFields?: Partial<Question>,
   ) => {
     const updateQuestion = { ...question, [field]: value, ...additionalFields };
-    if (
-      field === "type" &&
-      value === "structured" &&
-      !updateQuestion.structured_type
-    ) {
-      updateQuestion.structured_type = "allergy_intolerance";
-    }
     onChange(updateQuestion);
   };
 
@@ -1060,10 +1092,13 @@ function QuestionEditor({
                 <div>
                   <Label>{t("structured_type")}</Label>
                   <Select
-                    value={structured_type ?? "allergy_intolerance"}
-                    onValueChange={(val: StructuredQuestionType) =>
-                      updateField("structured_type", val)
-                    }
+                    value={structured_type || ""}
+                    onValueChange={(val: StructuredQuestionType) => {
+                      updateField("structured_type", val);
+                      if (setStructuredTypeError) {
+                        setStructuredTypeError(undefined);
+                      }
+                    }}
                   >
                     <SelectTrigger>
                       <SelectValue placeholder="Select structured type" />
@@ -1076,6 +1111,11 @@ function QuestionEditor({
                       ))}
                     </SelectContent>
                   </Select>
+                  {structuredTypeError && (
+                    <p className="text-sm text-red-500 mt-1">
+                      {structuredTypeError}
+                    </p>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -396,8 +396,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
 
     questionnaire.questions.forEach((q) => {
       if (q.type === "structured" && !q.structured_type) {
-        updatedErrors[q.id] =
-          "Please select a structured type for this question.";
+        updatedErrors[q.id] = t("select_structure_type");
         hasError = true;
       } else {
         updatedErrors[q.id] = undefined;


### PR DESCRIPTION
## Proposed Changes

- Fixes #11390
### Changes
- Updated the [updateField](http://_vscodecontentref_/3) function to set the default [structured_type](http://_vscodecontentref_/4).


## Screenshot

![Screenshot 2025-04-04 194915](https://github.com/user-attachments/assets/51023bf9-d3b1-4c7a-a2da-c84e85c507ca)

![Screenshot 2025-04-04 195708](https://github.com/user-attachments/assets/f3c19908-388c-4b62-985d-f96d7f186881)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the questionnaire editor experience with improved validation for structured question types.
	- Now displays inline error messages when structured question selections are missing, guiding users to correct issues before saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->