### PR TITLE
Fix: Unable to Submit Consent Edit Form 

### DIFF
--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -69,7 +69,7 @@ const consentFormSchema = (isEdit: boolean) =>
       date: tzAwareDateTime,
       period: z.object({
         start: tzAwareDateTime.optional(),
-        end: z.union([tzAwareDateTime, z.undefined()]).optional(),
+        end: tzAwareDateTime.optional(),
       }),
       note: z.string().optional(),
       fileEntries: z
@@ -230,10 +230,10 @@ export default function ConsentFormSheet({
         period: {
           start: existingConsent!.period.start
             ? new Date(existingConsent!.period.start).toISOString()
-            : "",
+            : undefined,
           end: existingConsent!.period.end
             ? new Date(existingConsent!.period.end).toISOString()
-            : "",
+            : undefined,
         },
         note: existingConsent!.note || "",
         fileEntries: [],
@@ -572,11 +572,12 @@ export default function ConsentFormSheet({
             <div className="flex justify-end mt-6 space-x-2">
               <Button
                 type="button"
+                variant="outline"
                 onClick={() => {
                   setIsOpen(false);
                   form.reset();
                 }}
-                className="bg-white text-gray-800 border border-gray-300 hover:bg-gray-100"
+                disabled={isPending}
               >
                 {t("cancel")}
               </Button>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12655 
- pass `undefined` instead of empty string which was causing invalid type passed
- Remove className styling , use variant instead
- disable cancel button while IsPending = true


https://github.com/user-attachments/assets/1ca99299-a77c-4c0a-9e6c-9f76e8a68f73



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty or missing period start and end dates in the consent form.
- **Style**
	- Updated the cancel button to use outline styling and to disable itself during pending actions for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->