### PR TITLE
fix: camera capture dialog issue #12341

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,8 @@
         "recharts": "^2.15.0",
         "sonner": "^2.0.3",
         "tailwind-merge": "^3.2.0",
-        "use-keyboard-shortcut": "^1.1.6"
+        "use-keyboard-shortcut": "^1.1.6",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",

--- a/src/components/Files/CameraCaptureDialog.tsx
+++ b/src/components/Files/CameraCaptureDialog.tsx
@@ -45,6 +45,14 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
     facingMode: cameraFacingMode,
   };
 
+  const closeMediaStream = () => {
+    if (stream) {
+      stream.getTracks().forEach((track) => {
+        track.stop();
+      });
+    }
+  };
+
   useEffect(() => {
     if (!open) return;
 
@@ -66,11 +74,7 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
     getCameraStream();
 
     return () => {
-      if (stream) {
-        stream.getTracks().forEach((track) => {
-          track.stop();
-        });
-      }
+      closeMediaStream();
     };
   }, [open, cameraFacingMode, onOpenChange]);
 
@@ -103,8 +107,13 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
     });
   };
 
+  const handleDialogClose = (open: boolean) => {
+    closeMediaStream();
+    onOpenChange(open);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogClose}>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>
@@ -196,6 +205,7 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
                     variant="primary"
                     onClick={() => {
                       setPreviewImage(null);
+                      closeMediaStream();
                       onOpenChange(false);
                       setPreview?.(false);
                     }}
@@ -212,6 +222,7 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
             <Button
               variant="outline"
               onClick={() => {
+                closeMediaStream();
                 setPreviewImage(null);
                 onResetCapture();
                 onOpenChange(false);
@@ -259,6 +270,7 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
                       variant="primary"
                       onClick={() => {
                         onOpenChange(false);
+                        closeMediaStream();
                         setPreviewImage(null);
                         setPreview?.(false);
                       }}
@@ -274,6 +286,7 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
               variant="outline"
               onClick={() => {
                 setPreviewImage(null);
+                closeMediaStream();
                 onResetCapture();
                 onOpenChange(false);
                 setPreview?.(false);


### PR DESCRIPTION
## Proposed Changes

- Fixes #12341 
- Change 1: Camera stream now closes after closing the dialog box.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by ensuring the camera stream is consistently stopped whenever the dialog is closed or the capture is reset, preventing potential issues with lingering camera access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->