### PR TITLE
fix: show dropdown options instead of selected text on prefix edit

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -363,6 +363,7 @@ export default function UserForm({
                   value={field.value || ""}
                   onChange={field.onChange}
                   noOptionsMessage=""
+                  className="min-w-0"
                   placeholder={t("select_or_type")}
                   inputPlaceholder={t("select_or_type")}
                 />

--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -347,7 +347,7 @@ export default function UserForm({
           />
         )}
 
-        <div className="md:flex gap-2 grid grid-cols-2 items-start">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2 items-start">
           <FormField
             control={form.control}
             name="prefix"
@@ -363,7 +363,6 @@ export default function UserForm({
                   value={field.value || ""}
                   onChange={field.onChange}
                   noOptionsMessage=""
-                  className="md:w-28"
                   placeholder={t("select_or_type")}
                   inputPlaceholder={t("select_or_type")}
                 />

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -212,7 +212,7 @@ export default function Autocomplete({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className={cn("min-w-0 justify-between", className)}
+          className={cn("w-full justify-between", className)}
           disabled={disabled}
           data-cy={dataCy}
           onClick={() => setOpen(!open)}

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -212,12 +212,17 @@ export default function Autocomplete({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className={cn("w-full justify-between", className)}
+          className={cn("min-w-0 justify-between", className)}
           disabled={disabled}
           data-cy={dataCy}
           onClick={() => setOpen(!open)}
         >
-          <span className={cn("truncate", !selectedOption && "text-gray-500")}>
+          <span
+            className={cn(
+              inputValue && "truncate",
+              !selectedOption && "text-gray-500",
+            )}
+          >
             {displayText}
           </span>
           <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -116,8 +116,6 @@ export default function Autocomplete({
         placeholder={inputPlaceholder}
         disabled={disabled}
         onValueChange={handleInputChange}
-        // Control the input when freeInput is true.
-        {...(freeInput ? { value: inputValue } : {})}
         className="outline-hidden border-none ring-0 shadow-none"
         autoFocus
       />


### PR DESCRIPTION
## Proposed Changes

- Fixes #12121
- Removed the condition that preset the previously selected value in `CommandInput`

[Screencast from 2025-05-09 11-22-18.webm](https://github.com/user-attachments/assets/0a86a287-bbc1-43d2-ab45-649a3afdbf48)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved input handling in the autocomplete component for better user input flexibility.
  - Enhanced user form layout with a more responsive grid design for name fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->