### PR TITLE
Enhance sidebar navigation button styling and fixed the tooltip issues

### DIFF
--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -152,9 +152,12 @@ function PopoverMenu({ link }: { link: NavigationLink }) {
       <PopoverTrigger asChild>
         <SidebarMenuButton
           tooltip={link.name}
-          className={cn("cursor-pointer", {
-            "bg-gray-100 text-green-700 shadow": isChildActive(link),
-          })}
+          className={cn(
+            "cursor-pointer hover:bg-gray-200 hover:text-green-700",
+            {
+              "bg-white text-green-700 shadow": isChildActive(link),
+            },
+          )}
         >
           {link.icon ? (
             <CareIcon icon={link.icon as IconName} />
@@ -163,7 +166,12 @@ function PopoverMenu({ link }: { link: NavigationLink }) {
           )}
         </SidebarMenuButton>
       </PopoverTrigger>
-      <PopoverContent side="right" align="start" className="w-48 p-1">
+      <PopoverContent
+        side="right"
+        align="start"
+        className="w-48 p-1"
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         <div className="flex flex-col gap-1">
           {link.children?.map((subItem) => (
             <ActiveLink


### PR DESCRIPTION
## Proposed Changes

- Fixes #12028 

Noticed a styling issue: no hover background for PopoverTrigger, and the active background didn’t match.

**issue**
https://github.com/user-attachments/assets/d0d26aec-f25a-4755-846f-dd5a36a808bd

**fix**
https://github.com/user-attachments/assets/53692028-4870-47ee-bb0c-d164f3722ca2



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [x] Request for Peer Reviews
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved sidebar menu button with enhanced hover effects and updated active state appearance.

- **Bug Fixes**
  - Adjusted popover behavior to prevent unwanted focus changes when closing automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->