### PR TITLE
FIXED: "Unable to preventDefault inside passive event listener" warning for image preview drag

### DIFF
--- a/src/components/Common/FilePreviewDialog.tsx
+++ b/src/components/Common/FilePreviewDialog.tsx
@@ -5,6 +5,7 @@ import {
   Suspense,
   lazy,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -124,6 +125,7 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
   const [index, setIndex] = useState<number>(currentIndex);
   const [scale, setScale] = useState(0.75);
   const [dragState, setDragState] = useState<DragState>(initialDragState);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (uploadedFiles && show) {
@@ -134,6 +136,23 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
   useEffect(() => {
     setDragState(initialDragState);
   }, [index, show]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    // Attach touchmove with passive: false
+    const handler = (e: TouchEvent) => {
+      // Only call the React handler if dragging
+      if (dragState.isDragging) {
+        // @ts-expect-error: React handler expects React.TouchEvent, but this is native
+        handleTouchMove(e);
+      }
+    };
+    container.addEventListener("touchmove", handler, { passive: false });
+    return () => {
+      container.removeEventListener("touchmove", handler);
+    };
+  }, [dragState.isDragging]);
 
   const handleZoomIn = () => {
     const checkFull = file_state.zoom === zoom_values.length;
@@ -357,6 +376,7 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
                 </Button>
               )}
               <div
+                ref={containerRef}
                 className={cn(
                   "flex h-[50vh] md:h-[70vh] w-full items-center justify-center overflow-hidden rounded-lg border border-secondary-200 touch-none",
                   dragState.isDragging ? "cursor-grabbing" : "cursor-grab",
@@ -366,7 +386,6 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
                 onMouseUp={handleMouseUp}
                 onMouseLeave={handleMouseUp}
                 onTouchStart={handleTouchStart}
-                onTouchMove={handleTouchMove}
                 onTouchEnd={handleTouchEnd}
               >
                 {file_state.isImage ? (

--- a/src/components/Common/FilePreviewDialog.tsx
+++ b/src/components/Common/FilePreviewDialog.tsx
@@ -126,6 +126,11 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
   const [scale, setScale] = useState(0.75);
   const [dragState, setDragState] = useState<DragState>(initialDragState);
   const containerRef = useRef<HTMLDivElement>(null);
+  const dragStateRef = useRef(dragState);
+
+  useEffect(() => {
+    dragStateRef.current = dragState;
+  }, [dragState]);
 
   useEffect(() => {
     if (uploadedFiles && show) {
@@ -140,19 +145,16 @@ const FilePreviewDialog = (props: FilePreviewProps) => {
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-    // Attach touchmove with passive: false
     const handler = (e: TouchEvent) => {
-      // Only call the React handler if dragging
-      if (dragState.isDragging) {
-        // @ts-expect-error: React handler expects React.TouchEvent, but this is native
-        handleTouchMove(e);
+      if (dragStateRef.current.isDragging) {
+        handleTouchMove(e as unknown as React.TouchEvent);
       }
     };
     container.addEventListener("touchmove", handler, { passive: false });
     return () => {
       container.removeEventListener("touchmove", handler);
     };
-  }, [dragState.isDragging]);
+  }, []);
 
   const handleZoomIn = () => {
     const checkFull = file_state.zoom === zoom_values.length;


### PR DESCRIPTION
## Proposed Changes
built custom touchmove

- Fixes #12609 
- Change 1
- Change 2
- More?

old 

https://github.com/user-attachments/assets/994fc8af-8ad4-4602-926d-d4bf284a38c1

updated

https://github.com/user-attachments/assets/d712836f-0e04-4f11-9417-c2e187857c95



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved touch drag behavior in the file preview dialog to prevent unwanted scrolling or default actions while dragging on touch devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->