### PR TITLE
Fix : Show only unselected options in repeatable choice questions

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -310,8 +310,9 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
                       (r) => r.question_id === question.id,
                     );
                     if (!response) return null;
-
-                    const value = response.values[0]?.value;
+                    const value = question.repeats
+                      ? response.values?.map((v) => v.value).join(", ")
+                      : response.values[0]?.value;
                     const unit = response.values[0]?.unit || question.unit;
                     const coding = response.values[0]?.coding;
 

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -310,9 +310,9 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
                       (r) => r.question_id === question.id,
                     );
                     if (!response) return null;
-                    const value = question.repeats
-                      ? response.values?.map((v) => v.value).join(", ")
-                      : response.values[0]?.value;
+                    const value = response.values
+                      ?.map((v) => v.value)
+                      .join(", ");
                     const unit = response.values[0]?.unit || question.unit;
                     const coding = response.values[0]?.coding;
 

--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -45,6 +45,19 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
       : "radio";
   const currentValue = questionnaireResponse.values[index]?.value?.toString();
   const currentCoding = questionnaireResponse.values[index]?.coding;
+
+  const selectedValues = question.repeats
+    ? questionnaireResponse.values
+        .map((v) => v.value?.toString())
+        .filter((v, i) => i !== index && v)
+    : [];
+
+  const availableOptions = question.repeats
+    ? options.filter(
+        (option) => !selectedValues.includes(option.value.toString()),
+      )
+    : options;
+
   const handleValueChange = (newValue: string) => {
     clearError();
     const newValues = [...questionnaireResponse.values];
@@ -90,7 +103,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
         <Autocomplete
           value={currentValue || ""}
           onChange={handleValueChange}
-          options={options.map((option) => ({
+          options={availableOptions.map((option) => ({
             label: properCase(option.display || option.value),
             value: option.value.toString(),
           }))}
@@ -105,7 +118,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
             className="flex flex-col gap-3"
             value={currentValue}
           >
-            {options.map((option: AnswerOption) => (
+            {availableOptions.map((option: AnswerOption) => (
               <Label
                 htmlFor={`${question.id}-${option.value.toString()}`}
                 className="cursor-pointer"

--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -46,15 +46,12 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
   const currentValue = questionnaireResponse.values[index]?.value?.toString();
   const currentCoding = questionnaireResponse.values[index]?.coding;
 
-  const selectedValues = question.repeats
-    ? questionnaireResponse.values
-        .map((v) => v.value?.toString())
-        .filter((v, i) => i !== index && v)
-    : [];
-
   const availableOptions = question.repeats
-    ? options.filter(
-        (option) => !selectedValues.includes(option.value.toString()),
+    ? options.filter((option) =>
+        questionnaireResponse.values.every(
+          (v, i) =>
+            i === index || v.value?.toString() !== option.value.toString(),
+        ),
       )
     : options;
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #12583 

- Updated logic in repeatable choice questions so that the "Add Another" field only shows unselected options instead of all available ones.
- Modified `QuestionnaireResponseList` to ensure all selected options are displayed correctly in the response view.


https://github.com/user-attachments/assets/47479594-d374-4276-bfbe-52811ac0f429



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved display of repeated questionnaire responses by showing all selected values as a comma-separated list.
  - Enhanced repeated choice questions to prevent users from selecting the same option more than once across repeated entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->