### PR TITLE
Typo error fixed from OPT to OTP

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1453,7 +1453,7 @@
   "invalid_latitude": "Invalid latitude",
   "invalid_link_msg": "It appears that the password reset link you have used is either invalid or expired. Please request a new password reset link.",
   "invalid_longitude": "Invalid longitude",
-  "invalid_otp": "Invalid OTP, Please check the OTP and try Again",
+  "invalid_otp": "Invalid OTP, Please check the OTP and try again",
   "invalid_password": "Password doesn't meet the requirements",
   "invalid_password_reset_link": "Invalid password reset link",
   "invalid_patient_data": "Invalid Patient Data",

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1453,7 +1453,7 @@
   "invalid_latitude": "Invalid latitude",
   "invalid_link_msg": "It appears that the password reset link you have used is either invalid or expired. Please request a new password reset link.",
   "invalid_longitude": "Invalid longitude",
-  "invalid_otp": "Invalid OTP, Please check the OPT and try Again",
+  "invalid_otp": "Invalid OTP, Please check the OTP and try Again",
   "invalid_password": "Password doesn't meet the requirements",
   "invalid_password_reset_link": "Invalid password reset link",
   "invalid_patient_data": "Invalid Patient Data",

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -564,7 +564,11 @@ const Login = (props: LoginProps) => {
                                   <InputOTPSlot
                                     key={index}
                                     index={index}
-                                    className="size-10"
+                                    className={cn(
+                                      "size-10",
+                                      otpValidationError &&
+                                        "border-red-500 focus-visible:ring-red-500",
+                                    )}
                                   />
                                 ))}
                               </InputOTPGroup>


### PR DESCRIPTION
## Proposed Changes

- Fixes #11866
- Change 1 Corrected typo from OPT to OTP in the UI text/component.
- Change 2 Highlights the exact input field causing the error by adding a red border.
- More?

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

Add specs that demonstrate bug / test a new feature.

 Update [product documentation](https://docs.ohc.network/).

 Ensure that UI text is kept in I18n files.

 Prep screenshot or demo video for changelog entry, and attach it to issue.

 Request for Peer Reviews

 Completion of QA in Mobile Devices

 Completion of QA in Desktop Devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the typo in the One-Time Password error message for improved clarity.
- **New Features**
  - Enhanced visual feedback in the OTP input section to indicate error states based on validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->