### PR TITLE
fix: remove uppercasing in dropdown and fix button overlap

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -10,7 +10,6 @@ import {
 
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
-import { properCase } from "@/Utils/utils";
 import { Code } from "@/types/questionnaire/code";
 import type {
   QuestionnaireResponse,
@@ -50,7 +49,6 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
       type: "string",
       value: newValue,
     };
-
     updateQuestionnaireResponseCB(
       newValues,
       questionnaireResponse.question_id,
@@ -100,7 +98,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
                 value={option.value.toString()}
                 className="whitespace-normal break-words py-3"
               >
-                {properCase(option.display || option.value)}
+                {option.display || option.value}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -98,7 +98,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
                 value={option.value.toString()}
                 className="whitespace-normal break-words py-3"
               >
-                {option.display || option.value}
+                {option.value}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
@@ -256,7 +256,8 @@ export function QuestionInput({
                 )}
                 <div
                   className={cn("w-full", {
-                    "flex flex-col md:flex-row": !question.structured_type,
+                    "flex flex-col gap-4 md:flex-row":
+                      !question.structured_type,
                     "flex-col": question.repeats || question.type === "text",
                   })}
                 >


### PR DESCRIPTION
## Proposed Changes

- Fixes #11876 
## This PR resolves two issues:

- Removes forced uppercase from dropdown values
- Previously, the properCase function caused inconsistent or undesired formatting (e.g., turning values like PS_o CARE_HELS into 
 Ps_O Care_Hels).
- Fixed by removing the properCase function from the SelectItem display — now values appear exactly as defined.

## Issue: In some layouts, the Select dropdown was overlapping with the "+ Add Note" button, making the UI look broken and hard to use.

## before

![Screenshot 2025-04-13 115632](https://github.com/user-attachments/assets/3839172d-d819-47e8-a413-e49320db0e58)

# After

![Screenshot 2025-04-13 125851](https://github.com/user-attachments/assets/aa30f12c-0481-4869-a46e-8c8f06a55adb)


- Fixes overlap between Select and Add Note button
- Wrapped both components in a flex container and added gap-4 to ensure proper spacing and prevent UI overlap.




@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Dropdown options now display text exactly as entered, removing automatic formatting.
  - Improved spacing between input fields for a cleaner and more organized layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->