### PR TITLE
Fix: Resolve text overlapping issues in appointment token card PNG ex…

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2105,6 +2105,7 @@
   "onset_date": "Onset Date",
   "op_encounter": "OP Encounter",
   "op_file_closed": "OP file closed",
+  "op_token": "OP TOKEN",
   "open": "Open",
   "open_camera": "Open Camera",
   "open_live_monitoring": "Open Live Monitoring",

--- a/src/pages/Appointments/components/AppointmentTokenCard.tsx
+++ b/src/pages/Appointments/components/AppointmentTokenCard.tsx
@@ -23,35 +23,34 @@ const AppointmentTokenCard = ({ id, appointment, facility }: Props) => {
   return (
     <Card
       id={id}
-      className="p-6 lg:w-[25rem] border border-gray-300 relative hover:scale-105 hover:rotate-1 hover:shadow-xl transition-all duration-300 ease-in-out"
+      className="p-6 lg:w-[25rem] border border-gray-300 relative hover:scale-105 hover:rotate-1 hover:shadow-xl transition-all duration-300 ease-in-out print:scale-100 print:rotate-0 print:shadow-none print:hover:scale-100 print:hover:rotate-0 print:hover:shadow-none"
     >
       <div className="absolute inset-0 opacity-[0.1] pointer-events-none bg-[url('/images/care_logo_gray.svg')] bg-center bg-no-repeat bg-[length:40%_auto] lg:bg-[length:60%_auto]" />
 
       <div className="relative">
-        <div className="flex items-start justify-between">
-          <div>
-            <h3 className="text-lg font-bold tracking-tight">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <h3 className="text-lg font-bold tracking-tight break-words">
               {facility.name}
             </h3>
-            <div className="flex flex-col lg:flex-row text-sm text-gray-600">
-              <span>{facility.pincode}, </span>
-              <span className="whitespace-nowrap">{`Ph.: ${facility.phone_number}`}</span>
+            <div className="text-sm text-gray-600">
+              <span>{facility.pincode}</span>
+              <div className="whitespace-normal">{`Ph.: ${facility.phone_number}`}</div>
             </div>
           </div>
 
-          <div>
+          <div className="flex-shrink-0">
             <div className="text-sm whitespace-nowrap text-center bg-gray-100 px-3 pb-2 pt-6 -mt-6 font-medium text-gray-500">
-              <p>GENERAL</p>
-              <p>OP TOKEN</p>
+              <p>{t("general")}</p>
+              <p>{t("op_token")}</p>
             </div>
           </div>
         </div>
-
-        <div className="mt-4 flex items-start justify-between">
-          <div>
+        <div className="mt-4 flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
             <Label>{t("name")}</Label>
-            <p className="font-semibold">{patient.name}</p>
-            <p className="text-sm text-gray-600 font-medium whitespace-nowrap">
+            <p className="font-semibold break-words">{patient.name}</p>
+            <p className="text-sm text-gray-600 font-medium">
               {formatPatientAge(patient, true)},{" "}
               {t(`GENDER__${patient.gender}`)}
             </p>
@@ -69,12 +68,11 @@ const AppointmentTokenCard = ({ id, appointment, facility }: Props) => {
             </div>
           </div>
         </div>
-
-        <div className="mt-4 flex justify-between">
-          <div className="space-y-2">
+        <div className="mt-4 flex justify-between items-start gap-4">
+          <div className="space-y-2 flex-1 min-w-0">
             <div>
               <Label>{t("practitioner")}:</Label>
-              <p className="text-sm font-semibold">
+              <p className="text-sm font-semibold break-words">
                 {formatName(appointment.user)}
               </p>
             </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12372 
- Split long patient names across multiple lines to prevent overflow during PNG export
- Add max-width constraints and break-words styling for better text wrapping


@ohcnetwork/care-fe-code-reviewers

##Screenshots

https://github.com/user-attachments/assets/cfb5fe2b-6c43-42b5-8237-ba87022d1b38

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added translation support for "OP TOKEN" in the English locale.
- **Style**
  - Improved print layout and text wrapping for appointment tokens, ensuring better readability and responsiveness.
  - Enhanced spacing and alignment for patient and practitioner information on appointment tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->