### PR TITLE
Fix : Prefix Dropdown Shows Selected Text Instead of Options on Edit User

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -359,7 +359,6 @@ export default function UserForm({
                     label: prefix,
                     value: prefix,
                   }))}
-                  freeInput
                   value={field.value || ""}
                   onChange={field.onChange}
                   noOptionsMessage=""

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -42,6 +42,7 @@ interface AutocompleteProps {
   className?: string;
   popoverClassName?: string;
   freeInput?: boolean;
+  closeOnSelect?: boolean;
   "data-cy"?: string;
 }
 
@@ -59,29 +60,28 @@ export default function Autocomplete({
   className,
   popoverClassName,
   freeInput = false,
+  closeOnSelect = true,
   "data-cy": dataCy,
 }: AutocompleteProps) {
   const [open, setOpen] = React.useState(false);
   const isMobile = useBreakpoints({ default: true, sm: false });
-  const [inputValue, setInputValue] = React.useState("");
 
+  // Maintain an internal state for the input text when freeInput is enabled.
+  // TODO : Find a better way to handle this, maybe as a seperate component
+  const [inputValue, setInputValue] = React.useState(value);
+
+  // Find a matching option from the options list (for non freeInput or when value matches an option)
   const selectedOption = options.find((option) => option.value === value);
+
+  // Sync the inputValue with value prop changes.
   React.useEffect(() => {
-    if (open) {
+    const selected = options.find((option) => option.value === value);
+    if (value) {
+      setInputValue(selected ? selected.label : value);
+    } else {
       setInputValue("");
     }
-  }, [open]);
-
-  React.useEffect(() => {
-    if (!open) {
-      const selected = options.find((option) => option.value === value);
-      if (value) {
-        setInputValue(selected ? selected.label : value);
-      } else {
-        setInputValue("");
-      }
-    }
-  }, [value, options, open]);
+  }, [value, options]);
 
   // Determine what text to display on the button.
   const displayText = freeInput
@@ -118,7 +118,6 @@ export default function Autocomplete({
         onValueChange={handleInputChange}
         // Control the input when freeInput is true.
         {...(freeInput ? { value: inputValue } : {})}
-        autoComplete="off"
         className="outline-hidden border-none ring-0 shadow-none"
         autoFocus
       />
@@ -145,7 +144,9 @@ export default function Autocomplete({
                   );
                   setInputValue(selected ? selected.label : currentValue);
                 }
-                setOpen(false);
+                if (closeOnSelect) {
+                  setOpen(false);
+                }
               }}
             >
               <CheckIcon

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -42,7 +42,6 @@ interface AutocompleteProps {
   className?: string;
   popoverClassName?: string;
   freeInput?: boolean;
-  closeOnSelect?: boolean;
   "data-cy"?: string;
 }
 
@@ -60,28 +59,29 @@ export default function Autocomplete({
   className,
   popoverClassName,
   freeInput = false,
-  closeOnSelect = true,
   "data-cy": dataCy,
 }: AutocompleteProps) {
   const [open, setOpen] = React.useState(false);
   const isMobile = useBreakpoints({ default: true, sm: false });
+  const [inputValue, setInputValue] = React.useState("");
 
-  // Maintain an internal state for the input text when freeInput is enabled.
-  // TODO : Find a better way to handle this, maybe as a seperate component
-  const [inputValue, setInputValue] = React.useState(value);
-
-  // Find a matching option from the options list (for non freeInput or when value matches an option)
   const selectedOption = options.find((option) => option.value === value);
-
-  // Sync the inputValue with value prop changes.
   React.useEffect(() => {
-    const selected = options.find((option) => option.value === value);
-    if (value) {
-      setInputValue(selected ? selected.label : value);
-    } else {
+    if (open) {
       setInputValue("");
     }
-  }, [value, options]);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) {
+      const selected = options.find((option) => option.value === value);
+      if (value) {
+        setInputValue(selected ? selected.label : value);
+      } else {
+        setInputValue("");
+      }
+    }
+  }, [value, options, open]);
 
   // Determine what text to display on the button.
   const displayText = freeInput
@@ -118,6 +118,7 @@ export default function Autocomplete({
         onValueChange={handleInputChange}
         // Control the input when freeInput is true.
         {...(freeInput ? { value: inputValue } : {})}
+        autoComplete="off"
         className="outline-hidden border-none ring-0 shadow-none"
         autoFocus
       />
@@ -144,9 +145,7 @@ export default function Autocomplete({
                   );
                   setInputValue(selected ? selected.label : currentValue);
                 }
-                if (closeOnSelect) {
-                  setOpen(false);
-                }
+                setOpen(false);
               }}
             >
               <CheckIcon


### PR DESCRIPTION
## Proposed Changes

- Fixes #12121 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
Desktop View, 

https://github.com/user-attachments/assets/db4bc663-f580-4f87-857f-783e9d11ac49

Mobile view, 

https://github.com/user-attachments/assets/281507dc-ac6e-493d-a0d4-91a4a3264b86


- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the user form so that the "prefix" field only allows selection from predefined options, removing the ability to enter custom values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->