### PR TITLE
Fix : Notes Textarea Incorrectly Positions At Start

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/NotesInput.tsx
+++ b/src/components/Questionnaire/QuestionTypes/NotesInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -26,8 +26,14 @@ export function NotesInput({
   className,
 }: NotesInputProps) {
   const [open, setOpen] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const notes = questionnaireResponse.note || "";
   const hasNotes = notes.length > 0;
+
+  const handleFocus = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    const len = e.target.value.length;
+    e.target.setSelectionRange(len, len);
+  };
 
   return (
     <div className={cn("space-y-2 rounded-md flex items-center", className)}>
@@ -50,12 +56,15 @@ export function NotesInput({
         </PopoverTrigger>
         <PopoverContent className="bg-yellow-100 border border-yellow-200 text-gray-900 shadow-lg p-2">
           <Textarea
+            ref={textareaRef}
             value={notes}
             onChange={(e) => handleUpdateNote(e.target.value)}
             className=" border-yellow-200 focus-visible:border-yellow-300 focus-visible:ring-yellow-300"
             placeholder="Add notes..."
             disabled={disabled}
             data-cy="notes-textarea"
+            autoFocus
+            onFocus={handleFocus}
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12440

- Added handlefocus event handler.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.

https://github.com/user-attachments/assets/b4833a04-a0e0-4834-bc66-d8d2e5205f7d


- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the notes input field so that when it is focused, the cursor automatically moves to the end of the existing text for a smoother editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->