### PR TITLE
Enhancement: Show Bed Start and End time in the location sidebar of the encounter

### DIFF
--- a/src/components/Location/LocationHistory.tsx
+++ b/src/components/Location/LocationHistory.tsx
@@ -23,7 +23,8 @@ export function LocationHistory({ history }: LocationHistoryProps) {
         <div key={index}>
           <LocationTree
             location={item.location}
-            datetime={item.start_datetime}
+            startTime={item.start_datetime}
+            endTime={item.end_datetime}
             isLatest={index === 0}
             showTimeline
           />

--- a/src/components/Location/LocationTree.tsx
+++ b/src/components/Location/LocationTree.tsx
@@ -7,7 +7,8 @@ import { LocationList } from "@/types/location/location";
 
 interface LocationPathProps {
   location: LocationList;
-  datetime?: string;
+  startTime?: string;
+  endTime?: string;
   isLatest?: boolean;
   showTimeline?: boolean;
 }
@@ -15,14 +16,17 @@ interface LocationPathProps {
 interface LocationNodeProps {
   location: LocationList;
   isLast: boolean;
-  datetime?: string;
+  startTime?: string;
+
+  endTime?: string;
   children?: React.ReactNode;
 }
 
 function LocationNode({
   location,
   isLast,
-  datetime,
+  startTime,
+  endTime,
   children,
 }: LocationNodeProps) {
   if (!location.parent?.id) {
@@ -37,9 +41,14 @@ function LocationNode({
           </span>
         </div>
         {children}
-        {isLast && datetime && (
-          <div className="pl-6 flex items-center text-sm font-normal text-gray-700 italic">
-            {format(new Date(datetime), "MMM d, yyyy h:mm a")}
+        {isLast && (startTime || endTime) && (
+          <div className="pl-6 text-sm font-normal text-gray-700 italic">
+            {[
+              startTime && format(new Date(startTime), "MMM d, yyyy h:mm a"),
+              endTime && format(new Date(endTime), "MMM d, yyyy h:mm a"),
+            ]
+              .filter(Boolean)
+              .join(" - ")}
           </div>
         )}
       </div>
@@ -47,7 +56,12 @@ function LocationNode({
   }
 
   return (
-    <LocationNode location={location.parent} isLast={false} datetime={datetime}>
+    <LocationNode
+      location={location.parent}
+      isLast={false}
+      startTime={startTime}
+      endTime={endTime}
+    >
       <div className="flex flex-col gap-2 ml-2">
         <div className="flex items-center text-sm">
           <CareIcon
@@ -61,9 +75,14 @@ function LocationNode({
           </span>
         </div>
         {children}
-        {isLast && datetime && (
-          <div className="pl-6 flex items-center text-sm font-normal text-gray-700 italic">
-            {format(new Date(datetime), "MMM d, yyyy h:mm a")}
+        {isLast && (startTime || endTime) && (
+          <div className="pl-6 text-sm font-normal text-gray-700 italic">
+            {[
+              startTime && format(new Date(startTime), "MMM d, yyyy h:mm a"),
+              endTime && format(new Date(endTime), "MMM d, yyyy h:mm a"),
+            ]
+              .filter(Boolean)
+              .join(" - ")}
           </div>
         )}
       </div>
@@ -73,7 +92,8 @@ function LocationNode({
 
 export function LocationTree({
   location,
-  datetime,
+  startTime,
+  endTime,
   isLatest,
   showTimeline = false,
 }: LocationPathProps) {
@@ -98,7 +118,12 @@ export function LocationTree({
         </div>
       )}
       <div className="flex flex-col gap-2">
-        <LocationNode location={location} isLast={true} datetime={datetime} />
+        <LocationNode
+          location={location}
+          isLast={true}
+          startTime={startTime}
+          endTime={endTime}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Proposed Changes

- Fixes #10875
- Add `startTime` and `endTime` of location to show up in history

<img width="470" alt="Screenshot 2025-05-06 at 10 19 53 PM" src="https://github.com/user-attachments/assets/e80089ed-6857-4885-9ebd-91e9837efd1f" />



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced location history display to show both start and end times, allowing users to view time ranges instead of a single timestamp.
- **Style**
  - Simplified the appearance of the timestamp container in the location tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->