### PR TITLE
Minor `EncounterInfoCard` UI fix to make it work for location association card as well

### DIFF
--- a/src/components/Encounter/EncounterInfoCard.tsx
+++ b/src/components/Encounter/EncounterInfoCard.tsx
@@ -113,10 +113,10 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
           </div>
         </div>
       </CardContent>
-      <CardFooter className="flex flex-col sm:flex-row justify-between gap-2 items-center py-2 px-4 bg-gray-50">
+      <CardFooter className="flex flex-wrap gap-2 items-center justify-between py-2 px-4 bg-gray-50">
         <Link
           href={`/facility/${facilityId}/patient/${encounter.patient.id}`}
-          className="w-full"
+          className="flex-1"
         >
           <Button
             variant="outline"
@@ -132,7 +132,7 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
         </Link>
         <Link
           href={`/facility/${facilityId}/patient/${encounter.patient.id}/encounter/${encounter.id}/updates`}
-          className="w-full"
+          className="flex-1"
         >
           <Button
             variant="primary"


### PR DESCRIPTION
## Proposed Changes

- Fixes #12635
- Update the CardFooter classes to wrap then no space and acquire flex-1
- card on encounter listing page works as it is 

![image](https://github.com/user-attachments/assets/9adaa91b-3b49-4b4e-b983-7c5a2fe2b893)
<img width="541" alt="Screenshot 2025-06-17 at 8 12 46 PM" src="https://github.com/user-attachments/assets/2f7bf3fd-46c9-4665-8195-4c416d4db959" />




@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the layout and styling of the Encounter Info Card footer for improved responsiveness and flexible link sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->