### PR TITLE
Fix UI Overflow for valid_from Date Field in Schedule Template Editor

### DIFF
--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -31,7 +31,7 @@ export function DatePicker({ date, onChange, disabled }: DatePickerProps) {
         <Button
           variant="outline"
           className={cn(
-            "w-full justify-start text-left font-normal",
+            "w-full h-10 px-3 justify-start text-left font-normal",
             !date && "text-gray-500",
             "sm:w-auto",
           )}

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -242,7 +242,7 @@ const ScheduleTemplateEditor = ({
             )}
           />
 
-          <div className="grid md:grid-cols-2 gap-4 ">
+          <div className="grid md:grid-cols-2 gap-4">
             <FormField
               control={form.control}
               name="valid_from"

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -242,12 +242,12 @@ const ScheduleTemplateEditor = ({
             )}
           />
 
-          <div className="grid md:grid-cols-2 gap-4 w-full">
+          <div className="grid md:grid-cols-2 gap-4 ">
             <FormField
               control={form.control}
               name="valid_from"
               render={({ field }) => (
-                <FormItem className="flex flex-col w-full min-w-[210px]">
+                <FormItem className="flex flex-col">
                   <FormLabel aria-required>{t("valid_from")}</FormLabel>
                   <DatePicker
                     date={field.value}

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -242,12 +242,12 @@ const ScheduleTemplateEditor = ({
             )}
           />
 
-          <div className="grid md:grid-cols-2 gap-4">
+          <div className="grid md:grid-cols-2 gap-4 w-full">
             <FormField
               control={form.control}
               name="valid_from"
               render={({ field }) => (
-                <FormItem className="flex flex-col">
+                <FormItem className="flex flex-col w-full min-w-[210px]">
                   <FormLabel aria-required>{t("valid_from")}</FormLabel>
                   <DatePicker
                     date={field.value}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12039 
- Applied a w-full min-w-[210px] style to the FormItem wrapping the valid_from date field.
- Wrapped the entire section in a div with w-full to ensure grid takes full width and prevents layout issues.
- More?

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved layout and sizing of date picker fields in the schedule template editor for a more consistent and user-friendly appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->