### PR TITLE
Implemented auto-scroll to new questions and Hide unit for Non-Quantity in Questionnaire page

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -933,6 +933,14 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                           setExpandedQuestions(
                             (prev) => new Set([...prev, newQuestion.id]),
                           );
+                          setTimeout(() => {
+                            const element = document.getElementById(
+                              `question-${newQuestion.id}`,
+                            );
+                            if (element) {
+                              element.scrollIntoView();
+                            }
+                          }, 100);
                         }}
                       >
                         <CareIcon icon="l-plus" className="mr-2 size-4" />
@@ -1387,7 +1395,7 @@ function QuestionEditor({
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <Label>{t("type")}</Label>
+                <Label className="mb-2">{t("type")}</Label>
                 <Select
                   value={type}
                   onValueChange={(val: QuestionType) => {
@@ -1423,7 +1431,7 @@ function QuestionEditor({
 
               {type === "structured" && (
                 <div>
-                  <Label>{t("structured_type")}</Label>
+                  <Label className="mb-2">{t("structured_type")}</Label>
                   <Select
                     value={structured_type || ""}
                     onValueChange={(val: StructuredQuestionType) => {
@@ -1455,39 +1463,39 @@ function QuestionEditor({
               )}
             </div>
 
+            {type === "quantity" && (
+              <FormField
+                control={form.control}
+                name={`questions.${index}.unit`}
+                render={({ field }) => (
+                  <FormItem className="pb-4">
+                    <FormLabel>{t("unit")}</FormLabel>
+                    <FormControl>
+                      <ValueSetSelect
+                        {...field}
+                        system="system-ucum-units"
+                        placeholder={t("add_unit")}
+                        value={unit}
+                        onSelect={(code) => {
+                          updateField("unit", code);
+                          form.setValue(`questions.${index}.unit`, code, {
+                            shouldValidate: true,
+                          });
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
             {type !== "structured" && (
-              <div className="flex flex-col gap-4">
-                <FormField
-                  control={form.control}
-                  name={`questions.${index}.unit`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t("unit")}</FormLabel>
-                      <FormControl>
-                        <ValueSetSelect
-                          {...field}
-                          system="system-ucum-units"
-                          placeholder={t("add_unit")}
-                          value={unit}
-                          onSelect={(code) => {
-                            updateField("unit", code);
-                            form.setValue(`questions.${index}.unit`, code, {
-                              shouldValidate: true,
-                            });
-                          }}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <CodingEditor
-                  code={code}
-                  form={form}
-                  questionIndex={index}
-                  onChange={(newCode) => updateField("code", newCode)}
-                />
-              </div>
+              <CodingEditor
+                code={code}
+                form={form}
+                questionIndex={index}
+                onChange={(newCode) => updateField("code", newCode)}
+              />
             )}
           </div>
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #12450 
- Set an auto-scroll which redirect to new Question when created
- Hide the Units for the non-quantity questions
- Fix the design issues in form filelds

Demo video :

[Screencast from 2025-05-29 16-58-49.webm](https://github.com/user-attachments/assets/d6eac3ca-4993-415a-9f2e-c91029c5f9aa)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically scrolls to newly added questions in the questionnaire editor.
  - Displays a unit selection field specifically for "quantity" type questions.

- **Style**
  - Improved spacing for type field labels in the question editor.

- **Refactor**
  - Unit selector is now shown only for "quantity" type questions, streamlining the editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->