### PR TITLE
Adds support for minimal field requirement in patient registration (configurable)

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -44,9 +44,8 @@ REACT_SENTRY_DSN=
 # Sentry environment (default: staging)
 REACT_SENTRY_ENVIRONMENT=
 
-# Feature flags
-REACT_ENABLE_HCX=true
-REACT_ENABLE_ABDM=true
+# Flag to allow some fields in patient registration to be non-mandatory
+REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION=true
 
 # JWT token refresh interval (in milliseconds) (default: 5 minutes)
 REACT_JWT_TOKEN_REFRESH_INTERVAL=

--- a/care.config.ts
+++ b/care.config.ts
@@ -80,14 +80,6 @@ const careConfig = {
     environment: env.REACT_SENTRY_ENVIRONMENT || "staging",
   },
 
-  hcx: {
-    enabled: boolean("REACT_ENABLE_HCX"),
-  },
-
-  abdm: {
-    enabled: boolean("REACT_ENABLE_ABDM", true),
-  },
-
   appointments: {
     /**
      * Relative number of days to show in the appointments page by default.
@@ -103,6 +95,11 @@ const careConfig = {
       true,
     ),
   },
+
+  enableMinimalPatientRegistration: boolean(
+    "REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION",
+    false,
+  ),
 
   careApps: env.REACT_ENABLED_APPS
     ? env.REACT_ENABLED_APPS.split(",").map((app) => {

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1902,6 +1902,7 @@
   "min_char_length_error": "Must be at least {{ min_length }} characters",
   "min_password_len_8": "Minimum password length 8",
   "min_time_bw_doses": "Min. time b/w doses",
+  "minimal_patient_registration_geo_organization_required": "Atleast one level geo-organization is required",
   "minimize": "Minimize",
   "missing_required_params_for_patient_verification": "Missing required parameters for patient verification",
   "mobile": "Mobile",

--- a/src/Utils/validators.ts
+++ b/src/Utils/validators.ts
@@ -30,4 +30,11 @@ export default () => ({
       .min(-180, t("invalid_longitude"))
       .max(180, t("invalid_longitude")),
   },
+
+  pincode: z
+    .number()
+    .int()
+    .positive()
+    .min(100000, t("pincode_must_be_6_digits"))
+    .max(999999, t("pincode_must_be_6_digits")),
 });

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -75,6 +75,7 @@ export const BLOOD_GROUPS = BLOOD_GROUP_CHOICES.map((bg) => bg.id) as [
 export default function PatientRegistration(
   props: PatientRegistrationPageProps,
 ) {
+  const { enableMinimalPatientRegistration } = careConfig;
   const [{ phone_number }] = useQueryParams();
   const { patientId, facilityId } = props;
   const { t } = useTranslation();
@@ -113,20 +114,22 @@ export default function PatientRegistration(
             .min(1, t("age_must_be_positive"))
             .max(120, t("age_must_be_below_120"))
             .optional(),
-          address: z.string().nonempty(t("address_is_required")),
+          address: enableMinimalPatientRegistration
+            ? z.string().optional()
+            : z.string().nonempty(t("address_is_required")),
           same_address: z.boolean(),
-          permanent_address: z.string().nonempty(t("field_required")),
-          pincode: z
-            .number()
-            .int()
-            .positive()
-            .min(100000, t("pincode_must_be_6_digits"))
-            .max(999999, t("pincode_must_be_6_digits")),
+          permanent_address: enableMinimalPatientRegistration
+            ? z.string().optional()
+            : z.string().nonempty(t("field_required")),
+          pincode: enableMinimalPatientRegistration
+            ? validators().pincode.optional()
+            : validators().pincode,
           nationality: z.string().nonempty(t("nationality_is_required")),
-          geo_organization: z
-            .string()
-            .uuid({ message: t("geo_organization_is_required") })
-            .optional(),
+          geo_organization: z.string().uuid({
+            message: enableMinimalPatientRegistration
+              ? t("minimal_patient_registration_geo_organization_required")
+              : t("geo_organization_is_required"),
+          }),
           _selected_levels: z.array(z.custom<Organization>()),
           _is_deceased: z.boolean(),
         })
@@ -242,6 +245,7 @@ export default function PatientRegistration(
         permanent_address: values.same_address
           ? values.address
           : values.permanent_address,
+        pincode: values.pincode || undefined,
       });
       return;
     }
@@ -715,7 +719,11 @@ export default function PatientRegistration(
                 name="address"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel aria-required>{t("current_address")}</FormLabel>
+                    <FormLabel
+                      aria-required={!enableMinimalPatientRegistration}
+                    >
+                      {t("current_address")}
+                    </FormLabel>
                     <FormControl>
                       <Textarea
                         {...field}
@@ -771,7 +779,9 @@ export default function PatientRegistration(
                 disabled={form.watch("same_address")}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel aria-required>
+                    <FormLabel
+                      aria-required={!enableMinimalPatientRegistration}
+                    >
                       {t("permanent_address")}
                     </FormLabel>
                     <FormControl>
@@ -787,7 +797,11 @@ export default function PatientRegistration(
                 name="pincode"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel aria-required>{t("pincode")}</FormLabel>
+                    <FormLabel
+                      aria-required={!enableMinimalPatientRegistration}
+                    >
+                      {t("pincode")}
+                    </FormLabel>
                     <FormControl>
                       <Input
                         type="number"
@@ -844,7 +858,7 @@ export default function PatientRegistration(
                         <FormControl>
                           <GovtOrganizationSelector
                             {...field}
-                            required={true}
+                            required={!enableMinimalPatientRegistration}
                             selected={form.watch("_selected_levels")}
                             value={form.watch("geo_organization")}
                             onChange={(value) =>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -26,13 +26,11 @@ interface ImportMetaEnv {
   readonly REACT_ALLOWED_LOCALES?: string;
   readonly REACT_ENABLED_APPS?: string;
   readonly REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB?: string;
+  readonly REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION?: string;
 
   // Plugins related envs...
   readonly REACT_SENTRY_DSN?: string;
   readonly REACT_SENTRY_ENVIRONMENT?: string;
-  readonly REACT_ENABLE_HCX?: string;
-  readonly REACT_ENABLE_ABDM?: string;
-  readonly REACT_ENABLE_SCRIBE?: string;
   readonly REACT_DEFAULT_COUNTRY?: string;
   readonly REACT_MAPS_FALLBACK_URL_TEMPLATE?: string;
 }


### PR DESCRIPTION

## Proposed Changes

- Fixes #12699 

Added a care config. env var to allow minimal field requirements in patient registration form: `REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION` (defaults to `false`).

The following fields are made optional:
- Address
- Permanent Address
- Pincode

Geo-Organization has been made to require atleast one level depth if this flag is enabled.

<img width="732" alt="image" src="https://github.com/user-attachments/assets/271257bf-0abd-4703-be2a-26e3fe6c1444" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a minimal patient registration mode, allowing some fields (address, permanent address, and pincode) to be optional.
  - Added validation for 6-digit pincodes.

- **Localization**
  - Added a new message: "Atleast one level geo-organization is required."

- **Chores**
  - Updated environment configuration to use a single flag for minimal patient registration, removing older feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->