### PR TITLE
Fix : Date validation error persists after entering valid dates

### DIFF
--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -340,6 +340,7 @@ export default function ConsentFormSheet({
                         onChange={(e) => {
                           const value = e.target.value;
                           field.onChange(value ? new Date(value) : null);
+                          form.trigger("period");
                         }}
                       />
                       <FormMessage />
@@ -368,6 +369,7 @@ export default function ConsentFormSheet({
                           onChange={(e) => {
                             const value = e.target.value;
                             field.onChange(value ? new Date(value) : null);
+                            form.trigger("period");
                           }}
                         />
                         <FormMessage />
@@ -395,6 +397,7 @@ export default function ConsentFormSheet({
                           onChange={(e) => {
                             const value = e.target.value;
                             field.onChange(value ? new Date(value) : null);
+                            form.trigger("period");
                           }}
                         />
                         <FormMessage />

--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -133,7 +133,6 @@ export default function ConsentFormSheet({
   const form = useForm({
     resolver: zodResolver(consentFormSchema(isEdit)),
     mode: "onChange",
-    reValidateMode: "onChange",
     defaultValues: {
       decision: "permit",
       category: "treatment",

--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -88,7 +88,7 @@ const consentFormSchema = (isEdit: boolean) =>
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: t("valid_from_after_valid_untill"),
-          path: ["period.start"],
+          path: ["period.end"],
         });
       }
 
@@ -132,6 +132,8 @@ export default function ConsentFormSheet({
 
   const form = useForm({
     resolver: zodResolver(consentFormSchema(isEdit)),
+    mode: "onChange",
+    reValidateMode: "onChange",
     defaultValues: {
       decision: "permit",
       category: "treatment",
@@ -340,7 +342,6 @@ export default function ConsentFormSheet({
                         onChange={(e) => {
                           const value = e.target.value;
                           field.onChange(value ? new Date(value) : null);
-                          form.trigger("period");
                         }}
                       />
                       <FormMessage />
@@ -369,7 +370,6 @@ export default function ConsentFormSheet({
                           onChange={(e) => {
                             const value = e.target.value;
                             field.onChange(value ? new Date(value) : null);
-                            form.trigger("period");
                           }}
                         />
                         <FormMessage />
@@ -397,7 +397,6 @@ export default function ConsentFormSheet({
                           onChange={(e) => {
                             const value = e.target.value;
                             field.onChange(value ? new Date(value) : null);
-                            form.trigger("period");
                           }}
                         />
                         <FormMessage />


### PR DESCRIPTION
## Proposed Changes

- Fixes #12318
- Added   form.trigger("period"); for validates the entire period start and end

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.

https://github.com/user-attachments/assets/2cafcd78-b5bc-4349-b90c-3035d88d0274

- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for consent date fields, ensuring the "period" field is re-validated whenever any related date input changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->