### PR TITLE
Demo implementation for offline support using workbox approach

### DIFF
--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -77,6 +77,25 @@ export default function AuthUserProvider({
 
   useEffect(() => {
     if (tokenRefreshQuery.isError) {
+      if (!navigator.onLine) {
+        // Offline fallback: try to read the old tokens (optional logging or warning UI here)
+        const cachedAccessToken = localStorage.getItem(
+          LocalStorageKeys.accessToken,
+        );
+        const cachedRefreshToken = localStorage.getItem(
+          LocalStorageKeys.refreshToken,
+        );
+
+        console.warn("Offline. Using cached tokens.", {
+          cachedAccessToken,
+          cachedRefreshToken,
+        });
+
+        // optionally: set these into state or a global store if needed
+        return;
+      }
+
+      // Online and still erroring: clear tokens
       localStorage.removeItem(LocalStorageKeys.accessToken);
       localStorage.removeItem(LocalStorageKeys.refreshToken);
       return;

--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -78,7 +78,6 @@ export default function AuthUserProvider({
   useEffect(() => {
     if (tokenRefreshQuery.isError) {
       if (!navigator.onLine) {
-        // Offline fallback: try to read the old tokens (optional logging or warning UI here)
         const cachedAccessToken = localStorage.getItem(
           LocalStorageKeys.accessToken,
         );
@@ -91,11 +90,9 @@ export default function AuthUserProvider({
           cachedRefreshToken,
         });
 
-        // optionally: set these into state or a global store if needed
         return;
       }
 
-      // Online and still erroring: clear tokens
       localStorage.removeItem(LocalStorageKeys.accessToken);
       localStorage.removeItem(LocalStorageKeys.refreshToken);
       return;

--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -10,6 +10,7 @@ import ErrorBoundary from "@/components/Common/ErrorBoundary";
 import BrowserWarning from "@/components/ErrorPages/BrowserWarning";
 import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 import SessionExpired from "@/components/ErrorPages/SessionExpired";
+import { useSyncOfflineWrites } from "@/components/offlinessupport/useofflinesyncfn";
 
 import useAuthUser from "@/hooks/useAuthUser";
 import { usePluginRoutes } from "@/hooks/useCareApps";
@@ -76,7 +77,7 @@ const AdminRouter: AppRoutes = {
 export default function AppRouter() {
   const pluginRoutes = usePluginRoutes();
   let routes = Routes;
-
+  useSyncOfflineWrites();
   useRedirect("/user", "/users");
 
   // Merge in Plugin Routes

--- a/src/Utils/request/api.tsx
+++ b/src/Utils/request/api.tsx
@@ -553,4 +553,11 @@ const routes = {
   },
 } as const;
 
+export const offlineRoutes = {
+  addPatient: routes.addPatient,
+  updatePatient: routes.updatePatient,
+} as const;
+
+export type OfflineRouteKey = keyof typeof offlineRoutes;
+
 export default routes;

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -41,6 +41,7 @@ import { Textarea } from "@/components/ui/textarea";
 import Loading from "@/components/Common/Loading";
 import Page from "@/components/Common/Page";
 import DuplicatePatientDialog from "@/components/Facility/DuplicatePatientDialog";
+import { saveOfflineWrite } from "@/components/offlinessupport/saveofflinewrites";
 
 import useAppHistory from "@/hooks/useAppHistory";
 import useAuthUser from "@/hooks/useAuthUser";
@@ -57,7 +58,6 @@ import query from "@/Utils/request/query";
 import { dateQueryString } from "@/Utils/utils";
 import validators from "@/Utils/validators";
 import GovtOrganizationSelector from "@/pages/Organization/components/GovtOrganizationSelector";
-import { saveOfflineWrite } from "@/src/components/offlinessupport/saveofflinewrites";
 import { PatientModel } from "@/types/emr/patient";
 import { Organization } from "@/types/organization/organization";
 

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -43,6 +43,7 @@ import Page from "@/components/Common/Page";
 import DuplicatePatientDialog from "@/components/Facility/DuplicatePatientDialog";
 
 import useAppHistory from "@/hooks/useAppHistory";
+import useAuthUser from "@/hooks/useAuthUser";
 
 import { BLOOD_GROUP_CHOICES, GENDER_TYPES } from "@/common/constants";
 import { GENDERS } from "@/common/constants";
@@ -56,6 +57,7 @@ import query from "@/Utils/request/query";
 import { dateQueryString } from "@/Utils/utils";
 import validators from "@/Utils/validators";
 import GovtOrganizationSelector from "@/pages/Organization/components/GovtOrganizationSelector";
+import { saveOfflineWrite } from "@/src/components/offlinessupport/saveofflinewrites";
 import { PatientModel } from "@/types/emr/patient";
 import { Organization } from "@/types/organization/organization";
 
@@ -81,7 +83,7 @@ export default function PatientRegistration(
     useState(!!patientId);
   const [selectedLevels, setSelectedLevels] = useState<Organization[]>([]);
   const [isDeceased, setIsDeceased] = useState(false);
-
+  const user = useAuthUser();
   const formSchema = useMemo(
     () =>
       z
@@ -224,7 +226,7 @@ export default function PatientRegistration(
 
   function onSubmit(values: z.infer<typeof formSchema>) {
     if (patientId) {
-      updatePatient({
+      const updateData = {
         ...values,
         ward_old: undefined,
         age: values.age_or_dob === "age" ? values.age : undefined,
@@ -236,7 +238,23 @@ export default function PatientRegistration(
         permanent_address: values.same_address
           ? values.address
           : values.permanent_address,
-      });
+      };
+      if (!navigator.onLine) {
+        console.log("Saving offline", patientQuery);
+        saveOfflineWrite({
+          userId: user.external_id,
+          syncrouteKey: "updatePatient",
+          resourceType: "patient",
+          payload: updateData,
+          pathParams: { id: patientId },
+          queryParams: { id: patientId },
+          queryrouteKey: "getPatient",
+          serverTimestamp: patientQuery.data?.modified_date,
+        });
+        toast.success("patient saved offline");
+        return;
+      }
+      updatePatient(updateData);
       return;
     }
 

--- a/src/components/offlinessupport/dexiepersister.ts
+++ b/src/components/offlinessupport/dexiepersister.ts
@@ -1,0 +1,32 @@
+import Dexie from "dexie";
+
+export class AppCacheDB extends Dexie {
+  offlineWrites!: Dexie.Table<
+    {
+      id: string;
+      userId: string;
+      syncrouteKey: string;
+      resourceType?: string;
+      pathParams?: Record<string, any>;
+      payload: unknown;
+      clientTimestamp: number;
+      serverTimestamp?: string;
+      lastAttemptAt?: number;
+      syncStatus: "pending" | "success" | "failed" | "conflict";
+      lastError?: string;
+      retries?: number;
+      conflictData?: unknown;
+      queryrouteKey?: string;
+      queryParams?: Record<string, any>;
+    },
+    string
+  >;
+
+  constructor() {
+    super("AppQueryCache");
+
+    this.version(1).stores({
+      offlineWrites: "id, userId, routeKey, timestamp",
+    });
+  }
+}

--- a/src/components/offlinessupport/offlinesync.ts
+++ b/src/components/offlinessupport/offlinesync.ts
@@ -1,0 +1,51 @@
+import { toast } from "sonner";
+
+import { OfflineRouteKey, offlineRoutes } from "@/Utils/request/api";
+import mutate from "@/Utils/request/mutate";
+
+import { AppCacheDB } from "./dexiepersister";
+
+export const syncOfflineWrites = async (userId: string) => {
+  const db = new AppCacheDB();
+  console.log("Syncing offline writes...");
+  console.log("User ID:", userId);
+  if (!navigator.onLine || !userId) return;
+  console.log("User is online. Proceeding with sync...");
+  const pendingWrites = await db.offlineWrites
+    .where("userId")
+    .equals(userId)
+    .and((w) => w.syncStatus === "pending")
+    .toArray();
+  console.log("Pending writes:", pendingWrites);
+  for (const write of pendingWrites) {
+    try {
+      const route = offlineRoutes[write.syncrouteKey as OfflineRouteKey];
+      const mutationFn = mutate(route, {
+        pathParams: write.pathParams as any,
+      });
+
+      await mutationFn(write.payload);
+
+      await db.offlineWrites.update(write.id, {
+        syncStatus: "success",
+        lastAttemptAt: Date.now(),
+      });
+      toast.success("Sync successful");
+    } catch (error: any) {
+      toast.error("Sync failed:", error);
+
+      const update: any = {
+        syncStatus: "failed",
+        lastAttemptAt: Date.now(),
+        lastError: error?.message || "Unknown error",
+        retries: (write.retries || 0) + 1,
+      };
+
+      if (error?.response?.status === 409) {
+        update.syncStatus = "conflict";
+      }
+
+      await db.offlineWrites.update(write.id, update);
+    }
+  }
+};

--- a/src/components/offlinessupport/offlinesync.ts
+++ b/src/components/offlinessupport/offlinesync.ts
@@ -8,7 +8,7 @@ import { AppCacheDB } from "./dexiepersister";
 export const syncOfflineWrites = async (userId: string) => {
   const db = new AppCacheDB();
   console.log("Syncing offline writes...");
-  console.log("User ID:", userId);
+  console.log("User ID:", userId, navigator.onLine);
   if (!navigator.onLine || !userId) return;
   console.log("User is online. Proceeding with sync...");
   const pendingWrites = await db.offlineWrites

--- a/src/components/offlinessupport/saveofflinewrites.ts
+++ b/src/components/offlinessupport/saveofflinewrites.ts
@@ -1,0 +1,49 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { AppCacheDB } from "./dexiepersister";
+
+const db = new AppCacheDB();
+
+interface SaveOfflineWriteParams {
+  userId: string;
+  syncrouteKey: string;
+  payload: unknown;
+  pathParams?: Record<string, any>;
+  resourceType?: string;
+  serverTimestamp?: string;
+  queryrouteKey?: string;
+  queryParams?: Record<string, any>;
+}
+
+export const saveOfflineWrite = async ({
+  userId,
+  syncrouteKey,
+  payload,
+  pathParams,
+  resourceType,
+  serverTimestamp,
+  queryParams,
+  queryrouteKey,
+}: SaveOfflineWriteParams) => {
+  const writeEntry = {
+    id: uuidv4(),
+    userId,
+    syncrouteKey,
+    payload,
+    pathParams,
+    resourceType,
+    clientTimestamp: Date.now(),
+    serverTimestamp,
+    syncStatus: "pending" as const,
+    retries: 0,
+    queryParams,
+    queryrouteKey,
+  };
+
+  try {
+    await db.offlineWrites.add(writeEntry);
+    console.log("Offline write saved successfully:", writeEntry);
+  } catch (error) {
+    console.error(" Failed to save offline write:", error);
+  }
+};

--- a/src/components/offlinessupport/useofflinesyncfn.ts
+++ b/src/components/offlinessupport/useofflinesyncfn.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+import useAuthUser from "@/hooks/useAuthUser";
+
+import { syncOfflineWrites } from "./offlinesync";
+
+export const useSyncOfflineWrites = () => {
+  const user = useAuthUser();
+
+  useEffect(() => {
+    console.log("Syncing offline writes useffect triggered");
+    console.log("User useffect ID:", user?.external_id);
+    if (user?.external_id && navigator.onLine) {
+      console.log("User is online. Proceeding with sync useffect");
+      syncOfflineWrites(user.external_id);
+    }
+  }, [user?.external_id, navigator.onLine]);
+};

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -6,8 +6,11 @@
 // You can also remove this file if you'd prefer not to use a
 // service worker, and the Workbox build step will be skipped.
 import { clientsClaim } from "workbox-core";
+import { ExpirationPlugin } from "workbox-expiration";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { precacheAndRoute } from "workbox-precaching";
+import { registerRoute } from "workbox-routing";
+import { NetworkFirst } from "workbox-strategies";
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -66,3 +69,75 @@ self.addEventListener("notificationclick", (e) => {
     }),
   );
 });
+
+registerRoute(
+  ({ request }) =>
+    request.destination === "style" ||
+    request.destination === "script" ||
+    request.destination === "image",
+  new NetworkFirst({
+    cacheName: "static-assets",
+    plugins: [
+      new ExpirationPlugin({
+        maxAgeSeconds: 7 * 24 * 60 * 60, // 1 week
+      }),
+    ],
+  }),
+);
+
+// ===========================================
+// 3. Navigation Routing (Network First for HTML)
+// ===========================================
+registerRoute(
+  ({ request }) => request.mode === "navigate",
+  new NetworkFirst({
+    cacheName: "html-cache",
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 10,
+        maxAgeSeconds: 7 * 24 * 60 * 60, // 1 week
+      }),
+    ],
+  }),
+);
+
+// ===========================================
+// 4. API Caching (Network First with Auth Support)
+// ===========================================
+registerRoute(
+  ({ url }) => url.pathname.startsWith("/api/"),
+  new NetworkFirst({
+    cacheName: "api-cache",
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 7 * 24 * 60 * 60, // 1 week
+      }),
+      {
+        cacheKeyWillBeUsed: async ({ request }) => {
+          // Add user ID to cache key if authenticated
+          const userId = await getUserIdFromRequest(request);
+          console.log("User ID from request:", userId);
+          return userId ? `${userId}|${request.url}` : request.url;
+        },
+      },
+    ],
+  }),
+);
+
+// ===========================================
+// Helper: Extract User ID from Auth Header
+// ===========================================
+async function getUserIdFromRequest(request: any) {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  try {
+    const token = authHeader.split(" ")[1];
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    console.log("JWT Payload:", payload);
+    return payload.user_id || null; // Adjust based on your JWT structure
+  } catch {
+    return null;
+  }
+}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -79,15 +79,12 @@ registerRoute(
     cacheName: "static-assets",
     plugins: [
       new ExpirationPlugin({
-        maxAgeSeconds: 7 * 24 * 60 * 60, // 1 week
+        maxAgeSeconds: 7 * 24 * 60 * 60,
       }),
     ],
   }),
 );
 
-// ===========================================
-// 3. Navigation Routing (Network First for HTML)
-// ===========================================
 registerRoute(
   ({ request }) => request.mode === "navigate",
   new NetworkFirst({
@@ -101,9 +98,6 @@ registerRoute(
   }),
 );
 
-// ===========================================
-// 4. API Caching (Network First with Auth Support)
-// ===========================================
 registerRoute(
   ({ url }) => url.pathname.startsWith("/api/"),
   new NetworkFirst({
@@ -115,7 +109,6 @@ registerRoute(
       }),
       {
         cacheKeyWillBeUsed: async ({ request }) => {
-          // Add user ID to cache key if authenticated
           const userId = await getUserIdFromRequest(request);
           console.log("User ID from request:", userId);
           return userId ? `${userId}|${request.url}` : request.url;
@@ -125,9 +118,6 @@ registerRoute(
   }),
 );
 
-// ===========================================
-// Helper: Extract User ID from Auth Header
-// ===========================================
 async function getUserIdFromRequest(request: any) {
   const authHeader = request.headers.get("Authorization");
   if (!authHeader?.startsWith("Bearer ")) return null;
@@ -136,7 +126,7 @@ async function getUserIdFromRequest(request: any) {
     const token = authHeader.split(" ")[1];
     const payload = JSON.parse(atob(token.split(".")[1]));
     console.log("JWT Payload:", payload);
-    return payload.user_id || null; // Adjust based on your JWT structure
+    return payload.user_id || null;
   } catch {
     return null;
   }


### PR DESCRIPTION
This is a demo implementation of offline support using a Workbox-based service worker approach. Please note that this is an early version and may contain some edge case errors. currently, the offline support is implemented only for the Update Patient workflow.

Core Focus of This PR:
- Caching API responses (GET requests) necessary for UI functionality using Workbox runtime caching.
- Offline form submission and background syncing of Update Patient data once back online.
- The offline write and sync logic is identical to the TanStack Query–based approach; only the caching mechanism differs.
-
How to Test the Implementation:

- While online, navigate through the Update Patient workflow so necessary API responses and UI assets are cached.
- Manually turn off your internet connection. 
- Refresh the page to confirm that cached UI and data load correctly in offline mode.
- Navigate to the previously visited Update Patient page and try submitting the form.
- Once submitted, wait on the dashboard or background page.
- Reconnect to the internet — the cached form data should now automatically sync with the server.

Note: This Workbox-based version does not include an "Offline Mode" toggle UI yet, but it will be in this approach as well

video:

https://github.com/user-attachments/assets/9b11cde2-fc32-4bf6-aa68-f64f473c8973

