### PR TITLE
Fixes #12585; Improve Questionnaire Visualisation - Stick to single column layout if content has long values to prevent excess whitespace

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -116,11 +116,29 @@ function QuestionGroup({
       return acc;
     }, []) || [];
 
-  const midPoint = isSingleGroup
+  // Check if any response has long text (>100 chars)
+  const hasLongText = questionsWithResponses.some((question) => {
+    const response = responses.find((r) => r.question_id === question.id);
+    if (!response) return false;
+
+    const value = response.values[0]?.value;
+    const coding = response.values[0]?.coding;
+    const text = [
+      value?.toString() || "",
+      coding?.display || "",
+      coding?.code || "",
+    ].join(" ");
+
+    return text.length > 50;
+  });
+
+  // Use single column if any response has long text
+  const shouldUseTwoColumns = isSingleGroup && !hasLongText;
+  const midPoint = shouldUseTwoColumns
     ? Math.ceil(questionsWithResponses.length / 2)
     : questionsWithResponses.length;
   const leftQuestions = questionsWithResponses.slice(0, midPoint);
-  const rightQuestions = isSingleGroup
+  const rightQuestions = shouldUseTwoColumns
     ? questionsWithResponses.slice(midPoint)
     : [];
 
@@ -161,7 +179,7 @@ function QuestionGroup({
       </h3>
       <div
         className={cn("w-full", {
-          "grid md:grid-cols-2 grid-cols-1 gap-8": isSingleGroup,
+          "grid md:grid-cols-2 grid-cols-1 gap-8": shouldUseTwoColumns,
         })}
       >
         {leftQuestions.length > 0 && (
@@ -172,7 +190,7 @@ function QuestionGroup({
           </div>
         )}
 
-        {isSingleGroup && rightQuestions.length > 0 && (
+        {shouldUseTwoColumns && rightQuestions.length > 0 && (
           <div className="w-full">
             <Table className="table-fixed w-full">
               <TableBody>{rightQuestions.map(renderQuestionRow)}</TableBody>


### PR DESCRIPTION


## Proposed Changes

- Fixes #12585

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/ee0dac96-8b22-4da9-b32d-11edff3d8d87" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the display of questionnaire responses by automatically switching to a single-column layout when any response text is long, ensuring better readability. Two-column layout is now only used when all response texts are short.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->