### PR TITLE
Fix: Improve consistency in image upload size

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -68,3 +68,6 @@ REACT_MAPS_FALLBACK_URL_TEMPLATE=
 
 # OTP resend timeout in seconds (eg. 90 seconds) (default : 120 seconds)
 REACT_APP_RESEND_OTP_TIMEOUT=
+
+# Maximum image upload size allowed (in megabytes)
+REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB=

--- a/care.config.ts
+++ b/care.config.ts
@@ -143,6 +143,10 @@ const careConfig = {
   resendOtpTimeout: env.REACT_APP_RESEND_OTP_TIMEOUT
     ? parseInt(env.REACT_APP_RESEND_OTP_TIMEOUT, 10)
     : 30,
+
+  MAX_IMAGE_UPLOAD_SIZE_MB: env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB
+    ? parseInt(env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB, 10)
+    : 2,
 } as const;
 
 export default careConfig;

--- a/care.config.ts
+++ b/care.config.ts
@@ -144,7 +144,7 @@ const careConfig = {
     ? parseInt(env.REACT_APP_RESEND_OTP_TIMEOUT, 10)
     : 30,
 
-  imageUploadMaxSizeInMB: env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB
+  MAX_IMAGE_UPLOAD_SIZE_MB: env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB
     ? parseInt(env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB, 10)
     : 2,
 } as const;

--- a/care.config.ts
+++ b/care.config.ts
@@ -144,7 +144,7 @@ const careConfig = {
     ? parseInt(env.REACT_APP_RESEND_OTP_TIMEOUT, 10)
     : 30,
 
-  MAX_IMAGE_UPLOAD_SIZE_MB: env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB
+  imageUploadMaxSizeInMB: env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB
     ? parseInt(env.REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB, 10)
     : 2,
 } as const;

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -625,7 +625,7 @@
   "central_nursing_station": "Central Nursing Station",
   "change": "Change",
   "change_avatar": "Change Avatar",
-  "change_avatar_note": "JPG, GIF or PNG. 1MB max.",
+  "change_avatar_note": "JPG, GIF or PNG. {{maxSize}}MB max.",
   "change_file": "Change File",
   "change_location": "Change Location",
   "change_phone_number": "Change Phone Number",

--- a/public/locale/ml.json
+++ b/public/locale/ml.json
@@ -485,7 +485,7 @@
   "caution": "ജാഗ്രത",
   "central_nursing_station": "സെൻട്രൽ നഴ്‌സിംഗ് സ്റ്റേഷൻ",
   "change_avatar": "അവതാർ മാറ്റുക",
-  "change_avatar_note": "JPG, GIF അല്ലെങ്കിൽ PNG. പരമാവധി 1MB.",
+  "change_avatar_note": "JPG, GIF അല്ലെങ്കിൽ PNG. പരമാവധി {{maxSize}}MB.",
   "change_file": "ഫയൽ മാറ്റുക",
   "change_password": "പാസ്വേഡ് മാറ്റുക",
   "change_phone_number": "ഫോൺ നമ്പർ മാറ്റുക",

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -220,7 +220,7 @@ const AvatarEditModal = ({
   const defaultHint = (
     <>
       {t("max_size_for_image_uploaded_should_be", {
-        maxSize: `${careConfig.MAX_IMAGE_UPLOAD_SIZE_MB}MB`,
+        maxSize: `${careConfig.imageUploadMaxSizeInMB}MB`,
       })}
       <br />
       {t("allowed_formats_are", { formats: "jpg, png, jpeg" })}{" "}

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -1,3 +1,4 @@
+import careConfig from "@careConfig";
 import DOMPurify from "dompurify";
 import React, {
   ChangeEventHandler,
@@ -218,7 +219,9 @@ const AvatarEditModal = ({
 
   const defaultHint = (
     <>
-      {t("max_size_for_image_uploaded_should_be", { maxSize: "1MB" })}
+      {t("max_size_for_image_uploaded_should_be", {
+        maxSize: `${careConfig.MAX_IMAGE_UPLOAD_SIZE_MB}MB`,
+      })}
       <br />
       {t("allowed_formats_are", { formats: "jpg, png, jpeg" })}{" "}
       {t("recommended_aspect_ratio_for", { aspectRatio: "1:1" })}

--- a/src/components/Facility/FacilityHome.tsx
+++ b/src/components/Facility/FacilityHome.tsx
@@ -185,7 +185,9 @@ export const FacilityHome = ({ facilityId }: Props) => {
 
   const coverImageHint = (
     <>
-      {t("max_size_for_image_uploaded_should_be", { maxSize: "1MB" })}
+      {t("max_size_for_image_uploaded_should_be", {
+        maxSize: `${careConfig.imageUploadMaxSizeInMB}MB`,
+      })}
       <br />
       {t("allowed_formats_are", { formats: "jpg, png, jpeg" })}{" "}
       {t("recommended_aspect_ratio_for", { aspectRatio: "16:9" })}

--- a/src/components/Users/UserAvatar.tsx
+++ b/src/components/Users/UserAvatar.tsx
@@ -146,7 +146,9 @@ export default function UserAvatar({ username }: { username: string }) {
               )}
 
               <p className="text-xs leading-5 text-gray-500">
-                {t("change_avatar_note")}
+                {t("change_avatar_note", {
+                  maxSize: careConfig.imageUploadMaxSizeInMB,
+                })}
               </p>
             </div>
           </div>

--- a/src/hooks/useFileUpload.tsx
+++ b/src/hooks/useFileUpload.tsx
@@ -1,3 +1,4 @@
+import careConfig from "@careConfig";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import imageCompression from "browser-image-compression";
 import jsPDF from "jspdf";
@@ -175,7 +176,7 @@ export default function useFileUpload(
         setError(t("file_error__file_name"));
         return false;
       }
-      if (file.size > 10e7) {
+      if (file.size > careConfig.imageUploadMaxSizeInMB * 1024 * 1024) {
         setError(t("file_error__file_size"));
         return false;
       }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -25,6 +25,7 @@ interface ImportMetaEnv {
   readonly REACT_DEFAULT_ENCOUNTER_TYPE?: string;
   readonly REACT_ALLOWED_LOCALES?: string;
   readonly REACT_ENABLED_APPS?: string;
+  readonly REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB?: string;
 
   // Plugins related envs...
   readonly REACT_SENTRY_DSN?: string;


### PR DESCRIPTION
## Proposed Changes

- Fixes #12343 

![image](https://github.com/user-attachments/assets/469513c0-8cfa-41ad-8d9b-2bf9a3441234)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The maximum image upload size displayed in the Avatar Edit modal and cover image hint now dynamically reflects the configured limit.

- **Chores**
  - Configuration updated to allow setting the maximum image upload size via an environment variable, with a default fallback value.
  - Image upload validation updated to enforce the configurable maximum file size limit.
  - Localization updated to support dynamic display of the maximum image upload size in user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->