### PR TITLE
Added auto-scroll to error fields in Questionnaire Editor

### DIFF
--- a/src/components/Questionnaire/CodingEditor.tsx
+++ b/src/components/Questionnaire/CodingEditor.tsx
@@ -35,7 +35,7 @@ import valuesetApi from "@/types/valueset/valuesetApi";
 
 interface CodingEditorProps {
   code?: Code;
-  questionIndex: number;
+  name: string;
   form: ReturnType<typeof useForm<any>>;
   onChange: (code: Code | undefined) => void;
 }
@@ -44,7 +44,7 @@ export function CodingEditor({
   code,
   onChange,
   form,
-  questionIndex,
+  name,
 }: CodingEditorProps) {
   const { mutate: verifyCode, isPending } = useMutation({
     mutationFn: mutate(valuesetApi.lookup),
@@ -59,7 +59,7 @@ export function CodingEditor({
     },
     onError: (error) => {
       console.error(error);
-      form.setError(`questions.${questionIndex}.code.display`, {
+      form.setError(`${name}.code.display`, {
         type: "manual",
         message: t("code_verification_required"),
       });
@@ -100,7 +100,7 @@ export function CodingEditor({
             onClick={(e) => {
               e.preventDefault();
               onChange(undefined);
-              form.clearErrors([`questions.${questionIndex}.code`]);
+              form.clearErrors([`${name}.code`]);
             }}
           >
             <CareIcon icon="l-trash-alt" className="mr-2 size-4" />
@@ -113,7 +113,7 @@ export function CodingEditor({
         <div>
           <FormField
             control={form.control}
-            name={`questions.${questionIndex}.code.system`}
+            name={`${name}.code.system`}
             render={({ field }) => (
               <FormItem>
                 <FormLabel>{t("system")}</FormLabel>
@@ -153,7 +153,7 @@ export function CodingEditor({
           <div>
             <FormField
               control={form.control}
-              name={`questions.${questionIndex}.code.code`}
+              name={`${name}.code.code`}
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t("code")}</FormLabel>
@@ -167,9 +167,7 @@ export function CodingEditor({
                           code: e.target.value,
                           display: "",
                         });
-                        form.clearErrors([
-                          `questions.${questionIndex}.code.display`,
-                        ]);
+                        form.clearErrors([`${name}.code.display`]);
                       }}
                       placeholder={t("enter_code")}
                     />
@@ -182,7 +180,7 @@ export function CodingEditor({
           <div>
             <FormField
               control={form.control}
-              name={`questions.${questionIndex}.code.display`}
+              name={`${name}.code.display`}
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t("display")}</FormLabel>

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -201,13 +201,27 @@ function LayoutOptionCard({
 
 const HIDE_REPEATABLE_QUESTION_TYPES = ["boolean", "group", "display"];
 
-function findFirstErrorIndex(errors: any): number | null {
-  if (!Array.isArray(errors)) return null;
+function findFirstErrorPath(errors: any, path: number[] = []): number[] | null {
   for (let i = 0; i < errors.length; i++) {
-    if (errors[i] && Object.keys(errors[i]).length > 0) {
-      return i;
+    const current = errors[i];
+    const currentPath = [...path, i];
+
+    if (current && typeof current === "object") {
+      const hasOwnErrors = Object.entries(current).some(([key, value]) => {
+        return key !== "questions" && value !== undefined;
+      });
+
+      if (hasOwnErrors) {
+        return currentPath;
+      }
+
+      if (Array.isArray(current.questions)) {
+        const subPath = findFirstErrorPath(current.questions, currentPath);
+        if (subPath) return subPath;
+      }
     }
   }
+
   return null;
 }
 
@@ -606,12 +620,10 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     const hasValidStructuredType = validateStructuredType();
 
     const validateQuestions = (questions: any[], path = "questions") => {
-      console.log(questions);
       questions.forEach((question, idx) => {
         const currentPath = `${path}.${idx}`;
 
         if (question.code && !question.code?.display) {
-          console.log(`${currentPath}.code.display`);
           form.setError(`${currentPath}.code.display`, {
             type: "manual",
             message: t("code_verification_required"),
@@ -637,21 +649,34 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
             break;
           }
         } else {
-          const firstErrorIdx = findFirstErrorIndex(error);
-
-          if (firstErrorIdx !== null) {
-            const question = rootQuestions[firstErrorIdx];
-            if (question && question.link_id) {
-              setExpandedQuestions((prev) =>
-                new Set(prev).add(question.link_id),
+          const errorPath = findFirstErrorPath(error);
+          if (errorPath) {
+            // Expand all parent groups
+            for (let i = 0; i < errorPath.length; i++) {
+              const question = getQuestionByPath(
+                rootQuestions,
+                errorPath.slice(0, i + 1),
               );
-              setTimeout(() => {
-                const el = questionRefs.current[question.link_id];
-                if (el) {
-                  el.scrollIntoView({ behavior: "smooth", block: "center" });
-                }
-              }, 100);
+              if (question?.link_id) {
+                setExpandedQuestions((prev) =>
+                  new Set(prev).add(question.link_id),
+                );
+              }
             }
+
+            // After expanding, scroll to the error question
+            setTimeout(() => {
+              const errorQuestion = getQuestionByPath(rootQuestions, errorPath);
+              if (
+                errorQuestion?.link_id &&
+                questionRefs.current[errorQuestion.link_id]
+              ) {
+                questionRefs.current[errorQuestion.link_id]?.scrollIntoView({
+                  behavior: "smooth",
+                  block: "center",
+                });
+              }
+            }, 200);
           }
         }
       }
@@ -1186,6 +1211,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                                 handleEnableWhenDependentClick
                               }
                               expandPath={expandPath}
+                              questionRefs={questionRefs}
                             />
                           </div>
                         ))}
@@ -1445,6 +1471,7 @@ interface QuestionEditorProps {
   >;
   handleEnableWhenDependentClick: (path: string[], targetId: string) => void;
   expandPath?: string[];
+  questionRefs: React.RefObject<{ [key: string]: HTMLDivElement | null }>;
 }
 
 function QuestionEditor({
@@ -1467,6 +1494,7 @@ function QuestionEditor({
   enableWhenDependencies,
   handleEnableWhenDependentClick,
   expandPath,
+  questionRefs,
 }: QuestionEditorProps): React.ReactElement {
   const { t } = useTranslation();
   const {
@@ -2585,6 +2613,9 @@ function QuestionEditor({
                     key={subQuestion.id}
                     id={`question-${subQuestion.link_id}`}
                     className="relative bg-white rounded-lg shadow-md"
+                    ref={(el) => {
+                      questionRefs.current[subQuestion.link_id] = el;
+                    }}
                   >
                     <QuestionEditor
                       name={`${name}.questions.${idx}`}
@@ -2636,6 +2667,7 @@ function QuestionEditor({
                       isFirst={idx === 0}
                       isLast={idx === (questions?.length || 0) - 1}
                       expandPath={expandPath?.slice(1)}
+                      questionRefs={questionRefs}
                     />
                   </div>
                 ))}
@@ -2925,4 +2957,12 @@ function QuestionEditor({
       </CollapsibleContent>
     </Collapsible>
   );
+}
+
+function getQuestionByPath(questions: any, path: number[]) {
+  let q = questions[path[0]];
+  for (let i = 1; i < path.length; i++) {
+    q = q?.questions?.[path[i]];
+  }
+  return q;
 }

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -10,7 +10,7 @@ import {
   ViewIcon,
 } from "lucide-react";
 import { useNavigate } from "raviger";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -201,6 +201,16 @@ function LayoutOptionCard({
 
 const HIDE_REPEATABLE_QUESTION_TYPES = ["boolean", "group", "display"];
 
+function findFirstErrorIndex(errors: any): number | null {
+  if (!Array.isArray(errors)) return null;
+  for (let i = 0; i < errors.length; i++) {
+    if (errors[i] && Object.keys(errors[i]).length > 0) {
+      return i;
+    }
+  }
+  return null;
+}
+
 export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -231,6 +241,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     Map<string, Set<{ question: Question; path: string[] }>>
   >(new Map());
   const [expandPath, setExpandPath] = useState<string[]>([]);
+  const questionRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
 
   const handleOnErrors = (error: HTTPError, fallbackMessage: string) => {
     const errorData = (
@@ -605,6 +616,34 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     });
 
     if (!isValid || !hasOrganizations || !hasValidStructuredType) {
+      const errorEntries = Object.entries(form.formState.errors);
+
+      for (const [fieldName, error] of errorEntries) {
+        if (fieldName !== "questions") {
+          const el = document.querySelector(`[name="${fieldName}"]`);
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+            break;
+          }
+        } else {
+          const firstErrorIdx = findFirstErrorIndex(error);
+
+          if (firstErrorIdx !== null) {
+            const question = rootQuestions[firstErrorIdx];
+            if (question && question.link_id) {
+              setExpandedQuestions((prev) =>
+                new Set(prev).add(question.link_id),
+              );
+              setTimeout(() => {
+                const el = questionRefs.current[question.link_id];
+                if (el) {
+                  el.scrollIntoView({ behavior: "smooth", block: "center" });
+                }
+              }, 100);
+            }
+          }
+        }
+      }
       return;
     }
 
@@ -1069,6 +1108,9 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                           <div
                             key={question.id}
                             id={`question-${question.link_id}`}
+                            ref={(el) => {
+                              questionRefs.current[question.link_id] = el;
+                            }}
                             className="relative bg-white rounded-lg shadow-md"
                           >
                             <div className="absolute -left-4 top-4 font-medium text-gray-500"></div>

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -605,15 +605,26 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     const hasOrganizations = validateOrganizations();
     const hasValidStructuredType = validateStructuredType();
 
-    rootQuestions.forEach((question, idx) => {
-      if (question.code && !question.code?.display) {
-        form.setError(`questions.${idx}.code.display`, {
-          type: "manual",
-          message: t("code_verification_required"),
-        });
-        isValid = false;
-      }
-    });
+    const validateQuestions = (questions: any[], path = "questions") => {
+      console.log(questions);
+      questions.forEach((question, idx) => {
+        const currentPath = `${path}.${idx}`;
+
+        if (question.code && !question.code?.display) {
+          console.log(`${currentPath}.code.display`);
+          form.setError(`${currentPath}.code.display`, {
+            type: "manual",
+            message: t("code_verification_required"),
+          });
+          isValid = false;
+        }
+
+        if (question.type === "group" && Array.isArray(question.questions)) {
+          validateQuestions(question.questions, `${currentPath}.questions`);
+        }
+      });
+    };
+    validateQuestions(rootQuestions);
 
     if (!isValid || !hasOrganizations || !hasValidStructuredType) {
       const errorEntries = Object.entries(form.formState.errors);
@@ -1979,7 +1990,7 @@ function QuestionEditor({
               <CodingEditor
                 code={code}
                 form={form}
-                questionIndex={index}
+                name={name}
                 onChange={(newCode) => updateField("code", newCode)}
               />
             )}

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -639,47 +639,52 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
     validateQuestions(rootQuestions);
 
     if (!isValid || !hasOrganizations || !hasValidStructuredType) {
-      const errorEntries = Object.entries(form.formState.errors);
+      setTimeout(() => {
+        const errorEntries = Object.entries(form.formState.errors);
 
-      for (const [fieldName, error] of errorEntries) {
-        if (fieldName !== "questions") {
-          const el = document.querySelector(`[name="${fieldName}"]`);
-          if (el) {
-            el.scrollIntoView({ behavior: "smooth", block: "center" });
-            break;
-          }
-        } else {
-          const errorPath = findFirstErrorPath(error);
-          if (errorPath) {
-            // Expand all parent groups
-            for (let i = 0; i < errorPath.length; i++) {
-              const question = getQuestionByPath(
-                rootQuestions,
-                errorPath.slice(0, i + 1),
-              );
-              if (question?.link_id) {
-                setExpandedQuestions((prev) =>
-                  new Set(prev).add(question.link_id),
-                );
-              }
+        for (const [fieldName, error] of errorEntries) {
+          if (fieldName !== "questions") {
+            const el = document.querySelector(`[name="${fieldName}"]`);
+            if (el) {
+              el.scrollIntoView({ behavior: "smooth", block: "center" });
+              break;
             }
-
-            // After expanding, scroll to the error question
-            setTimeout(() => {
-              const errorQuestion = getQuestionByPath(rootQuestions, errorPath);
-              if (
-                errorQuestion?.link_id &&
-                questionRefs.current[errorQuestion.link_id]
-              ) {
-                questionRefs.current[errorQuestion.link_id]?.scrollIntoView({
-                  behavior: "smooth",
-                  block: "center",
-                });
+          } else {
+            const errorPath = findFirstErrorPath(error);
+            if (errorPath) {
+              // Expand parent groups
+              for (let i = 0; i < errorPath.length; i++) {
+                const question = getQuestionByPath(
+                  rootQuestions,
+                  errorPath.slice(0, i + 1),
+                );
+                if (question?.link_id) {
+                  setExpandedQuestions((prev) =>
+                    new Set(prev).add(question.link_id),
+                  );
+                }
               }
-            }, 200);
+
+              // After expanding, scroll to the error question
+              setTimeout(() => {
+                const errorQuestion = getQuestionByPath(
+                  rootQuestions,
+                  errorPath,
+                );
+                if (
+                  errorQuestion?.link_id &&
+                  questionRefs.current[errorQuestion.link_id]
+                ) {
+                  questionRefs.current[errorQuestion.link_id]?.scrollIntoView({
+                    behavior: "smooth",
+                    block: "center",
+                  });
+                }
+              }, 200);
+            }
           }
         }
-      }
+      }, 0); // delay lets react-hook-form update `formState.errors`
       return;
     }
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #12677 
- Added validation for coding in Nested Question (previously missing)
- Improved Error handling by auto-scroll to error fields

![image](https://github.com/user-attachments/assets/7240c29a-cd21-4035-916d-04d2ad987bc1)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The form now automatically expands nested sections and scrolls to the first validation error when saving, improving error visibility and navigation.
  - Enhanced validation for nested questionnaire questions ensures missing fields are clearly indicated for correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->