### PR TITLE
Fix password field alignment issue in reset password field

### DIFF
--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -135,7 +135,7 @@ export default function UserResetPassword({
                   control={form.control}
                   name="new_password_1"
                   render={({ field }) => (
-                    <FormItem>
+                    <FormItem className="h-full flex flex-col">
                       <FormLabel>{t("new_password")}</FormLabel>
                       <FormControl>
                         <PasswordInput
@@ -147,10 +147,16 @@ export default function UserResetPassword({
                           onBlur={() => setIsPasswordFieldFocused(false)}
                         />
                       </FormControl>
-                      {isPasswordFieldFocused ? (
+                      <div
+                        className="text-small mt-2 pl-2 min-h-[120px] overflow-hidden relative"
+                        aria-live="polite"
+                      >
                         <div
-                          className="text-small mt-2 pl-2 text-secondary-500"
-                          aria-live="polite"
+                          className={`transition-opacity duration-150 ${
+                            isPasswordFieldFocused
+                              ? "opacity-100"
+                              : "opacity-0 absolute"
+                          }`}
                         >
                           <ValidationHelper
                             isInputEmpty={!field.value}
@@ -180,9 +186,16 @@ export default function UserResetPassword({
                             ]}
                           />
                         </div>
-                      ) : (
-                        <FormMessage />
-                      )}
+                        <div
+                          className={`transition-opacity duration-150 ${
+                            !isPasswordFieldFocused
+                              ? "opacity-100"
+                              : "opacity-0 absolute"
+                          }`}
+                        >
+                          <FormMessage />
+                        </div>
+                      </div>
                     </FormItem>
                   )}
                 />
@@ -191,7 +204,7 @@ export default function UserResetPassword({
                   control={form.control}
                   name="new_password_2"
                   render={({ field }) => (
-                    <FormItem>
+                    <FormItem className="h-full flex flex-col">
                       <FormLabel>{t("new_password_confirmation")}</FormLabel>
                       <FormControl>
                         <PasswordInput
@@ -201,7 +214,9 @@ export default function UserResetPassword({
                           }}
                         />
                       </FormControl>
-                      <FormMessage />
+                      <div className="text-small mt-2 pl-2 min-h-[120px]">
+                        <FormMessage />
+                      </div>
                     </FormItem>
                   )}
                 />


### PR DESCRIPTION
## Proposed Changes

- Fixes #12353
- Change Proposed

https://github.com/user-attachments/assets/a7e4b0af-30b7-470c-b8a0-673986209f0d


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the layout and spacing of the password reset form fields for a more consistent appearance.

- **Accessibility**
  - Enhanced accessibility by providing clearer and more consistent validation feedback for new password inputs, including improved screen reader announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->