### PR TITLE
move form related states to form schema

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -83,8 +83,6 @@ export default function PatientRegistration(
 
   const [suppressDuplicateWarning, setSuppressDuplicateWarning] =
     useState(!!patientId);
-  const [selectedLevels, setSelectedLevels] = useState<Organization[]>([]);
-  const [isDeceased, setIsDeceased] = useState(false);
 
   const formSchema = useMemo(
     () =>
@@ -129,6 +127,8 @@ export default function PatientRegistration(
             .string()
             .uuid({ message: t("geo_organization_is_required") })
             .optional(),
+          _selected_levels: z.array(z.custom<Organization>()),
+          _is_deceased: z.boolean(),
         })
         .refine(
           (data) => (data.age_or_dob === "dob" ? !!data.date_of_birth : true),
@@ -186,6 +186,8 @@ export default function PatientRegistration(
       age_or_dob: "dob",
       same_phone_number: false,
       same_address: true,
+      _selected_levels: [],
+      _is_deceased: false,
     },
     mode: "onSubmit",
   });
@@ -305,11 +307,11 @@ export default function PatientRegistration(
 
   useEffect(() => {
     if (patientQuery.data) {
-      setSelectedLevels([
-        patientQuery.data.geo_organization as unknown as Organization,
-      ]);
-      setIsDeceased(!!patientQuery.data.deceased_datetime);
       form.reset({
+        _selected_levels: [
+          patientQuery.data.geo_organization as unknown as Organization,
+        ],
+        _is_deceased: !!patientQuery.data.deceased_datetime,
         name: patientQuery.data.name || "",
         phone_number: patientQuery.data.phone_number || "",
         emergency_phone_number: patientQuery.data.emergency_phone_number || "",
@@ -664,9 +666,9 @@ export default function PatientRegistration(
                   <div className="flex items-center gap-2">
                     <Checkbox
                       id="is-deceased"
-                      checked={isDeceased}
+                      checked={form.watch("_is_deceased")}
                       onCheckedChange={(checked) => {
-                        setIsDeceased(checked as boolean);
+                        form.setValue("_is_deceased", checked as boolean);
                         form.setValue(
                           "deceased_datetime",
                           checked ? form.getValues("deceased_datetime") : "",
@@ -683,7 +685,8 @@ export default function PatientRegistration(
                   </div>
                 </div>
 
-                {(isDeceased || form.watch("deceased_datetime")) && (
+                {(form.watch("_is_deceased") ||
+                  form.watch("deceased_datetime")) && (
                   <div className="mt-4">
                     <div className="flex items-center gap-2 mb-4 text-gray-500">
                       <InfoIcon className="size-4" />
@@ -705,7 +708,7 @@ export default function PatientRegistration(
                               value={field.value ?? ""}
                               onDateChange={(val) => {
                                 field.onChange(val);
-                                setIsDeceased(!!val);
+                                form.setValue("_is_deceased", !!val);
                               }}
                               max={format(new Date(), "yyyy-MM-dd'T'HH:mm")}
                             />
@@ -853,7 +856,7 @@ export default function PatientRegistration(
                           <GovtOrganizationSelector
                             {...field}
                             required={true}
-                            selected={selectedLevels}
+                            selected={form.watch("_selected_levels")}
                             value={form.watch("geo_organization")}
                             onChange={(value) =>
                               form.setValue("geo_organization", value, {


### PR DESCRIPTION
## Proposed Changes

- move form related states to form schema
- this is needed because, plugs can't directly control the states defined inside the component, but form is passed to plugs, this way plugs can access or change these values

eg usecase: abdm plug wants to auto fill state and district after abha generation

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved form consistency by managing organization levels and deceased status directly within the form state, streamlining user interactions and ensuring more reliable form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->