### PR TITLE
Bug: Fixed misalignment of `Medication History` button

### DIFF
--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -347,7 +347,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
       }}
     >
       <SheetTrigger asChild>
-        <div className="flex items-center justify-end">
+        <div className="flex max-w-4xl justify-end">
           <Button
             variant="outline"
             data-cy="view-history"

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -346,8 +346,8 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
         }
       }}
     >
-      <SheetTrigger asChild>
-        <div className="flex max-w-4xl justify-end">
+      <div className="flex items-center max-w-4xl justify-end">
+        <SheetTrigger asChild>
           <Button
             variant="outline"
             data-cy="view-history"
@@ -356,8 +356,8 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
             <Clock className="size-4" />
             <span className="font-semibold">{buttonLabel}</span>
           </Button>
-        </div>
-      </SheetTrigger>
+        </SheetTrigger>
+      </div>
       <SheetContent className="w-full sm:max-w-3xl p-0 overflow-y-auto">
         <div className="flex flex-col gap-2 p-2">
           <SheetHeader className="p-0">


### PR DESCRIPTION
## Proposed Changes

- Fixes #12249
- Aligned the `Medication history` button similar to `diagnosis history` and `symptom history` button

## Screenshots

**Desktop View:**
![image](https://github.com/user-attachments/assets/31b0c8e2-2643-4cf4-b515-44b846297593)

**Mobile View:**
![image](https://github.com/user-attachments/assets/79b9302c-de7c-495e-9d02-33fc91bcb7dd)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated layout styling for the history sheet trigger button to improve alignment and apply a maximum width constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->