### PR TITLE
fix: Correct translation key format for medication status in MedicationStatementQuestion component

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -812,7 +812,7 @@ const MedicationStatementGridRow: React.FC<MedicationStatementGridRowProps> = ({
               (status) =>
                 (medication.id || status !== "entered_in_error") && (
                   <SelectItem key={status} value={status}>
-                    {t(`medication_status_${status}`)}
+                    {t(`medication_status__${status}`)}
                   </SelectItem>
                 ),
             )}


### PR DESCRIPTION
fix: Correct translation key format for medication status in MedicationStatementQuestion component

@ohcnetwork/care-fe-code-reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the translation key format for medication status labels in the medication status dropdown. No visible changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->