### PR TITLE
Fixed scroller in medication request

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -512,8 +512,10 @@ export function MedicationRequestQuestion({
       {medications.length > 0 && (
         <div
           className={cn(
-            "md:overflow-x-auto",
-            isSidebarOpen ? "w-[calc(100vw-44rem)]" : "w-[calc(100vw-30rem)]",
+            "md:overflow-x-auto w-auto",
+            isSidebarOpen
+              ? "lg:w-[calc(100vw-44rem)]"
+              : "lg:w-[calc(100vw-30rem)]",
           )}
         >
           <div className="min-w-fit">

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -40,6 +40,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useSidebar } from "@/components/ui/sidebar";
 
 import { ComboboxQuantityInput } from "@/components/Common/ComboboxQuantityInput";
 import { HistoricalRecordSelector } from "@/components/HistoricalRecordSelector";
@@ -200,6 +201,7 @@ export function MedicationRequestQuestion({
   const { t } = useTranslation();
 
   const isPreview = patientId === "preview";
+  const { open: isSidebarOpen } = useSidebar();
   const medications =
     (questionnaireResponse.values?.[0]?.value as MedicationRequest[]) || [];
 
@@ -508,7 +510,12 @@ export function MedicationRequestQuestion({
         onAddSelected={handleAddHistoricalMedications}
       />
       {medications.length > 0 && (
-        <div className="md:overflow-x-auto w-auto">
+        <div
+          className={cn(
+            "md:overflow-x-auto",
+            isSidebarOpen ? "w-[calc(100vw-44rem)]" : "w-[calc(100vw-30rem)]",
+          )}
+        >
           <div className="min-w-fit">
             <div
               className={cn(


### PR DESCRIPTION
## Proposed Changes

- Fixes #12232 
- Changed width of medication request section
- Dynamic width based on whether sidebar is open or not

![image](https://github.com/user-attachments/assets/d1c9a72d-53de-40c6-a4a4-31bfb9ae2bde)
![image](https://github.com/user-attachments/assets/00334f92-ab97-437b-9304-08dc857de067)
![image](https://github.com/user-attachments/assets/465fbb7e-897b-42ca-97c7-55697df55854)
![image](https://github.com/user-attachments/assets/2ad1d529-2021-4264-ab7e-e0f48621e7d6)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the responsive layout of the medication list to better adjust its width based on whether the sidebar is open or closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->