### PR TITLE
fixes the alignment issue of view detail button of encounter info card within the Beds card

### DIFF
--- a/src/components/Encounter/EncounterInfoCard.tsx
+++ b/src/components/Encounter/EncounterInfoCard.tsx
@@ -62,7 +62,7 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
       data-status={encounter.status}
       key={props.encounter.id}
       className={cn(
-        "hover:shadow-lg transition-shadow group md:flex md:flex-col",
+        "hover:shadow-lg transition-shadow group md:flex md:flex-col h-full ",
         hideBorder && "border-none shadow-none",
       )}
     >

--- a/src/components/Encounter/EncounterInfoCard.tsx
+++ b/src/components/Encounter/EncounterInfoCard.tsx
@@ -62,7 +62,7 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
       data-status={encounter.status}
       key={props.encounter.id}
       className={cn(
-        "hover:shadow-lg transition-shadow group md:flex md:flex-col h-full ",
+        "hover:shadow-lg transition-shadow group md:flex md:flex-col h-full",
         hideBorder && "border-none shadow-none",
       )}
     >

--- a/src/pages/Facility/locations/LocationContent.tsx
+++ b/src/pages/Facility/locations/LocationContent.tsx
@@ -35,7 +35,7 @@ function BedCard({ location, facilityId }: BedCardProps) {
   return (
     <div
       className={cn(
-        "border rounded-lg overflow-hidden shadow-xs h-full",
+        "border rounded-lg overflow-hidden shadow-xs h-full flex flex-col ",
         isOccupied
           ? "bg-white border-gray-200"
           : "bg-green-50 border-green-200",
@@ -70,7 +70,7 @@ function BedCard({ location, facilityId }: BedCardProps) {
         </div>
       </div>
 
-      <div>
+      <div className="h-full">
         {!location.current_encounter ? (
           <div className="flex flex-col items-center justify-center py-4 h-auto">
             <p className="text-sm text-gray-600 mb-3">

--- a/src/pages/Facility/locations/LocationContent.tsx
+++ b/src/pages/Facility/locations/LocationContent.tsx
@@ -35,7 +35,7 @@ function BedCard({ location, facilityId }: BedCardProps) {
   return (
     <div
       className={cn(
-        "border rounded-lg overflow-hidden shadow-xs h-full flex flex-col ",
+        "border rounded-lg overflow-hidden shadow-xs h-full flex flex-col",
         isOccupied
           ? "bg-white border-gray-200"
           : "bg-green-50 border-green-200",


### PR DESCRIPTION


## Proposed Changes

- Fixes #11888 
  Use the flex property in the bed card and ensure that the encounter info card takes up the full height  of its parent. 

@ohcnetwork/care-fe-code-reviewers
before change: 
![Screenshot 2025-04-12 112819](https://github.com/user-attachments/assets/0f5b659b-1006-4b94-a2ec-2f3eae239264)

after change :
![image](https://github.com/user-attachments/assets/80952e29-0ea3-4891-b82f-a5be803cbf1e)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [X] Completion of QA in Mobile Devices
- [X] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated the encounter card’s layout to ensure it consistently occupies the full height of its container.
	- Enhanced the facility’s bed card design by introducing a vertical stacking layout and applying full-height styling for a more balanced presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->