### PR TITLE
fix: Update HistoricalRecordSelector component to restrict sheet opening to only when button clicks 

### DIFF
--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -347,7 +347,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
       }}
     >
       <SheetTrigger asChild>
-        <div className="flex items-center justify-end">
+        <div className="w-fit ml-auto">
           <Button
             variant="outline"
             data-cy="view-history"

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -347,16 +347,14 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
       }}
     >
       <SheetTrigger asChild>
-        <div className="w-fit ml-auto">
-          <Button
-            variant="outline"
-            data-cy="view-history"
-            className="border-gray-400"
-          >
-            <Clock className="size-4" />
-            <span className="font-semibold">{buttonLabel}</span>
-          </Button>
-        </div>
+        <Button
+          variant="outline"
+          data-cy="view-history"
+          className="border-gray-400 flex ml-auto"
+        >
+          <Clock className="size-4" />
+          <span className="font-semibold">{buttonLabel}</span>
+        </Button>
       </SheetTrigger>
       <SheetContent className="w-full sm:max-w-3xl p-0 overflow-y-auto">
         <div className="flex flex-col gap-2 p-2">


### PR DESCRIPTION
## Proposed Changes

- Fixes #12313 

https://github.com/user-attachments/assets/f2078392-2149-42f8-a762-f0f23e222250



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the alignment and layout of the "View History" button for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->