### PR TITLE
Fix : Previous Thread Title Persists in New Discussion Dialog

### DIFF
--- a/src/pages/Encounters/tabs/EncounterNotesTab.tsx
+++ b/src/pages/Encounters/tabs/EncounterNotesTab.tsx
@@ -215,6 +215,9 @@ const NewThreadDialog = ({
 }) => {
   const { t } = useTranslation();
   const [title, setTitle] = useState("");
+  useEffect(() => {
+    if (isOpen) setTitle("");
+  }, [isOpen]);
 
   return (
     <Dialog

--- a/src/pages/Encounters/tabs/EncounterNotesTab.tsx
+++ b/src/pages/Encounters/tabs/EncounterNotesTab.tsx
@@ -216,7 +216,9 @@ const NewThreadDialog = ({
   const { t } = useTranslation();
   const [title, setTitle] = useState("");
   useEffect(() => {
-    if (isOpen) setTitle("");
+    if (isOpen) {
+      setTitle("");
+    }
   }, [isOpen]);
 
   return (


### PR DESCRIPTION
## Proposed Changes

- Fixes #12579
- used useEffect  that resets the title state whenever the dialog is opened.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.

https://github.com/user-attachments/assets/5d977a36-c1e0-4461-9bd2-fc19a3b43250

- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The new thread title field in the dialog now resets each time the dialog is opened, ensuring a blank input for every new thread creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->