### PR TITLE
Revert Generate Discharge Summary tab

### DIFF
--- a/.unimportedrc.json
+++ b/.unimportedrc.json
@@ -6,6 +6,7 @@
   "ignoreUnimported": [
     "src/Locale/update_locale.js",
     "src/PluginRegistry.ts",
+    "src/pages/Encounters/ReportBuilder/ReportBuilderSheet.tsx",
     "src/pluginTypes.ts",
     "src/service-worker.ts"
   ],

--- a/src/Utils/request/api.tsx
+++ b/src/Utils/request/api.tsx
@@ -457,6 +457,11 @@ const routes = {
       TRes: Type<Encounter>(),
       TBody: Type<{ organization: string }>(),
     },
+    generateDischargeSummary: {
+      path: "/api/v1/encounter/{encounterId}/generate_discharge_summary/",
+      method: "POST",
+      TRes: Type<{ detail: string }>(),
+    },
   },
 
   // New Patient Routes

--- a/src/components/Files/DischargeSummarySubTab.tsx
+++ b/src/components/Files/DischargeSummarySubTab.tsx
@@ -50,16 +50,18 @@ import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { HTTPError } from "@/Utils/request/types";
 import { formatName } from "@/Utils/utils";
+import { Encounter } from "@/types/emr/encounter";
 
 interface DischargeTabProps {
   type: "encounter" | "patient";
-  encounterId: string;
+  // facilityId: string;
+  encounter: Encounter;
   canEdit: boolean | undefined;
 }
 
 export const DischargeTab = ({
   type,
-  encounterId,
+  encounter,
   canEdit,
 }: DischargeTabProps) => {
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
@@ -77,7 +79,7 @@ export const DischargeTab = ({
   const { mutate: generateDischargeSummary, isPending: isGenerating } =
     useMutation<{ detail: string }, HTTPError>({
       mutationFn: mutate(routes.encounter.generateDischargeSummary, {
-        pathParams: { encounterId },
+        pathParams: { encounterId: encounter.id },
       }),
       onSuccess: (response) => {
         toast.success(response.detail);
@@ -85,16 +87,18 @@ export const DischargeTab = ({
       },
     });
 
+  // const queryClient = useQueryClient();
+
   const {
     data: files,
     isLoading: filesLoading,
     refetch,
   } = useQuery({
-    queryKey: ["discharge_files", encounterId, qParams],
+    queryKey: ["discharge_files", encounter.id, qParams],
     queryFn: query.debounced(routes.viewUpload, {
       queryParams: {
         file_type: type,
-        associating_id: encounterId,
+        associating_id: encounter.id,
         name: qParams.name,
         file_category: "discharge_summary",
         limit: qParams.limit,
@@ -117,7 +121,7 @@ export const DischargeTab = ({
         .reverse()
         .map((file) => ({
           ...file,
-          associating_id: encounterId,
+          associating_id: encounter.id,
         })) || [],
   });
 
@@ -206,7 +210,7 @@ export const DischargeTab = ({
           {fileManager.isPreviewable(file) && (
             <Button
               variant="secondary"
-              onClick={() => fileManager.viewFile(file, encounterId)}
+              onClick={() => fileManager.viewFile(file, encounter.id)}
             >
               <span className="flex flex-row items-center gap-1">
                 <CareIcon icon="l-eye" />
@@ -224,7 +228,7 @@ export const DischargeTab = ({
               <DropdownMenuItem asChild className="text-primary-900">
                 <Button
                   size="sm"
-                  onClick={() => fileManager.downloadFile(file, encounterId)}
+                  onClick={() => fileManager.downloadFile(file, encounter.id)}
                   variant="ghost"
                   className="w-full flex flex-row justify-stretch items-center"
                 >
@@ -237,7 +241,9 @@ export const DischargeTab = ({
                   <DropdownMenuItem asChild className="text-primary-900">
                     <Button
                       size="sm"
-                      onClick={() => fileManager.archiveFile(file, encounterId)}
+                      onClick={() =>
+                        fileManager.archiveFile(file, encounter.id)
+                      }
                       variant="ghost"
                       className="w-full flex flex-row justify-stretch items-center"
                     >
@@ -248,7 +254,7 @@ export const DischargeTab = ({
                   <DropdownMenuItem asChild className="text-primary-900">
                     <Button
                       size="sm"
-                      onClick={() => fileManager.editFile(file, encounterId)}
+                      onClick={() => fileManager.editFile(file, encounter.id)}
                       variant="ghost"
                       className="w-full flex flex-row justify-stretch items-center"
                     >
@@ -576,7 +582,7 @@ export const DischargeTab = ({
           }}
           file={selectedAudioFile || null}
           type={type}
-          associatingId={encounterId}
+          associatingId={encounter.id}
         />
       </div>
       <ArchivedFileDialog
@@ -588,7 +594,7 @@ export const DischargeTab = ({
         open={openUploadDialog}
         onOpenChange={setOpenUploadDialog}
         fileUpload={fileUpload}
-        associatingId={encounterId}
+        associatingId={encounter.id}
         type={type}
       />
       <div className="flex flex-wrap items-center gap-2 -mt-2">

--- a/src/components/Files/DischargeSummarySubTab.tsx
+++ b/src/components/Files/DischargeSummarySubTab.tsx
@@ -48,7 +48,6 @@ import {
 import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
-import { HTTPError } from "@/Utils/request/types";
 import { formatName } from "@/Utils/utils";
 import { Encounter } from "@/types/emr/encounter";
 
@@ -77,7 +76,7 @@ export const DischargeTab = ({
   });
 
   const { mutate: generateDischargeSummary, isPending: isGenerating } =
-    useMutation<{ detail: string }, HTTPError>({
+    useMutation<{ detail: string }>({
       mutationFn: mutate(routes.encounter.generateDischargeSummary, {
         pathParams: { encounterId: encounter.id },
       }),
@@ -86,8 +85,6 @@ export const DischargeTab = ({
         refetch();
       },
     });
-
-  // const queryClient = useQueryClient();
 
   const {
     data: files,

--- a/src/components/Files/DischargeSummarySubTab.tsx
+++ b/src/components/Files/DischargeSummarySubTab.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { t } from "i18next";
 import { SearchIcon } from "lucide-react";
@@ -46,22 +46,20 @@ import {
 } from "@/common/constants";
 
 import routes from "@/Utils/request/api";
+import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { HTTPError } from "@/Utils/request/types";
 import { formatName } from "@/Utils/utils";
-import ReportBuilderSheet from "@/pages/Encounters/ReportBuilder/ReportBuilderSheet";
-import { Encounter } from "@/types/emr/encounter";
 
 interface DischargeTabProps {
   type: "encounter" | "patient";
-  facilityId: string;
-  encounter: Encounter;
+  encounterId: string;
   canEdit: boolean | undefined;
 }
 
 export const DischargeTab = ({
   type,
-  facilityId,
-  encounter,
+  encounterId,
   canEdit,
 }: DischargeTabProps) => {
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
@@ -76,16 +74,27 @@ export const DischargeTab = ({
     limit: 15,
   });
 
+  const { mutate: generateDischargeSummary, isPending: isGenerating } =
+    useMutation<{ detail: string }, HTTPError>({
+      mutationFn: mutate(routes.encounter.generateDischargeSummary, {
+        pathParams: { encounterId },
+      }),
+      onSuccess: (response) => {
+        toast.success(response.detail);
+        refetch();
+      },
+    });
+
   const {
     data: files,
     isLoading: filesLoading,
     refetch,
   } = useQuery({
-    queryKey: ["discharge_files", encounter.id, qParams],
+    queryKey: ["discharge_files", encounterId, qParams],
     queryFn: query.debounced(routes.viewUpload, {
       queryParams: {
         file_type: type,
-        associating_id: encounter.id,
+        associating_id: encounterId,
         name: qParams.name,
         file_category: "discharge_summary",
         limit: qParams.limit,
@@ -108,7 +117,7 @@ export const DischargeTab = ({
         .reverse()
         .map((file) => ({
           ...file,
-          associating_id: encounter.id,
+          associating_id: encounterId,
         })) || [],
   });
 
@@ -197,7 +206,7 @@ export const DischargeTab = ({
           {fileManager.isPreviewable(file) && (
             <Button
               variant="secondary"
-              onClick={() => fileManager.viewFile(file, encounter.id)}
+              onClick={() => fileManager.viewFile(file, encounterId)}
             >
               <span className="flex flex-row items-center gap-1">
                 <CareIcon icon="l-eye" />
@@ -215,7 +224,7 @@ export const DischargeTab = ({
               <DropdownMenuItem asChild className="text-primary-900">
                 <Button
                   size="sm"
-                  onClick={() => fileManager.downloadFile(file, encounter.id)}
+                  onClick={() => fileManager.downloadFile(file, encounterId)}
                   variant="ghost"
                   className="w-full flex flex-row justify-stretch items-center"
                 >
@@ -228,9 +237,7 @@ export const DischargeTab = ({
                   <DropdownMenuItem asChild className="text-primary-900">
                     <Button
                       size="sm"
-                      onClick={() =>
-                        fileManager.archiveFile(file, encounter.id)
-                      }
+                      onClick={() => fileManager.archiveFile(file, encounterId)}
                       variant="ghost"
                       className="w-full flex flex-row justify-stretch items-center"
                     >
@@ -241,7 +248,7 @@ export const DischargeTab = ({
                   <DropdownMenuItem asChild className="text-primary-900">
                     <Button
                       size="sm"
-                      onClick={() => fileManager.editFile(file, encounter.id)}
+                      onClick={() => fileManager.editFile(file, encounterId)}
                       variant="ghost"
                       className="w-full flex flex-row justify-stretch items-center"
                     >
@@ -569,7 +576,7 @@ export const DischargeTab = ({
           }}
           file={selectedAudioFile || null}
           type={type}
-          associatingId={encounter.id}
+          associatingId={encounterId}
         />
       </div>
       <ArchivedFileDialog
@@ -581,7 +588,7 @@ export const DischargeTab = ({
         open={openUploadDialog}
         onOpenChange={setOpenUploadDialog}
         fileUpload={fileUpload}
-        associatingId={encounter.id}
+        associatingId={encounterId}
         type={type}
       />
       <div className="flex flex-wrap items-center gap-2 -mt-2">
@@ -616,7 +623,16 @@ export const DischargeTab = ({
             <CareIcon icon="l-sync" className="mr-2" />
             {t("refresh")}
           </Button>
-          <ReportBuilderSheet
+          <Button
+            variant="primary"
+            className="min-w-24 sm:min-w-28"
+            onClick={() => generateDischargeSummary()}
+            disabled={isGenerating}
+          >
+            <CareIcon icon="l-file-medical" className="hidden sm:block mr-2" />
+            {isGenerating ? t("generating") : t("generate_discharge_summary")}
+          </Button>
+          {/* <ReportBuilderSheet
             facilityId={facilityId || ""}
             patientId={encounter?.patient.id || ""}
             encounterId={encounter?.id || ""}
@@ -642,7 +658,7 @@ export const DischargeTab = ({
                 queryKey: ["files"],
               });
             }}
-          />
+          /> */}
         </div>
 
         <div className="w-full sm:w-auto ml-auto">

--- a/src/components/Files/FileSubTab.tsx
+++ b/src/components/Files/FileSubTab.tsx
@@ -78,6 +78,7 @@ export const FilesPage = ({
   const { qParams, updateQuery, Pagination } = useFilters({
     limit: 15,
   });
+  // const queryClient = useQueryClient();
   const { canViewClinicalData } = getPermissions(
     hasPermission,
     patient?.permissions ?? [],

--- a/src/components/Files/FileSubTab.tsx
+++ b/src/components/Files/FileSubTab.tsx
@@ -1,9 +1,8 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { t } from "i18next";
 import { SearchIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 
@@ -50,7 +49,6 @@ import routes from "@/Utils/request/api";
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
 import { usePermissions } from "@/context/PermissionContext";
-import ReportBuilderSheet from "@/pages/Encounters/ReportBuilder/ReportBuilderSheet";
 import { Encounter } from "@/types/emr/encounter";
 import { Patient } from "@/types/emr/patient";
 
@@ -60,7 +58,6 @@ interface FilesTabProps {
   patient?: Patient;
   associatingId: string;
   canEdit: boolean | undefined;
-  facilityId: string;
 }
 
 export const FilesPage = ({
@@ -69,7 +66,6 @@ export const FilesPage = ({
   patient,
   encounter,
   canEdit,
-  facilityId,
 }: FilesTabProps) => {
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
   const [openArchivedFileDialog, setOpenArchivedFileDialog] = useState(false);
@@ -94,7 +90,6 @@ export const FilesPage = ({
     type === "encounter"
       ? canViewClinicalData || canViewEncounter
       : canViewClinicalData;
-  const queryClient = useQueryClient();
 
   const {
     data: files,
@@ -636,7 +631,7 @@ export const FilesPage = ({
 
         <div className="flex items-center gap-2">
           <FilterButton />
-          {type === "encounter" && (
+          {/* {type === "encounter" && (
             <>
               <Button
                 variant="outline_primary"
@@ -682,7 +677,7 @@ export const FilesPage = ({
                 }}
               />
             </>
-          )}
+          )} */}
         </div>
 
         <div className="ml-auto">

--- a/src/components/Files/FilesTab.tsx
+++ b/src/components/Files/FilesTab.tsx
@@ -74,7 +74,7 @@ export const FilesTab = (props: FilesTabsProps) => {
           >
             {t("files")}
           </TabsTrigger>
-          {type === "encounter" && (
+          {type === "encounter" && encounter && (
             <TabsTrigger
               value="discharge_summary"
               className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
@@ -100,13 +100,9 @@ export const FilesTab = (props: FilesTabsProps) => {
           />
         </TabsContent>
 
-        {type === "encounter" && (
+        {type === "encounter" && encounter && (
           <TabsContent value="discharge_summary">
-            <DischargeTab
-              type={type}
-              encounterId={encounter?.id || ""}
-              canEdit={canEdit}
-            />
+            <DischargeTab type={type} encounter={encounter} canEdit={canEdit} />
           </TabsContent>
         )}
 

--- a/src/components/Files/FilesTab.tsx
+++ b/src/components/Files/FilesTab.tsx
@@ -28,7 +28,7 @@ const allowedTabs = ["all", "discharge_summary", "drawings"] as const;
 type TabType = (typeof allowedTabs)[number];
 
 export const FilesTab = (props: FilesTabsProps) => {
-  const { patient, type, encounter, facilityId } = props;
+  const { patient, type, encounter } = props;
   const [qParams, setQParams] = useQueryParams<QueryParams>();
 
   const { hasPermission } = usePermissions();
@@ -74,7 +74,7 @@ export const FilesTab = (props: FilesTabsProps) => {
           >
             {t("files")}
           </TabsTrigger>
-          {type === "encounter" && encounter && (
+          {type === "encounter" && (
             <TabsTrigger
               value="discharge_summary"
               className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
@@ -97,16 +97,14 @@ export const FilesTab = (props: FilesTabsProps) => {
             patient={patient}
             associatingId={associatingId}
             canEdit={canEdit}
-            facilityId={facilityId || ""}
           />
         </TabsContent>
 
-        {type === "encounter" && encounter && (
+        {type === "encounter" && (
           <TabsContent value="discharge_summary">
             <DischargeTab
               type={type}
-              facilityId={facilityId || ""}
-              encounter={encounter}
+              encounterId={encounter?.id || ""}
               canEdit={canEdit}
             />
           </TabsContent>

--- a/src/components/Files/FilesTab.tsx
+++ b/src/components/Files/FilesTab.tsx
@@ -102,7 +102,12 @@ export const FilesTab = (props: FilesTabsProps) => {
 
         {type === "encounter" && encounter && (
           <TabsContent value="discharge_summary">
-            <DischargeTab type={type} encounter={encounter} canEdit={canEdit} />
+            <DischargeTab
+              type={type}
+              encounter={encounter}
+              canEdit={canEdit}
+              // facilityId={facilityId || ""}
+            />
           </TabsContent>
         )}
 


### PR DESCRIPTION
## Proposed Changes

- Reverting discharge button (older fn; hiding button for report builder) for prod release

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a button to generate a discharge summary for an encounter, with real-time feedback and automatic file list refresh upon completion.

- **Refactor**
  - Removed unused facility ID props from file management components.
  - Disabled legacy report generation UI and related refresh buttons in file tabs.

- **Style**
  - Updated button states to indicate progress during discharge summary generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->