### PR TITLE
fix: Reset form on cancel button click in schedule template sheet

### DIFF
--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -277,15 +277,7 @@ export default function ConsentFormSheet({
   };
 
   return (
-    <Sheet
-      open={isOpen}
-      onOpenChange={(open) => {
-        setIsOpen(open);
-        if (!open) {
-          form.reset();
-        }
-      }}
-    >
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
         <Button variant={isEdit ? "outline" : "primary"} className="gap-2">
           {isEdit ? (
@@ -567,7 +559,10 @@ export default function ConsentFormSheet({
             <div className="flex justify-end mt-6 space-x-2">
               <Button
                 type="button"
-                onClick={() => setIsOpen(false)}
+                onClick={() => {
+                  setIsOpen(false);
+                  form.reset();
+                }}
                 className="bg-white text-gray-800 border border-gray-300 hover:bg-gray-100"
               >
                 {t("cancel")}

--- a/src/components/Encounter/CreateEncounterForm.tsx
+++ b/src/components/Encounter/CreateEncounterForm.tsx
@@ -127,15 +127,7 @@ export default function CreateEncounterForm({
   }
 
   return (
-    <Sheet
-      open={isOpen}
-      onOpenChange={(open) => {
-        setIsOpen(open);
-        if (!open) {
-          form.reset();
-        }
-      }}
-    >
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
         {trigger || (
           <Button
@@ -340,13 +332,24 @@ export default function CreateEncounterForm({
                 </FormItem>
               )}
             />
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={isPending || !form.watch("organizations").length}
-            >
-              {isPending ? t("creating") : t("create_encounter")}
-            </Button>
+            <div className="flex justify-end mt-6 space-x-2">
+              <Button
+                type="button"
+                onClick={() => {
+                  setIsOpen(false);
+                  form.reset();
+                }}
+                className="bg-white text-gray-800 border border-gray-300 hover:bg-gray-100"
+              >
+                {t("cancel")}
+              </Button>
+              <Button
+                type="submit"
+                disabled={isPending || !form.watch("organizations").length}
+              >
+                {isPending ? t("creating") : t("create")}
+              </Button>
+            </div>
           </form>
         </Form>
       </SheetContent>

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -334,18 +334,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
   );
 
   return (
-    <Sheet
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (open) {
-          resetState();
-          setActiveType(structuredTypes[0]?.type || "");
-          setIsOpen(true);
-        } else {
-          setIsOpen(false);
-        }
-      }}
-    >
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
         <div className="flex items-center justify-end">
           <Button

--- a/src/components/Medicine/MedicationAdministration/MedicineAdminSheet.tsx
+++ b/src/components/Medicine/MedicationAdministration/MedicineAdminSheet.tsx
@@ -184,6 +184,7 @@ export function MedicineAdminSheet({
     onOpenChange(false);
     setSelectedMedicines(new Set());
     setAdministrationRequests({});
+    setSearch("");
   };
 
   const handleAdministrationChange = useCallback(

--- a/src/components/Questionnaire/ManageQuestionnaireTagsSheet.tsx
+++ b/src/components/Questionnaire/ManageQuestionnaireTagsSheet.tsx
@@ -372,6 +372,9 @@ export default function ManageQuestionnaireTagsSheet({
               variant="outline"
               onClick={() => {
                 setSelectedTags(questionnaire.tags);
+                setNewTagName("");
+                setNewTagSlug("");
+                setIsCreateOpen(false);
                 setOpen(false);
               }}
             >

--- a/src/pages/Encounters/AssociateDeviceSheet.tsx
+++ b/src/pages/Encounters/AssociateDeviceSheet.tsx
@@ -57,7 +57,13 @@ export default function AssociateDeviceSheet({
   };
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
+    <Sheet
+      open={open}
+      onOpenChange={() => {
+        setOpen((prev) => !prev);
+        setSelectedDevice(null);
+      }}
+    >
       <SheetTrigger asChild>{children}</SheetTrigger>
       <SheetContent>
         <SheetHeader>

--- a/src/pages/Encounters/AssociateDeviceSheet.tsx
+++ b/src/pages/Encounters/AssociateDeviceSheet.tsx
@@ -59,8 +59,8 @@ export default function AssociateDeviceSheet({
   return (
     <Sheet
       open={open}
-      onOpenChange={() => {
-        setOpen((prev) => !prev);
+      onOpenChange={(open) => {
+        setOpen(open);
         setSelectedDevice(null);
       }}
     >

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
@@ -247,16 +247,27 @@ export default function FacilityOrganizationFormSheet({
                 </FormItem>
               )}
             />
-
-            <Button type="submit" className="w-full" disabled={isPending}>
-              {isPending
-                ? isEditMode
-                  ? t("updating")
-                  : t("creating")
-                : isEditMode
-                  ? t("update_organization")
-                  : t("create_organization")}
-            </Button>
+            <div className="flex justify-end mt-6 space-x-2">
+              <Button
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  form.reset();
+                }}
+                className="bg-white text-gray-800 border border-gray-300 hover:bg-gray-100"
+              >
+                {t("cancel")}
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending
+                  ? isEditMode
+                    ? t("updating")
+                    : t("creating")
+                  : isEditMode
+                    ? t("update_organization")
+                    : t("create_organization")}
+              </Button>
+            </div>
           </form>
         </Form>
       </SheetContent>

--- a/src/pages/Scheduling/components/CreateScheduleExceptionSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleExceptionSheet.tsx
@@ -332,6 +332,7 @@ export default function CreateScheduleExceptionSheet({
                       className="mt-2 md:mt-0"
                       type="button"
                       disabled={isPending}
+                      onClick={() => form.reset()}
                     >
                       {t("cancel")}
                     </Button>

--- a/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
@@ -700,7 +700,12 @@ export default function CreateScheduleTemplateSheet({
 
               <SheetFooter className="absolute inset-x-0 bottom-0 border-t border-gray-200 bg-white p-6">
                 <SheetClose asChild>
-                  <Button variant="outline" type="button" disabled={isPending}>
+                  <Button
+                    variant="outline"
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => form.reset()}
+                  >
                     {t("cancel")}
                   </Button>
                 </SheetClose>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12224 
- Added form reset on cancel to prevent stale data when reopening the schedule template form.

[Screencast from 2025-05-12 23-00-52.webm](https://github.com/user-attachments/assets/aefc79cf-883f-4e9e-89c3-71c08217647a)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the "Cancel" button in the schedule template creation sheet to clear form fields when clicked, ensuring the form resets to its default state.
  - Enhanced cancel buttons across multiple forms to reset input fields and UI states upon cancellation.
  - Updated form sheets to separate form reset logic from sheet open/close events, triggering resets only on user-initiated cancel actions.
  - Added clearing of search inputs and selections when closing relevant sheets.
  - Ensured device selection is cleared when opening or closing the associate device sheet.
- **New Features**
  - Introduced explicit cancel buttons alongside submit buttons in various forms for clearer user control.
  - Improved button layouts with grouped cancel and submit buttons for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->