### PR TITLE
fix: resolves validation errors shown after clicking fill my details in resource request form

### DIFF
--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -207,13 +207,19 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
     form.setValue(
       "referring_facility_contact_name",
       `${authUser.first_name} ${authUser.last_name}`.trim(),
-      { shouldDirty: true },
+      {
+        shouldDirty: true,
+        shouldValidate: true,
+      },
     );
     if (authUser.phone_number) {
       form.setValue(
         "referring_facility_contact_number",
         authUser.phone_number,
-        { shouldDirty: true },
+        {
+          shouldDirty: true,
+          shouldValidate: true,
+        },
       );
     }
   };
@@ -290,6 +296,7 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                           if (facility) {
                             form.setValue("assigned_facility", facility, {
                               shouldDirty: true,
+                              shouldValidate: true,
                             });
                           } else {
                             form.resetField("assigned_facility");


### PR DESCRIPTION
## Proposed Changes

- Fixes #12518 
- Added `shouldValidate: true` to validate the inputs

@ohcnetwork/care-fe-code-reviewers

Demo:
[Screencast from 2025-06-09 18-24-52.webm](https://github.com/user-attachments/assets/c72d24f5-ced8-421e-915f-017a189159e2)
## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form validation to trigger immediately when certain fields are updated automatically in the resource form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->