### PR TITLE
Added support for selecting another practitioner when rescheduling

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -36,6 +36,7 @@ import {
 import { Badge, BadgeProps } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
@@ -63,6 +64,7 @@ import {
 } from "@/Utils/utils";
 import { usePermissions } from "@/context/PermissionContext";
 import { AppointmentTokenCard } from "@/pages/Appointments/components/AppointmentTokenCard";
+import { PractitionerSelector } from "@/pages/Appointments/components/PractitionerSelector";
 import { FacilityData } from "@/types/facility/facility";
 import {
   Appointment,
@@ -415,7 +417,11 @@ const AppointmentActions = ({
 }: AppointmentActionsProps) => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+
   const [isRescheduleOpen, setIsRescheduleOpen] = useState(false);
+  const [selectedPractitioner, setSelectedPractitioner] = useState(
+    appointment.user,
+  );
   const [selectedSlotId, setSelectedSlotId] = useState<string>();
 
   const currentStatus = appointment.status;
@@ -484,9 +490,18 @@ const AppointmentActions = ({
             </SheetHeader>
 
             <div className="mt-6">
+              <div className="my-4">
+                <Label className="mb-2">{t("select_practitioner")}</Label>
+                <PractitionerSelector
+                  facilityId={facilityId}
+                  selected={selectedPractitioner}
+                  onSelect={(user) => user && setSelectedPractitioner(user)}
+                  clearSelection={t("show_all")}
+                />
+              </div>
               <AppointmentSlotPicker
                 facilityId={facilityId}
-                resourceId={appointment.user?.id}
+                resourceId={selectedPractitioner?.id}
                 selectedSlotId={selectedSlotId}
                 onSlotSelect={setSelectedSlotId}
               />


### PR DESCRIPTION
## Required Backend Changes
- https://github.com/ohcnetwork/care/pull/3063

## Proposed Changes

- Fixes #12499

<img width="955" alt="image" src="https://github.com/user-attachments/assets/da4dde74-f593-4db0-a663-cb6792354b83" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to select a practitioner when rescheduling an appointment, allowing users to choose from available practitioners at the facility.
  - Users can now clear their practitioner selection to view all available slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->