### PR TITLE
fix: DatePicker input cuts off in EditSchecule Template

### DIFF
--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -92,7 +92,7 @@ export default function EditScheduleTemplateSheet({
       <SheetTrigger asChild>
         {trigger || <Button variant="outline" size="sm"></Button>}
       </SheetTrigger>
-      <SheetContent className="flex min-w-full flex-col bg-gray-100 sm:min-w-[32rem]">
+      <SheetContent className="flex min-w-full flex-col bg-gray-100 sm:min-w-fit">
         <SheetHeader>
           <SheetTitle>{t("edit_schedule_template")}</SheetTitle>
           <SheetDescription className="sr-only">

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -92,7 +92,7 @@ export default function EditScheduleTemplateSheet({
       <SheetTrigger asChild>
         {trigger || <Button variant="outline" size="sm"></Button>}
       </SheetTrigger>
-      <SheetContent className="flex min-w-full flex-col bg-gray-100 sm:min-w-fit">
+      <SheetContent className="flex min-w-full flex-col bg-gray-100 sm:min-w-fit max-w-screen-lg">
         <SheetHeader>
           <SheetTitle>{t("edit_schedule_template")}</SheetTitle>
           <SheetDescription className="sr-only">


### PR DESCRIPTION
## Proposed Changes

- Fixes #12039 
## Changes
- Updated the sheetContent in editScheduleTemplateSheet  to use the same width classes as create schedule template's sheet
- This ensures that long month names and full date strings are always visible and not visually clipped in the DatePicker input.

##  Screenshot
 

https://github.com/user-attachments/assets/7b0b483b-e0d7-4446-bf39-f2935559df0e


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Style**
  - Updated the minimum width styling of the schedule template editing sheet for improved content fit on small screens and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->