### PR TITLE
fix : add proper password validation and focus behavior

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -88,8 +88,8 @@ export default function UserForm({
               t("username_not_valid"),
             ),
       password_setup_method: z.enum(["immediate", "email"]).optional(),
-      password: z.string().optional(),
-      c_password: z.string().optional(),
+      password: z.string().min(8, t("field_required")),
+      c_password: z.string().min(1, t("field_required")),
       first_name: z.string().min(1, t("field_required")),
       last_name: z.string().min(1, t("field_required")),
       email: isEditMode
@@ -643,7 +643,6 @@ export default function UserForm({
                           ]}
                         />
                       </div>
-
                       <div className={cn(isPasswordFieldFocused && "hidden")}>
                         <FormMessage />
                       </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12529 
- Added `min(8)` validation for `password` and `c_password` fields to trigger correct focus

- Made `password` fields required when `password_setup_method === "immediate"` and not in edit mode

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices

![Screenshot 2025-06-07 154541](https://github.com/user-attachments/assets/20f33640-5d17-4f87-8f76-68d0051cb6b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced stricter password validation in the user form, requiring passwords to have at least 8 characters and confirmation passwords to be provided.
- **Style**
  - Removed an unnecessary blank line in the password input section of the user form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->