### PR TITLE
New Cypress test for questionnaire status based visibility check

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -117,6 +117,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
           COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
           CYPRESS_CHROME_ARGS: "--no-sandbox --disable-dev-shm-usage"
+          CYPRESS_BROWSER_VERSION: "136"
 
       # For forked PRs
       - name: "UI Tests - Chrome (Forked)"
@@ -142,6 +143,7 @@ jobs:
           SPLIT_INDEX: ${{ strategy.job-index }}
           DEBUG: "cypress-split,find-cypress-specs"
           CYPRESS_CHROME_ARGS: "--no-sandbox --disable-dev-shm-usage"
+          CYPRESS_BROWSER_VERSION: "136"
 
       - name: Upload cypress screenshots on failure 📸
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -104,7 +104,6 @@ jobs:
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
           browser: chrome
-          browser-version: "136"
           record: true
           parallel: true
           group: "UI - Chrome"
@@ -130,7 +129,6 @@ jobs:
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
           browser: chrome
-          browser-version: "136"
           record: false
           parallel: false
           install-command: npm ci

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -104,6 +104,7 @@ jobs:
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
           browser: chrome
+          browser-version: "136"
           record: true
           parallel: true
           group: "UI - Chrome"
@@ -129,6 +130,7 @@ jobs:
           wait-on: "http://localhost:4000"
           wait-on-timeout: 300
           browser: chrome
+          browser-version: "136"
           record: false
           parallel: false
           install-command: npm ci

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -28,6 +28,15 @@ export default defineConfig({
         cypressSplit(on, config);
       }
 
+      // Add required environment parameters for parallel execution
+      config.env = {
+        ...config.env,
+        osName: "linux",
+        osVersion: "Ubuntu",
+        browserName: "Chrome",
+        browserVersion: "136",
+      };
+
       return config;
     },
     baseUrl: "http://localhost:4000",

--- a/cypress/e2e/dashboard_spec/questionnaire.cy.ts
+++ b/cypress/e2e/dashboard_spec/questionnaire.cy.ts
@@ -1,0 +1,83 @@
+import { PatientEncounter } from "@/pageObject/Patients/PatientEncounter";
+import { Questionnaire } from "@/pageObject/dashboard/Questionnaire";
+import { FacilityCreation } from "@/pageObject/facility/FacilityCreation";
+
+const facilityCreation = new FacilityCreation();
+const patientEncounter = new PatientEncounter();
+const questionnaire = new Questionnaire();
+
+describe("Operation on Questionnaire", () => {
+  beforeEach(() => {
+    cy.loginByApi("superadmin");
+    cy.visit("/");
+  });
+
+  it("verify questionnaire status functionality in encounter", () => {
+    const questionnaireName = "Respiratory Support";
+
+    // Step 1: Navigate to a random facility and open an in-progress encounter
+    facilityCreation.selectFirstRandomFacility();
+    patientEncounter
+      .navigateToEncounters()
+      .clickInProgressEncounterFilter()
+      .openFirstEncounterDetails()
+      .clickUpdateEncounter();
+
+    // Save the encounter URL for later use
+    cy.saveCurrentUrl().as("patientEncounterUrl");
+
+    // Add the questionnaire to the encounter
+    patientEncounter.addQuestionnaire(questionnaireName);
+
+    // Step 2: Update questionnaire status to retired in admin dashboard
+    cy.visit("/");
+    questionnaire
+      .clickAdminDashboard()
+      .searchQuestionnaire(questionnaireName)
+      .clickFirstQuestionnaireView();
+
+    // Save the questionnaire URL for later use
+    cy.saveCurrentUrl().as("questionnaireUrl");
+
+    questionnaire
+      .clickRetiredStatus()
+      .saveQuestionnaire()
+      .verifyQuestionnaireUpdate();
+
+    // Step 3: Verify questionnaire is not visible in encounter when retired
+    cy.get<string>("@patientEncounterUrl").then((url) => {
+      cy.visit(url);
+    });
+    questionnaire.verifyQuestionnaireNotPresent(questionnaireName);
+
+    // Step 4: Update questionnaire status to draft in admin dashboard
+    cy.get<string>("@questionnaireUrl").then((url) => {
+      cy.visit(url);
+    });
+    questionnaire
+      .clickDraftStatus()
+      .saveQuestionnaire()
+      .verifyQuestionnaireUpdate();
+
+    // Step 5: Verify questionnaire is not visible in encounter when in draft
+    cy.get<string>("@patientEncounterUrl").then((url) => {
+      cy.visit(url);
+    });
+    questionnaire.verifyQuestionnaireNotPresent(questionnaireName);
+
+    // Step 6: Update questionnaire status to active
+    cy.get<string>("@questionnaireUrl").then((url) => {
+      cy.visit(url);
+    });
+    questionnaire
+      .clickActiveStatus()
+      .saveQuestionnaire()
+      .verifyQuestionnaireUpdate();
+
+    // Step 7: Verify questionnaire is visible and can be added to encounter when active
+    cy.get<string>("@patientEncounterUrl").then((url) => {
+      cy.visit(url);
+    });
+    patientEncounter.addQuestionnaire(questionnaireName);
+  });
+});

