### PR TITLE
Resource Request: Assigned to users made optional and within assigned facility

### DIFF
--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -404,6 +404,7 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                       <FormControl>
                         <div data-cy="select-assigned-user">
                           <UserSelector
+                            facilityId={form.watch("assigned_facility")?.id}
                             selected={assignedToUser}
                             onChange={handleUserChange}
                             placeholder={t("search_users")}

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -265,7 +265,9 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                 name="assigned_facility"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{t("facility_for_care_support")}</FormLabel>
+                    <FormLabel aria-required>
+                      {t("facility_for_care_support")}
+                    </FormLabel>
                     <FormControl>
                       <Autocomplete
                         data-cy="select-facility"

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -81,9 +81,7 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
       .min(1, { message: t("field_required") }),
     referring_facility_contact_number: validators().phoneNumber.required,
     priority: z.number().default(1),
-    assigned_to: id
-      ? z.string().min(1, { message: t("field_required") })
-      : z.string().optional(),
+    assigned_to: z.string().optional(),
   });
 
   type ResourceFormValues = z.infer<typeof resourceFormSchema>;
@@ -294,6 +292,12 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                           } else {
                             form.resetField("assigned_facility");
                           }
+
+                          // When the assigned facility changes, we need to clear the assigned to user
+                          form.setValue("assigned_to", undefined, {
+                            shouldDirty: true,
+                          });
+                          setAssignedToUser(undefined);
                         }}
                       />
                     </FormControl>
@@ -400,7 +404,7 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                   name="assigned_to"
                   render={() => (
                     <FormItem>
-                      <FormLabel aria-required>{t("assigned_to")}</FormLabel>
+                      <FormLabel>{t("assigned_to")}</FormLabel>
                       <FormControl>
                         <div data-cy="select-assigned-user">
                           <UserSelector


### PR DESCRIPTION
## Related backend changes:

- https://github.com/ohcnetwork/care/pull/3046

## Proposed Changes

- Fixes #12335 

https://github.com/user-attachments/assets/f8ff75c5-ca6b-4773-beac-625408890dab



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Improvements**
  - The "Assigned To" field in the resource form is now always optional.
  - Changing the "Assigned Facility" field will automatically clear any selection in the "Assigned To" field.
  - The user selection list for "Assigned To" is now filtered based on the selected facility, making it easier to find relevant users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->