### PR TITLE
Fix: Show “Add” button instead of “Edit” in Prescription section

### DIFF
--- a/cypress/pageObject/Patients/PatientPrescription.ts
+++ b/cypress/pageObject/Patients/PatientPrescription.ts
@@ -13,7 +13,7 @@ export class PatientPrescription {
   }
   clickEditPrescription() {
     cy.intercept("GET", "**/medication/request/**").as("getMedications");
-    cy.verifyAndClickElement('[data-cy="edit-prescription"]', "Edit");
+    cy.verifyAndClickElement('[data-cy="edit-prescription"]', /Add|Edit/);
     cy.wait("@getMedications").its("response.statusCode").should("eq", 200);
     return this;
   }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -133,7 +133,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "verifyAndClickElement",
-  (element: string, reference: string) => {
+  (element: string, reference: string | RegExp) => {
     cy.get(element).scrollIntoView();
     cy.get(element).contains(reference).should("be.visible").click();
   },

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -30,7 +30,7 @@ declare global {
       ): Chainable<Element>;
       verifyAndClickElement(
         element: string,
-        reference: string,
+        reference: string | RegExp,
       ): Chainable<Element>;
       preventPrint(): Chainable<Window>;
       closeNotification(): Chainable<JQuery<HTMLElement>>;

--- a/src/components/Medicine/MedicationRequestTable/index.tsx
+++ b/src/components/Medicine/MedicationRequestTable/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { PencilIcon } from "lucide-react";
+import { PencilIcon, PlusIcon } from "lucide-react";
 import { Link, usePathParams } from "raviger";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -136,6 +136,7 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
       );
 
   const isLoading = loadingActive || loadingStopped;
+  const shouldShowAdd = !activeMedications?.results?.length && !showStopped;
 
   return (
     <div className="space-y-2">
@@ -197,8 +198,12 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
                       data-cy="edit-prescription"
                     >
                       <Link href={`questionnaire/medication_request`}>
-                        <PencilIcon className="mr-2 size-4" />
-                        {t("edit")}
+                        {shouldShowAdd ? (
+                          <PlusIcon className="mr-2 size-4" />
+                        ) : (
+                          <PencilIcon className="mr-2 size-4" />
+                        )}
+                        {shouldShowAdd ? t("add") : t("edit")}
                       </Link>
                     </Button>
                   )}

--- a/src/components/Medicine/MedicationRequestTable/index.tsx
+++ b/src/components/Medicine/MedicationRequestTable/index.tsx
@@ -136,7 +136,6 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
       );
 
   const isLoading = loadingActive || loadingStopped;
-  const shouldShowAdd = !activeMedications?.results?.length && !showStopped;
 
   return (
     <div className="space-y-2">
@@ -198,12 +197,17 @@ export default function MedicationRequestTable({ patient, encounter }: Props) {
                       data-cy="edit-prescription"
                     >
                       <Link href={`questionnaire/medication_request`}>
-                        {shouldShowAdd ? (
-                          <PlusIcon className="mr-2 size-4" />
+                        {!activeMedications?.results?.length ? (
+                          <>
+                            <PlusIcon className="mr-2 size-4" />
+                            {t("add")}
+                          </>
                         ) : (
-                          <PencilIcon className="mr-2 size-4" />
+                          <>
+                            <PencilIcon className="mr-2 size-4" />
+                            {t("edit")}
+                          </>
                         )}
-                        {shouldShowAdd ? t("add") : t("edit")}
                       </Link>
                     </Button>
                   )}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12727 
- Shows Add button when no active prescriptions.

https://github.com/user-attachments/assets/7b1ebaca-08d8-46f2-afc5-57314296de7f



- Incase the user wants to edit stopped prescriptions(add notes), changes add to edit to avoid confusion. *Removed

https://github.com/user-attachments/assets/1534ab47-929b-406c-8512-073312f50f21



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * The medication table's edit button now dynamically switches to an "add" button with a plus icon and label when no active medications are present.

* **Tests**
  * Enhanced test commands to support clicking buttons labeled either "Add" or "Edit" for better interaction coverage.

* **Style**
  * Updated button icons and labels in the medication table for clearer user guidance based on medication status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->