### PR TITLE
Fixed styling for update password in User Profile

### DIFF
--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -131,80 +131,83 @@ export default function UserResetPassword({
                 )}
               />
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="new_password_1"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t("new_password")}</FormLabel>
-                      <FormControl>
-                        <PasswordInput
-                          {...field}
-                          onChange={(e) => {
-                            field.onChange(e.target.value);
-                          }}
-                          onFocus={() => setIsPasswordFieldFocused(true)}
-                          onBlur={() => setIsPasswordFieldFocused(false)}
-                        />
-                      </FormControl>
-                      {isPasswordFieldFocused ? (
-                        <div
-                          className="text-small mt-2 pl-2 text-secondary-500"
-                          aria-live="polite"
-                        >
-                          <ValidationHelper
-                            isInputEmpty={!field.value}
-                            successMessage={t("password_success_message")}
-                            validations={[
-                              {
-                                description: "password_length_validation",
-                                fulfilled: field.value.length >= 8,
-                              },
-                              {
-                                description: "password_lowercase_validation",
-                                fulfilled: /[a-z]/.test(field.value),
-                              },
-                              {
-                                description: "password_uppercase_validation",
-                                fulfilled: /[A-Z]/.test(field.value),
-                              },
-                              {
-                                description: "password_number_validation",
-                                fulfilled: /\d/.test(field.value),
-                              },
-                              {
-                                description: "new_password_same_as_old",
-                                fulfilled:
-                                  field.value !== form.watch("old_password"),
-                              },
-                            ]}
+                <div className="flex flex-col">
+                  <FormField
+                    control={form.control}
+                    name="new_password_1"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("new_password")}</FormLabel>
+                        <FormControl>
+                          <PasswordInput
+                            {...field}
+                            onChange={(e) => {
+                              field.onChange(e.target.value);
+                            }}
+                            onFocus={() => setIsPasswordFieldFocused(true)}
+                            onBlur={() => setIsPasswordFieldFocused(false)}
                           />
-                        </div>
-                      ) : (
+                        </FormControl>
+                        {isPasswordFieldFocused ? (
+                          <div
+                            className="text-small mt-2 pl-2 text-secondary-500"
+                            aria-live="polite"
+                          >
+                            <ValidationHelper
+                              isInputEmpty={!field.value}
+                              successMessage={t("password_success_message")}
+                              validations={[
+                                {
+                                  description: "password_length_validation",
+                                  fulfilled: field.value.length >= 8,
+                                },
+                                {
+                                  description: "password_lowercase_validation",
+                                  fulfilled: /[a-z]/.test(field.value),
+                                },
+                                {
+                                  description: "password_uppercase_validation",
+                                  fulfilled: /[A-Z]/.test(field.value),
+                                },
+                                {
+                                  description: "password_number_validation",
+                                  fulfilled: /\d/.test(field.value),
+                                },
+                                {
+                                  description: "new_password_same_as_old",
+                                  fulfilled:
+                                    field.value !== form.watch("old_password"),
+                                },
+                              ]}
+                            />
+                          </div>
+                        ) : (
+                          <FormMessage />
+                        )}
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <FormField
+                    control={form.control}
+                    name="new_password_2"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("new_password_confirmation")}</FormLabel>
+                        <FormControl>
+                          <PasswordInput
+                            {...field}
+                            onChange={(e) => {
+                              field.onChange(e.target.value);
+                            }}
+                          />
+                        </FormControl>
                         <FormMessage />
-                      )}
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="new_password_2"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t("new_password_confirmation")}</FormLabel>
-                      <FormControl>
-                        <PasswordInput
-                          {...field}
-                          onChange={(e) => {
-                            field.onChange(e.target.value);
-                          }}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                      </FormItem>
+                    )}
+                  />
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #12353 

https://github.com/user-attachments/assets/458c7c27-e09a-4cf1-a852-06dd6eb0a8be



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the layout of the password reset form for consistent styling.
  - Removed duplicate input field for confirming the new password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->