### PR TITLE
Add Exception popup should be disabled for past dates #12127

### DIFF
--- a/src/components/Users/UserAvailabilityTab.tsx
+++ b/src/components/Users/UserAvailabilityTab.tsx
@@ -321,20 +321,22 @@ function DayDetailsPopover({
             year: "numeric",
           })}
         </p>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() =>
-            setQParams({
-              tab: "exceptions",
-              sheet: "add_exception",
-              valid_from: dateQueryString(date),
-              valid_to: dateQueryString(date),
-            })
-          }
-        >
-          {t("add_exception")}
-        </Button>
+        {!dayjs(date).isBefore(dayjs(), "day") && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              setQParams({
+                tab: "exceptions",
+                sheet: "add_exception",
+                valid_from: dateQueryString(date),
+                valid_to: dateQueryString(date),
+              })
+            }
+          >
+            {t("add_exception")}
+          </Button>
+        )}
       </div>
 
       <ScrollArea className="max-h-[22rem] overflow-auto">


### PR DESCRIPTION
## Proposed Changes

- Fixes #12127 
- added the logic for the addexception button so that for past days in the calender  it will not show the addexception button  inside the popup .

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "Add Exception" button is now only shown for today or future dates, preventing it from appearing for past dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->