### PR TITLE
Default value of Visibility of Facilty as Public

### DIFF
--- a/cypress/e2e/facility_spec/facility_creation.cy.ts
+++ b/cypress/e2e/facility_spec/facility_creation.cy.ts
@@ -67,7 +67,6 @@ describe("Facility Management", () => {
           testFacility.address,
         )
         .fillLocationDetails("Ernakulam")
-        .makePublicFacility()
         .interceptFacilityCreation()
         .submitFacilityCreationForm()
         .verifyFacilityCreation()

--- a/cypress/pageObject/facility/FacilityCreation.ts
+++ b/cypress/pageObject/facility/FacilityCreation.ts
@@ -97,11 +97,6 @@ export class FacilityCreation {
     return this;
   }
 
-  makePublicFacility() {
-    cy.get('[data-cy="make-facility-public"]').click();
-    return this;
-  }
-
   submitFacilityCreationForm() {
     cy.clickSubmitButton("Create Facility");
     return this;

--- a/src/components/Facility/FacilityForm.tsx
+++ b/src/components/Facility/FacilityForm.tsx
@@ -91,7 +91,7 @@ export default function FacilityForm({
       phone_number: "",
       latitude: undefined,
       longitude: undefined,
-      is_public: false,
+      is_public: true,
     },
   });
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #12385
- Change the default value as true
- Fix cypress 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Facilities are now set to public by default when creating a new facility.

- **Tests**
  - Updated facility creation tests to reflect the new default public status for facilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->