### PR TITLE
Creating a subquestion results in a completely separate question instead

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1073,6 +1073,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                           >
                             <div className="absolute -left-4 top-4 font-medium text-gray-500"></div>
                             <QuestionEditor
+                              name={`questions.${index}`}
                               index={index}
                               key={question.link_id}
                               question={question}
@@ -1369,6 +1370,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
 }
 
 interface QuestionEditorProps {
+  name: string;
   form: ReturnType<typeof useForm<any>>;
   index: number;
   question: Question;
@@ -1393,6 +1395,7 @@ interface QuestionEditorProps {
 }
 
 function QuestionEditor({
+  name,
   form,
   question,
   onChange,
@@ -1755,7 +1758,7 @@ function QuestionEditor({
             <div className="flex-1">
               <FormField
                 control={form.control}
-                name={`questions.${index}.text`}
+                name={`${name}.text`}
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>{t("question_text")}</FormLabel>
@@ -1765,11 +1768,9 @@ function QuestionEditor({
                         value={text}
                         onChange={(e) => {
                           updateField("text", e.target.value);
-                          form.setValue(
-                            `questions.${index}.text`,
-                            e.target.value,
-                            { shouldValidate: true },
-                          );
+                          form.setValue(`${name}.text`, e.target.value, {
+                            shouldValidate: true,
+                          });
                         }}
                       />
                     </FormControl>
@@ -1783,7 +1784,7 @@ function QuestionEditor({
           <div>
             <FormField
               control={form.control}
-              name={`questions.${index}.description`}
+              name={`${name}.description`}
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t("description")}</FormLabel>
@@ -1793,11 +1794,9 @@ function QuestionEditor({
                       value={question.description || ""}
                       onChange={(e) => {
                         updateField("description", e.target.value);
-                        form.setValue(
-                          `questions.${index}.description`,
-                          e.target.value,
-                          { shouldValidate: true },
-                        );
+                        form.setValue(`${name}.description`, e.target.value, {
+                          shouldValidate: true,
+                        });
                       }}
                       placeholder={t("question_description_placeholder")}
                       className="h-20"
@@ -1911,7 +1910,7 @@ function QuestionEditor({
             {UNIT_TYPES.includes(type) && (
               <FormField
                 control={form.control}
-                name={`questions.${index}.unit`}
+                name={`${name}.unit`}
                 render={({ field }) => (
                   <FormItem className="pb-4">
                     <FormLabel>{t("unit")}</FormLabel>
@@ -1923,7 +1922,7 @@ function QuestionEditor({
                         value={unit}
                         onSelect={(code) => {
                           updateField("unit", code);
-                          form.setValue(`questions.${index}.unit`, code, {
+                          form.setValue(`${name}.unit`, code, {
                             shouldValidate: true,
                           });
                         }}
@@ -2535,6 +2534,7 @@ function QuestionEditor({
                     className="relative bg-white rounded-lg shadow-md"
                   >
                     <QuestionEditor
+                      name={`${name}.questions.${idx}`}
                       handleEnableWhenDependentClick={
                         handleEnableWhenDependentClick
                       }


### PR DESCRIPTION
## Proposed Changes

- Issue : The issue was that when creating a sub-question, it failed to be created under the parent group; instead, the sub-question was being created as an entirely separate group.
- Fixes #12689

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the consistency of form field naming for questions and sub-questions, ensuring hierarchical names that reflect the nesting structure. This enhances clarity and maintainability when editing questionnaires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->