### PR TITLE
fix: Disable cancel button during creation or update in Questionnaire

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -679,7 +679,11 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
             </Button>
           )}
           {!id && (
-            <Button variant="outline" onClick={() => setShowImportDialog(true)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowImportDialog(true)}
+              disabled={isCreating || isUpdating}
+            >
               <CareIcon icon="l-import" className="mr-1 size-4" />
               {t("import_from_url")}
             </Button>

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -663,6 +663,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
             type="button"
             variant="outline"
             onClick={handleCancel}
+            disabled={isCreating || isUpdating}
             data-cy="cancel-questionnaire-form"
           >
             {t("cancel")}


### PR DESCRIPTION
## Proposed Changes

https://github.com/user-attachments/assets/9a471a45-5ec5-441a-8e3b-25f3a3f039ab

- Fixes #12506

This pull request includes a minor update to the `QuestionnaireEditor` component. The change ensures that the "Cancel" button is disabled while a questionnaire is being created or updated, improving the user experience by preventing unintended actions.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "Cancel" button in the questionnaire editor is now disabled while saving or updating, preventing accidental actions during these processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->