### PR TITLE
Added navitems support for apps

### DIFF
--- a/src/components/ui/sidebar/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility-nav.tsx
@@ -16,7 +16,7 @@ import { usePermissions } from "@/context/PermissionContext";
 export interface NavigationLink {
   name: string;
   url: string;
-  icon?: string;
+  icon?: string | React.ReactNode;
   visibility?: boolean;
   children?: NavigationLink[];
 }

--- a/src/components/ui/sidebar/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility-nav.tsx
@@ -112,7 +112,10 @@ export function FacilityNav({ selectedFacility }: FacilityNavProps) {
   const pluginNavItems = careApps
     .filter((c) => !!c.navItems)
     .flatMap((c) =>
-      c.navItems?.({ facilityId: selectedFacility?.id }),
+      c.navItems?.map((item) => ({
+        ...item,
+        url: item.url.replace(":facilityId", selectedFacility?.id ?? ""),
+      })),
     ) as NavigationLink[];
 
   const { data: facilityData } = useQuery({

--- a/src/components/ui/sidebar/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility-nav.tsx
@@ -6,6 +6,8 @@ import { NavMain } from "@/components/ui/sidebar/nav-main";
 
 import { UserFacilityModel } from "@/components/Users/models";
 
+import { useCareApps } from "@/hooks/useCareApps";
+
 import { getPermissions } from "@/common/Permissions";
 
 import routes from "@/Utils/request/api";
@@ -106,6 +108,12 @@ function generateFacilityLinks(
 export function FacilityNav({ selectedFacility }: FacilityNavProps) {
   const { t } = useTranslation();
   const { hasPermission } = usePermissions();
+  const careApps = useCareApps();
+  const navItems = careApps
+    .filter((c) => !!c.navItems)
+    .flatMap((c) =>
+      c.navItems?.({ facilityId: selectedFacility?.id }),
+    ) as NavigationLink[];
 
   const { data: facilityData } = useQuery({
     queryKey: ["facility", selectedFacility?.id],
@@ -130,6 +138,11 @@ export function FacilityNav({ selectedFacility }: FacilityNavProps) {
     canViewEncounter,
   };
   return (
-    <NavMain links={generateFacilityLinks(selectedFacility, t, permissions)} />
+    <NavMain
+      links={[
+        ...generateFacilityLinks(selectedFacility, t, permissions),
+        ...navItems,
+      ]}
+    />
   );
 }

--- a/src/components/ui/sidebar/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility-nav.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 
 import { NavMain } from "@/components/ui/sidebar/nav-main";
@@ -28,19 +27,50 @@ interface FacilityNavProps {
 
 function generateFacilityLinks(
   selectedFacility: UserFacilityModel | null,
-  t: TFunction,
-  permissions: {
-    canViewAppointments: boolean;
-    canListEncounters: boolean;
-    canCreateAppointment: boolean;
-    canCreateEncounter: boolean;
-    canViewEncounter: boolean;
-  },
+  links: NavigationLink[],
 ) {
   if (!selectedFacility) return [];
 
-  const baseUrl = `/facility/${selectedFacility.id}`;
-  const links: NavigationLink[] = [
+  return links.map((link) => ({
+    ...link,
+    url: link.url.replace(":facilityId", selectedFacility.id),
+  }));
+}
+
+export function FacilityNav({ selectedFacility }: FacilityNavProps) {
+  const { t } = useTranslation();
+  const { hasPermission } = usePermissions();
+  const careApps = useCareApps();
+  const pluginNavItems = careApps
+    .filter((c) => !!c.navItems)
+    .flatMap((c) => c.navItems) as NavigationLink[];
+
+  const { data: facilityData } = useQuery({
+    queryKey: ["facility", selectedFacility?.id],
+    queryFn: query(routes.getPermittedFacility, {
+      pathParams: { id: selectedFacility?.id ?? "" },
+    }),
+    enabled: !!selectedFacility?.id,
+  });
+
+  const {
+    canViewAppointments,
+    canListEncounters,
+    canCreateAppointment,
+    canCreateEncounter,
+    canViewEncounter,
+  } = getPermissions(hasPermission, facilityData?.permissions ?? []);
+  const permissions = {
+    canViewAppointments,
+    canListEncounters,
+    canCreateAppointment,
+    canCreateEncounter,
+    canViewEncounter,
+  };
+
+  const baseUrl = `/facility/:facilityId`;
+
+  const baseLinks: NavigationLink[] = [
     { name: t("overview"), url: `${baseUrl}/overview`, icon: "d-hospital" },
     {
       name: t("appointments"),
@@ -102,50 +132,12 @@ function generateFacilityLinks(
     },
   ];
 
-  return links;
-}
-
-export function FacilityNav({ selectedFacility }: FacilityNavProps) {
-  const { t } = useTranslation();
-  const { hasPermission } = usePermissions();
-  const careApps = useCareApps();
-  const pluginNavItems = careApps
-    .filter((c) => !!c.navItems)
-    .flatMap((c) =>
-      c.navItems?.map((item) => ({
-        ...item,
-        url: item.url.replace(":facilityId", selectedFacility?.id ?? ""),
-      })),
-    ) as NavigationLink[];
-
-  const { data: facilityData } = useQuery({
-    queryKey: ["facility", selectedFacility?.id],
-    queryFn: query(routes.getPermittedFacility, {
-      pathParams: { id: selectedFacility?.id ?? "" },
-    }),
-    enabled: !!selectedFacility?.id,
-  });
-
-  const {
-    canViewAppointments,
-    canListEncounters,
-    canCreateAppointment,
-    canCreateEncounter,
-    canViewEncounter,
-  } = getPermissions(hasPermission, facilityData?.permissions ?? []);
-  const permissions = {
-    canViewAppointments,
-    canListEncounters,
-    canCreateAppointment,
-    canCreateEncounter,
-    canViewEncounter,
-  };
   return (
     <NavMain
-      links={[
-        ...generateFacilityLinks(selectedFacility, t, permissions),
+      links={generateFacilityLinks(selectedFacility, [
+        ...baseLinks,
         ...pluginNavItems,
-      ]}
+      ])}
     />
   );
 }

--- a/src/components/ui/sidebar/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility-nav.tsx
@@ -109,7 +109,7 @@ export function FacilityNav({ selectedFacility }: FacilityNavProps) {
   const { t } = useTranslation();
   const { hasPermission } = usePermissions();
   const careApps = useCareApps();
-  const navItems = careApps
+  const pluginNavItems = careApps
     .filter((c) => !!c.navItems)
     .flatMap((c) =>
       c.navItems?.({ facilityId: selectedFacility?.id }),
@@ -141,7 +141,7 @@ export function FacilityNav({ selectedFacility }: FacilityNavProps) {
     <NavMain
       links={[
         ...generateFacilityLinks(selectedFacility, t, permissions),
-        ...navItems,
+        ...pluginNavItems,
       ]}
     />
   );

--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -66,7 +66,11 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                           className="cursor-pointer hover:bg-gray-200 hover:text-green-700"
                         >
                           {link.icon ? (
-                            <CareIcon icon={link.icon as IconName} />
+                            typeof link.icon === "string" ? (
+                              <CareIcon icon={link.icon as IconName} />
+                            ) : (
+                              link.icon
+                            )
                           ) : (
                             <Avatar
                               name={link.name}
@@ -122,7 +126,11 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                       exactActiveClass="bg-white text-green-700 shadow-sm"
                     >
                       {link.icon ? (
-                        <CareIcon icon={link.icon as IconName} />
+                        typeof link.icon === "string" ? (
+                          <CareIcon icon={link.icon as IconName} />
+                        ) : (
+                          link.icon
+                        )
                       ) : (
                         <Avatar
                           name={link.name}
@@ -160,7 +168,11 @@ function PopoverMenu({ link }: { link: NavigationLink }) {
           )}
         >
           {link.icon ? (
-            <CareIcon icon={link.icon as IconName} />
+            typeof link.icon === "string" ? (
+              <CareIcon icon={link.icon as IconName} />
+            ) : (
+              link.icon
+            )
           ) : (
             <Avatar name={link.name} className="size-6 -m-1 rounded-sm" />
           )}

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -106,7 +106,7 @@ export type PluginManifest = {
   components?: PluginComponentMap;
   encounterTabs?: Record<string, LazyComponent<React.FC<EncounterTabProps>>>;
   devices?: readonly PluginDeviceManifest[];
-  navItems?: ({ facilityId }: { facilityId?: string }) => NavigationLink[];
+  navItems?: NavigationLink[];
 };
 
 export { pluginMap };

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -9,6 +9,7 @@ import { UserBase } from "@/types/user/user";
 
 import { AppRoutes } from "./Routers/AppRouter";
 import { QuestionnaireFormState } from "./components/Questionnaire/QuestionnaireForm";
+import { NavigationLink } from "./components/ui/sidebar/facility-nav";
 import { pluginMap } from "./pluginMap";
 import { FacilityData } from "./types/facility/facility";
 
@@ -105,6 +106,7 @@ export type PluginManifest = {
   components?: PluginComponentMap;
   encounterTabs?: Record<string, LazyComponent<React.FC<EncounterTabProps>>>;
   devices?: readonly PluginDeviceManifest[];
+  navItems?: ({ facilityId }: { facilityId?: string }) => NavigationLink[];
 };
 
 export { pluginMap };


### PR DESCRIPTION
## Proposed Changes

- Allows apps to append links to the navbar 

example:
```js
navItems: [
    {
      url: `/facility/:facilityId/autofill-history`,
      name: "Autofill History",
      icon: <Icon/>,
    },
  ],
```

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Facility navigation now includes dynamic links from care applications, providing additional navigation options based on the selected facility.
- **Chores**
  - Updated plugin support to allow care applications to define custom navigation links for facilities.
- **Refactor**
  - Improved navigation link handling by merging static and dynamic links before rendering.
  - Enhanced icon rendering to support both string-based icons and custom React nodes for sidebar navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->