### PR TITLE
fix: update tab label from "patients" to "encounters" in EncountersOv…

### DIFF
--- a/src/pages/Encounters/EncountersOverview.tsx
+++ b/src/pages/Encounters/EncountersOverview.tsx
@@ -34,7 +34,7 @@ export default function EncountersOverview({
               value="patients"
               className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
             >
-              {t("patients")}
+              {t("encounters")}
             </TabsTrigger>
             <TabsTrigger
               value="locations"


### PR DESCRIPTION
## Proposed Changes
Tab name should be 'Encounters' instead of 'Patients'

- Fixes [Bug: Active name in sidebar and Tab name is mismatching for Encounter #12649](https://github.com/ohcnetwork/care_fe/issues/12649)
- Change 1
- Change 2
- More?

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices

![image](https://github.com/user-attachments/assets/38d1581a-28dc-4dc7-8096-43c2359c1bb1)

