### PR TITLE
Rehide question for exist condition

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
@@ -58,7 +58,9 @@ export function isQuestionEnabled(
       case "exists":
         return (
           normalizedAnswers.length > 0 &&
-          normalizedAnswers.some((v) => v !== "")
+          normalizedAnswers.some(
+            (v) => v !== "" && v !== null && v !== undefined,
+          )
         );
 
       case "equals":

--- a/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
@@ -56,7 +56,10 @@ export function isQuestionEnabled(
 
     switch (enableWhen.operator) {
       case "exists":
-        return normalizedAnswers.length > 0;
+        return (
+          normalizedAnswers.length > 0 &&
+          normalizedAnswers.some((v) => v !== "")
+        );
 
       case "equals":
         return normalizedAnswers.includes(enableWhen.answer);


### PR DESCRIPTION
## Proposed Changes

- Fixes #12644 
    - Hide true/false for exists (so only exists condition, not "not exists") 
    - Minor adjustments for resetting when deleting/re-adding condition (ensure dropdown isn't populated with deleted values)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "exists" operator in enable-when conditions for string, URL, and choice question types in the questionnaire editor.
  - Updated the UI to hide the answer input when the "exists" operator is selected.

- **Bug Fixes**
  - Improved logic for the "exists" operator to only consider non-empty answers as existing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->