### PR TITLE
Added Medication Statement view to Encounter Page

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2109,6 +2109,7 @@
   "on_emergency_basis": " on emergency basis",
   "on_hold": "On Hold",
   "ongoing": "Ongoing",
+  "ongoing_medicines": "Ongoing Medicines",
   "online": "Online",
   "only_indian_mobile_numbers_supported": "Currently only Indian numbers are supported",
   "only_mark_if_applicable": "Only mark if applicable",

--- a/src/components/Medicine/MedicationRequestTable/index.tsx
+++ b/src/components/Medicine/MedicationRequestTable/index.tsx
@@ -141,26 +141,29 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
     <div className="space-y-2">
       <div className="rounded-lg">
         <Tabs defaultValue="prescriptions">
-          <TabsList className="w-full h-full sm:w-fit flex flex-wrap">
-            <TabsTrigger
-              value="prescriptions"
-              className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
-            >
-              {t("prescriptions")}
-            </TabsTrigger>
-            <TabsTrigger
-              value="ongoing"
-              className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
-            >
-              {t("ongoing_medicines")}
-            </TabsTrigger>
-            <TabsTrigger
-              value="administration"
-              className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
-            >
-              {t("medicine_administration")}
-            </TabsTrigger>
-          </TabsList>
+          <ScrollArea className="w-full">
+            <TabsList className="w-fit">
+              <TabsTrigger
+                value="prescriptions"
+                className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
+              >
+                {t("prescriptions")}
+              </TabsTrigger>
+              <TabsTrigger
+                value="ongoing"
+                className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
+              >
+                {t("ongoing_medicines")}
+              </TabsTrigger>
+              <TabsTrigger
+                value="administration"
+                className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
+              >
+                {t("medicine_administration")}
+              </TabsTrigger>
+            </TabsList>
+            <ScrollBar orientation="horizontal" />
+          </ScrollArea>
 
           <TabsContent value="prescriptions">
             <div className="flex flex-col gap-2">

--- a/src/components/Medicine/MedicationRequestTable/index.tsx
+++ b/src/components/Medicine/MedicationRequestTable/index.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Loading from "@/components/Common/Loading";
 import { AdministrationTab } from "@/components/Medicine/MedicationAdministration/AdministrationTab";
 import { MedicationsTable } from "@/components/Medicine/MedicationsTable";
+import { MedicationStatementList } from "@/components/Patient/MedicationStatementList";
 
 import { getPermissions } from "@/common/Permissions";
 
@@ -148,6 +149,12 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
               {t("prescriptions")}
             </TabsTrigger>
             <TabsTrigger
+              value="ongoing"
+              className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
+            >
+              {t("ongoing_medicines")}
+            </TabsTrigger>
+            <TabsTrigger
               value="administration"
               className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
             >
@@ -246,6 +253,13 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
                 </ScrollArea>
               )}
             </div>
+          </TabsContent>
+
+          <TabsContent value="ongoing">
+            <MedicationStatementList
+              patientId={patientId}
+              canAccess={canAccess}
+            />
           </TabsContent>
 
           <TabsContent value="administration">

--- a/src/components/Medicine/MedicationRequestTable/index.tsx
+++ b/src/components/Medicine/MedicationRequestTable/index.tsx
@@ -141,7 +141,7 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
     <div className="space-y-2">
       <div className="rounded-lg">
         <Tabs defaultValue="prescriptions">
-          <TabsList>
+          <TabsList className="w-full h-full sm:w-fit flex flex-wrap">
             <TabsTrigger
               value="prescriptions"
               className="data-[state=active]:bg-white rounded-md px-4 font-semibold"


### PR DESCRIPTION
## Proposed Changes

- Fixes #12416 


- ![image](https://github.com/user-attachments/assets/2d1961e4-abe7-42e6-a869-0fd320d2c03f)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Ongoing Medicines" tab to the medication table, allowing users to view ongoing medication statements separately from prescriptions and administration records.

- **Localization**
  - Introduced a new English localization string for "Ongoing Medicines".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->