### PR TITLE
Allow mark as fullfilled as long as appointment is `in_consultation` as status

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -553,7 +553,6 @@ const AppointmentActions = ({
 
       {currentStatus === "in_consultation" && (
         <Button
-          disabled={!isToday}
           variant="outline_primary"
           onClick={() => onChange("fulfilled")}
           size="lg"


### PR DESCRIPTION

## Proposed Changes

- Allow mark as fullfilled as long as appointment is `in_consultation` as status

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Mark as fulfilled" button for appointments in consultation is now always enabled, regardless of the appointment date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->