### PR TITLE
Dept Select: Auto confirm if no children

### DIFF
--- a/cypress/pageObject/Patients/PatientVerify.ts
+++ b/cypress/pageObject/Patients/PatientVerify.ts
@@ -51,7 +51,6 @@ class PatientVerify {
 
   selectOrganization(organization: string) {
     cy.clickAndSelectOption('[data-cy="facility-organization"]', organization);
-    cy.get('[data-cy="confirm-organization"]').click();
     return this;
   }
 

--- a/src/hooks/useQuestionnaireOptions.ts
+++ b/src/hooks/useQuestionnaireOptions.ts
@@ -21,6 +21,8 @@ export default function useQuestionnaireOptions(slug: string, enabled = true) {
     queryFn: query(questionnaireApi.list, {
       queryParams: {
         tag_slug: slug,
+        status: "active",
+        subject_type: "encounter",
       },
       silent: (res) => res.status === 404,
     }),

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
@@ -98,19 +98,18 @@ export default function FacilityOrganizationSelector(
       setCurrentSelection(org);
     } else {
       setCurrentSelection(org);
+      handleConfirmSelection(org);
     }
     setFacilityOrgSearch("");
   };
 
-  const handleConfirmSelection = () => {
-    if (currentSelection) {
-      const newSelection = [...selectedOrganizations, currentSelection];
-      setSelectedOrganizations(newSelection);
-      onChange(newSelection.map((org) => org.id));
-      setCurrentSelection(null);
-      setNavigationLevels([]);
-      setOpen(false);
-    }
+  const handleConfirmSelection = (org: FacilityOrganization) => {
+    const newSelection = [...selectedOrganizations, org];
+    setSelectedOrganizations(newSelection);
+    onChange(newSelection.map((org) => org.id));
+    setCurrentSelection(null);
+    setNavigationLevels([]);
+    setOpen(false);
   };
 
   const handleRemoveOrganization = (index: number) => {
@@ -264,26 +263,28 @@ export default function FacilityOrganizationSelector(
                 {currentSelection.name}
               </span>
             </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 gap-2"
-              onClick={handleConfirmSelection}
-              disabled={isDisabled}
-              data-cy="confirm-organization"
-            >
-              {isDisabled ? (
-                <>
-                  <span>{t("already_selected")}</span>
-                  <CareIcon icon="l-multiply" className="h-4 w-4" />
-                </>
-              ) : (
-                <>
-                  <span>{t("confirm")}</span>
-                  <CareIcon icon="l-check" className="h-4 w-4" />
-                </>
-              )}
-            </Button>
+            {currentSelection.has_children && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-2"
+                onClick={() => handleConfirmSelection(currentSelection)}
+                disabled={isDisabled}
+                data-cy="confirm-organization"
+              >
+                {isDisabled ? (
+                  <>
+                    <span>{t("already_selected")}</span>
+                    <CareIcon icon="l-multiply" className="h-4 w-4" />
+                  </>
+                ) : (
+                  <>
+                    <span>{t("confirm")}</span>
+                    <CareIcon icon="l-check" className="h-4 w-4" />
+                  </>
+                )}
+              </Button>
+            )}
           </div>
         )}
       </Command>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12119 
- Auto confirm the selection if there are no children (skipping the confirm step).

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the confirmation logic when selecting organizations to provide a more explicit selection process.
  - The confirmation button now appears only for organizations that have child organizations.
- **Bug Fixes**
  - Streamlined organization selection by removing unnecessary confirmation clicks during patient verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->