### PR TITLE
Fix multiple values not being shown in questionnaire group

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -153,10 +153,11 @@ function QuestionGroup({
     const response = responses.find((r) => r.question_id === question.id);
     if (!response) return null;
 
-    const value = response.values[0]?.value;
-    const unit = response.values[0]?.unit || question.unit;
-    const coding = response.values[0]?.coding;
-    const note = response?.note;
+    const values = response.values;
+    if (!values?.length) return null;
+
+    const hasAnyValue = values.some((v) => v.value || v.coding);
+    if (!hasAnyValue) return null;
 
     return (
       <TableRow key={question.id}>
@@ -165,18 +166,28 @@ function QuestionGroup({
             {question.text}
           </div>
         </TableCell>
-        <TableCell className="py-1 pr-0 align-top" colSpan={note ? 1 : 2}>
+        <TableCell
+          className="py-1 pr-0 align-top"
+          colSpan={response.note ? 1 : 2}
+        >
           <div className="text-sm font-medium break-words whitespace-normal">
-            {formatValue(value, question.type)}
-            {unit && <span className="ml-1 text-gray-600">{unit.code}</span>}
-            {coding && (
-              <span className="ml-1 text-gray-600">
-                {coding.display} ({coding.code})
-              </span>
-            )}
+            {values.map((val, idx) => (
+              <React.Fragment key={idx}>
+                {idx > 0 && ", "}
+                {val.value && formatValue(val.value, question.type)}
+                {val.unit && (
+                  <span className="ml-1 text-gray-600">{val.unit.code}</span>
+                )}
+                {val.coding && (
+                  <span className="ml-1 text-gray-600">
+                    {val.coding.display} ({val.coding.code})
+                  </span>
+                )}
+              </React.Fragment>
+            ))}
           </div>
         </TableCell>
-        {note && (
+        {response.note && (
           <TableCell className="py-1 pr-0 align-top">
             <div className="flex justify-end">
               <Popover>
@@ -191,7 +202,7 @@ function QuestionGroup({
                 </PopoverTrigger>
                 <PopoverContent className="w-52 p-4">
                   <p className="text-sm text-gray-700 whitespace-pre-wrap">
-                    {note}
+                    {response.note}
                   </p>
                 </PopoverContent>
               </Popover>
@@ -340,14 +351,12 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
                       (r) => r.question_id === question.id,
                     );
                     if (!response) return null;
-                    const value = response.values
-                      ?.map((v) => v.value)
-                      .join(", ");
-                    const unit = response.values[0]?.unit || question.unit;
-                    const coding = response.values[0]?.coding;
-                    const note = response?.note;
 
-                    if (!value && !coding) return null;
+                    const values = response.values;
+                    if (!values?.length) return null;
+
+                    const hasAnyValue = values.some((v) => v.value || v.coding);
+                    if (!hasAnyValue) return null;
 
                     return (
                       <TableRow key={question.id}>
@@ -358,23 +367,29 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
                         </TableCell>
                         <TableCell
                           className="py-1 pr-0 align-top"
-                          colSpan={note ? 1 : 2}
+                          colSpan={response.note ? 1 : 2}
                         >
                           <div className="text-sm font-medium break-words whitespace-normal">
-                            {formatValue(value, question.type)}
-                            {unit && (
-                              <span className="ml-1 text-gray-600">
-                                {unit.code}
-                              </span>
-                            )}
-                            {coding && (
-                              <span className="ml-1 text-gray-600">
-                                {coding.display} ({coding.code})
-                              </span>
-                            )}
+                            {values.map((val, idx) => (
+                              <React.Fragment key={idx}>
+                                {idx > 0 && ", "}
+                                {val.value &&
+                                  formatValue(val.value, question.type)}
+                                {val.unit && (
+                                  <span className="ml-1 text-gray-600">
+                                    {val.unit.code}
+                                  </span>
+                                )}
+                                {val.coding && (
+                                  <span className="ml-1 text-gray-600">
+                                    {val.coding.display} ({val.coding.code})
+                                  </span>
+                                )}
+                              </React.Fragment>
+                            ))}
                           </div>
                         </TableCell>
-                        {note && (
+                        {response.note && (
                           <TableCell className="py-1 pr-0 align-top text-right">
                             <div className="flex justify-end">
                               <Popover>
@@ -389,7 +404,7 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
                                 </PopoverTrigger>
                                 <PopoverContent className="w-52 p-4">
                                   <p className="text-sm text-gray-700 whitespace-pre-wrap">
-                                    {note}
+                                    {response.note}
                                   </p>
                                 </PopoverContent>
                               </Popover>


### PR DESCRIPTION
## Proposed Changes

- Fix multiple values not being shown in questionnaire group


### Before

![image](https://github.com/user-attachments/assets/6a9e9972-f702-4949-bd34-332ecd0d8ba7)


### After

![image](https://github.com/user-attachments/assets/64b2964d-11e5-479e-8996-e7d6c1294144)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced questionnaire response display to support and show multiple values per response, with improved formatting for value, unit, and coding information.
- **Bug Fixes**
  - Fixed issues where only the first value in a response was shown; now all relevant values are displayed.
- **Style**
  - Updated layout to consistently display notes and handle empty responses more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->