### PR TITLE
Fix: Remove accordion for questionnaire response issue #12275

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -19,7 +19,7 @@ import { Separator } from "@/components/ui/separator";
 
 import PaginationComponent from "@/components/Common/Pagination";
 import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
-import { EncounterAccordionLayout } from "@/components/Patient/EncounterAccordionLayout";
+import { QuestionnaireResponseItem } from "@/components/Questionnaire/QuestionnaireResponseItem";
 
 import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 
@@ -272,7 +272,7 @@ function ResponseCard({
       : item.questionnaire?.title || "";
 
   return (
-    <EncounterAccordionLayout
+    <QuestionnaireResponseItem
       title={isStructured && structuredType ? structuredType : title}
       actionButton={isPrintPreview ? null : <PrintButton item={item} />}
       className={cn(isPrintPreview && "shadow-none")}
@@ -328,7 +328,7 @@ function ResponseCard({
           </div>
         </div>
       )}
-    </EncounterAccordionLayout>
+    </QuestionnaireResponseItem>
   );
 }
 

--- a/src/components/Questionnaire/QuestionnaireResponseItem.tsx
+++ b/src/components/Questionnaire/QuestionnaireResponseItem.tsx
@@ -1,0 +1,60 @@
+import { Link } from "raviger";
+import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+
+import CareIcon from "@/CAREUI/icons/CareIcon";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface QuestionnaireResponseItemProps {
+  children: ReactNode;
+  className?: string;
+  readOnly?: boolean;
+  title: string;
+  editLink?: string;
+  actionButton?: ReactNode;
+}
+
+export function QuestionnaireResponseItem({
+  children,
+  className,
+  readOnly = false,
+  actionButton,
+  title,
+  editLink,
+}: QuestionnaireResponseItemProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Card className={cn("border-none rounded-sm", className)}>
+      <div>
+        <div className="p-4 py-2 flex items-center">
+          <CardHeader className="w-full flex flex-row justify-between p-0 m-0 translate-y-0.5">
+            <CardTitle className="text-base font-semibold">
+              {t(title)}
+            </CardTitle>
+            {!readOnly && editLink ? (
+              <Button variant="outline" size="xs">
+                <Link
+                  href={editLink}
+                  className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950"
+                >
+                  <CareIcon icon="l-pen" className="size-4" />
+                  {t("edit")}
+                </Link>
+              </Button>
+            ) : (
+              actionButton && actionButton
+            )}
+          </CardHeader>
+        </div>
+        <div>
+          <CardContent className="px-2 pb-2">{children}</CardContent>
+        </div>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12275 
- Added new component for viewing questionnaire responses in treatment summary
- Changed mention of accordion in the treatment summary page to the new component

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist
![image](https://github.com/user-attachments/assets/5b1e12d4-6143-46e7-a8c3-f1d2134263ce)

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new card-style component for displaying questionnaire responses, featuring a localized title and optional action or edit button.
- **Style**
  - Updated the appearance of questionnaire response cards for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->