### PR TITLE
fix resource not reschedulable error

### DIFF
--- a/src/components/Users/UserAvailabilityTab.tsx
+++ b/src/components/Users/UserAvailabilityTab.tsx
@@ -179,13 +179,15 @@ export default function UserAvailabilityTab({
                   <div />
                 </div>
               </PopoverTrigger>
-              <DayDetailsPopover
-                date={date}
-                templates={templates}
-                unavailableExceptions={unavailableExceptions}
-                setQParams={setQParams}
-                user={user}
-              />
+              {isSchedulableResource && (
+                <DayDetailsPopover
+                  date={date}
+                  templates={templates}
+                  unavailableExceptions={unavailableExceptions}
+                  setQParams={setQParams}
+                  user={user}
+                />
+              )}
             </Popover>
           );
         }}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12230
- Added `isSchedulableResource` check to conditionally render `DayDetailsPopover`

[Screencast from 2025-05-06 22-30-31.webm](https://github.com/user-attachments/assets/e126c2f2-d26c-4edc-8bd0-afcba15d8293)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The detailed day availability popover now only appears for users marked as schedulable resources, ensuring that non-schedulable users no longer see this information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->