### PR TITLE
Encounter patient perms: only fetch patient for org level

### DIFF
--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -89,7 +89,7 @@ export const EncounterShow = (props: Props) => {
         id: patientId,
       },
     }),
-    enabled: !!patientId,
+    enabled: !facilityIdFromProps && !!patientId,
   });
 
   const facilityId = facilityIdFromProps ?? encounterData?.facility.id;
@@ -131,13 +131,13 @@ export const EncounterShow = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, isPatientLoading]);
 
-  if (isLoading || !encounterData || !patient) {
+  if (isLoading || !encounterData || (!facilityIdFromProps && !patient)) {
     return <Loading />;
   }
 
   const encounterTabProps: EncounterTabProps = {
     encounter: encounterData,
-    patient: patient,
+    patient: patient ?? encounterData.patient,
   };
 
   if (!props.tab) {


### PR DESCRIPTION
## Proposed Changes

- Adjust perms so that patient is only called when encounter is visited from org.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of patient data loading, especially when a facility ID is provided, ensuring more accurate and reliable display of patient information in encounter details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->