### PR TITLE
Fixed structured records uneditable when in entered-in-error status #11966

### DIFF
--- a/src/components/Patient/diagnosis/list.tsx
+++ b/src/components/Patient/diagnosis/list.tsx
@@ -1,12 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "raviger";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -31,6 +32,13 @@ export function DiagnosisList({
 }: DiagnosisListProps) {
   const { t } = useTranslation();
 
+  const [showEnteredInErrorOfDiagnoses, setShowEnteredInErrorOfDiagnoses] =
+    useState(false);
+  const [
+    showEnteredInErrorOfChronicConditions,
+    setShowEnteredInErrorOfChronicConditions,
+  ] = useState(false);
+
   const { data: diagnoses, isLoading: isDiagnosesLoading } = useQuery({
     queryKey: ["encounter_diagnosis", patientId, encounterId],
     queryFn: query(diagnosisApi.listDiagnosis, {
@@ -38,7 +46,6 @@ export function DiagnosisList({
       queryParams: {
         category: ["encounter_diagnosis"],
         clinical_status: ACTIVE_DIAGNOSIS_CLINICAL_STATUS.join(","),
-        exclude_verification_status: "entered_in_error",
         ...(encounterId ? { encounter: encounterId } : {}),
       },
     }),
@@ -52,12 +59,42 @@ export function DiagnosisList({
         queryParams: {
           category: "chronic_condition",
           clinical_status: ACTIVE_DIAGNOSIS_CLINICAL_STATUS.join(","),
-          exclude_verification_status: "entered_in_error",
         },
       }),
     });
 
-  if (!diagnoses?.results.length && !chronicConditions?.results.length) {
+  if (isChronicConditionsLoading || isDiagnosesLoading) {
+    return (
+      <DiagnosisListLayout readOnly={readOnly} className={className}>
+        <CardContent className="px-2 pb-2">
+          <Skeleton className="h-[100px] w-full" />
+        </CardContent>
+      </DiagnosisListLayout>
+    );
+  }
+
+  const filteredDiagnoses = diagnoses?.results?.filter(
+    (diagnose) =>
+      showEnteredInErrorOfDiagnoses ||
+      diagnose.verification_status !== "entered_in_error",
+  );
+
+  const filteredChronicConditions = chronicConditions?.results?.filter(
+    (chronicCondition) =>
+      showEnteredInErrorOfChronicConditions ||
+      chronicCondition.verification_status !== "entered_in_error",
+  );
+
+  const hasEnteredInErrorOfDiagnoses = diagnoses?.results?.some(
+    (diagnose) => diagnose.verification_status === "entered_in_error",
+  );
+
+  const hasEnteredInErrorOfChronicConditions = chronicConditions?.results?.some(
+    (chronicCondition) =>
+      chronicCondition.verification_status === "entered_in_error",
+  );
+
+  if (!filteredDiagnoses?.length && !filteredChronicConditions?.length) {
     return (
       <DiagnosisListLayout className={className} readOnly={readOnly}>
         <CardContent className="px-2 pb-3 pt-2">
@@ -76,23 +113,82 @@ export function DiagnosisList({
             <Skeleton className="h-[100px] w-full" />
           </CardContent>
         )}
-        {chronicConditions?.results.length ? (
+        {filteredChronicConditions?.length ? (
           <DiagnosisTable
-            diagnoses={chronicConditions?.results}
+            diagnoses={[
+              ...(filteredChronicConditions || []).filter(
+                (chronicConditions) =>
+                  chronicConditions.verification_status !== "entered_in_error",
+              ),
+              ...(showEnteredInErrorOfChronicConditions
+                ? (filteredChronicConditions || []).filter(
+                    (chronicConditions) =>
+                      chronicConditions.verification_status ===
+                      "entered_in_error",
+                  )
+                : []),
+            ]}
             title={t("chronic_condition", {
               count: 2,
             })}
           />
         ) : null}
+        {hasEnteredInErrorOfChronicConditions &&
+          (filteredChronicConditions || []).length > 0 &&
+          !showEnteredInErrorOfChronicConditions && (
+            <>
+              <div className="border-b border-dashed border-gray-200 my-2" />
+              <div className="flex justify-center ">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => setShowEnteredInErrorOfChronicConditions(true)}
+                  className="text-xs underline text-gray-950"
+                >
+                  {t("view_all")}
+                </Button>
+              </div>
+            </>
+          )}
         {isDiagnosesLoading && (
           <CardContent className="px-2 pb-2">
             <Skeleton className="h-[100px] w-full" />
             <Skeleton className="h-[100px] w-full" />
           </CardContent>
         )}
-        {diagnoses?.results?.length ? (
-          <DiagnosisTable diagnoses={diagnoses.results} />
+        {filteredDiagnoses?.length ? (
+          <DiagnosisTable
+            diagnoses={[
+              ...(filteredDiagnoses || []).filter(
+                (diagnose) =>
+                  diagnose.verification_status !== "entered_in_error",
+              ),
+              ...(showEnteredInErrorOfDiagnoses
+                ? (filteredDiagnoses || []).filter(
+                    (diagnose) =>
+                      diagnose.verification_status === "entered_in_error",
+                  )
+                : []),
+            ]}
+          />
         ) : null}
+        {hasEnteredInErrorOfDiagnoses &&
+          (filteredDiagnoses || []).length > 0 &&
+          !showEnteredInErrorOfDiagnoses && (
+            <>
+              <div className="border-b border-dashed border-gray-200 my-2" />
+              <div className="flex justify-center ">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => setShowEnteredInErrorOfDiagnoses(true)}
+                  className="text-xs underline text-gray-950"
+                >
+                  {t("view_all")}
+                </Button>
+              </div>
+            </>
+          )}
       </div>
     </DiagnosisListLayout>
   );

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -115,7 +115,7 @@ function convertToDiagnosisRequest(diagnosis: Diagnosis): DiagnosisRequest {
     category: diagnosis.category,
     note: diagnosis.note,
     encounter: diagnosis.encounter,
-    dirty: false,
+    dirty: true,
   };
 }
 
@@ -176,7 +176,6 @@ export function DiagnosisQuestion({
         encounter: encounterId,
         limit: 100,
         category: "encounter_diagnosis",
-        exclude_verification_status: "entered_in_error",
       },
     }),
     enabled: !isPreview,
@@ -190,7 +189,6 @@ export function DiagnosisQuestion({
         category: "chronic_condition",
         limit: 100,
         clinical_status: ACTIVE_DIAGNOSIS_CLINICAL_STATUS.join(","),
-        exclude_verification_status: "entered_in_error",
       },
     }),
     enabled: !isPreview,


### PR DESCRIPTION
## Proposed Changes

- Fixes #11966

- Fixed the error and done some ui changes for consistent layout as Symptoms and Allergies.
- Managed state of *View All* for both *Chronic Conditions* & *Diagnoses* and appropriate actions when things are added or deleted in them.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

https://github.com/user-attachments/assets/33ad808b-09c8-47ba-b421-c73ad6ba5868




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to toggle the visibility of diagnoses and chronic conditions marked as "entered in error" within the diagnosis list.
  - Introduced "View All" buttons to reveal hidden "entered in error" entries when available.

- **Improvements**
  - Enhanced loading states with skeleton placeholders for diagnoses and chronic conditions.
  - Diagnoses and chronic conditions are now displayed in separate tables, with clear separation of standard and "entered in error" entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->