### PR TITLE
Fix: AutoComplete not getting scroll and focused on error 

### DIFF
--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -415,7 +415,7 @@ export default function ConsentFormSheet({
                         value={field.value}
                       >
                         <FormControl>
-                          <SelectTrigger>
+                          <SelectTrigger ref={field.ref}>
                             <SelectValue
                               placeholder={t("select_category")}
                               className="flex justify-start items-center w-full"
@@ -469,7 +469,7 @@ export default function ConsentFormSheet({
                     value={field.value}
                   >
                     <FormControl>
-                      <SelectTrigger>
+                      <SelectTrigger ref={field.ref}>
                         <SelectValue placeholder={t("select_status")} />
                       </SelectTrigger>
                     </FormControl>

--- a/src/components/Encounter/CreateEncounterForm.tsx
+++ b/src/components/Encounter/CreateEncounterForm.tsx
@@ -267,7 +267,10 @@ export default function CreateEncounterForm({
                       defaultValue={field.value}
                     >
                       <FormControl>
-                        <SelectTrigger data-cy="encounter-status">
+                        <SelectTrigger
+                          data-cy="encounter-status"
+                          ref={field.ref}
+                        >
                           <SelectValue placeholder="Select status" />
                         </SelectTrigger>
                       </FormControl>
@@ -295,7 +298,10 @@ export default function CreateEncounterForm({
                       defaultValue={field.value}
                     >
                       <FormControl>
-                        <SelectTrigger data-cy="encounter-priority">
+                        <SelectTrigger
+                          data-cy="encounter-priority"
+                          ref={field.ref}
+                        >
                           <SelectValue placeholder="Select priority" />
                         </SelectTrigger>
                       </FormControl>

--- a/src/components/Facility/FacilityForm.tsx
+++ b/src/components/Facility/FacilityForm.tsx
@@ -369,7 +369,6 @@ export default function FacilityForm({
                     <div className="grid-cols-1 grid md:grid-cols-2 gap-5">
                       <GovtOrganizationSelector
                         {...field}
-                        isError={!!form.formState.errors.geo_organization}
                         value={form.watch("geo_organization")}
                         selected={selectedLevels}
                         onChange={(value) =>

--- a/src/components/Facility/FacilityForm.tsx
+++ b/src/components/Facility/FacilityForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -60,7 +60,6 @@ export default function FacilityForm({
   const queryClient = useQueryClient();
   const [isGettingLocation, setIsGettingLocation] = useState(false);
   const [selectedLevels, setSelectedLevels] = useState<Organization[]>([]);
-  const geoOrganizationRef = useRef<HTMLDivElement>(null);
 
   const facilityFormSchema = z.object({
     facility_type: z.string().min(1, t("facility_type_required")),
@@ -160,16 +159,6 @@ export default function FacilityForm({
     }
   };
 
-  const handleSubmit = form.handleSubmit(onSubmit, (errors) => {
-    // Show generic error toast for any validation error
-    toast.error(t("please_fill_all_required_fields"));
-
-    // Scroll to geo-organization field if it has an error
-    if (errors.geo_organization) {
-      geoOrganizationRef.current?.scrollIntoView({ block: "center" });
-    }
-  });
-
   const handleFeatureChange = (value: string[]) => {
     const features = value.map((val) => Number(val));
     form.setValue("features", features, { shouldDirty: true });
@@ -230,7 +219,7 @@ export default function FacilityForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={handleSubmit} className="space-y-8">
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
         {/* Basic Information */}
         <div className="space-y-4 rounded-lg border border-gray-200 p-4">
           <h3 className="text-lg font-medium">{t("basic_info")}</h3>
@@ -246,6 +235,7 @@ export default function FacilityForm({
                       <SelectTrigger
                         data-cy="facility-type"
                         className="max-w-full truncate"
+                        ref={field.ref}
                       >
                         <SelectValue placeholder={t("select_facility_type")} />
                       </SelectTrigger>
@@ -374,11 +364,12 @@ export default function FacilityForm({
               name="geo_organization"
               control={form.control}
               render={({ field }) => (
-                <FormItem className="md:col-span-2" ref={geoOrganizationRef}>
+                <FormItem className="md:col-span-2">
                   <FormControl>
                     <div className="grid-cols-1 grid md:grid-cols-2 gap-5">
                       <GovtOrganizationSelector
                         {...field}
+                        isError={!!form.formState.errors.geo_organization}
                         value={form.watch("geo_organization")}
                         selected={selectedLevels}
                         onChange={(value) =>

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -530,7 +530,10 @@ export default function PatientRegistration(
                       defaultValue={field.value}
                     >
                       <FormControl>
-                        <SelectTrigger data-cy="blood-group-select">
+                        <SelectTrigger
+                          data-cy="blood-group-select"
+                          ref={field.ref}
+                        >
                           <SelectValue
                             placeholder={t("please_select_blood_group")}
                           />

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -852,7 +852,6 @@ export default function PatientRegistration(
                         <FormControl>
                           <GovtOrganizationSelector
                             {...field}
-                            isError={!!form.formState.errors.geo_organization}
                             required={true}
                             selected={selectedLevels}
                             value={form.watch("geo_organization")}

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -852,6 +852,7 @@ export default function PatientRegistration(
                         <FormControl>
                           <GovtOrganizationSelector
                             {...field}
+                            isError={!!form.formState.errors.geo_organization}
                             required={true}
                             selected={selectedLevels}
                             value={form.watch("geo_organization")}

--- a/src/components/Questionnaire/CodingEditor.tsx
+++ b/src/components/Questionnaire/CodingEditor.tsx
@@ -129,7 +129,7 @@ export function CodingEditor({
                       });
                     }}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger ref={field.ref}>
                       <SelectValue placeholder={t("select_system")} />
                     </SelectTrigger>
                     <SelectContent>

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -276,8 +276,8 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                     </FormLabel>
                     <FormControl>
                       <Autocomplete
+                        {...field}
                         data-cy="select-facility"
-                        isError={!!form.formState.errors.assigned_facility}
                         options={mergeAutocompleteOptions(
                           facilityOptions ?? [],
                           field.value

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -277,6 +277,7 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                     <FormControl>
                       <Autocomplete
                         data-cy="select-facility"
+                        isError={!!form.formState.errors.assigned_facility}
                         options={mergeAutocompleteOptions(
                           facilityOptions ?? [],
                           field.value
@@ -289,6 +290,7 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                         value={field.value?.id ?? ""}
                         placeholder={t("start_typing_to_search")}
                         onSearch={setFacilitySearch}
+                        ref={field.ref}
                         onChange={(value) => {
                           const facility = facilities?.results.find(
                             (f) => f.id === value,

--- a/src/components/Resource/ResourceForm.tsx
+++ b/src/components/Resource/ResourceForm.tsx
@@ -290,7 +290,6 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                         value={field.value?.id ?? ""}
                         placeholder={t("start_typing_to_search")}
                         onSearch={setFacilitySearch}
-                        ref={field.ref}
                         onChange={(value) => {
                           const facility = facilities?.results.find(
                             (f) => f.id === value,
@@ -366,7 +365,10 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                     <FormLabel aria-required>{t("status")}</FormLabel>
                     <Select onValueChange={field.onChange} value={field.value}>
                       <FormControl>
-                        <SelectTrigger data-cy="select-status-dropdown">
+                        <SelectTrigger
+                          data-cy="select-status-dropdown"
+                          ref={field.ref}
+                        >
                           <SelectValue placeholder={t("select_status")} />
                         </SelectTrigger>
                       </FormControl>
@@ -391,7 +393,10 @@ export default function ResourceForm({ facilityId, id }: ResourceProps) {
                     <FormLabel aria-required>{t("category")}</FormLabel>
                     <Select onValueChange={field.onChange} value={field.value}>
                       <FormControl>
-                        <SelectTrigger data-cy="select-category-dropdown">
+                        <SelectTrigger
+                          data-cy="select-category-dropdown"
+                          ref={field.ref}
+                        >
                           <SelectValue
                             placeholder={t("category_description")}
                           />

--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -363,6 +363,8 @@ export default function UserForm({
                     label: prefix,
                     value: prefix,
                   }))}
+                  isError={!!form.formState.errors.prefix}
+                  ref={field.ref}
                   freeInput
                   value={field.value || ""}
                   onChange={field.onChange}
@@ -800,6 +802,7 @@ export default function UserForm({
               <FormControl>
                 <GovtOrganizationSelector
                   {...field}
+                  isError={!!form.formState.errors.geo_organization}
                   value={form.watch("geo_organization")}
                   selected={selectedLevels}
                   onChange={(value) =>

--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -359,12 +359,11 @@ export default function UserForm({
               <FormItem>
                 <FormLabel>{t("prefix")}</FormLabel>
                 <Autocomplete
+                  {...field}
                   options={NAME_PREFIXES.map((prefix) => ({
                     label: prefix,
                     value: prefix,
                   }))}
-                  isError={!!form.formState.errors.prefix}
-                  ref={field.ref}
                   freeInput
                   value={field.value || ""}
                   onChange={field.onChange}
@@ -802,7 +801,6 @@ export default function UserForm({
               <FormControl>
                 <GovtOrganizationSelector
                   {...field}
-                  isError={!!form.formState.errors.geo_organization}
                   value={form.watch("geo_organization")}
                   selected={selectedLevels}
                   onChange={(value) =>

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -44,6 +44,10 @@ interface AutocompleteProps {
   freeInput?: boolean;
   closeOnSelect?: boolean;
   "data-cy"?: string;
+
+  ref?: React.RefCallback<HTMLButtonElement | null>;
+
+  isError?: boolean;
 }
 
 export default function Autocomplete({
@@ -62,6 +66,8 @@ export default function Autocomplete({
   freeInput = false,
   closeOnSelect = true,
   "data-cy": dataCy,
+  ref,
+  isError,
 }: AutocompleteProps) {
   const [open, setOpen] = React.useState(false);
   const isMobile = useBreakpoints({ default: true, sm: false });
@@ -174,9 +180,14 @@ export default function Autocomplete({
                 : undefined
             }
             variant="outline"
+            ref={ref}
             role="combobox"
             aria-expanded={open}
-            className={cn("w-full justify-between", className)}
+            className={cn(
+              "w-full justify-between",
+              isError && "border-red-500",
+              className,
+            )}
             disabled={disabled}
             data-cy={dataCy}
             type="button"
@@ -212,10 +223,15 @@ export default function Autocomplete({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className={cn("w-full justify-between", className)}
+          className={cn(
+            "w-full justify-between",
+            isError && "border-red-500",
+            className,
+          )}
           disabled={disabled}
           data-cy={dataCy}
           onClick={() => setOpen(!open)}
+          ref={ref}
         >
           <span
             className={cn(

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -47,7 +47,7 @@ interface AutocompleteProps {
 
   ref?: React.RefCallback<HTMLButtonElement | null>;
 
-  isError?: boolean;
+  "aria-invalid"?: boolean;
 }
 
 export default function Autocomplete({
@@ -67,7 +67,7 @@ export default function Autocomplete({
   closeOnSelect = true,
   "data-cy": dataCy,
   ref,
-  isError,
+  ...props
 }: AutocompleteProps) {
   const [open, setOpen] = React.useState(false);
   const isMobile = useBreakpoints({ default: true, sm: false });
@@ -172,6 +172,7 @@ export default function Autocomplete({
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
           <Button
+            aria-invalid={props["aria-invalid"]}
             title={
               value
                 ? freeInput
@@ -185,7 +186,7 @@ export default function Autocomplete({
             aria-expanded={open}
             className={cn(
               "w-full justify-between",
-              isError && "border-red-500",
+
               className,
             )}
             disabled={disabled}
@@ -222,12 +223,9 @@ export default function Autocomplete({
           title={selectedOption ? selectedOption.label : undefined}
           variant="outline"
           role="combobox"
+          aria-invalid={props["aria-invalid"]}
           aria-expanded={open}
-          className={cn(
-            "w-full justify-between",
-            isError && "border-red-500",
-            className,
-          )}
+          className={cn("w-full justify-between", className)}
           disabled={disabled}
           data-cy={dataCy}
           onClick={() => setOpen(!open)}

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -184,11 +184,7 @@ export default function Autocomplete({
             ref={ref}
             role="combobox"
             aria-expanded={open}
-            className={cn(
-              "w-full justify-between",
-
-              className,
-            )}
+            className={cn("w-full justify-between", className)}
             disabled={disabled}
             data-cy={dataCy}
             type="button"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-gray-950 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 dark:focus-visible:ring-gray-300",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-gray-950 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 dark:focus-visible:ring-gray-300 aria-invalid:border-red-500 aria-invalid:ring-red-500/20",
   {
     variants: {
       variant: {

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationFormSheet.tsx
@@ -214,7 +214,10 @@ export default function FacilityOrganizationFormSheet({
                   <FormLabel>{t(`type`)}</FormLabel>
                   <Select value={field.value} onValueChange={field.onChange}>
                     <FormControl>
-                      <SelectTrigger data-cy="select-type-dropdown">
+                      <SelectTrigger
+                        data-cy="select-type-dropdown"
+                        ref={field.ref}
+                      >
                         <SelectValue
                           placeholder={t("select_organization_type")}
                         />

--- a/src/pages/Organization/components/GovtOrganizationSelector.tsx
+++ b/src/pages/Organization/components/GovtOrganizationSelector.tsx
@@ -17,9 +17,9 @@ interface GovtOrganizationSelectorProps {
   authToken?: string;
   selected?: Organization[];
 
-  isError?: boolean;
-
   ref?: React.RefCallback<HTMLButtonElement | null>;
+
+  "aria-invalid"?: boolean;
 }
 
 interface OrganizationLevelProps {
@@ -83,7 +83,7 @@ function OrganizationLevelSelect({
       <div className="flex items-center gap-2">
         {isFetching && <Loader2 className="size-6 animate-spin" />}
         <Autocomplete
-          isError={isError}
+          aria-invalid={isError}
           ref={ref}
           value={currentLevel?.id || ""}
           options={options}
@@ -163,7 +163,7 @@ export default function GovtOrganizationSelector(
     <>
       {Array.from({ length: totalLevels }).map((_, index) => (
         <OrganizationLevelSelect
-          isError={props.isError && !selectedLevels[index]}
+          isError={props["aria-invalid"] && !selectedLevels[index]}
           key={index}
           ref={props.ref}
           index={index}

--- a/src/pages/Organization/components/GovtOrganizationSelector.tsx
+++ b/src/pages/Organization/components/GovtOrganizationSelector.tsx
@@ -16,6 +16,10 @@ interface GovtOrganizationSelectorProps {
   required?: boolean;
   authToken?: string;
   selected?: Organization[];
+
+  isError?: boolean;
+
+  ref?: React.RefCallback<HTMLButtonElement | null>;
 }
 
 interface OrganizationLevelProps {
@@ -29,6 +33,10 @@ interface OrganizationLevelProps {
   ) => void;
   required?: boolean;
   authToken?: string;
+
+  isError?: boolean;
+
+  ref?: React.RefCallback<HTMLButtonElement | null>;
 }
 
 function OrganizationLevelSelect({
@@ -38,6 +46,8 @@ function OrganizationLevelSelect({
   onChange,
   required,
   authToken,
+  isError,
+  ref,
 }: OrganizationLevelProps) {
   const { t } = useTranslation();
 
@@ -73,6 +83,8 @@ function OrganizationLevelSelect({
       <div className="flex items-center gap-2">
         {isFetching && <Loader2 className="size-6 animate-spin" />}
         <Autocomplete
+          isError={isError}
+          ref={ref}
           value={currentLevel?.id || ""}
           options={options}
           onChange={handleChange}
@@ -151,7 +163,9 @@ export default function GovtOrganizationSelector(
     <>
       {Array.from({ length: totalLevels }).map((_, index) => (
         <OrganizationLevelSelect
+          isError={props.isError && !selectedLevels[index]}
           key={index}
+          ref={props.ref}
           index={index}
           currentLevel={selectedLevels[index]}
           previousLevel={selectedLevels[index - 1]}

--- a/src/pages/PublicAppointments/PatientRegistration.tsx
+++ b/src/pages/PublicAppointments/PatientRegistration.tsx
@@ -414,6 +414,7 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                         onChange={(value) => {
                           field.onChange(value);
                         }}
+                        isError={!!form.formState.errors.geo_organization}
                       />
                     </FormControl>
                     <FormMessage />

--- a/src/pages/PublicAppointments/PatientRegistration.tsx
+++ b/src/pages/PublicAppointments/PatientRegistration.tsx
@@ -409,12 +409,12 @@ export function PatientRegistration(props: PatientRegistrationProps) {
                   <FormItem className="flex flex-col">
                     <FormControl>
                       <GovtOrganizationSelector
+                        {...field}
                         required
                         authToken={tokenData.token}
                         onChange={(value) => {
                           field.onChange(value);
                         }}
-                        isError={!!form.formState.errors.geo_organization}
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
## Proposed Changes

- Fixes #12672
- Added `ref ` to trigger button so it could get ref passed by field from form
- Used `aria-invalid` attibute injected  by FormControl to the child (here <autocomplete/>)


https://github.com/user-attachments/assets/ba173b82-2fef-4f27-8982-d18eff94e9cf



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved visual feedback for invalid form fields by highlighting buttons with a red border and ring when invalid.
- **Refactor**
  - Simplified form submission and error handling in the facility form for a smoother user experience.
  - Enhanced form field integration and accessibility by forwarding refs and using standard `aria-invalid` attributes in form components.
  - Improved synchronization and event handling for autocomplete and organization selector fields.
- **Accessibility**
  - Increased accessibility compliance by adopting `aria-invalid` attributes for form controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->