### PR TITLE
Disallow future `deceased_datetime` and fixed tz not being sent

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -705,9 +705,9 @@ export default function PatientRegistration(
                                   : ""
                               }
                               onChange={(e) => {
-                                const value =
-                                  dayjs(e.target.value).toISOString() ||
-                                  undefined;
+                                const value = e.target.value
+                                  ? dayjs(e.target.value).toISOString()
+                                  : undefined;
                                 field.onChange(value);
                                 setIsDeceased(!!value);
                               }}

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -690,8 +690,6 @@ export default function PatientRegistration(
                       control={form.control}
                       name="deceased_datetime"
                       render={({ field }) => {
-                        console.log("field.value:", field.value); // 👈 log here for debugging
-
                         return (
                           <FormItem>
                             <FormLabel>{t("date_and_time_of_death")}</FormLabel>

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -1,6 +1,7 @@
 import careConfig from "@careConfig";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
 import { InfoIcon } from "lucide-react";
 import { navigate, useNavigationPrompt, useQueryParams } from "raviger";
 import { useEffect, useMemo, useState } from "react";
@@ -688,27 +689,39 @@ export default function PatientRegistration(
                     <FormField
                       control={form.control}
                       name="deceased_datetime"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>{t("date_and_time_of_death")}</FormLabel>
-                          <FormControl>
-                            <Input
-                              type="datetime-local"
-                              {...field}
-                              value={field.value ?? ""}
-                              onChange={(e) => {
-                                const value = e.target.value || undefined;
-                                field.onChange(value);
-                                setIsDeceased(!!value);
-                              }}
-                              max={dayjs().format("YYYY-MM-DDTHH:mm")}
-                              id="death-datetime"
-                              data-cy="death-datetime-input"
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+                      render={({ field }) => {
+                        console.log("field.value:", field.value); // 👈 log here for debugging
+
+                        return (
+                          <FormItem>
+                            <FormLabel>{t("date_and_time_of_death")}</FormLabel>
+                            <FormControl>
+                              <Input
+                                type="datetime-local"
+                                {...field}
+                                value={
+                                  field.value
+                                    ? format(
+                                        new Date(field.value),
+                                        "yyyy-MM-dd'T'HH:mm",
+                                      )
+                                    : ""
+                                }
+                                onChange={(e) => {
+                                  const value =
+                                    dayjs(e.target.value).toISOString() ||
+                                    undefined;
+                                  field.onChange(value);
+                                  setIsDeceased(!!value);
+                                }}
+                                max={dayjs().format("YYYY-MM-DDTHH:mm")}
+                                id="death-datetime"
+                                data-cy="death-datetime-input"
+                              />
+                            </FormControl>
+                          </FormItem>
+                        );
+                      }}
                     />
                   </div>
                 )}

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -689,37 +689,36 @@ export default function PatientRegistration(
                     <FormField
                       control={form.control}
                       name="deceased_datetime"
-                      render={({ field }) => {
-                        return (
-                          <FormItem>
-                            <FormLabel>{t("date_and_time_of_death")}</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="datetime-local"
-                                {...field}
-                                value={
-                                  field.value
-                                    ? format(
-                                        new Date(field.value),
-                                        "yyyy-MM-dd'T'HH:mm",
-                                      )
-                                    : ""
-                                }
-                                onChange={(e) => {
-                                  const value =
-                                    dayjs(e.target.value).toISOString() ||
-                                    undefined;
-                                  field.onChange(value);
-                                  setIsDeceased(!!value);
-                                }}
-                                max={dayjs().format("YYYY-MM-DDTHH:mm")}
-                                id="death-datetime"
-                                data-cy="death-datetime-input"
-                              />
-                            </FormControl>
-                          </FormItem>
-                        );
-                      }}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("date_and_time_of_death")}</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="datetime-local"
+                              {...field}
+                              value={
+                                field.value
+                                  ? format(
+                                      new Date(field.value),
+                                      "yyyy-MM-dd'T'HH:mm",
+                                    )
+                                  : ""
+                              }
+                              onChange={(e) => {
+                                const value =
+                                  dayjs(e.target.value).toISOString() ||
+                                  undefined;
+                                field.onChange(value);
+                                setIsDeceased(!!value);
+                              }}
+                              max={dayjs().format("YYYY-MM-DDTHH:mm")}
+                              id="death-datetime"
+                              data-cy="death-datetime-input"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
                     />
                   </div>
                 )}

--- a/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
@@ -50,7 +50,10 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
           : undefined
       }
       max={format(new Date(), "yyyy-MM-dd'T'HH:mm")}
