### PR TITLE
Migrate raviger to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "next-themes": "^0.4.3",
         "pigeon-maps": "^0.22.1",
         "qrcode.react": "^4.1.0",
-        "raviger": "^5.0.0-1",
+        "raviger": "^4.2.1",
         "react": "18.3.1",
         "react-day-picker": "^9.6.3",
         "react-dom": "18.3.1",
@@ -14509,15 +14509,15 @@
       }
     },
     "node_modules/raviger": {
-      "version": "5.0.0-1",
-      "resolved": "https://registry.npmjs.org/raviger/-/raviger-5.0.0-1.tgz",
-      "integrity": "sha512-BuBQNmrNWjRVinxe6jeV3Opk/Ue8JePTMv5aWZTpvSMsUnIyfGEGGemzHd74UcSnP7GWQXaBT5lAp3WUAfjcKA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/raviger/-/raviger-4.2.1.tgz",
+      "integrity": "sha512-NOsFsNj+ukYA5FqrZzNBfSmbhzuiEsM/15CbffoPaQV4pM0n4RaBB2NzLElh3vbd9xasF+7AATjE6PA5koUURw==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/rc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "next-themes": "^0.4.3",
         "pigeon-maps": "^0.22.1",
         "qrcode.react": "^4.1.0",
-        "raviger": "^4.2.1",
+        "raviger": "^5.0.0-2",
         "react": "18.3.1",
         "react-day-picker": "^9.6.3",
         "react-dom": "18.3.1",
@@ -14509,15 +14509,15 @@
       }
     },
     "node_modules/raviger": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/raviger/-/raviger-4.2.1.tgz",
-      "integrity": "sha512-NOsFsNj+ukYA5FqrZzNBfSmbhzuiEsM/15CbffoPaQV4pM0n4RaBB2NzLElh3vbd9xasF+7AATjE6PA5koUURw==",
+      "version": "5.0.0-2",
+      "resolved": "https://registry.npmjs.org/raviger/-/raviger-5.0.0-2.tgz",
+      "integrity": "sha512-wvBFpVynRuArMep5xzGQqGXjvsu8UxRmK3Atv0388N5+vGMvgKc1Uuw78W0NRB0PmblW+4ziQZ09WkJ52lsFaA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/rc": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "next-themes": "^0.4.3",
     "pigeon-maps": "^0.22.1",
     "qrcode.react": "^4.1.0",
-    "raviger": "^4.2.1",
+    "raviger": "^5.0.0-2",
     "react": "18.3.1",
     "react-day-picker": "^9.6.3",
     "react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "next-themes": "^0.4.3",
     "pigeon-maps": "^0.22.1",
     "qrcode.react": "^4.1.0",
-    "raviger": "^5.0.0-1",
+    "raviger": "^4.2.1",
     "react": "18.3.1",
     "react-day-picker": "^9.6.3",
     "react-dom": "18.3.1",

--- a/src/hooks/useFilters.tsx
+++ b/src/hooks/useFilters.tsx
@@ -52,18 +52,18 @@ export default function useFilters({
     options?: setQueryParamsOptions,
   ) => {
     query = FiltersCache.utils.clean(query);
-    _setQueryParams(query, { ...options, historyReplace: true });
+    _setQueryParams(query, { ...options, replace: true });
     updateCache(query);
   };
 
   const updateQuery = (filter: FilterState) => {
     filter = hasPagination ? { page: 1, limit, ...filter } : filter;
-    setQueryParams(Object.assign({}, qParams, filter), { replace: true });
+    setQueryParams(Object.assign({}, qParams, filter), { overwrite: true });
     setClearSearch({ value: false });
   };
   const updatePage = (page: number) => {
     if (!hasPagination) return;
-    setQueryParams(Object.assign({}, qParams, { page }), { replace: true });
+    setQueryParams(Object.assign({}, qParams, { page }), { overwrite: true });
   };
   const removeFilters = (params?: string[]) => {
     params ??= Object.keys(qParams);

--- a/src/pages/Scheduling/components/CreateScheduleExceptionSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleExceptionSheet.tsx
@@ -59,7 +59,7 @@ export default function CreateScheduleExceptionSheet({
 
   // Voluntarily masking the setQParams function to merge with other query params if any (since path is not unique within the user availability tab)
   const [qParams, _setQParams] = useQueryParams<QueryParams>();
-  const setQParams = (p: QueryParams) => _setQParams(p, { replace: false });
+  const setQParams = (p: QueryParams) => _setQParams(p, { overwrite: false });
 
   const formSchema = z
     .object({

--- a/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
@@ -72,7 +72,7 @@ export default function CreateScheduleTemplateSheet({
 
   // Voluntarily masking the setQParams function to merge with other query params if any (since path is not unique within the user availability tab)
   const [qParams, _setQParams] = useQueryParams<QueryParams>();
-  const setQParams = (p: QueryParams) => _setQParams(p, { replace: false });
+  const setQParams = (p: QueryParams) => _setQParams(p, { overwrite: false });
 
   const weekdayFormat = useBreakpoints({
     default: "alphabet",


### PR DESCRIPTION
## Proposed Changes

- Migrate raviger to v5 as versioning issue has been solved: https://github.com/kyeotic/raviger/issues/140#issuecomment-2787101834
- Refer: https://kyeotic.github.io/raviger/migraiton-to-v5/



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `raviger` dependency from version `^5.0.0-1` to `^5.0.0-2`, enhancing stability and reliability.
- **Bug Fixes**
	- Adjusted the handling of query parameters in multiple components to improve state management during updates, ensuring existing parameters are preserved or correctly overwritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->