### PR TITLE
Refactored RadioGroup into a reusable component.

### DIFF
--- a/cypress/pageObject/Patients/PatientCreation.ts
+++ b/cypress/pageObject/Patients/PatientCreation.ts
@@ -37,7 +37,6 @@ export class PatientCreation {
     dobMonthInput: '[data-cy="dob-month-input"]',
     dobYearInput: '[data-cy="dob-year-input"]',
     ageInput: '[data-cy="age-input"]',
-    genderRadio: '[data-cy="gender-radio-{value}"]',
     bloodGroupSelect: '[data-cy="blood-group-select"]',
     addressInput: '[data-cy="current-address-input"]',
     sameAddressCheckbox: '[data-cy="same-address-checkbox"]',
@@ -111,9 +110,7 @@ export class PatientCreation {
 
   selectGender(gender: string) {
     const lowercaseGender = gender.toLowerCase();
-    cy.get(
-      this.selectors.genderRadio.replace("{value}", lowercaseGender),
-    ).click();
+    cy.get(`#${lowercaseGender}`).click();
     return this;
   }
 

--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -24,7 +24,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -42,6 +41,7 @@ import {
 } from "@/components/ui/sheet";
 
 import { DateTimeInput } from "@/components/Common/DateTimeInput";
+import RadioInput from "@/components/Questionnaire/RadioInput";
 
 import useFileUpload from "@/hooks/useFileUpload";
 
@@ -377,27 +377,16 @@ export default function ConsentFormSheet({
                   control={form.control}
                   name="decision"
                   render={({ field }) => (
-                    <FormItem className="space-y-2">
+                    <FormItem>
                       <FormLabel>{t("consent_decision")}</FormLabel>
-                      <RadioGroup
+                      <RadioInput
+                        {...field}
+                        options={CONSENT_DECISIONS.map((decision) => ({
+                          label: t(`consent_decision__${decision}`),
+                          value: decision,
+                        }))}
                         onValueChange={field.onChange}
-                        defaultValue={field.value}
-                        value={field.value}
-                        className="flex gap-4"
-                      >
-                        <div className="flex items-center space-x-2">
-                          <RadioGroupItem value="permit" id="permit" />
-                          <Label htmlFor="permit">
-                            {t("consent_decision__permit")}
-                          </Label>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <RadioGroupItem value="deny" id="deny" />
-                          <Label htmlFor="deny">
-                            {t("consent_decision__deny")}
-                          </Label>
-                        </div>
-                      </RadioGroup>
+                      />
                       <FormMessage />
                     </FormItem>
                   )}

--- a/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
+++ b/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
@@ -15,7 +15,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -26,6 +25,7 @@ import {
 
 import { getFrequencyDisplay } from "@/components/Medicine/MedicationsTable";
 import { formatDosage } from "@/components/Medicine/utils";
+import RadioInput from "@/components/Questionnaire/RadioInput";
 
 import { formatName } from "@/Utils/utils";
 import {
@@ -289,10 +289,10 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
       {!administrationRequest.id && (
         <div className="space-y-2">
           <Label>{t("is_this_administration_for_a_past_time")}?</Label>
-          <RadioGroup
+          <RadioInput
             name={`${formId}isPastTime`}
             value={isPastTime ? "yes" : "no"}
-            onValueChange={(newValue) => {
+            onValueChange={(newValue: string) => {
               setIsPastTime(newValue === "yes");
               if (newValue === "no") {
                 const now = new Date().toISOString();
@@ -313,17 +313,11 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
                 onChange(newRequest);
               }
             }}
-            className="flex gap-4"
-          >
-            <div className="flex gap-1">
-              <RadioGroupItem value="yes" id={`yes-${formId}`} />
-              <Label htmlFor={`yes-${formId}`}>{t("yes")}</Label>
-            </div>
-            <div className="flex gap-1">
-              <RadioGroupItem value="no" id={`no-${formId}`} />
-              <Label htmlFor={`no-${formId}`}>{t("no")}</Label>
-            </div>
-          </RadioGroup>
+            options={[
+              { value: "yes", label: t("yes") },
+              { value: "no", label: t("no") },
+            ]}
+          />
         </div>
       )}
 

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -30,7 +30,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { PhoneInput } from "@/components/ui/phone-input";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -45,6 +44,7 @@ import { DateTimeInput } from "@/components/Common/DateTimeInput";
 import Loading from "@/components/Common/Loading";
 import Page from "@/components/Common/Page";
 import DuplicatePatientDialog from "@/components/Facility/DuplicatePatientDialog";
+import RadioInput from "@/components/Questionnaire/RadioInput";
 
 import useAppHistory from "@/hooks/useAppHistory";
 
@@ -489,29 +489,18 @@ export default function PatientRegistration(
                 control={form.control}
                 name="gender"
                 render={({ field }) => (
-                  <FormItem className="space-y-3">
+                  <FormItem>
                     <FormLabel aria-required>{t("sex")}</FormLabel>
                     <FormControl>
-                      <RadioGroup
+                      <RadioInput
                         {...field}
                         onValueChange={field.onChange}
                         value={field.value ?? undefined}
-                        className="flex gap-5 flex-wrap"
-                      >
-                        {GENDER_TYPES.map((g) => (
-                          <FormItem key={g.id} className="flex">
-                            <FormControl>
-                              <RadioGroupItem
-                                value={g.id}
-                                data-cy={`gender-radio-${g.id.toLowerCase()}`}
-                              />
-                            </FormControl>
-                            <FormLabel className="font-normal">
-                              {t(`GENDER__${g.id}`)}
-                            </FormLabel>
-                          </FormItem>
-                        ))}
-                      </RadioGroup>
+                        options={GENDER_TYPES.map((g) => ({
+                          value: g.id,
+                          label: t(`GENDER__${g.id}`),
+                        }))}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/components/Questionnaire/QuestionTypes/BooleanQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/BooleanQuestion.tsx
@@ -6,10 +6,8 @@ import type {
   QuestionnaireResponse,
   ResponseValue,
 } from "@/types/questionnaire/form";
-import type { Question } from "@/types/questionnaire/question";
 
 interface BooleanQuestionProps {
-  question: Question;
   questionnaireResponse: QuestionnaireResponse;
   updateQuestionnaireResponseCB: (
     values: ResponseValue[],
@@ -21,7 +19,6 @@ interface BooleanQuestionProps {
 }
 
 export function BooleanQuestion({
-  question,
   questionnaireResponse,
   updateQuestionnaireResponseCB,
   disabled,
@@ -38,8 +35,8 @@ export function BooleanQuestion({
   return (
     <RadioInput
       options={options}
-      selectedValue={selectedValue ?? ""}
-      handleValueChange={(value) => {
+      value={selectedValue ?? ""}
+      onValueChange={(value) => {
         clearError();
         updateQuestionnaireResponseCB(
           [{ type: "boolean", value: value === "true" }],
@@ -48,7 +45,6 @@ export function BooleanQuestion({
         );
       }}
       disabled={disabled}
-      question={question}
     />
   );
 }

--- a/src/components/Questionnaire/QuestionTypes/BooleanQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/BooleanQuestion.tsx
@@ -1,9 +1,6 @@
 import { useTranslation } from "react-i18next";
 
-import { cn } from "@/lib/utils";
-
-import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import RadioInput from "@/components/Questionnaire/RadioInput";
 
 import type {
   QuestionnaireResponse,
@@ -33,11 +30,16 @@ export function BooleanQuestion({
   const { t } = useTranslation();
 
   const selectedValue = questionnaireResponse.values[0]?.value?.toString();
+  const options = [
+    { value: "true", label: t("yes") },
+    { value: "false", label: t("no") },
+  ];
 
   return (
-    <RadioGroup
-      value={selectedValue}
-      onValueChange={(value) => {
+    <RadioInput
+      options={options}
+      selectedValue={selectedValue ?? ""}
+      handleValueChange={(value) => {
         clearError();
         updateQuestionnaireResponseCB(
           [{ type: "boolean", value: value === "true" }],
@@ -46,46 +48,7 @@ export function BooleanQuestion({
         );
       }}
       disabled={disabled}
-      className="flex flex-row gap-4"
-    >
-      {[
-        { value: "true", label: t("yes") },
-        { value: "false", label: t("no") },
-      ].map((option) => (
-        <button
-          type="button"
-          className={cn(
-            "border rounded-md p-2 cursor-pointer sm:w-auto hover:border-primary-500 group text-left",
-            selectedValue === option.value
-              ? "bg-primary-100 border-primary-500"
-              : "bg-white border-gray-300",
-          )}
-          key={option.value}
-          onClick={() => {
-            clearError();
-            updateQuestionnaireResponseCB(
-              [{ type: "boolean", value: option.value === "true" }],
-              questionnaireResponse.question_id,
-              questionnaireResponse.note,
-            );
-          }}
-          disabled={disabled}
-        >
-          <div className="flex items-center space-x-2">
-            <RadioGroupItem
-              value={option.value}
-              id={`${question.id}-${option.value}`}
-              className="h-4 w-4 border-2 border-gray-300 text-primary focus:ring-primary group-hover:border-primary-500"
-            />
-            <Label
-              htmlFor={`${question.id}-${option.value}`}
-              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-            >
-              {option.label}
-            </Label>
-          </div>
-        </button>
-      ))}
-    </RadioGroup>
+      question={question}
+    />
   );
 }

--- a/src/components/Questionnaire/QuestionTypes/BooleanQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/BooleanQuestion.tsx
@@ -27,14 +27,13 @@ export function BooleanQuestion({
   const { t } = useTranslation();
 
   const selectedValue = questionnaireResponse.values[0]?.value?.toString();
-  const options = [
-    { value: "true", label: t("yes") },
-    { value: "false", label: t("no") },
-  ];
 
   return (
     <RadioInput
-      options={options}
+      options={[
+        { value: "true", label: t("yes") },
+        { value: "false", label: t("no") },
+      ]}
       value={selectedValue ?? ""}
       onValueChange={(value) => {
         clearError();

--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -139,11 +139,13 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
   return (
     <div className="mt-2">
       <RadioInput
-        options={options}
-        selectedValue={selectedValue ?? ""}
-        handleValueChange={handleValueChange}
+        options={options.map((option) => ({
+          label: properCase(option.display || option.value),
+          value: option.value.toString(),
+        }))}
+        value={selectedValue ?? ""}
+        onValueChange={handleValueChange}
         disabled={disabled}
-        question={question}
       />
     </div>
   );

--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -1,13 +1,10 @@
 import { t } from "i18next";
 import { memo } from "react";
 
-import { cn } from "@/lib/utils";
-
 import Autocomplete from "@/components/ui/autocomplete";
-import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
+import RadioInput from "@/components/Questionnaire/RadioInput";
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
 import { properCase } from "@/Utils/utils";
@@ -141,41 +138,13 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
 
   return (
     <div className="mt-2">
-      <RadioGroup
-        onValueChange={handleValueChange}
+      <RadioInput
+        options={options}
+        selectedValue={selectedValue ?? ""}
+        handleValueChange={handleValueChange}
         disabled={disabled}
-        className="flex flex-wrap gap-4 ml-2"
-        value={selectedValue}
-      >
-        {options.map((option) => (
-          <button
-            type="button"
-            className={cn(
-              "border rounded-md p-2 w-full cursor-pointer sm:w-auto hover:border-primary-500 group text-left",
-              selectedValue === option.value
-                ? "bg-primary-100 border-primary-500"
-                : "bg-white border-gray-300",
-            )}
-            key={`${question.id}-${option.value.toString()}`}
-            onClick={() => handleValueChange(option.value.toString())}
-            disabled={disabled}
-          >
-            <div className="flex items-center space-x-2">
-              <RadioGroupItem
-                value={option.value.toString()}
-                id={`${question.id}-${option.value.toString()}`}
-                className="h-4 w-4 border-2 border-gray-300 text-primary focus:ring-primary group-hover:border-primary-500"
-              />
-              <Label
-                htmlFor={`${question.id}-${option.value.toString()}`}
-                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed cursor-pointer peer-disabled:opacity-70"
-              >
-                {properCase(option.display || option.value)}
-              </Label>
-            </div>
-          </button>
-        ))}
-      </RadioGroup>
+        question={question}
+      />
     </div>
   );
 });

--- a/src/components/Questionnaire/RadioInput.tsx
+++ b/src/components/Questionnaire/RadioInput.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/utils";
+
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+import { properCase } from "@/Utils/utils";
+import { AnswerOption, Question } from "@/types/questionnaire/question";
+
+interface RadioInputProps {
+  options: AnswerOption[];
+  selectedValue: string;
+  handleValueChange: (value: string) => void;
+  disabled?: boolean;
+  question: Question;
+}
+
+export default function RadioInput({
+  options,
+  selectedValue,
+  handleValueChange,
+  disabled,
+  question,
+}: RadioInputProps) {
+  return (
+    <RadioGroup
+      onValueChange={handleValueChange}
+      disabled={disabled}
+      className="flex flex-wrap gap-4 ml-2"
+      value={selectedValue}
+    >
+      {options.map((option) => (
+        <button
+          type="button"
+          className={cn(
+            "border rounded-md p-2 w-full cursor-pointer sm:w-auto hover:border-primary-500 group text-left",
+            selectedValue === option.value
+              ? "bg-primary-100 border-primary-500"
+              : "bg-white border-gray-300",
+          )}
+          key={`${question.id}-${option.value.toString()}`}
+          onClick={() => handleValueChange(option.value.toString())}
+          disabled={disabled}
+        >
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem
+              value={option.value.toString()}
+              id={`${question.id}-${option.value.toString()}`}
+              className="h-4 w-4 border-2 border-gray-300 text-primary focus:ring-primary group-hover:border-primary-500"
+            />
+            <Label
+              htmlFor={`${question.id}-${option.value.toString()}`}
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed cursor-pointer peer-disabled:opacity-70"
+            >
+              {properCase(option.display || option.value)}
+            </Label>
+          </div>
+        </button>
+      ))}
+    </RadioGroup>
+  );
+}

--- a/src/components/Questionnaire/RadioInput.tsx
+++ b/src/components/Questionnaire/RadioInput.tsx
@@ -3,8 +3,6 @@ import { cn } from "@/lib/utils";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
-import { properCase } from "@/Utils/utils";
-
 interface RadioInputProps extends React.ComponentProps<typeof RadioGroup> {
   options: {
     label: string;
@@ -26,7 +24,7 @@ export default function RadioInput({ options, ...props }: RadioInputProps) {
               ? "bg-primary-100 border-primary-500"
               : "bg-white border-gray-300",
           )}
-          key={`${option.value}-${props.value}`}
+          key={`${option.value}-${props.value}`} // to prevent race condition
           onClick={() => {
             if (!props.disabled) {
               props.onValueChange?.(option.value.toString());
@@ -43,7 +41,7 @@ export default function RadioInput({ options, ...props }: RadioInputProps) {
               htmlFor={option.value}
               className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed cursor-pointer peer-disabled:opacity-70"
             >
-              {properCase(option.label)}
+              {option.label}
             </Label>
           </div>
         </div>

--- a/src/components/Questionnaire/RadioInput.tsx
+++ b/src/components/Questionnaire/RadioInput.tsx
@@ -4,57 +4,49 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
 import { properCase } from "@/Utils/utils";
-import { AnswerOption, Question } from "@/types/questionnaire/question";
 
-interface RadioInputProps {
-  options: AnswerOption[];
-  selectedValue: string;
-  handleValueChange: (value: string) => void;
-  disabled?: boolean;
-  question: Question;
+interface RadioInputProps extends React.ComponentProps<typeof RadioGroup> {
+  options: {
+    label: string;
+    value: string;
+  }[];
 }
 
-export default function RadioInput({
-  options,
-  selectedValue,
-  handleValueChange,
-  disabled,
-  question,
-}: RadioInputProps) {
+export default function RadioInput({ options, ...props }: RadioInputProps) {
   return (
     <RadioGroup
-      onValueChange={handleValueChange}
-      disabled={disabled}
-      className="flex flex-wrap gap-4 ml-2"
-      value={selectedValue}
+      {...props}
+      className={cn("flex flex-wrap gap-4", props.className)}
     >
       {options.map((option) => (
-        <button
-          type="button"
+        <div
           className={cn(
             "border rounded-md p-2 w-full cursor-pointer sm:w-auto hover:border-primary-500 group text-left",
-            selectedValue === option.value
+            props.value === option.value
               ? "bg-primary-100 border-primary-500"
               : "bg-white border-gray-300",
           )}
-          key={`${question.id}-${option.value.toString()}`}
-          onClick={() => handleValueChange(option.value.toString())}
-          disabled={disabled}
+          key={`${option.value}-${props.value}`}
+          onClick={() => {
+            if (!props.disabled) {
+              props.onValueChange?.(option.value.toString());
+            }
+          }}
         >
           <div className="flex items-center space-x-2">
             <RadioGroupItem
               value={option.value.toString()}
-              id={`${question.id}-${option.value.toString()}`}
+              id={option.value}
               className="h-4 w-4 border-2 border-gray-300 text-primary focus:ring-primary group-hover:border-primary-500"
             />
             <Label
-              htmlFor={`${question.id}-${option.value.toString()}`}
+              htmlFor={option.value}
               className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed cursor-pointer peer-disabled:opacity-70"
             >
-              {properCase(option.display || option.value)}
+              {properCase(option.label)}
             </Label>
           </div>
-        </button>
+        </div>
       ))}
     </RadioGroup>
   );

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { PhoneInput } from "@/components/ui/phone-input";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -37,6 +36,7 @@ import { Textarea } from "@/components/ui/textarea";
 import Loading from "@/components/Common/Loading";
 import PageTitle from "@/components/Common/PageTitle";
 import UserSelector from "@/components/Common/UserSelector";
+import RadioInput from "@/components/Questionnaire/RadioInput";
 
 import useAppHistory from "@/hooks/useAppHistory";
 import useAuthUser from "@/hooks/useAuthUser";
@@ -322,31 +322,18 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                 control={form.control}
                 name="emergency"
                 render={({ field }) => (
-                  <FormItem className="space-y-3">
+                  <FormItem>
                     <FormLabel>{t("is_this_an_emergency")}</FormLabel>
                     <FormControl>
-                      <RadioGroup
+                      <RadioInput
+                        {...field}
                         onValueChange={field.onChange}
-                        value={field.value}
-                        className="flex gap-4"
-                      >
-                        <FormItem className="flex">
-                          <FormControl>
-                            <RadioGroupItem value="true" />
-                          </FormControl>
-                          <FormLabel className="font-normal">
-                            {t("yes")}
-                          </FormLabel>
-                        </FormItem>
-                        <FormItem className="flex">
-                          <FormControl>
-                            <RadioGroupItem value="false" />
-                          </FormControl>
-                          <FormLabel className="font-normal">
-                            {t("no")}
-                          </FormLabel>
-                        </FormItem>
-                      </RadioGroup>
+                        options={[
+                          { value: "true", label: t("yes") },
+                          { value: "false", label: t("no") },
+                        ]}
+                        className="m"
+                      />
                     </FormControl>
                     <FormDescription>
                       {t("emergency_description")}

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -332,7 +332,6 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                           { value: "true", label: t("yes") },
                           { value: "false", label: t("no") },
                         ]}
-                        className="m"
                       />
                     </FormControl>
                     <FormDescription>

--- a/src/pages/Encounters/ReportBuilder/LayoutBuilder.tsx
+++ b/src/pages/Encounters/ReportBuilder/LayoutBuilder.tsx
@@ -24,7 +24,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -33,6 +32,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+
+import RadioInput from "@/components/Questionnaire/RadioInput";
 
 import { ReportTemplateFormData } from "@/pages/Encounters/ReportBuilder/schema";
 import {
@@ -156,20 +157,14 @@ export default function LayoutBuilder({ form }: LayoutBuilderProps) {
             <FormItem>
               <FormLabel>{t("page_margin")}</FormLabel>
               <FormControl>
-                <RadioGroup
-                  value={field.value}
+                <RadioInput
+                  {...field}
                   onValueChange={field.onChange}
-                  className="flex flex-row gap-2 mt-2"
-                >
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="uniform" id="uniform" />
-                    <FormLabel htmlFor="uniform">{t("uniform")}</FormLabel>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="custom" id="custom" />
-                    <FormLabel htmlFor="custom">{t("custom")}</FormLabel>
-                  </div>
-                </RadioGroup>
+                  options={[
+                    { value: "uniform", label: t("uniform") },
+                    { value: "custom", label: t("custom") },
+                  ]}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/pages/PublicAppointments/PatientRegistration.tsx
+++ b/src/pages/PublicAppointments/PatientRegistration.tsx
@@ -17,9 +17,9 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Textarea } from "@/components/ui/textarea";
+
+import RadioInput from "@/components/Questionnaire/RadioInput";
 
 import { usePatientContext } from "@/hooks/usePatientUser";
 
@@ -244,29 +244,17 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                 control={form.control}
                 name="gender"
                 render={({ field }) => (
-                  <FormItem className="space-y-3">
+                  <FormItem className="flex flex-col">
                     <FormLabel aria-required>{t("sex")}</FormLabel>
                     <FormControl>
-                      <RadioGroup
+                      <RadioInput
                         {...field}
                         onValueChange={field.onChange}
-                        value={field.value}
-                        className="flex gap-5 flex-wrap"
-                      >
-                        {GENDER_TYPES.map((g) => (
-                          <FormItem key={g.id} className="flex">
-                            <FormControl>
-                              <RadioGroupItem
-                                value={g.id}
-                                data-cy={`gender-radio-${g.id.toLowerCase()}`}
-                              />
-                            </FormControl>
-                            <FormLabel className="font-normal">
-                              {t(`GENDER__${g.id}`)}
-                            </FormLabel>
-                          </FormItem>
-                        ))}
-                      </RadioGroup>
+                        options={GENDER_TYPES.map((g) => ({
+                          value: g.id,
+                          label: t(`GENDER__${g.id}`),
+                        }))}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -283,25 +271,17 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                         {t("date_of_birth_or_age")}
                       </FormLabel>
                       <FormControl>
-                        <RadioGroup
-                          value={field.value}
+                        <RadioInput
+                          {...field}
                           onValueChange={field.onChange}
-                          className="flex items-center divide-x divide-secondary-400 bg-white rounded-md w-fit border border-secondary-400"
-                        >
-                          <div className="flex items-center gap-2 px-4 py-2">
-                            <RadioGroupItem
-                              id="dob-option"
-                              value="date_of_birth"
-                            />
-                            <Label htmlFor="dob-option">
-                              {t("date_of_birth")}
-                            </Label>
-                          </div>
-                          <div className="flex items-center gap-2 px-4 py-2">
-                            <RadioGroupItem id="age-option" value="age" />
-                            <Label htmlFor="age-option">{t("age")}</Label>
-                          </div>
-                        </RadioGroup>
+                          options={[
+                            {
+                              value: "date_of_birth",
+                              label: t("date_of_birth"),
+                            },
+                            { value: "age", label: t("age") },
+                          ]}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12659 
- Refactored RadioGroup into a reusable component.
- Used in ChoiceQuestion and BooleanQuestion

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a reusable radio button group component for questionnaire questions.

- **Refactor**
  - Updated Boolean and single-choice question components to use the new radio button group, streamlining their appearance and behavior.
  - Replaced multiple radio button implementations across forms and pages—including consent forms, medication administration, patient registration, resource forms, report builders, and public appointment registrations—with the unified radio input component, simplifying UI code and ensuring consistent styling and interaction.

- **Chores**
  - Improved test selectors for gender selection to align with updated radio input structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->