### PR TITLE
Fix: Toaster notifications wont close on click, if sidebar is open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,7 @@ const App = () => {
                 // For `richColors` to work, pass at-least an empty object.
                 // Refer: https://github.com/shadcn-ui/ui/issues/2234.
                 toastOptions={{ closeButton: true }}
+                className="pointer-events-auto"
               />
             </PluginEngine>
           </PubSubProvider>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12212 
- Added `pointer-events-auto` to Toaster, this will make it work even when any modal like property is in background (eg. sidebar)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated toaster notifications to allow user interactions such as clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->