### PR TITLE
Add asterik and disable create button based on validation for location & department form

### DIFF
--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -553,11 +553,11 @@ export default function LocationForm({
 
         <Button
           type="submit"
-          disabled={Boolean(
+          disabled={
             isPending ||
-              !form.formState.isValid ||
-              (location?.id && !form.formState.isDirty),
-          )}
+            !form.formState.isValid ||
+            (!!location?.id && !form.formState.isDirty)
+          }
         >
           {isPending ? (
             <>{isEditMode ? t("updating") : t("creating")}</>

--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -372,7 +372,7 @@ export default function LocationForm({
           name="name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>{t("name")}</FormLabel>
+              <FormLabel aria-required>{t("name")}</FormLabel>
               <FormControl>
                 <Input {...field} data-cy="location-name-input" />
               </FormControl>
@@ -554,7 +554,9 @@ export default function LocationForm({
         <Button
           type="submit"
           disabled={Boolean(
-            isPending || (location?.id && !form.formState.isDirty),
+            isPending ||
+              !form.formState.isValid ||
+              (location?.id && !form.formState.isDirty),
           )}
         >
           {isPending ? (

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
@@ -260,7 +260,7 @@ export default function FacilityOrganizationFormSheet({
               </Button>
               <Button
                 type="submit"
-                disabled={Boolean(isPending || !form.formState.isValid)}
+                disabled={isPending || !form.formState.isValid}
               >
                 {isPending
                   ? isEditMode

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
@@ -192,7 +192,7 @@ export default function FacilityOrganizationFormSheet({
               name="name"
               render={({ field }) => (
                 <FormItem className="space-y-2">
-                  <FormLabel>{t("name")}</FormLabel>
+                  <FormLabel aria-required>{t("name")}</FormLabel>
                   <FormControl>
                     <Input
                       {...field}
@@ -258,7 +258,10 @@ export default function FacilityOrganizationFormSheet({
               >
                 {t("cancel")}
               </Button>
-              <Button type="submit" disabled={isPending}>
+              <Button
+                type="submit"
+                disabled={Boolean(isPending || !form.formState.isValid)}
+              >
                 {isPending
                   ? isEditMode
                     ? t("updating")


### PR DESCRIPTION
## Proposed Changes

- Fixes #12403 
- add * mark for the required fields in location & organization form
- disable create button when field is not filled(when user visits first time)

Demo:

https://github.com/user-attachments/assets/19f1397e-bd0a-4f42-9929-de380cb7aea0


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Added the `aria-required` attribute to "name" field labels in forms to improve accessibility for assistive technologies.

- **Bug Fixes**
  - Enhanced form validation to ensure the submit button is disabled when the form is invalid, preventing accidental submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->