### PR TITLE
chore: add schedule for automated dependency updates in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,9 @@
   ],
   "automergeStrategy": "squash",
   "automergeType": "pr",
+  "schedule": [
+    "* * * * 0,1"
+  ],
   "packageRules": [
     {
       "groupName": "all dependencies (minor, patch)",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "automergeStrategy": "squash",
   "automergeType": "pr",
   "schedule": [
-    "* * * * 0,1"
+    "* 0-3 * * 1"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Scheduled for every mondays

refs:
- https://docs.renovatebot.com/key-concepts/scheduling/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a scheduling option in the configuration that enables the bot to run automatically during early hours on Mondays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->