### PR TITLE
Fix device list not showing correct icon and make add device button responsive

### DIFF
--- a/src/pages/Facility/settings/devices/DevicesList.tsx
+++ b/src/pages/Facility/settings/devices/DevicesList.tsx
@@ -96,7 +96,7 @@ export default function DevicesList({ facilityId }: Props) {
 
         {pluginDevices.length > 0 ? (
           <DropdownMenu>
-            <DropdownMenuTrigger asChild className="lg:w-1/5 w-full">
+            <DropdownMenuTrigger asChild className="w-full sm:w-auto">
               <Button variant="white" className="flex items-center gap-2">
                 {t("add_device")}
                 <CareIcon icon="l-angle-down" className="size-4" />
@@ -104,7 +104,7 @@ export default function DevicesList({ facilityId }: Props) {
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="end"
-              className="w-[var(--radix-dropdown-menu-trigger-width)]"
+              className="w-[var(--radix-dropdown-menu-trigger-width)] md:w-auto"
             >
               {pluginDevices.map((pluginDevice) => {
                 const DeviceIcon = pluginDevice.icon || CubeIcon;

--- a/src/pages/Facility/settings/devices/components/DeviceCard.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceCard.tsx
@@ -60,7 +60,10 @@ export default function DeviceCard({ device, encounter }: Props) {
           <div className="flex items-start justify-between">
             <div className="flex items-start gap-2">
               <div className="mt-1">
-                <DeviceTypeIcon className="size-5 text-gray-500" />
+                <DeviceTypeIcon
+                  className="size-5 text-gray-500"
+                  type={device.care_type}
+                />
               </div>
               <div>
                 <CardTitle className="text-lg font-semibold line-clamp-1">

--- a/src/pages/Facility/settings/devices/components/DeviceTypeIcon.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceTypeIcon.tsx
@@ -6,8 +6,7 @@ const DeviceTypeIcon = ({
   type,
   ...props
 }: {
-  type?: string | undefined;
-  // TODO: switch to using React.ComponentProps<"div"> once upgraded to React 19
+  type: string | undefined;
   className?: string;
 }) => {
   const deviceTypes = usePluginDevices();


### PR DESCRIPTION


- Make add device button responsive
- Fixes device type icon not shown in device card in device list


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Device icons now provide enhanced details reflecting device care types.
- **Style**
	- Improved responsive layouts for dropdown menus, ensuring a consistent experience across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->