### PR TITLE
FIXED: File/Photo Deletion Not Functioning Correctly on Questionnaire Page

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/FileQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/FileQuestion.tsx
@@ -168,7 +168,19 @@ export function FilesQuestion(props: FilesQuestionProps) {
           <Button
             variant={"outline"}
             className="border border-secondary-300"
-            onClick={() => fileUpload.removeFile(index)}
+            onClick={() => {
+              fileUpload.removeFile(index);
+              updateQuestionnaireResponseCB(
+                [
+                  {
+                    type: "files",
+                    value: values.filter((_, i) => i !== index),
+                  },
+                ],
+                questionnaireResponse.question_id,
+                questionnaireResponse.note,
+              );
+            }}
           >
             <CareIcon icon="l-trash" className="size-4" />
           </Button>


### PR DESCRIPTION
## Proposed Changes
updateQuestionnaireResponseCB function add

- Fixes #12134 


https://github.com/user-attachments/assets/a01092e7-9477-4501-aec8-7706a5201c59


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file removal in questionnaires to ensure the response updates immediately after a file is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->