### PR TITLE
Fixes contact point value not being reset when switching in/out of phone system in Device form

### DIFF
--- a/src/pages/Facility/settings/devices/components/DeviceForm.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceForm.tsx
@@ -486,19 +486,16 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                   <FormItem className="space-y-0">
                     <Select
                       value={field.value}
-                      onValueChange={(newSystem) => {
-                        const isPhoneSystem = (system: string) =>
+                      onValueChange={(value) => {
+                        const isPhone = (system: string) =>
                           ["phone", "fax", "sms"].includes(system);
-                        const oldSystem = form.getValues(
-                          `contact.${index}.system`,
-                        );
-                        const wasPhoneType = isPhoneSystem(oldSystem);
-                        const isNowPhoneType = isPhoneSystem(newSystem);
 
-                        if (wasPhoneType !== isNowPhoneType) {
+                        // If the system is changing from a phone type to a non-phone type, clear the value
+                        if (isPhone(value) !== isPhone(field.value)) {
                           form.setValue(`contact.${index}.value`, "");
                         }
-                        field.onChange(newSystem);
+
+                        field.onChange(value);
                       }}
                     >
                       <FormControl>

--- a/src/pages/Facility/settings/devices/components/DeviceForm.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceForm.tsx
@@ -510,14 +510,20 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                 name={`contact.${index}.value`}
                 render={({ field }) => {
                   const system = form.watch(`contact.${index}.system`);
+                  const isPhoneSystem = ["phone", "fax", "sms"].includes(
+                    system,
+                  );
+                  const inputValue =
+                    isPhoneSystem && field.value && !field.value.startsWith("+")
+                      ? ""
+                      : field.value;
                   return (
                     <FormItem className="space-y-0">
                       <FormControl>
-                        {system === "phone" ||
-                        system === "fax" ||
-                        system === "sms" ? (
+                        {isPhoneSystem ? (
                           <PhoneInput
                             {...field}
+                            value={inputValue}
                             placeholder={t(
                               `contact_point_placeholder__${system}`,
                             )}

--- a/src/pages/Facility/settings/devices/components/DeviceForm.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceForm.tsx
@@ -484,7 +484,23 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                 name={`contact.${index}.system`}
                 render={({ field }) => (
                   <FormItem className="space-y-0">
-                    <Select onValueChange={field.onChange} value={field.value}>
+                    <Select
+                      value={field.value}
+                      onValueChange={(newSystem) => {
+                        const isPhoneSystem = (system: string) =>
+                          ["phone", "fax", "sms"].includes(system);
+                        const oldSystem = form.getValues(
+                          `contact.${index}.system`,
+                        );
+                        const wasPhoneType = isPhoneSystem(oldSystem);
+                        const isNowPhoneType = isPhoneSystem(newSystem);
+
+                        if (wasPhoneType !== isNowPhoneType) {
+                          form.setValue(`contact.${index}.value`, "");
+                        }
+                        field.onChange(newSystem);
+                      }}
+                    >
                       <FormControl>
                         <SelectTrigger className="h-[42px] md:h-[38px]">
                           <SelectValue
@@ -510,20 +526,14 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                 name={`contact.${index}.value`}
                 render={({ field }) => {
                   const system = form.watch(`contact.${index}.system`);
-                  const isPhoneSystem = ["phone", "fax", "sms"].includes(
-                    system,
-                  );
-                  const inputValue =
-                    isPhoneSystem && field.value && !field.value.startsWith("+")
-                      ? ""
-                      : field.value;
                   return (
                     <FormItem className="space-y-0">
                       <FormControl>
-                        {isPhoneSystem ? (
+                        {system === "phone" ||
+                        system === "fax" ||
+                        system === "sms" ? (
                           <PhoneInput
                             {...field}
-                            value={inputValue}
                             placeholder={t(
                               `contact_point_placeholder__${system}`,
                             )}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12319 
- Sanitize input value when switching to PhoneInput component

[Screencast from 2025-05-15 21-26-22.webm](https://github.com/user-attachments/assets/0848f990-4e72-4566-98e6-31027771b8e7)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the device form to automatically clear contact values when switching between phone-related and other contact system types, ensuring data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->