### PR TITLE
Fixed avatar image size issue while capturing in mobile

### DIFF
--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -42,14 +42,26 @@ interface Props {
 
 const VideoConstraints = {
   user: {
-    width: 1024,
-    height: 576,
+    width: {
+      min: 400,
+      max: 1024,
+    },
+    height: {
+      min: 400,
+      max: 1024,
+    },
     facingMode: "user",
   },
   environment: {
-    width: 1024,
-    height: 576,
-    facingMode: { exact: "environment" },
+    width: {
+      min: 400,
+      max: 1024,
+    },
+    height: {
+      min: 400,
+      max: 1024,
+    },
+    facingMode: "environment",
   },
 } as const;
 
@@ -265,7 +277,7 @@ const AvatarEditModal = ({
               <>
                 {preview || imageUrl ? (
                   <>
-                    <div className="flex h-[50vh] md:h-[75vh] w-full items-center justify-center rounded-lg border border-secondary-200">
+                    <div className="flex h-[30vh] md:h-[75vh] w-full items-center justify-center rounded-lg border border-secondary-200">
                       <img
                         src={
                           preview && preview.startsWith("blob:")
@@ -416,11 +428,19 @@ const AvatarEditModal = ({
                     <>
                       <Webcam
                         audio={false}
-                        height={720}
                         screenshotFormat="image/jpeg"
-                        width={1280}
                         ref={webRef}
-                        videoConstraints={constraint}
+                        videoConstraints={{
+                          ...constraint,
+                          width: {
+                            ...constraint.width,
+                            ideal: window.innerWidth,
+                          },
+                          height: {
+                            ...constraint.height,
+                            ideal: window.innerHeight,
+                          },
+                        }}
                         onUserMediaError={async () => {
                           const requestValue = await requestPermission("user");
                           if (!requestValue.hasPermission) {

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -42,13 +42,13 @@ interface Props {
 
 const VideoConstraints = {
   user: {
-    width: 1280,
-    height: 720,
+    width: 1024,
+    height: 576,
     facingMode: "user",
   },
   environment: {
-    width: 1280,
-    height: 720,
+    width: 1024,
+    height: 576,
     facingMode: { exact: "environment" },
   },
 } as const;
@@ -92,19 +92,39 @@ const AvatarEditModal = ({
 
   const captureImage = () => {
     if (webRef.current) {
-      setPreviewImage(webRef.current.getScreenshot());
+      const video = webRef.current.video;
+      if (!video) return;
+
+      const canvas = document.createElement("canvas");
+      const context = canvas.getContext("2d");
+      if (!context) return;
+
+      const width = Math.min(Math.max(video.videoWidth, 400), 1024);
+      const height = Math.min(Math.max(video.videoHeight, 400), 1024);
+
+      canvas.width = width;
+      canvas.height = height;
+
+      context.drawImage(video, 0, 0, width, height);
+
+      const imageData = canvas.toDataURL("image/jpeg");
+      setPreviewImage(imageData);
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            const myFile = new File([blob], "image.png", {
+              type: blob.type,
+            });
+            setSelectedFile(myFile);
+          } else {
+            toast.error(t("failed_to_capture_image"));
+          }
+        },
+        "image/jpeg",
+        1.0,
+      );
     }
-    const canvas = webRef.current?.getCanvas();
-    canvas?.toBlob((blob) => {
-      if (blob) {
-        const myFile = new File([blob], "image.png", {
-          type: blob.type,
-        });
-        setSelectedFile(myFile);
-      } else {
-        toast.error(t("failed_to_capture_image"));
-      }
-    });
   };
   const stopCamera = useCallback(() => {
     try {

--- a/src/components/Files/CameraCaptureDialog.tsx
+++ b/src/components/Files/CameraCaptureDialog.tsx
@@ -134,6 +134,14 @@ export default function CameraCaptureDialog(props: CameraCaptureDialogProps) {
                 ref={webRef}
                 videoConstraints={{
                   ...videoConstraints,
+                  width: {
+                    ...videoConstraints.width,
+                    ideal: window.innerWidth,
+                  },
+                  height: {
+                    ...videoConstraints.height,
+                    ideal: window.innerHeight,
+                  },
                   facingMode: cameraFacingMode,
                 }}
               />


### PR DESCRIPTION
## Proposed Changes

When an image is taken via camera in mobile, the width and height was out of the given constraints, so when an image is taken, its is resized.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced avatar image capture with dynamic resolution constraints and improved image processing.
- **Style**
  - Adjusted camera preview sizing for better display on various screen sizes.
  - Updated camera resolution settings to adapt to current window dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->