### PR TITLE
Fix: Display error message if file upload fails

### DIFF
--- a/src/components/Files/FileUploadDialog.tsx
+++ b/src/components/Files/FileUploadDialog.tsx
@@ -155,7 +155,7 @@ export default function FileUploadDialog({
                     }}
                     className="ml-0.5 mb-0.5"
                   />
-                  {!fileUpload.fileNames[index] && fileUpload.error && (
+                  {fileUpload.error && (
                     <p className="mt-2 text-sm text-red-600">
                       {fileUpload.error}
                     </p>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12129 
- Error message not displaying properly after upload attempts
![image](https://github.com/user-attachments/assets/2d67809d-2ec4-4e56-b95b-fd60770a827f)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message display during file uploads to ensure errors are shown consistently, regardless of whether a file name is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->