### PR TITLE
Enhance autocomplete styling with padding for popover trigger

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -357,6 +357,11 @@
     @apply data-[state=checked]:border-primary-500 data-[state=checked]:text-primary-500 border-gray-300 shadow-sm;
   }
 
+  /* Styling for autocomplete */
+  [data-slot="popover-trigger"] {
+    @apply px-3;
+  }
+
   /* Styling fix for Select for backwards compatibility */
   button[role="combobox"] {
     @apply w-full;


### PR DESCRIPTION
Enhance autocomplete styling with padding for popover trigger in index.css

The styling of the reusable Autocomplete component by adding horizontal padding (px-3) to the [data-slot="popover-trigger"] element in index.css. The trigger is implemented using a button, which was previously not visually aligned with other standard input fields due to extra padding. This update ensures consistent spacing and a more uniform appearance across all form elements where the autocomplete is used, enhancing the overall user interface consistency.


Issue
<img width="1451" alt="image" src="https://github.com/user-attachments/assets/55be8d96-d03f-43c3-9496-d86da589cf30" />

Fix
<img width="1451" alt="image" src="https://github.com/user-attachments/assets/57b5814d-7409-4d37-9fe2-14470b8e1837" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [x] Request for Peer Reviews

