### PR TITLE
fixe calender layout in tablet screen

### DIFF
--- a/src/pages/Appointments/BookAppointment.tsx
+++ b/src/pages/Appointments/BookAppointment.tsx
@@ -125,7 +125,7 @@ export default function BookAppointment(props: Props) {
 
           <div
             className={cn(
-              "grid grid-cols-1 md:grid-cols-2 gap-12",
+              "grid grid-cols-1 lg:grid-cols-2 gap-12",
               !resourceId && "opacity-50 pointer-events-none",
             )}
           >


### PR DESCRIPTION
## Proposed Changes

- Fixes #11828
  change md:grid-colo-2  to lg:grid-col-2

@ohcnetwork/care-fe-code-reviewers

screenshot:
![image](https://github.com/user-attachments/assets/5a2bb756-bc98-4eb7-881e-1b244efac854)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Request for Peer Reviews
- [X] Completion of QA in Mobile Devices
- [X] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the responsive grid layout on the appointment booking interface so that a two-column display now activates at larger screen sizes, enhancing the viewing experience on desktops and larger devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->