### PR TITLE
Clean up invalid Tailwind CSS class (text-muted-foreground)

### DIFF
--- a/src/components/Common/UserSelector.tsx
+++ b/src/components/Common/UserSelector.tsx
@@ -164,9 +164,7 @@ export default function UserSelector({
                 </CommandItem>
               ))}
               {isFetchingNextPage && (
-                <div className="text-center text-sm text-muted py-2">
-                  {t("loading")}
-                </div>
+                <div className="text-center text-sm py-2">{t("loading")}</div>
               )}
             </CommandGroup>
           </CommandList>

--- a/src/components/Facility/ConsultationDetails/PrintQuestionnaireQuestionnaireResponses.tsx
+++ b/src/components/Facility/ConsultationDetails/PrintQuestionnaireQuestionnaireResponses.tsx
@@ -349,7 +349,7 @@ export function ResponseCard({ item }: ResponseCardProps) {
   if (isStructured && structuredType) return null;
 
   return (
-    <div className="flex flex-col py-3 transition-colors hover:bg-muted/50">
+    <div className="flex flex-col py-3 transition-colors">
       <div className="text-sm m-1">
         <p>
           {t("created_by")}: {formatName(item.created_by)}

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -275,10 +275,7 @@ function ResponseCard({
     <EncounterAccordionLayout
       title={isStructured && structuredType ? structuredType : title}
       actionButton={isPrintPreview ? null : <PrintButton item={item} />}
-      className={cn(
-        "transition-colors hover:bg-muted/50",
-        isPrintPreview && "shadow-none",
-      )}
+      className={cn(isPrintPreview && "shadow-none")}
     >
       {item.questionnaire && (
         <div className="px-2 space-y-4">

--- a/src/components/Facility/FacilityForm.tsx
+++ b/src/components/Facility/FacilityForm.tsx
@@ -433,7 +433,7 @@ export default function FacilityForm({
             control={form.control}
             name="is_public"
             render={({ field }) => (
-              <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-gray-200 p-4 bg-muted/5">
+              <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-gray-200 p-4">
                 <FormControl>
                   <Checkbox
                     checked={field.value}

--- a/src/components/Facility/FacilityHome.tsx
+++ b/src/components/Facility/FacilityHome.tsx
@@ -405,7 +405,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
                         <p className="text-sm font-medium">
                           {t("delete_facility")}
                         </p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-sm text-gray-700">
                           {t("delete_facility_description")}
                         </p>
                       </div>

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -215,7 +215,7 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
                             {patientList.results.map((patient) => (
                               <TableRow
                                 key={patient.id}
-                                className="cursor-pointer hover:bg-muted/50"
+                                className="cursor-pointer"
                                 onClick={() => handlePatientSelect(patient)}
                               >
                                 <TableCell className="font-medium">

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1398,7 +1398,7 @@ function QuestionEditor({
                       <SelectItem key={type.value} value={type.value}>
                         <div className="flex flex-col items-start">
                           <span>{type.name}</span>
-                          <span className="text-xs max-w-xs text-muted-foreground whitespace-normal">
+                          <span className="text-xs max-w-xs text-gray-500 whitespace-normal">
                             {t(type.description)}
                           </span>
                         </div>
@@ -1610,7 +1610,7 @@ function QuestionEditor({
                 <h3 className="text-sm font-medium mb-2">
                   {t("group_layout_options")}
                 </h3>
-                <p className="text-sm text-muted-foreground mb-4">
+                <p className="text-sm text-gray-500 mb-4">
                   {t("choose_layout_style")}
                 </p>
                 <RadioGroup

--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -549,7 +549,7 @@ export default function UserForm({
                             <Lock className="size-4" />
                             {t("set_password_now")}
                           </Label>
-                          <p className="text-sm text-muted-foreground">
+                          <p className="text-sm text-gray-500">
                             {t("set_password_now_description")}
                           </p>
                         </div>
@@ -575,7 +575,7 @@ export default function UserForm({
                             <Mail className="size-4" />
                             {t("send_email_invitation")}
                           </Label>
-                          <p className="text-sm text-muted-foreground">
+                          <p className="text-sm text-gray-500">
                             {t("send_email_invitation_description")}
                           </p>
                         </div>

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
   );
   const _weekdaysClassName = cn("flex flex-row", props.weekdaysClassName);
   const _weekdayClassName = cn(
-    "w-8 text-sm font-normal text-gray-900",
+    "w-8 text-sm font-normal text-gray-700",
     props.weekdayClassName,
   );
   const _monthClassName = cn("w-full", props.monthClassName);
@@ -155,11 +155,11 @@ function Calendar({
     props.todayClassName,
   );
   const _outsideClassName = cn(
-    "day-outside text-gray-700 opacity-50 aria-selected:bg-accent/50 aria-selected:text-gray-900 aria-selected:opacity-30",
+    "day-outside text-gray-500 opacity-50 aria-selected:bg-accent/50 aria-selected:text-gray-700 aria-selected:opacity-30",
     props.outsideClassName,
   );
   const _disabledClassName = cn(
-    "text-gray-700 opacity-50",
+    "text-gray-500 opacity-50",
     props.disabledClassName,
   );
   const _hiddenClassName = cn("invisible flex-1", props.hiddenClassName);

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
   );
   const _weekdaysClassName = cn("flex flex-row", props.weekdaysClassName);
   const _weekdayClassName = cn(
-    "w-8 text-sm font-normal text-muted-foreground",
+    "w-8 text-sm font-normal text-gray-900",
     props.weekdayClassName,
   );
   const _monthClassName = cn("w-full", props.monthClassName);
@@ -155,11 +155,11 @@ function Calendar({
     props.todayClassName,
   );
   const _outsideClassName = cn(
-    "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
+    "day-outside text-gray-700 opacity-50 aria-selected:bg-accent/50 aria-selected:text-gray-900 aria-selected:opacity-30",
     props.outsideClassName,
   );
   const _disabledClassName = cn(
-    "text-muted-foreground opacity-50",
+    "text-gray-700 opacity-50",
     props.disabledClassName,
   );
   const _hiddenClassName = cn("invisible flex-1", props.hiddenClassName);

--- a/src/pages/Facility/settings/devices/DeviceShow.tsx
+++ b/src/pages/Facility/settings/devices/DeviceShow.tsx
@@ -448,7 +448,7 @@ export default function DeviceShow({ facilityId, deviceId }: Props) {
                 <h3 className="text-sm font-medium">
                   {t("delete_this_device")}
                 </h3>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm text-gray-700">
                   {t("delete_device_description")}
                 </p>
               </div>

--- a/src/pages/Facility/settings/devices/components/DeviceForm.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceForm.tsx
@@ -459,7 +459,7 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
           </div>
 
           {fields.length === 0 && (
-            <div className="py-4 text-center text-sm text-muted-foreground">
+            <div className="py-4 text-center text-sm text-gray-7ss00">
               {t("no_contact_points_added")}
             </div>
           )}

--- a/src/pages/Facility/settings/devices/components/DeviceForm.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceForm.tsx
@@ -459,7 +459,7 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
           </div>
 
           {fields.length === 0 && (
-            <div className="py-4 text-center text-sm text-gray-7ss00">
+            <div className="py-4 text-center text-sm text-gray-700">
               {t("no_contact_points_added")}
             </div>
           )}

--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -464,7 +464,7 @@ export default function LocationForm({
                   </div>
                 </div>
               ) : (
-                <div className="rounded-md bg-muted p-4">
+                <div className="rounded-md p-4">
                   <h4 className="font-medium mb-2">{t("preview_bed_names")}</h4>
                   <div className="text-sm text-gray-700 flex flex-wrap gap-2">
                     {bedFields.map((field) => (

--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -331,7 +331,7 @@ export default function LocationForm({
                 </FormControl>
                 <div className="space-y-1 leading-none">
                   <FormLabel>{t("create_multiple_beds")}</FormLabel>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-sm text-gray-500">
                     {t("create_multiple_beds_description")}
                   </p>
                 </div>
@@ -405,7 +405,7 @@ export default function LocationForm({
                     </FormControl>
                     <div className="space-y-1 leading-none">
                       <FormLabel>{t("customize_bed_names")}</FormLabel>
-                      <p className="text-sm text-muted-foreground">
+                      <p className="text-sm text-gray-500">
                         {t("customize_bed_names_description")}
                       </p>
                     </div>
@@ -466,7 +466,7 @@ export default function LocationForm({
               ) : (
                 <div className="rounded-md bg-muted p-4">
                   <h4 className="font-medium mb-2">{t("preview_bed_names")}</h4>
-                  <div className="text-sm text-muted-foreground flex flex-wrap gap-2">
+                  <div className="text-sm text-gray-700 flex flex-wrap gap-2">
                     {bedFields.map((field) => (
                       <div
                         key={field.id}

--- a/src/pages/PublicAppointments/PatientSelect.tsx
+++ b/src/pages/PublicAppointments/PatientSelect.tsx
@@ -59,7 +59,7 @@ function PatientCard({
       </CardHeader>
       <CardContent className="space-y-2">
         <div className="flex justify-between">
-          <span className="text-sm text-muted-foreground font-medium">
+          <span className="text-sm text-gray-700 font-medium">
             {t("date_of_birth_age")}:
           </span>
           <span className="text-sm font-semibold">
@@ -67,9 +67,7 @@ function PatientCard({
           </span>
         </div>
         <div className="flex justify-between">
-          <span className="text-sm text-muted-foreground font-medium">
-            {t("sex")}:
-          </span>
+          <span className="text-sm text-gray-700 font-medium">{t("sex")}:</span>
           <span className="text-sm font-semibold">
             {t(`GENDER__${patient.gender}`)}
           </span>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12199 

 Replaced text-muted-foreground in:
- src/components/Users/UserForm.tsx
- src/components/Questionnaire/QuestionnaireEditor.tsx
- src/components/ui/calendar.tsx
- src/components/Facility/FacilityHome.tsx
- src/pages/PublicAppointments/PatientSelect.tsx
- src/pages/Facility/settings/devices/DeviceShow.tsx
- src/pages/Facility/settings/devices/components/DeviceForm.tsx
- src/pages/Facility/settings/locations/LocationForm.tsx

![Screenshot (577)](https://github.com/user-attachments/assets/503085c4-7f61-427e-a5a0-41cc1ca20c67)
![Screenshot (584)](https://github.com/user-attachments/assets/1921fc54-c0a0-4e47-aed8-1427b4d61765)
![Screenshot (590)](https://github.com/user-attachments/assets/ee733570-1314-41a8-9ccd-ea0810d53824)
![Screenshot (593)](https://github.com/user-attachments/assets/0a3871c7-cf02-481d-b72c-513699c4c214)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [X] Completion of QA in Mobile Devices
- [X] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
  - Updated text color styling across multiple components and pages for improved visual consistency, replacing muted foreground classes with specific gray shades.
  - Adjusted descriptive and label text colors in forms, calendars, and informational sections for better readability.
  - Removed hover background effects from various list and card elements to simplify visual interactions.
  - Modified background shading on form elements and containers for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->