### PR TITLE
Added support for injecting NavItems from Apps

### DIFF
--- a/src/components/ui/sidebar/admin-nav.tsx
+++ b/src/components/ui/sidebar/admin-nav.tsx
@@ -1,13 +1,11 @@
 import { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 
+import CareIcon from "@/CAREUI/icons/CareIcon";
+
 import { NavMain } from "@/components/ui/sidebar/nav-main";
 
-interface NavigationLink {
-  name: string;
-  url: string;
-  icon?: string;
-}
+import { NavigationLink } from "./facility-nav";
 
 function generateAdminLinks(t: TFunction) {
   const baseUrl = "/admin";
@@ -15,17 +13,17 @@ function generateAdminLinks(t: TFunction) {
     {
       name: t("questionnaire_one"),
       url: `${baseUrl}/questionnaire`,
-      icon: "d-book-open",
+      icon: <CareIcon icon="d-book-open" />,
     },
     {
       name: "Valuesets",
       url: `${baseUrl}/valuesets`,
-      icon: "l-list-ol-alt",
+      icon: <CareIcon icon="l-list-ol-alt" />,
     },
     {
       name: "Roles",
       url: `${baseUrl}/roles`,
-      icon: "d-people",
+      icon: <CareIcon icon="d-people" />,
     },
   ];
 

--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -4,8 +4,6 @@ import { useState } from "react";
 
 import { cn } from "@/lib/utils";
 
-import CareIcon, { IconName } from "@/CAREUI/icons/CareIcon";
-
 import {
   Collapsible,
   CollapsibleContent,
@@ -66,7 +64,7 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                           className="cursor-pointer hover:bg-gray-200 hover:text-green-700"
                         >
                           {link.icon ? (
-                            <CareIcon icon={link.icon as IconName} />
+                            link.icon
                           ) : (
                             <Avatar
                               name={link.name}
@@ -122,7 +120,7 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                       exactActiveClass="bg-white text-green-700 shadow-sm"
                     >
                       {link.icon ? (
-                        <CareIcon icon={link.icon as IconName} />
+                        link.icon
                       ) : (
                         <Avatar
                           name={link.name}
@@ -160,7 +158,7 @@ function PopoverMenu({ link }: { link: NavigationLink }) {
           )}
         >
           {link.icon ? (
-            <CareIcon icon={link.icon as IconName} />
+            link.icon
           ) : (
             <Avatar name={link.name} className="size-6 -m-1 rounded-sm" />
           )}

--- a/src/components/ui/sidebar/patient-nav.tsx
+++ b/src/components/ui/sidebar/patient-nav.tsx
@@ -8,11 +8,7 @@ import { usePatientContext } from "@/hooks/usePatientUser";
 
 import { Patient } from "@/types/emr/newPatient";
 
-interface NavigationLink {
-  name: string;
-  url: string;
-  icon?: string;
-}
+import { NavigationLink } from "./facility-nav";
 
 function generatePatientLinks(
   selectedUser: Patient | null,

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -9,6 +9,7 @@ import { UserBase } from "@/types/user/user";
 
 import { AppRoutes } from "./Routers/AppRouter";
 import { QuestionnaireFormState } from "./components/Questionnaire/QuestionnaireForm";
+import { NavigationLink } from "./components/ui/sidebar/facility-nav";
 import { pluginMap } from "./pluginMap";
 import { FacilityData } from "./types/facility/facility";
 
@@ -102,6 +103,7 @@ export type PluginManifest = {
   plugin: string;
   routes?: AppRoutes;
   extends?: readonly SupportedPluginExtensions[];
+  navItems?: NavigationLink[];
   components?: PluginComponentMap;
   encounterTabs?: Record<string, LazyComponent<React.FC<EncounterTabProps>>>;
   devices?: readonly PluginDeviceManifest[];


### PR DESCRIPTION
## Proposed Changes

- Add Support for Injection Nav Items from Apps

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plugins can now provide their own navigation links, which are displayed alongside default facility links in the sidebar.

- **Refactor**
  - Improved consistency by centralizing the navigation link type definition and updating icon handling to use icon components instead of string identifiers.

- **Chores**
  - Removed redundant local interface declarations for navigation links in sidebar components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->