--- a/cypress/pageObject/dashboard/Questionnaire.ts
+++ b/cypress/pageObject/dashboard/Questionnaire.ts
@@ -1,0 +1,55 @@
+export class Questionnaire {
+  // ... existing methods ...
+
+  clickAdminDashboard() {
+    cy.verifyAndClickElement(
+      '[data-cy="admin-dashboard-button"]',
+      "Admin Dashboard",
+    );
+    return this;
+  }
+
+  searchQuestionnaire(value: string) {
+    cy.typeIntoField('[data-cy="questionnaire-search"]', value);
+    return this;
+  }
+
+  clickFirstQuestionnaireView() {
+    cy.get('[data-cy="questionnaire-view"]').first().click({ force: true });
+    return this;
+  }
+
+  clickRetiredStatus() {
+    cy.get("#status-retired").click();
+    return this;
+  }
+
+  clickDraftStatus() {
+    cy.get("#status-draft").click();
+    return this;
+  }
+
+  clickActiveStatus() {
+    cy.get("#status-active").click();
+    return this;
+  }
+
+  saveQuestionnaire() {
+    cy.verifyAndClickElement('[data-cy="save-questionnaire-form"]', "Save");
+    return this;
+  }
+
+  verifyQuestionnaireUpdate() {
+    cy.verifyNotification("Questionnaire updated successfully");
+    return this;
+  }
+
+  verifyQuestionnaireNotPresent(questionnaireName: string) {
+    cy.typeAndVerifyOptionNotPresent(
+      '[data-cy="add-questionnaire-button"]',
+      questionnaireName,
+      "No questionnaires found",
+    );
+    return this;
+  }
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -72,6 +72,24 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  "typeAndVerifyOptionNotPresent",
+  (selector: string, value: string, emptyMessage: string) => {
+    cy.get(selector)
+      .click()
+      .then(() => {
+        cy.get("[cmdk-input]")
+          .should("be.visible")
+          .type(value)
+          .then(() => {
+            cy.get("[cmdk-empty]")
+              .should("be.visible")
+              .and("contain", emptyMessage);
+          });
+      });
+  },
+);
+
+Cypress.Commands.add(
   "clickAndMultiSelectOption",
   (selector: string, options: string | string[]) => {
     const optionArray = Array.isArray(options) ? options : [options];

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -9,6 +9,11 @@ declare global {
       getAttached(selector: string): Chainable<Subject>;
       clickSubmitButton(buttonText?: string): Chainable<Element>;
       clickCancelButton(buttonText?: string): Chainable<Element>;
+      typeAndVerifyOptionNotPresent(
+        selector: string,
+        value: string,
+        emptyMessage: string,
+      ): Chainable<void>;
       typeAndSelectOption(
         element: string,
         reference: string,

--- a/src/components/Questionnaire/ManageQuestionnaireOrganizationsSheet.tsx
+++ b/src/components/Questionnaire/ManageQuestionnaireOrganizationsSheet.tsx
@@ -86,6 +86,7 @@ export function OrgSelectorPopover({
     >
       <PopoverTrigger asChild>
         <Button
+          data-cy="manage-organisation-search"
           variant="outline"
           className={cn(
             "w-full justify-start text-left font-normal",
@@ -297,7 +298,11 @@ export default function ManageQuestionnaireOrganizationsSheet({
             >
               {t("cancel")}
             </Button>
-            <Button onClick={handleSave} disabled={isUpdating || !hasChanges}>
+            <Button
+              onClick={handleSave}
+              disabled={isUpdating || !hasChanges}
+              data-cy="save-manage-organization"
+            >
               {isUpdating ? (
                 <>
                   <Loader2 className="mr-2 size-4 animate-spin" />

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -656,11 +656,20 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
           <p className="text-sm text-gray-500">{questionnaire.description}</p>
         </div>
         <div className="flex gap-2">
-          <Button type="button" variant="outline" onClick={handleCancel}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCancel}
+            data-cy="cancel-questionnaire-form"
+          >
             {t("cancel")}
           </Button>
           {id && (
-            <Button variant="outline" onClick={handleDownload}>
+            <Button
+              variant="outline"
+              onClick={handleDownload}
+              data-cy="download-questionnaire-form"
+            >
               <CareIcon icon="l-import" className="mr-1 size-4" />
               {t("download")}
             </Button>
@@ -671,7 +680,11 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
               {t("import_from_url")}
             </Button>
           )}
-          <Button onClick={handleSave} disabled={isCreating || isUpdating}>
+          <Button
+            onClick={handleSave}
+            disabled={isCreating || isUpdating}
+            data-cy="save-questionnaire-form"
+          >
             <CareIcon icon="l-save" className="mr-2 size-4" />
             {id ? t("save") : t("create")}
           </Button>

--- a/src/components/Questionnaire/QuestionnaireList.tsx
+++ b/src/components/Questionnaire/QuestionnaireList.tsx
@@ -126,6 +126,7 @@ const RenderCard = ({
 
                 <div className="mt-4 flex justify-end">
                   <Button
+                    data-cy="questionnaire-view"
                     variant="outline"
                     size="sm"
                     onClick={(e) => {
@@ -208,6 +209,7 @@ const RenderTable = ({
                       {questionnaire.description}
                     </div>
                     <Button
+                      data-cy="questionnaire-view"
                       variant="outline"
                       size="sm"
                       className="font-semibold shadow-gray-300 text-gray-950 border-gray-400"
@@ -282,6 +284,7 @@ export function QuestionnaireList() {
             <div className="relative md:min-w-80 w-full">
               <Search className="absolute left-2 top-2.5 size-4 text-gray-500" />
               <Input
+                data-cy="questionnaire-search"
                 placeholder={t("search_questionnaires")}
                 className="pl-10"
                 value={qParams.title || ""}

--- a/src/components/Questionnaire/QuestionnaireProperties.tsx
+++ b/src/components/Questionnaire/QuestionnaireProperties.tsx
@@ -94,6 +94,7 @@ function StatusSelector({
           >
             <RadioGroupItem value={status} id={`status-${status}`} />
             <Label
+              data-cy={`questionnaire-status-${status}`}
               htmlFor={`status-${status}`}
               className="text-sm font-normal text-gray-950"
             >
@@ -184,7 +185,11 @@ function OrganizationSelector({
         <ManageQuestionnaireOrganizationsSheet
           questionnaireId={id}
           trigger={
-            <Button variant="outline" className="w-full justify-start">
+            <Button
+              variant="outline"
+              className="w-full justify-start"
+              data-cy="manage-organisation-questionnaire"
+            >
               <Building className="mr-2 size-4" />
               {t("manage_organization_one")}
             </Button>

--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -90,7 +90,13 @@ export default function UserDashboard() {
         </div>
         <div className="flex gap-2">
           {user.is_superuser && (
-            <Button variant="outline" size="sm" className="w-full" asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              asChild
+              data-cy="admin-dashboard-button"
+            >
               <Link
                 href="/admin/questionnaire"
                 className="gap-2 text-inherit flex items-center"


### PR DESCRIPTION
## Proposed Changes

- fixes #12303 
- added new test to verify questionnaire visibility based on status (retired, active and drafted)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end tests to verify questionnaire status changes and their impact on patient encounters.
  - Introduced new UI test helpers for questionnaire management in the admin dashboard.

- **Style**
  - Added data-cy attributes to various buttons, search fields, and status selectors to improve UI testability.

- **Chores**
  - Enhanced the Cypress test suite with new page objects and custom commands for more robust and maintainable testing.
  - Updated Cypress configuration and GitHub Actions workflow to specify browser versions for consistent test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->