### PR TITLE
Replace history when updating filters; Upgrade raviger to beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "next-themes": "^0.4.3",
         "pigeon-maps": "^0.22.1",
         "qrcode.react": "^4.1.0",
-        "raviger": "^4.1.2",
+        "raviger": "^5.0.0-1",
         "react": "18.3.1",
         "react-day-picker": "^9.6.3",
         "react-dom": "18.3.1",
@@ -14509,15 +14509,15 @@
       }
     },
     "node_modules/raviger": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/raviger/-/raviger-4.2.0.tgz",
-      "integrity": "sha512-sReFkMZlj4IPsQ7d8f2ABzPOnG/C8V1pNX4YtoJRc+SkeWWiapTIllaGBHYS7lYR30SBFUIQm2QEI4IpesqD6g==",
+      "version": "5.0.0-1",
+      "resolved": "https://registry.npmjs.org/raviger/-/raviger-5.0.0-1.tgz",
+      "integrity": "sha512-BuBQNmrNWjRVinxe6jeV3Opk/Ue8JePTMv5aWZTpvSMsUnIyfGEGGemzHd74UcSnP7GWQXaBT5lAp3WUAfjcKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/rc": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "next-themes": "^0.4.3",
     "pigeon-maps": "^0.22.1",
     "qrcode.react": "^4.1.0",
-    "raviger": "^4.1.2",
+    "raviger": "^5.0.0-1",
     "react": "18.3.1",
     "react-day-picker": "^9.6.3",
     "react-dom": "18.3.1",

--- a/src/hooks/useFilters.tsx
+++ b/src/hooks/useFilters.tsx
@@ -52,7 +52,7 @@ export default function useFilters({
     options?: setQueryParamsOptions,
   ) => {
     query = FiltersCache.utils.clean(query);
-    _setQueryParams(query, options);
+    _setQueryParams(query, { ...options, historyReplace: true });
     updateCache(query);
   };
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #10657
- Requires https://github.com/kyeotic/raviger/pull/135
- Upgrade dependency: `raviger` to beta (`v5.0.0-1`)
- Known versioning issue with raviger: https://github.com/kyeotic/raviger/issues/140#issuecomment-2785240236

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated a key navigation dependency to its latest major version.
- **New Features**
  - Enhanced filter updates by replacing the browser’s history state, ensuring a smoother navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->