### PR TITLE
fix: Update reason_for_visit handling to preserve whitespace

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
@@ -135,7 +135,7 @@ export function AppointmentQuestion({
           value={value.reason_for_visit || ""}
           onChange={(e) =>
             handleUpdate({
-              reason_for_visit: e.target.value.trim() || undefined,
+              reason_for_visit: e.target.value || undefined,
             })
           }
           disabled={disabled}

--- a/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AppointmentQuestion.tsx
@@ -95,8 +95,7 @@ export function AppointmentQuestion({
 
   const handleUpdate = (updates: Partial<CreateAppointmentQuestion>) => {
     const updatedValue = { ...value, ...updates };
-
-    if (!updatedValue.reason_for_visit && !updatedValue.slot_id) {
+    if (!updatedValue.reason_for_visit?.trim() && !updatedValue.slot_id) {
       updateQuestionnaireResponseCB(
         [],
         questionnaireResponse.question_id,


### PR DESCRIPTION
## Proposed Changes

- Fixes #12673 
![image](https://github.com/user-attachments/assets/91fb04c2-54be-4999-a9bb-31c877b14de9)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of whitespace in the "reason for visit" field, allowing users to enter input with leading or trailing spaces as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->