### PR TITLE
fix overaping of tabbar over navbar by reducing the z-index of tababr

### DIFF
--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -135,7 +135,7 @@ export const PatientHome = (props: {
         </div>
 
         <div
-          className="sticky top-0 z-10 mt-4 w-full border-b border-gray-200 bg-gray-50"
+          className="sticky top-0 z-9 mt-4 w-full border-b border-gray-200 bg-gray-50"
           role="navigation"
         >
           <div className="overflow-x-auto pb-3">


### PR DESCRIPTION
## Proposed Changes

- Fixes #11911 
   Reduce the z-index of the tab bar in relation to the navbar so that the tab bar does not overlap it.

@ohcnetwork/care-fe-code-reviewers

![image](https://github.com/user-attachments/assets/fd908d31-ede3-4642-b670-33c16a43fd8f)

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [X] Completion of QA in Mobile Devices
- [X] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the layering of elements on the Patient Home view to enhance visual stacking and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->