### PR TITLE
fix: Add field dynamically in Patient Information section of Report Template Builder

### DIFF
--- a/src/pages/Encounters/ReportBuilder/SectionBuilder.tsx
+++ b/src/pages/Encounters/ReportBuilder/SectionBuilder.tsx
@@ -64,7 +64,6 @@ function StandardLayout({
   form,
   index,
   fieldName,
-  availableFieldsAndColumns,
   isEnabled,
   addButtonText,
   selectPlaceholder,
@@ -83,18 +82,11 @@ function StandardLayout({
           <FormItem>
             <FormControl>
               <div className="flex flex-col w-full justify-between mb-4 gap-2">
-                <Select value={selectedField} onValueChange={setSelectedField}>
-                  <SelectTrigger>
-                    <SelectValue placeholder={selectPlaceholder} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableFieldsAndColumns?.map((field) => (
-                      <SelectItem key={field} value={field}>
-                        {t(field)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Input
+                  placeholder={selectPlaceholder}
+                  value={selectedField}
+                  onChange={(e) => setSelectedField(e.target.value)}
+                />
                 <Button
                   type="button"
                   variant="outline"
@@ -102,8 +94,10 @@ function StandardLayout({
                   className="w-full sm:w-auto"
                   disabled={!selectedField}
                   onClick={() => {
-                    onChange([...items, selectedField]);
-                    setSelectedField("");
+                    if (!items.includes(selectedField)) {
+                      onChange([...items, selectedField]);
+                      setSelectedField("");
+                    }
                   }}
                 >
                   <Plus className="size-2 mr-2" />
@@ -453,7 +447,7 @@ function SectionFieldsAndColumns({
           availableFieldsAndColumns={availableFieldsAndColumns}
           isEnabled={isEnabled}
           addButtonText={t("add_column")}
-          selectPlaceholder={t("select_column")}
+          selectPlaceholder={t("add_column")}
           emptyText={t("no_columns")}
         />
       ) : (
@@ -464,7 +458,7 @@ function SectionFieldsAndColumns({
           availableFieldsAndColumns={availableFieldsAndColumns}
           isEnabled={isEnabled}
           addButtonText={t("add_field")}
-          selectPlaceholder={t("select_field")}
+          selectPlaceholder={t("add_field")}
           emptyText={t("no_fields")}
         />
       )}

--- a/src/pages/Encounters/ReportBuilder/SectionBuilder.tsx
+++ b/src/pages/Encounters/ReportBuilder/SectionBuilder.tsx
@@ -53,7 +53,6 @@ interface StandardLayoutProps {
   form: UseFormReturn<ReportTemplateFormData>;
   index: number;
   fieldName: `config.sections.${number}.options.${"fields" | "columns"}`;
-  availableFieldsAndColumns?: string[];
   isEnabled: boolean;
   addButtonText: string;
   selectPlaceholder: string;
@@ -406,7 +405,6 @@ function CustomTableAndFields({
 function SectionFieldsAndColumns({
   form,
   index,
-  availableSections,
   isEnabled,
   isTable,
 }: {
@@ -427,7 +425,6 @@ function SectionFieldsAndColumns({
   }) as "list" | "text" | undefined;
 
   const isCustomSection = section === "custom_section";
-  const availableFieldsAndColumns = availableSections?.[section];
 
   return (
     <div className="space-y-4">
@@ -444,7 +441,6 @@ function SectionFieldsAndColumns({
           form={form}
           index={index}
           fieldName={`config.sections.${index}.options.columns`}
-          availableFieldsAndColumns={availableFieldsAndColumns}
           isEnabled={isEnabled}
           addButtonText={t("add_column")}
           selectPlaceholder={t("add_column")}
@@ -455,7 +451,6 @@ function SectionFieldsAndColumns({
           form={form}
           index={index}
           fieldName={`config.sections.${index}.options.fields`}
-          availableFieldsAndColumns={availableFieldsAndColumns}
           isEnabled={isEnabled}
           addButtonText={t("add_field")}
           selectPlaceholder={t("add_field")}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12477


https://github.com/user-attachments/assets/be6b2f27-50af-4cb5-88c7-f90aed513c7b



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Replaced dropdown selection with a text input for adding fields or columns.
- **Bug Fixes**
  - Prevented duplicate fields or columns from being added.
- **Style**
  - Updated placeholder text to improve clarity when adding fields or columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->