### PR TITLE
fix: Unable to Save Questionnaire After Importing from JSON File

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -592,7 +592,10 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
       title: mappedData.title || "",
       slug: mappedData.slug || "",
       description: mappedData.description || "",
+      questions: mappedData.questions || [],
     });
+
+    form.trigger();
 
     setShowImportDialog(false);
     setImportUrl("");


### PR DESCRIPTION
## Proposed Changes

- Fixes #12438 
- Ensure questions are initialized in QuestionnaireEditor form state


https://github.com/user-attachments/assets/1b82eff2-0f33-4761-902c-757df2836630



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that imported questionnaire data now includes questions when resetting the form after import confirmation.
  - Improved form validation by triggering it immediately after importing questionnaire data, ensuring accurate validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->