### PR TITLE
Make user rendering consistent 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
     "cpus": 4
   },
   "waitFor": "onCreateCommand",
-  "postCreateCommand": "npm run install-all",
+  "postCreateCommand": "npm install",
   "postAttachCommand": {
     "server": "npm run dev"
   },

--- a/src/components/Patient/diagnosis/DiagnosisTable.tsx
+++ b/src/components/Patient/diagnosis/DiagnosisTable.tsx
@@ -20,6 +20,7 @@ import {
 
 import { Avatar } from "@/components/Common/Avatar";
 
+import { formatName } from "@/Utils/utils";
 import {
   DIAGNOSIS_CLINICAL_STATUS_STYLES,
   DIAGNOSIS_VERIFICATION_STATUS_STYLES,
@@ -135,7 +136,9 @@ export function DiagnosisTable({ diagnoses, title }: DiagnosisTableProps) {
                   imageUrl={diagnosis.created_by.profile_picture_url}
                 />
 
-                <span className="text-sm">{diagnosis.created_by.username}</span>
+                <span className="text-sm">
+                  {formatName(diagnosis.created_by)}
+                </span>
               </div>
             </TableCell>
           </TableRow>

--- a/src/components/Patient/symptoms/SymptomTable.tsx
+++ b/src/components/Patient/symptoms/SymptomTable.tsx
@@ -144,7 +144,11 @@ export function SymptomTable({ symptoms }: SymptomTableProps) {
                   name={symptom.created_by.username}
                   className="size-4"
                   imageUrl={symptom.created_by.profile_picture_url}
-                  prefix="Dr."
+<Avatar
+  name={symptom.created_by.username}
+  className="size-4"
+  imageUrl={symptom.created_by.profile_picture_url}
+/>
                 />
 
                 <span className="text-sm">

--- a/src/components/Patient/symptoms/SymptomTable.tsx
+++ b/src/components/Patient/symptoms/SymptomTable.tsx
@@ -18,6 +18,7 @@ import {
 
 import { Avatar } from "@/components/Common/Avatar";
 
+import { formatName } from "@/Utils/utils";
 import {
   SYMPTOM_CLINICAL_STATUS_STYLES,
   SYMPTOM_SEVERITY_STYLES,
@@ -143,9 +144,12 @@ export function SymptomTable({ symptoms }: SymptomTableProps) {
                   name={symptom.created_by.username}
                   className="size-4"
                   imageUrl={symptom.created_by.profile_picture_url}
+                  prefix="Dr."
                 />
 
-                <span className="text-sm">{symptom.created_by.username}</span>
+                <span className="text-sm">
+                  {formatName(symptom.created_by)}
+                </span>
               </div>
             </TableCell>
           </TableRow>


### PR DESCRIPTION
## Proposed Changes

- Fixes ohcnetwork/care_fe#12118
- Imported and used `formatName` from `utils` for consistent name rendering.
- Updated `DiagnosisTable.tsx` to use `formatName`.
- Updated `SymptomTable.tsx` to use `formatName`.
- Minor update in `.devcontainer/devcontainer.json`

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature. (Not needed here — refactor only.)
- [ ] Update [product documentation](https://docs.ohc.network). (Not needed for this change.)
- [x] Ensure that UI text is kept in I18n files. (Not needed here.)
- [x] Prep screenshot or demo video for changelog entry, and attach it to the issue. (Attached below.)
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices (If checked manually.)
- [x] Completion of QA in Desktop Devices (If checked manually.)

## UI Changes

**Before:**
<img width="763" alt="Screenshot 2025-04-29 at 4 42 53 AM" src="https://github.com/user-attachments/assets/2f0afea7-9a5d-4d0d-a1c8-cc6ec9fca58d" />

**After:**
<img width="813" alt="Screenshot 2025-04-29 at 4 43 31 AM" src="https://github.com/user-attachments/assets/ee36c0d2-7ec3-4ace-9ee3-3ce06ff98e0e" />
)*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced the display of creator names in diagnosis and symptom tables for clearer and more consistent formatting.

- **Chores**
  - Updated development container setup to use the standard npm install command during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->