### PR TITLE
Fixes cursor auto-positioning at end in Notes Textarea 

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/NotesInput.tsx
+++ b/src/components/Questionnaire/QuestionTypes/NotesInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -28,6 +28,23 @@ export function NotesInput({
   const [open, setOpen] = useState(false);
   const notes = questionnaireResponse.note || "";
   const hasNotes = notes.length > 0;
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      // Use a small delay to ensure the textarea is fully rendered and ready
+      const timeoutId = setTimeout(() => {
+        if (textareaRef.current) {
+          const length = textareaRef.current.value.length || 0;
+          textareaRef.current.setSelectionRange(length, length);
+          textareaRef.current.focus();
+        }
+      }, 50); // Using a 50ms delay as a balance
+
+      // Clean up the timeout if the popover closes before the timeout fires
+      return () => clearTimeout(timeoutId);
+    }
+  }, [open]);
 
   return (
     <div className={cn("space-y-2 rounded-md flex items-center", className)}>
@@ -56,6 +73,7 @@ export function NotesInput({
             placeholder="Add notes..."
             disabled={disabled}
             data-cy="notes-textarea"
+            ref={textareaRef}
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
### Proposed Changes
  Fixes ✅ cursor positioning to end in Notes textarea when viewing an existing note. #12440

- Automatically sets the cursor at the **end** of the existing text in the notes field.
- Triggered when the user clicks on "View Note" under the **Add Questionnaire** section.
- Improves user experience when editing previously entered notes.
- Verified across major browsers.

**Demo video**:

https://github.com/user-attachments/assets/02847a7e-66fb-4c3b-8765-d970962cd8c0

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test the fix.
- [x] Update product documentation if necessary.
- [x] Ensure that UI text is kept in I18n files (if applicable).
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews.
- [x] Completion of QA in Mobile Devices.
- [x] Completion of QA in Desktop Devices.

---

## 📌 Summary by CodeRabbit

### Bug Fix

- Ensures the cursor is placed at the end of the notes text when opening an existing note.

### UX Improvement

- Eliminates the need for users to manually scroll to the end of their notes, improving workflow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When opening the notes popover, the textarea is now automatically focused with the cursor positioned at the end of the existing text for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->