### PR TITLE
Show only completed medication administration in print

### DIFF
--- a/src/components/Medicine/MedicationAdministration/PrintMedicationAdministration.tsx
+++ b/src/components/Medicine/MedicationAdministration/PrintMedicationAdministration.tsx
@@ -53,6 +53,7 @@ export const PrintMedicationAdministration = (props: {
       pathParams: { patientId: patientId },
       queryParams: {
         encounter: encounterId,
+        status: "completed",
       },
       pageSize: 1000,
     }),


### PR DESCRIPTION
## Proposed Changes

- Fixes #12153

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Medication administration records now only display items with a status of "completed."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->