### PR TITLE
Fixed overflow in appointments page

### DIFF
--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -556,7 +556,7 @@ export default function AppointmentsPage({
       </div>
 
       {activeTab === "board" ? (
-        <ScrollArea style={{ width: "calc(100vw - 8rem)" }}>
+        <ScrollArea className="w-[calc(100vw-8rem)]">
           <div className="flex w-max space-x-4">
             {(
               [

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -556,7 +556,7 @@ export default function AppointmentsPage({
       </div>
 
       {activeTab === "board" ? (
-        <ScrollArea>
+        <ScrollArea style={{ width: "calc(100vw - 8rem)" }}>
           <div className="flex w-max space-x-4">
             {(
               [


### PR DESCRIPTION
## Proposed Changes

- Fixes #12046 
- Changed width of `ScrollArea`, as by-default it uses min-width:100% which was the reason behind the overflow in board style.

@ohcnetwork/care-fe-code-reviewers

https://github.com/user-attachments/assets/5125437a-15f5-48ba-86ac-ac37417a08c2

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted the width of the scrollable area in the "board" tab for improved layout and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->