-      onChange={(e) => handleUpdate(dayjs(e.target.value).toISOString() || "")}
+      onChange={(e) => {
+        const value = e.target.value ? dayjs(e.target.value).toISOString() : "";
+        handleUpdate(value);
+      }}
       disabled={props.disabled}
     />
   );

--- a/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { format, isFuture } from "date-fns";
 
 import { Input } from "@/components/ui/input";
 
@@ -25,9 +25,7 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
   const values = (questionnaireResponse.values?.[0]?.value as string[]) || [];
 
   const handleUpdate = (updates: string) => {
-    const selectedDate = new Date(updates);
-    const now = new Date();
-    if (selectedDate > now) {
+    if (isFuture(updates)) {
       return;
     }
     updateQuestionnaireResponseCB(

--- a/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
@@ -1,4 +1,5 @@
 import { format, isFuture } from "date-fns";
+import dayjs from "dayjs";
 
 import { Input } from "@/components/ui/input";
 
@@ -23,6 +24,8 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
   const { questionnaireResponse, updateQuestionnaireResponseCB } = props;
 
   const values = (questionnaireResponse.values?.[0]?.value as string[]) || [];
+
+  console.log("jey:", dayjs(values[0]).toISOString());
 
   const handleUpdate = (updates: string) => {
     if (isFuture(updates)) {
@@ -49,7 +52,7 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
           : undefined
       }
       max={format(new Date(), "yyyy-MM-dd'T'HH:mm")}
-      onChange={(e) => handleUpdate(e.target.value || "")}
+      onChange={(e) => handleUpdate(dayjs(e.target.value).toISOString() || "")}
       disabled={props.disabled}
     />
   );

--- a/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
@@ -25,6 +25,11 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
   const values = (questionnaireResponse.values?.[0]?.value as string[]) || [];
 
   const handleUpdate = (updates: string) => {
+    const selectedDate = new Date(updates);
+    const now = new Date();
+    if (selectedDate > now) {
+      return;
+    }
     updateQuestionnaireResponseCB(
       [
         {
@@ -45,6 +50,7 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
           ? format(new Date(values[0]), "yyyy-MM-dd'T'HH:mm")
           : undefined
       }
+      max={format(new Date(), "yyyy-MM-dd'T'HH:mm")}
       onChange={(e) => handleUpdate(e.target.value || "")}
       disabled={props.disabled}
     />

--- a/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
@@ -25,8 +25,6 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
 
   const values = (questionnaireResponse.values?.[0]?.value as string[]) || [];
 
-  console.log("jey:", dayjs(values[0]).toISOString());
-
   const handleUpdate = (updates: string) => {
     if (isFuture(updates)) {
       return;

--- a/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DeathQuestion.tsx
@@ -1,4 +1,4 @@
-import { format, isFuture } from "date-fns";
+import { format } from "date-fns";
 import dayjs from "dayjs";
 
 import { Input } from "@/components/ui/input";
@@ -26,9 +26,6 @@ export function TimeOfDeathQuestion(props: TimeOfDeathQuestionProps) {
   const values = (questionnaireResponse.values?.[0]?.value as string[]) || [];
 
   const handleUpdate = (updates: string) => {
-    if (isFuture(updates)) {
-      return;
-    }
     updateQuestionnaireResponseCB(
       [
         {


### PR DESCRIPTION
## Proposed Changes

- Fixes #12333

- Set a max value in the Calendar
- Implemented a condition to restrict users from selecting a future time.
- Related BE changes will updated soon

Demo video :
[Screencast from 2025-05-10 18-40-47.webm](https://github.com/user-attachments/assets/0825f4c3-7843-46a5-b072-4d3dd432072c)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented users from selecting a future date/time for the time of death input in the questionnaire.
  - The date/time picker now restricts input to the current date/time or earlier.
  - Improved date/time formatting and validation in patient registration for deceased date/time entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->