### PR TITLE
Fix: Add missing React key props in Navigation Sidebar

### DIFF
--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight } from "lucide-react";
 import { ActiveLink } from "raviger";
 import { useState } from "react";
+import React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -45,13 +46,12 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
         {links
           .filter((link) => link.visibility !== false)
           .map((link) => (
-            <>
+            <React.Fragment key={link.name}>
               {link.children ? (
                 isCollapsed ? (
-                  <PopoverMenu key={link.name} link={link} />
+                  <PopoverMenu link={link} />
                 ) : (
                   <Collapsible
-                    key={link.name}
                     asChild
                     defaultOpen={isChildActive(link)}
                     className="group/collapsible"
@@ -135,7 +135,7 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               )}
-            </>
+            </React.Fragment>
           ))}
       </SidebarMenu>
     </SidebarGroup>


### PR DESCRIPTION
# Proposed Changes

- https://github.com/ohcnetwork/care_fe/issues/12542
## Screenshots

![Screenshot 2025-06-09 133819](https://github.com/user-attachments/assets/afeee682-859b-4ad7-b25a-1c8224d20ef3)
@ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [ ] Add specs that demonstrate bug / test a new feature
- [ ] Ensure that UI text is kept in I18n files
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices

## Summary by CodeRabbit
### Refactor
- Added React import to nav-main.tsx
- Replaced empty fragments with React.Fragment components
- Added unique key props to mapped elements using link.name
- Removed redundant key props from child components

### Bug Fixes
- Fixed React warning about missing key props in SidebarMenu
- Improved component reconciliation performance
- Follows React best practices for list rendering

## Technical Details
- File changed: `src/components/ui/sidebar/nav-main.tsx`
- Impact: Improves React's reconciliation process and removes console warnings
- Testing: Verified no key prop warnings in console after changes

## Testing Instructions
1. Navigate to organization page
2. Open browser developer console
3. Verify no key prop warnings are present
4. Test navigation functionality
5. Verify sidebar collapse/expand behavior
6. Check mobile responsiveness

## Related Issues
Closes #12542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved key assignment for navigation links to enhance React's rendering performance and reliability. No visible changes to the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->