### PR TITLE
fix: update project status based on issue state and assignee count

### DIFF
--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -84,44 +84,63 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
+          ISSUE_STATE=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} --jq '.state')
+          ASSIGNEES_COUNT=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} --jq '.assignees | length')
+
           if [[ "${{ github.event.action }}" == "opened" || "${{ github.event.action }}" == "reopened" ]]; then
-            gh api graphql -f query='
-              mutation($project: ID!, $item: ID!, $status_field: ID!, $triage_value: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $project
-                  itemId: $item
-                  fieldId: $status_field
-                  value: {
-                    singleSelectOptionId: $triage_value
+            if [[ $ASSIGNEES_COUNT -gt 0 ]]; then
+              gh api graphql -f query='
+                mutation($project: ID!, $item: ID!, $status_field: ID!, $in_progress_value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $status_field
+                    value: {
+                      singleSelectOptionId: $in_progress_value
+                    }
+                  }) {
+                    projectV2Item {
+                      id
+                    }
                   }
-                }) {
-                  projectV2Item {
-                    id
+                }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f in_progress_value=${{ env.IN_PROGRESS_OPTION_ID }}
+            else
+              gh api graphql -f query='
+                mutation($project: ID!, $item: ID!, $status_field: ID!, $triage_value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $status_field
+                    value: {
+                      singleSelectOptionId: $triage_value
+                    }
+                  }) {
+                    projectV2Item {
+                      id
+                    }
                   }
-                }
-              }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f triage_value=${{ env.TRIAGE_OPTION_ID }}
-
+                }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f triage_value=${{ env.TRIAGE_OPTION_ID }}
+            fi
           elif [[ "${{ github.event.action }}" == "assigned" ]]; then
-            gh api graphql -f query='
-              mutation($project: ID!, $item: ID!, $status_field: ID!, $in_progress_value: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $project
-                  itemId: $item
-                  fieldId: $status_field
-                  value: {
-                    singleSelectOptionId: $in_progress_value
+            if [[ "$ISSUE_STATE" != "closed" ]]; then
+              gh api graphql -f query='
+                mutation($project: ID!, $item: ID!, $status_field: ID!, $in_progress_value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $status_field
+                    value: {
+                      singleSelectOptionId: $in_progress_value
+                    }
+                  }) {
+                    projectV2Item {
+                      id
+                    }
                   }
-                }) {
-                  projectV2Item {
-                    id
-                  }
-                }
-              }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f in_progress_value=${{ env.IN_PROGRESS_OPTION_ID }}
-
+                }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f in_progress_value=${{ env.IN_PROGRESS_OPTION_ID }}
+            fi
           elif [[ "${{ github.event.action }}" == "unassigned" ]]; then
-            ASSIGNEES_COUNT=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} --jq '.assignees | length')
-
-            if [[ $ASSIGNEES_COUNT -eq 0 ]]; then
+            if [[ $ASSIGNEES_COUNT -eq 0 && "$ISSUE_STATE" != "closed" ]]; then
               gh api graphql -f query='
                 mutation($project: ID!, $item: ID!, $status_field: ID!, $triage_value: String!) {
                   updateProjectV2ItemFieldValue(input: {


### PR DESCRIPTION
## Proposed Changes

Fixes #12326

- Maintain "Done" status when changing assignees on closed issues
(This was infact not a one line fix)

Tested:

![image](https://github.com/user-attachments/assets/c147ff27-e837-43e4-b078-96d109af29a8)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automation for issue status updates to more accurately reflect the current state and assignee count, ensuring transitions between "Triage" and "In Progress" are handled with greater precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->