### PR TITLE
FIXED: Make Google Location (URL) Clickable in Patient Update Form on Patient Details Page

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -99,12 +99,26 @@ function QuestionResponseValue({ question, response }: QuestionResponseProps) {
 
           const precedentUnit = unit ? unit : question.unit;
 
+          const isUrl =
+            question.type === "url" && typeof value === "string" && value;
           return (
             <div
               key={index}
               className="text-sm font-medium whitespace-pre-wrap"
             >
-              {formatValue(value, question.type)}
+              {isUrl ? (
+                <a
+                  href={value}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline break-all hover:text-blue-800"
+                >
+                  {value}
+                </a>
+              ) : (
+                formatValue(value, question.type)
+              )}
+
               {precedentUnit && (
                 <span className="ml-1 text-xs">{precedentUnit.code}</span>
               )}


### PR DESCRIPTION
## Proposed Changes
if question type url <a> added

- Fixes #12407 
- Change 1

https://github.com/user-attachments/assets/e77de186-32fd-4315-9ce7-936161c7b667


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Responses of type "url" are now displayed as clickable links that open in a new tab, with improved styling and security.

- **Style**
  - Enhanced appearance for URL responses with blue underline and hover effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->