### PR TITLE
Fixes layout jumps when popover's open state switches due to scrollbar tweaks in css

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -152,24 +152,6 @@
     display: block;
   }
 
-  ::-webkit-scrollbar {
-    width: 10px;
-    height: 8px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: rgba(0, 0, 0, 0.3);
-    border-radius: 6px;
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.4);
-  }
-
   /* for gmaps search dropdown */
   .pac-container {
     z-index: 100000 !important;


### PR DESCRIPTION
## Proposed Changes

- remove unnecessary scrollbar tweaks in css

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed custom scrollbar appearance, reverting to the default browser scrollbar styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->