### PR TITLE
Fix condition check for boolean questions in questionnaire

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
@@ -50,6 +50,10 @@ function isQuestionEnabled(
         return value ? "Yes" : "No";
       }
 
+      if (typeof value === "number") {
+        return value.toString();
+      }
+
       return value;
     }
 

--- a/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
@@ -43,15 +43,25 @@ function isQuestionEnabled(
     )?.values[0];
 
     // Early return if no dependent value exists
-    if (!dependentValue?.value) return false;
+    if (dependentValue?.value == null) return false;
+
+    function normalizeValue(value: unknown): unknown {
+      if (typeof value === "boolean") {
+        return value ? "Yes" : "No";
+      }
+
+      return value;
+    }
 
     switch (enableWhen.operator) {
       case "exists":
         return dependentValue !== undefined && dependentValue !== null;
-      case "equals":
-        return dependentValue.value === enableWhen.answer;
-      case "not_equals":
-        return dependentValue.value !== enableWhen.answer;
+      case "equals": {
+        return normalizeValue(dependentValue.value) === enableWhen.answer;
+      }
+      case "not_equals": {
+        return normalizeValue(dependentValue.value) !== enableWhen.answer;
+      }
       case "greater":
         return (
           typeof dependentValue.value === "number" &&


### PR DESCRIPTION
## Proposed Changes

- Fixes #12176 
- Normalized boolean values to ensure correct condition checks in `enableWhen` logic.
- Modified the `null` check for the question responses

[Screencast from 2025-05-20 17-38-09.webm](https://github.com/user-attachments/assets/2153f82a-7970-4517-a511-5e74b07cf881)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of dependent responses in questionnaires, ensuring questions are enabled or disabled more accurately based on previous answers, especially for boolean values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->