### PR TITLE
FIXED: Reset Button Not Restoring Zoom Level in File Preview

### DIFF
--- a/src/components/Common/FilePreviewDialog.tsx
+++ b/src/components/Common/FilePreviewDialog.tsx
@@ -466,7 +466,11 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
                         label: t("reset"),
                         icon: "l-minus-circle",
                         action: () =>
-                          setFileState((prev) => ({ ...prev, rotation: 0 })),
+                          setFileState((prev) => ({
+                            ...prev,
+                            rotation: 0,
+                            zoom: 4,
+                          })),
                         disabled: false,
                       },
                       {


### PR DESCRIPTION
## Proposed Changes
-  set zoom:4

- Fixes #12464 
- Change 1

https://github.com/user-attachments/assets/a48a4d14-1f5c-4ad4-bd6f-165d0931148e

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reset button in the image preview controls to reset both rotation and zoom to their default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->