### PR TITLE
Fix: Disable FacilityOrg Form Submit when no changes made while Editing 

### DIFF
--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
@@ -251,17 +251,21 @@ export default function FacilityOrganizationFormSheet({
             <div className="flex justify-end mt-6 space-x-2">
               <Button
                 type="button"
+                variant="outline"
                 onClick={() => {
                   setOpen(false);
                   form.reset();
                 }}
-                className="bg-white text-gray-800 border border-gray-300 hover:bg-gray-100"
               >
                 {t("cancel")}
               </Button>
               <Button
                 type="submit"
-                disabled={isPending || !form.formState.isValid}
+                disabled={
+                  isPending ||
+                  !form.formState.isValid ||
+                  !form.formState.isDirty
+                }
                 data-cy={
                   isEditMode
                     ? "update-organization-button"


### PR DESCRIPTION
## Proposed Changes
- Added !form.formstate.isDirty to disable 
- rm classname and use variant for cancel btn
- Fixes #12449 



https://github.com/user-attachments/assets/ee4f6d9f-7d46-4a35-bfac-1d1735b5d185



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the cancel button appearance for consistency by using the "outline" style.
  - Enhanced the submit button behavior to prevent submission unless changes have been made to the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->