### PR TITLE
Change threshold for deciding between radio and dropdown in choice question

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -39,7 +39,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
 }: ChoiceQuestionProps) {
   const options = question.answer_option || [];
   const selectType =
-    question.answer_option?.length && question.answer_option?.length > 4
+    question.answer_option?.length && question.answer_option?.length > 5
       ? "dropdown"
       : "radio";
   const currentValue = questionnaireResponse.values[index]?.value?.toString();


### PR DESCRIPTION


## Proposed Changes

- Change threshold for deciding between radio and dropdown in choice question



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the threshold for displaying answer options as radio buttons instead of a dropdown. Now, radio buttons are shown for up to 5 options; dropdown is used for more than 5 options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->