### PR TITLE
fix: Double Border on <Input /> Component Focus State

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       type={type}
       className={cn(
-        "flex w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-base shadow-xs transition-colors file:border-0 file:bg-transparent focus:ring-primary-500 focus:border-primary-500 file:text-sm file:font-medium file:text-gray-950 placeholder:text-gray-500 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-gray-950 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-gray-800 dark:file:text-gray-50 dark:placeholder:text-gray-400 dark:focus-visible:ring-gray-300 duration-300",
+        "flex w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-base shadow-xs transition-colors file:border-0 file:bg-transparent focus:ring-primary-500 focus:border-primary-500 file:text-sm file:font-medium file:text-gray-950 placeholder:text-gray-500 focus-visible:outline-hidden  disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-gray-800 dark:file:text-gray-50 dark:placeholder:text-gray-400 dark:focus-visible:ring-gray-300 duration-300",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12713 
![Screenshot 2025-06-27 141001](https://github.com/user-attachments/assets/f3f6e560-ce68-49d5-805b-91c034a51257)
![Screenshot 2025-06-27 141022](https://github.com/user-attachments/assets/12247ba9-01af-40b9-95d9-37b7769b23f9)
![Screenshot 2025-06-27 141033](https://github.com/user-attachments/assets/b5a7c60d-79e0-42e6-aa01-94e696d2a0e8)
![Screenshot 2025-06-27 141046](https://github.com/user-attachments/assets/bcb93deb-c2e2-4514-833b-031ff62da2eb)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated input field styling by removing the focus-visible ring effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->