### PR TITLE
Fixes booked by not being shown in appointment details page if booked by patient

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -392,9 +392,11 @@ const AppointmentDetails = ({
       </Card>
 
       <div className="text-sm text-gray-600">
-        {t("booked_by")} {appointment.booked_by?.first_name}{" "}
-        {appointment.booked_by?.last_name} {t("on")}{" "}
-        {format(appointment.booked_on, "MMMM d, yyyy 'at' h:mm a")}
+        {t("booked_by")}{" "}
+        {appointment.booked_by
+          ? `${appointment.booked_by.first_name} ${appointment.booked_by.last_name}`
+          : appointment.patient.name}{" "}
+        {t("on")} {format(appointment.booked_on, "MMMM d, yyyy 'at' h:mm a")}
       </div>
     </div>
   );

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -394,8 +394,8 @@ const AppointmentDetails = ({
       <div className="text-sm text-gray-600">
         {t("booked_by")}{" "}
         {appointment.booked_by
-          ? `${appointment.booked_by.first_name} ${appointment.booked_by.last_name}`
-          : appointment.patient.name}{" "}
+          ? formatName(appointment.booked_by)
+          : `${appointment.patient.name} (${t("patient")})`}{" "}
         {t("on")} {format(appointment.booked_on, "MMMM d, yyyy 'at' h:mm a")}
       </div>
     </div>


### PR DESCRIPTION
## Proposed Changes

- Fixes bug - patient name in appointments card
- updated the code to conditionally show the patient's name if appointment.booked_by is null

![image](https://github.com/user-attachments/assets/807dea4a-acdd-40f8-861f-fc402c48d71e)


@ohcnetwork/care-fe-code-reviewers @rithviknishad 

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display logic for appointment booking details to correctly show the name of the person who booked the appointment or the patient's name when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->