### PR TITLE
Fix: Improve spacing between radio buttons in questionnaire

### DIFF
--- a/src/components/Questionnaire/QuestionnaireProperties.tsx
+++ b/src/components/Questionnaire/QuestionnaireProperties.tsx
@@ -96,7 +96,7 @@ function StatusSelector({
             <Label
               data-cy={`questionnaire-status-${status}`}
               htmlFor={`status-${status}`}
-              className="text-sm font-normal text-gray-950"
+              className="text-sm mx-1 font-normal text-gray-950"
             >
               {t(status)}
             </Label>
@@ -142,7 +142,7 @@ function SubjectTypeSelector({
             />
             <Label
               htmlFor={`subject-type-${type.value}`}
-              className="text-sm font-normal text-gray-950"
+              className="text-sm mx-1 font-normal text-gray-950"
             >
               {t(type.label)}
             </Label>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12398 
- Added margin for labels under status and Subject Type section.

![image](https://github.com/user-attachments/assets/c267427b-37e5-45a3-ac2e-ddd78423926f)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing between label options in status and subject type selectors for a cleaner and more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->