### PR TITLE
Switch discharge summary to reports api

### DIFF
--- a/src/components/Files/DischargeSummarySubTab.tsx
+++ b/src/components/Files/DischargeSummarySubTab.tsx
@@ -40,16 +40,18 @@ import useFileManager from "@/hooks/useFileManager";
 import useFileUpload from "@/hooks/useFileUpload";
 import useFilters from "@/hooks/useFilters";
 
+import { getPermissions } from "@/common/Permissions";
 import {
   BACKEND_ALLOWED_EXTENSIONS,
   FILE_EXTENSIONS,
 } from "@/common/constants";
 
-import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
+import { usePermissions } from "@/context/PermissionContext";
 import ReportBuilderSheet from "@/pages/Encounters/ReportBuilder/ReportBuilderSheet";
 import { Encounter } from "@/types/emr/encounter";
+import reportApi from "@/types/reportTemplate/reportApi";
 
 interface DischargeTabProps {
   type: "encounter" | "patient";
@@ -76,18 +78,23 @@ export const DischargeTab = ({
     limit: 15,
   });
 
+  const { hasPermission } = usePermissions();
+  const { canListTemplate } = getPermissions(
+    hasPermission,
+    encounter.permissions,
+  );
+
   const {
     data: files,
     isLoading: filesLoading,
     refetch,
   } = useQuery({
     queryKey: ["discharge_files", encounter.id, qParams],
-    queryFn: query.debounced(routes.viewUpload, {
+    queryFn: query.debounced(reportApi.viewReports, {
       queryParams: {
-        file_type: type,
+        file_type: "discharge_summary",
         associating_id: encounter.id,
         name: qParams.name,
-        file_category: "discharge_summary",
         limit: qParams.limit,
         offset: ((qParams.page || 1) - 1) * qParams.limit,
         ...(qParams.is_archived !== undefined && {
@@ -99,6 +106,7 @@ export const DischargeTab = ({
 
   const fileManager = useFileManager({
     type: type,
+    mode: "report",
     onArchive: refetch,
     onEdit: refetch,
     uploadedFiles:
@@ -600,49 +608,49 @@ export const DischargeTab = ({
 
         <div className="flex flex-wrap items-center gap-2">
           <FilterButton />
-          <Button
-            variant="outline_primary"
-            className="min-w-24 sm:min-w-28"
-            onClick={async () => {
-              await queryClient.invalidateQueries({
-                queryKey: ["discharge_files"],
-              });
-              await queryClient.invalidateQueries({
-                queryKey: ["files"],
-              });
-              toast.success(t("refreshed"));
-            }}
-          >
-            <CareIcon icon="l-sync" className="mr-2" />
-            {t("refresh")}
-          </Button>
-          <ReportBuilderSheet
-            facilityId={facilityId || ""}
-            patientId={encounter?.patient.id || ""}
-            encounterId={encounter?.id || ""}
-            permissions={encounter?.permissions || []}
-            trigger={
-              <Button variant="primary" asChild>
-                <div className="flex items-center gap-1 text-gray-950 py-0.5 cursor-pointer">
-                  <CareIcon
-                    icon="l-file-export"
-                    className="size-4 text-green-600"
-                  />
-                  {t("generate_report", {
-                    count: 2,
-                  })}
-                </div>
+          {type === "encounter" && encounter && canListTemplate && (
+            <>
+              <Button
+                variant="outline_primary"
+                className="min-w-24 sm:min-w-28"
+                onClick={async () => {
+                  await queryClient.invalidateQueries({
+                    queryKey: ["discharge_files"],
+                  });
+                  await queryClient.invalidateQueries({
+                    queryKey: ["files"],
+                  });
+                  toast.success(t("refreshed"));
+                }}
+              >
+                <CareIcon icon="l-sync" className="mr-2" />
+                {t("refresh")}
               </Button>
-            }
-            onSuccess={() => {
-              queryClient.invalidateQueries({
-                queryKey: ["discharge_files"],
-              });
-              queryClient.invalidateQueries({
-                queryKey: ["files"],
-              });
-            }}
-          />
+              <ReportBuilderSheet
+                facilityId={facilityId || ""}
+                patientId={encounter?.patient.id || ""}
+                encounterId={encounter?.id || ""}
+                trigger={
+                  <Button variant="primary" asChild>
+                    <div className="flex items-center gap-1 text-gray-950 py-0.5 cursor-pointer">
+                      <CareIcon
+                        icon="l-file-export"
+                        className="size-4 text-green-600"
+                      />
+                      {t("generate_report", {
+                        count: 2,
+                      })}
+                    </div>
+                  </Button>
+                }
+                onSuccess={() => {
+                  queryClient.invalidateQueries({
+                    queryKey: ["discharge_files"],
+                  });
+                }}
+              />
+            </>
+          )}
         </div>
 
         <div className="w-full sm:w-auto ml-auto">

--- a/src/components/Files/FileSubTab.tsx
+++ b/src/components/Files/FileSubTab.tsx
@@ -1,9 +1,8 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { t } from "i18next";
 import { SearchIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 
@@ -50,7 +49,6 @@ import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
 import { usePermissions } from "@/context/PermissionContext";
-import ReportBuilderSheet from "@/pages/Encounters/ReportBuilder/ReportBuilderSheet";
 import { Encounter } from "@/types/emr/encounter";
 import { Patient } from "@/types/emr/patient";
 
@@ -69,7 +67,6 @@ export const FilesPage = ({
   patient,
   encounter,
   canEdit,
-  facilityId,
 }: FilesTabProps) => {
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
   const [openArchivedFileDialog, setOpenArchivedFileDialog] = useState(false);
@@ -94,7 +91,6 @@ export const FilesPage = ({
     type === "encounter"
       ? canViewClinicalData || canViewEncounter
       : canViewClinicalData;
-  const queryClient = useQueryClient();
 
   const {
     data: files,
@@ -636,53 +632,6 @@ export const FilesPage = ({
 
         <div className="flex items-center gap-2">
           <FilterButton />
-          {type === "encounter" && (
-            <>
-              <Button
-                variant="outline_primary"
-                className="min-w-24 sm:min-w-28"
-                onClick={async () => {
-                  await queryClient.invalidateQueries({
-                    queryKey: ["files"],
-                  });
-                  queryClient.invalidateQueries({
-                    queryKey: ["discharge_files"],
-                  });
-                  toast.success(t("refreshed"));
-                }}
-              >
-                <CareIcon icon="l-sync" className="mr-2" />
-                {t("refresh")}
-              </Button>
-              <ReportBuilderSheet
-                facilityId={facilityId || ""}
-                patientId={encounter?.patient.id || ""}
-                encounterId={encounter?.id || ""}
-                permissions={encounter?.permissions || []}
-                trigger={
-                  <Button variant="primary" asChild>
-                    <div className="flex items-center gap-1 text-gray-950 py-0.5 cursor-pointer">
-                      <CareIcon
-                        icon="l-file-export"
-                        className="size-4 text-green-600"
-                      />
-                      {t("generate_report", {
-                        count: 2,
-                      })}
-                    </div>
-                  </Button>
-                }
-                onSuccess={() => {
-                  queryClient.invalidateQueries({
-                    queryKey: ["files"],
-                  });
-                  queryClient.invalidateQueries({
-                    queryKey: ["discharge_files"],
-                  });
-                }}
-              />
-            </>
-          )}
         </div>
 
         <div className="ml-auto">

--- a/src/hooks/useFileManager.tsx
+++ b/src/hooks/useFileManager.tsx
@@ -31,9 +31,11 @@ import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { formatDateTime } from "@/Utils/utils";
+import reportApi from "@/types/reportTemplate/reportApi";
 
 export interface FileManagerOptions {
   type: string;
+  mode?: "file" | "report";
   onArchive?: () => void;
   onEdit?: () => void;
   uploadedFiles?: FileUploadModel[];
@@ -58,10 +60,39 @@ export interface FileManagerResult {
   type: string;
 }
 
+const getApiRoutes = (type: string, mode: "file" | "report" = "file") => {
+  const isReport = mode === "report";
+  return {
+    retrieve: {
+      route: isReport ? reportApi.retrieveReport : routes.retrieveUpload,
+      getQueryParams: (associating_id: string) => ({
+        file_type: type,
+        associating_id,
+      }),
+      getPathParams: (id: string) => ({ id }),
+    },
+    edit: {
+      route: isReport ? reportApi.editReport : routes.editUpload,
+      getPathParams: (id: string) => ({ id }),
+    },
+    archive: {
+      route: isReport ? reportApi.archiveReport : routes.archiveUpload,
+      getPathParams: (id: string) => ({ id }),
+    },
+  };
+};
+
 export default function useFileManager(
   options: FileManagerOptions,
 ): FileManagerResult {
-  const { type: fileType, onArchive, onEdit, uploadedFiles } = options;
+  const {
+    type: fileType,
+    mode = "file",
+    onArchive,
+    onEdit,
+    uploadedFiles,
+  } = options;
+  const apiRoutes = getApiRoutes(fileType, mode);
 
   const { t } = useTranslation();
   const [file_state, setFileState] = useState<StateInterface>({
@@ -101,14 +132,10 @@ export default function useFileManager(
   ) => {
     return queryClient.fetchQuery({
       queryKey: ["file", fileType, associating_id, file.id],
-      queryFn: () =>
-        query(routes.retrieveUpload, {
-          queryParams: {
-            file_type: fileType,
-            associating_id,
-          },
-          pathParams: { id: file.id || "" },
-        })({} as any),
+      queryFn: query(apiRoutes.retrieve.route, {
+        queryParams: apiRoutes.retrieve.getQueryParams(associating_id),
+        pathParams: apiRoutes.retrieve.getPathParams(file.id || ""),
+      }),
     });
   };
 
@@ -150,9 +177,9 @@ export default function useFileManager(
 
   const { mutateAsync: archiveUpload } = useMutation({
     mutationFn: (body: { id: string; archive_reason: string }) =>
-      query(routes.archiveUpload, {
+      query(apiRoutes.archive.route, {
         body: { archive_reason: body.archive_reason },
-        pathParams: { id: body.id },
+        pathParams: apiRoutes.archive.getPathParams(body.id),
       })({} as any),
     onSuccess: () => {
       toast.success(t("file_archived_successfully"));
@@ -219,9 +246,9 @@ export default function useFileManager(
 
   const { mutateAsync: editUpload } = useMutation({
     mutationFn: (body: { id: string; name: string; associating_id: string }) =>
-      mutate(routes.editUpload, {
+      mutate(apiRoutes.edit.route, {
         body: { name: body.name },
-        pathParams: { id: body.id },
+        pathParams: apiRoutes.edit.getPathParams(body.id),
       })(body),
     onSuccess: (_, { associating_id }) => {
       toast.success(t("file_name_changed_successfully"));

--- a/src/pages/Encounters/ReportBuilder/ReportBuilderSheet.tsx
+++ b/src/pages/Encounters/ReportBuilder/ReportBuilderSheet.tsx
@@ -15,11 +15,8 @@ import {
 
 import { CardGridSkeleton } from "@/components/Common/SkeletonLoading";
 
-import { getPermissions } from "@/common/Permissions";
-
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
-import { usePermissions } from "@/context/PermissionContext";
 import { ReportTemplateType } from "@/types/reportTemplate/reportTemplate";
 import reportTemplateApi from "@/types/reportTemplate/reportTemplateApi";
 
@@ -31,20 +28,16 @@ interface ReportBuilderSheetProps {
   patientId: string;
   trigger: React.ReactNode;
   onSuccess?: () => void;
-  permissions: string[];
 }
 
 export default function ReportBuilderSheet({
   facilityId,
   patientId,
   trigger,
-  permissions,
   onSuccess,
 }: ReportBuilderSheetProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const { hasPermission } = usePermissions();
-  const { canListTemplate } = getPermissions(hasPermission, permissions);
   const { data: reportTemplateData, isLoading: isReportTemplateLoading } =
     useQuery({
       queryKey: ["report-templates", facilityId],
@@ -53,7 +46,7 @@ export default function ReportBuilderSheet({
           facility: facilityId,
         },
       }),
-      enabled: open && canListTemplate,
+      enabled: open,
     });
 
   const { mutate: generateReport } = useMutation({

--- a/src/types/reportTemplate/report.ts
+++ b/src/types/reportTemplate/report.ts
@@ -1,0 +1,36 @@
+import { UserBareMinimum } from "@/components/Users/models";
+
+interface ReportBase {
+  id?: string;
+  name: string;
+}
+
+type ReportType = "discharge_summary" | "lab_report";
+
+export interface ReportCreateModel extends ReportBase {
+  file_type: ReportType;
+  associating_id: string;
+  original_name: string;
+  mime_type: string | null;
+}
+
+export interface ReportList extends ReportBase {
+  file_type: ReportType;
+  associating_id: string;
+  archived_by?: UserBareMinimum;
+  archived_datetime?: string;
+
+  upload_completed: boolean;
+  is_archived?: boolean;
+  archive_reason?: string;
+  created_date: string;
+  extension?: string;
+
+  uploaded_by?: UserBareMinimum;
+  mime_type?: string;
+}
+
+export interface ReportModel extends ReportList {
+  signed_url?: string;
+  read_signed_url?: string;
+}

--- a/src/types/reportTemplate/reportApi.ts
+++ b/src/types/reportTemplate/reportApi.ts
@@ -5,29 +5,29 @@ import { ReportModel } from "./report";
 
 export default {
   viewReports: {
-    path: "/api/v1/reports/",
+    path: "/api/v1/report/",
     method: HttpMethod.GET,
     TRes: Type<PaginatedResponse<ReportModel>>(),
   },
   retrieveReport: {
-    path: "/api/v1/reports/{id}/",
+    path: "/api/v1/report/{id}/",
     method: HttpMethod.GET,
     TRes: Type<ReportModel>(),
   },
   editReport: {
-    path: "/api/v1/reports/{id}/",
+    path: "/api/v1/report/{id}/",
     method: HttpMethod.PUT,
     TBody: Type<Partial<ReportModel>>(),
     TRes: Type<ReportModel>(),
   },
   archiveReport: {
-    path: "/api/v1/reports/{id}/archive/",
+    path: "/api/v1/report/{id}/archive/",
     method: HttpMethod.POST,
     TRes: Type<ReportModel>(),
     TBody: Type<{ archive_reason: string }>(),
   },
   markReportCompleted: {
-    path: "/api/v1/reports/{id}/mark_upload_completed/",
+    path: "/api/v1/report/{id}/mark_upload_completed/",
     method: HttpMethod.POST,
     TRes: Type<ReportModel>(),
   },

--- a/src/types/reportTemplate/reportApi.ts
+++ b/src/types/reportTemplate/reportApi.ts
@@ -1,0 +1,34 @@
+import { HttpMethod, Type } from "@/Utils/request/api";
+import { PaginatedResponse } from "@/Utils/request/types";
+
+import { ReportModel } from "./report";
+
+export default {
+  viewReports: {
+    path: "/api/v1/reports/",
+    method: HttpMethod.GET,
+    TRes: Type<PaginatedResponse<ReportModel>>(),
+  },
+  retrieveReport: {
+    path: "/api/v1/reports/{id}/",
+    method: HttpMethod.GET,
+    TRes: Type<ReportModel>(),
+  },
+  editReport: {
+    path: "/api/v1/reports/{id}/",
+    method: HttpMethod.PUT,
+    TBody: Type<Partial<ReportModel>>(),
+    TRes: Type<ReportModel>(),
+  },
+  archiveReport: {
+    path: "/api/v1/reports/{id}/archive/",
+    method: HttpMethod.POST,
+    TRes: Type<ReportModel>(),
+    TBody: Type<{ archive_reason: string }>(),
+  },
+  markReportCompleted: {
+    path: "/api/v1/reports/{id}/mark_upload_completed/",
+    method: HttpMethod.POST,
+    TRes: Type<ReportModel>(),
+  },
+};


### PR DESCRIPTION
## Proposed Changes

- Switch to Reports API for discharge summary
- Needed [BE](https://github.com/ohcnetwork/care/pull/3005)
 
@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new data structures and API endpoint configurations for managing report templates and reports.

- **Bug Fixes**
  - The "Generate Report" and refresh buttons in the Discharge Summary tab are now only visible to users with appropriate permissions.

- **Refactor**
  - Simplified permission checks and conditional rendering for report generation.
  - Centralized API route selection in file management to support different modes and improve maintainability.

- **Chores**
  - Removed unused refresh functionality and related dependencies from the file management component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->