### PR TITLE
Tab Bar Hover Shows Default Arrow

### DIFF
--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -356,11 +356,20 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
             className="w-full"
           >
             <TabsList className="w-full">
-              {structuredTypes.map(({ type }) => (
-                <TabsTrigger key={type} value={type} className="flex-1">
-                  {type}
-                </TabsTrigger>
-              ))}
+              {structuredTypes.map(({ type }) =>
+                structuredTypes.length > 1 ? (
+                  <TabsTrigger key={type} value={type} className="flex-1">
+                    {type}
+                  </TabsTrigger>
+                ) : (
+                  <div
+                    key={type}
+                    className="flex-1 cursor-default text-center py-1 text-sm text-black bg-white border border-gray-200 rounded-md"
+                  >
+                    {type}
+                  </div>
+                ),
+              )}
             </TabsList>
           </Tabs>
         </div>

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -369,7 +369,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
               {structuredTypes.map(({ type }) => (
                 <div
                   key={type}
-                  className="flex-1 cursor-default text-center py-1 text-sm text-black bg-white border border-gray-200 rounded-md shadow-sm"
+                  className="flex-1 font-semibold text-center py-1 text-md"
                 >
                   {type}
                 </div>

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -350,28 +350,32 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
           <SheetHeader className="p-0">
             <SheetTitle className="text-lg font-medium">{title}</SheetTitle>
           </SheetHeader>
-          <Tabs
-            value={activeType}
-            onValueChange={handleTabChange}
-            className="w-full"
-          >
-            <TabsList className="w-full">
-              {structuredTypes.map(({ type }) =>
-                structuredTypes.length > 1 ? (
+          {structuredTypes.length > 1 ? (
+            <Tabs
+              value={activeType}
+              onValueChange={handleTabChange}
+              className="w-full"
+            >
+              <TabsList className="w-full">
+                {structuredTypes.map(({ type }) => (
                   <TabsTrigger key={type} value={type} className="flex-1">
                     {type}
                   </TabsTrigger>
-                ) : (
-                  <div
-                    key={type}
-                    className="flex-1 cursor-default text-center py-1 text-sm text-black bg-white border border-gray-200 rounded-md"
-                  >
-                    {type}
-                  </div>
-                ),
-              )}
-            </TabsList>
-          </Tabs>
+                ))}
+              </TabsList>
+            </Tabs>
+          ) : (
+            <div className="w-full">
+              {structuredTypes.map(({ type }) => (
+                <div
+                  key={type}
+                  className="flex-1 cursor-default text-center py-1 text-sm text-black bg-white border border-gray-200 rounded-md shadow-sm"
+                >
+                  {type}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="space-y-0">

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -140,8 +140,8 @@ function useRecordSelection<T extends BaseRecord>(
 export function HistoricalRecordSelector<T extends BaseRecord>({
   structuredTypes,
   onAddSelected,
-  buttonLabel = "View History",
-  title = "History",
+  buttonLabel,
+  title,
 }: HistoricalRecordSelectorProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeType, setActiveType] = useState<string>(
@@ -342,14 +342,16 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
           className="border-gray-400 flex ml-auto"
         >
           <Clock className="size-4" />
-          <span className="font-semibold">{buttonLabel}</span>
+          <span className="font-semibold">
+            {buttonLabel || t("view_history")}
+          </span>
         </Button>
       </SheetTrigger>
       <SheetContent className="w-full sm:max-w-3xl p-0 overflow-y-auto">
         <div className="flex flex-col gap-2 p-2">
           <SheetHeader className="p-0">
             <SheetTitle className="text-lg font-medium text-center">
-              {title}
+              {title || t("history")}
             </SheetTitle>
           </SheetHeader>
           {structuredTypes.length > 1 && (

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -348,9 +348,11 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
       <SheetContent className="w-full sm:max-w-3xl p-0 overflow-y-auto">
         <div className="flex flex-col gap-2 p-2">
           <SheetHeader className="p-0">
-            <SheetTitle className="text-lg font-medium">{title}</SheetTitle>
+            <SheetTitle className="text-lg font-medium text-center">
+              {title}
+            </SheetTitle>
           </SheetHeader>
-          {structuredTypes.length > 1 ? (
+          {structuredTypes.length > 1 && (
             <Tabs
               value={activeType}
               onValueChange={handleTabChange}
@@ -364,17 +366,6 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
                 ))}
               </TabsList>
             </Tabs>
-          ) : (
-            <div className="w-full">
-              {structuredTypes.map(({ type }) => (
-                <div
-                  key={type}
-                  className="flex-1 font-semibold text-center py-1 text-md"
-                >
-                  {type}
-                </div>
-              ))}
-            </div>
           )}
         </div>
 

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -504,6 +504,7 @@ export function DiagnosisQuestion({
   return (
     <div className="space-y-4">
       <HistoricalRecordSelector<DiagnosisRequest>
+        title={t("diagnosis_history")}
         structuredTypes={[
           {
             type: t("diagnoses"),

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -402,6 +402,7 @@ export function MedicationRequestQuestion({
         </AlertDialogContent>
       </AlertDialog>
       <HistoricalRecordSelector<MedicationRequestRead | MedicationStatementRead>
+        title={t("medication_history")}
         structuredTypes={[
           {
             type: t("past_prescriptions"),

--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -323,6 +323,7 @@ export function MedicationStatementQuestion({
       </AlertDialog>
 
       <HistoricalRecordSelector<MedicationRequestRead | MedicationStatementRead>
+        title={t("medication_history")}
         structuredTypes={[
           {
             type: t("past_prescriptions"),

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -805,6 +805,7 @@ export function SymptomQuestion({
   return (
     <div className="space-y-2">
       <HistoricalRecordSelector<SymptomRequest>
+        title={t("symptom_history")}
         structuredTypes={[
           {
             type: t("symptoms"),


### PR DESCRIPTION
## Proposed Changes

- Fixes #12562 
- Hide tab for structuredTypes's length equals 1.
- Implemented new div for 1 tab

- Demo video : 

https://github.com/user-attachments/assets/30d0c5a2-843a-4ebe-ab2a-5afc0d8d46b3



@ohcnetwork/care-fe-code-reviewers @rithviknishad 

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the tab interface in the historical record selector: when only one tab is available, it now appears as a centered, non-interactive label instead of a clickable tab.
  - Added descriptive, localized titles to the historical record selector for diagnosis, medication, and symptom history sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->