### PR TITLE
Fixed the overflow in appointments section

### DIFF
--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -48,6 +48,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useSidebar } from "@/components/ui/sidebar";
 import {
   Table,
   TableBody,
@@ -266,6 +267,7 @@ export default function AppointmentsPage({
   });
 
   const [activeTab, setActiveTab] = useView("appointments", "board");
+  const { open: isSidebarOpen } = useSidebar();
 
   const { hasPermission } = usePermissions();
   const { goBack } = useAppHistory();
@@ -556,7 +558,12 @@ export default function AppointmentsPage({
       </div>
 
       {activeTab === "board" ? (
-        <ScrollArea className="md:w-[calc(100vw-8rem)]">
+        <ScrollArea
+          className={cn(
+            `transition-all duration-200 ease-${isSidebarOpen ? "out" : "in"}`,
+            `md:w-[calc(100vw-${isSidebarOpen ? "21.5" : "8"}rem)]`,
+          )}
+        >
           <div className="flex w-max space-x-4">
             {(
               [

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -560,8 +560,10 @@ export default function AppointmentsPage({
       {activeTab === "board" ? (
         <ScrollArea
           className={cn(
-            `transition-all duration-200 ease-${isSidebarOpen ? "out" : "in"}`,
-            `md:w-[calc(100vw-${isSidebarOpen ? "21.5" : "8"}rem)]`,
+            "transition-all duration-200",
+            isSidebarOpen
+              ? "ease-out md:w-[calc(100vw-21.5rem)]"
+              : "ease-in md:w-[calc(100vw-8rem)]",
           )}
         >
           <div className="flex w-max space-x-4">

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -556,7 +556,7 @@ export default function AppointmentsPage({
       </div>
 
       {activeTab === "board" ? (
-        <ScrollArea style={{ width: "calc(100vw - 8rem)" }}>
+        <ScrollArea className="w-[calc(100vw-8rem)]">
           <div className="flex w-max space-x-4">
             {(
               [

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -556,7 +556,7 @@ export default function AppointmentsPage({
       </div>
 
       {activeTab === "board" ? (
-        <ScrollArea className="w-[calc(100vw-8rem)]">
+        <ScrollArea className="md:w-[calc(100vw-8rem)]">
           <div className="flex w-max space-x-4">
             {(
               [

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -556,7 +556,7 @@ export default function AppointmentsPage({
       </div>
 
       {activeTab === "board" ? (
-        <ScrollArea>
+        <ScrollArea style={{ width: "calc(100vw - 8rem)" }}>
           <div className="flex w-max space-x-4">
             {(
               [


### PR DESCRIPTION
## Proposed Changes

- Fixes #12046 
- By default `ScrollArea` has min-width:100%. So, I added tailwind classes to restrict it from growing outside container in medium devices. Smaller devices don't face the issue.

@ohcnetwork/care-fe-code-reviewers

https://github.com/user-attachments/assets/e8d8c5b8-943c-4df7-82f7-a81534f627af

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the layout of the appointment board on medium and larger screens for better visual consistency and smoother transitions when toggling the sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->