### PR TITLE
Fix: Hide the zone and milli seconds in the time date component of questionnaire

### DIFF
--- a/src/components/Facility/ConsultationDetails/PrintQuestionnaireQuestionnaireResponses.tsx
+++ b/src/components/Facility/ConsultationDetails/PrintQuestionnaireQuestionnaireResponses.tsx
@@ -207,7 +207,9 @@ function formatValue(value: ResponseValue["value"], type: string): string {
 
   switch (type) {
     case "dateTime":
-      return formatDateTime(value as string);
+      return formatDateTime(value as string, "hh:mm A; DD/MM/YYYY");
+    case "date":
+      return formatDateTime(value as string, "DD/MM/YYYY");
     case "choice":
       return properCase(value.toString());
     case "decimal":

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -57,15 +57,17 @@ export function formatValue(
   switch (type) {
     case "dateTime":
       return value instanceof Date
-        ? formatDateTime(value.toISOString())
-        : formatDateTime(value.toString());
+        ? formatDateTime(value.toISOString(), "hh:mm A; DD/MM/YYYY")
+        : formatDateTime(value.toString(), "hh:mm A; DD/MM/YYYY");
+    case "date":
+      return formatDateTime(value.toString());
     case "choice":
       return properCase(value.toString());
     case "decimal":
     case "integer":
-      return typeof value === "number" ? value.toString() : value.toString();
+      return value.toString();
     case "boolean":
-      return value === "true" ? t("yes") : t("no");
+      return value === true || value === "true" ? t("yes") : t("no");
     case "time":
       return value.toString().slice(0, 5);
     default:

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -66,9 +66,9 @@ export function formatValue(
       return properCase(value.toString());
     case "decimal":
     case "integer":
-      return value.toString();
+      return typeof value === "number" ? value.toString() : value.toString();
     case "boolean":
-      return value === true || value === "true" ? t("yes") : t("no");
+      return value === "true" ? t("yes") : t("no");
     case "time":
       return value.toString().slice(0, 5);
     default:

--- a/src/components/Questionnaire/QuestionTypes/DateQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DateQuestion.tsx
@@ -38,7 +38,7 @@ export function DateQuestion({
     clearError();
     const newValues = [...questionnaireResponse.values];
     newValues[index] = {
-      type: "dateTime",
+      type: "date",
       value: date,
     };
 

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -18,6 +18,7 @@ import { PLUGIN_Component } from "@/PluginEngine";
 import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { dateQueryString } from "@/Utils/utils";
 import { MedicationRequest } from "@/types/emr/medicationRequest";
 import { MedicationStatementRequest } from "@/types/emr/medicationStatement";
 import { FileUploadQuestion } from "@/types/files/files";
@@ -664,7 +665,7 @@ export function QuestionnaireForm({
                   if (isNaN(date.getTime())) {
                     return { ...value, value: "" };
                   }
-                  const formattedDate = date.toISOString().split("T")[0];
+                  const formattedDate = dateQueryString(date);
                   return {
                     ...value,
                     value: formattedDate,

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -659,16 +659,20 @@ export function QuestionnaireForm({
             results: validResponses.map((response) => ({
               question_id: response.question_id,
               values: response.values.map((value) => {
-                if (value.type === "dateTime" && value.value) {
+                if (value.type === "date" && value.value) {
                   const date = new Date(value.value);
                   if (isNaN(date.getTime())) {
                     return { ...value, value: "" };
                   }
                   const formattedDate = date.toISOString().split("T")[0];
-                  console.log(formattedDate);
                   return {
                     ...value,
                     value: formattedDate,
+                  };
+                } else if (value.type === "dateTime" && value.value) {
+                  return {
+                    ...value,
+                    value: value.value.toISOString(),
                   };
                 }
                 if (value.unit) {

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -660,9 +660,14 @@ export function QuestionnaireForm({
               question_id: response.question_id,
               values: response.values.map((value) => {
                 if (value.type === "dateTime" && value.value) {
+                  const date = new Date(value.value);
+                  if (isNaN(date.getTime())) {
+                    return { value: "" };
+                  }
+                  const formattedDate = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
                   return {
                     ...value,
-                    value: value.value.toISOString(),
+                    value: formattedDate,
                   };
                 }
                 if (value.unit) {

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -662,9 +662,10 @@ export function QuestionnaireForm({
                 if (value.type === "dateTime" && value.value) {
                   const date = new Date(value.value);
                   if (isNaN(date.getTime())) {
-                    return { value: "" };
+                    return { ...value, value: "" };
                   }
-                  const formattedDate = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+                  const formattedDate = date.toISOString().split("T")[0];
+                  console.log(formattedDate);
                   return {
                     ...value,
                     value: formattedDate,

--- a/src/types/questionnaire/form.ts
+++ b/src/types/questionnaire/form.ts
@@ -25,6 +25,7 @@ export type ResponseValue =
   | RV<"number", number | undefined>
   | RV<"boolean", boolean | undefined>
   | RV<"dateTime", Date | undefined>
+  | RV<"date", Date | undefined>
   | RV<"quantity", number | undefined>
   | RV<"allergy_intolerance", AllergyIntoleranceRequest[]>
   | RV<"medication_request", MedicationRequest[]>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12565

This pull request refines the `formatValue` function in `src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx` to improve date formatting, simplify numeric value handling, and enhance boolean value interpretation.

### Improvements to date formatting:
* Updated the `dateTime` case to include a specific format (`"hh:mm A; DD/MM/YYYY"`) for better readability.
* Added a new `date` case to handle date values separately using `formatDateTime`.

### Simplification of numeric value handling:
* Removed redundant type checks for `decimal` and `integer` cases, simplifying the logic to directly convert values to strings.

### Enhanced boolean value interpretation:
* Adjusted the `boolean` case to correctly interpret both `true` (boolean) and `"true"` (string) as `t("yes")`.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved formatting of questionnaire response values, including enhanced handling of date and date-time types for clearer and more consistent display.
	- Enhanced validation and serialization of date and date-time responses during questionnaire submission to ensure accurate and simplified date formatting.
- **New Features**
	- Added support for a distinct "date" response type in questionnaires, enabling users to submit and view date-only values separately from date-time entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->