### PR TITLE
fix text overflow

### DIFF
--- a/src/components/Files/ArchivedFileDialog.tsx
+++ b/src/components/Files/ArchivedFileDialog.tsx
@@ -36,14 +36,14 @@ export default function ArchivedFileDialog({
       aria-labelledby="file-archive-dialog"
     >
       <DialogContent
-        className="mb-8 rounded-lg p-4 w-[calc(100vw-2.5rem)] sm:w-[calc(100%-2rem)]"
+        className="mb-8 rounded-lg p-4 w-[calc(100vw-2.5rem)] sm:w-[calc(100%-2rem)] max-w-2xl"
         aria-describedby="file-archive"
       >
         <DialogHeader>
-          <DialogTitle>
+          <DialogTitle className="break-words">
             {t("archived_file")}:{" "}
             <TooltipComponent content={fileName}>
-              <span className="max-w-sm truncate inline-block align-bottom">
+              <span className="max-w-[200px] sm:max-w-sm truncate inline-block align-bottom">
                 {fileName}
               </span>
             </TooltipComponent>
@@ -54,13 +54,15 @@ export default function ArchivedFileDialog({
             <span className="text-sm text-gray-500">
               {t("archived_reason")}:
             </span>
-            <span data-cy="archived-reason">{file?.archive_reason}</span>
+            <span className="break-words" data-cy="archived-reason">
+              {file?.archive_reason}
+            </span>
           </div>
-          <div className="flex flex-row gap-2 justify-between text-sm bg-blue-100 text-blue-900 p-2 rounded-md">
-            <span>
+          <div className="flex flex-col sm:flex-row gap-2 justify-between text-sm bg-blue-100 text-blue-900 p-2 rounded-md">
+            <span className="break-words">
               {t("archived_by")}: {file.archived_by?.username}
             </span>
-            <span>
+            <span className="whitespace-nowrap">
               {t("archived_at")}:{" "}
               {dayjs(file.archived_datetime).format("DD MMM YYYY, hh:mm A")}
             </span>

--- a/src/components/Files/ArchivedFileDialog.tsx
+++ b/src/components/Files/ArchivedFileDialog.tsx
@@ -43,7 +43,7 @@ export default function ArchivedFileDialog({
           <DialogTitle className="break-words">
             {t("archived_file")}:{" "}
             <TooltipComponent content={fileName}>
-              <span className="max-w-[200px] sm:max-w-sm truncate inline-block align-bottom">
+              <span className="sm:max-w-sm inline-block align-bottom">
                 {fileName}
               </span>
             </TooltipComponent>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12382 
- Added break-word tailwind class for dialog title, archived-reason span and archived-by span
- Other tailwind changes added for sm devices

https://github.com/user-attachments/assets/f6485be9-8044-4bf7-b2ea-c7ae98e046ab


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved layout and readability of the archived file dialog, including better handling of long text, adaptive spacing, and enhanced responsiveness on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->