### PR TITLE
Fix : Delete Avatar Shows Uploading Transition Instead of Deleting

### DIFF
--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -514,7 +514,13 @@ export default function AvatarEditModal({
                       onClick={deleteAvatar}
                       disabled={isProcessing || isDeleting}
                     >
-                      {t("delete")}
+                      {isDeleting ? (
+                        <CareIcon
+                          icon="l-spinner"
+                          className="animate-spin text-lg mr-1"
+                        />
+                      ) : null}
+                      {isDeleting ? `${t("deleting")}...` : t("delete")}
                     </Button>
                   )}
                   <Button
@@ -528,7 +534,7 @@ export default function AvatarEditModal({
                       (!croppedAreaPixels && !showCroppedPreview)
                     }
                   >
-                    {isProcessing || isDeleting ? (
+                    {isProcessing ? (
                       <CareIcon
                         icon="l-spinner"
                         className="animate-spin text-lg"
@@ -541,11 +547,9 @@ export default function AvatarEditModal({
                     <span>
                       {isProcessing
                         ? `${t("uploading")}...`
-                        : isDeleting
-                          ? `${t("deleting")}...`
-                          : showCroppedPreview
-                            ? `${t("upload")}`
-                            : `${t("crop")}`}
+                        : showCroppedPreview
+                          ? `${t("upload")}`
+                          : `${t("crop")}`}
                     </span>
                   </Button>
                 </div>

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -89,6 +89,7 @@ export default function AvatarEditModal({
   aspectRatio = 1,
 }: Props) {
   const [isProcessing, setIsProcessing] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File>();
   const [preview, setPreview] = useState<string>();
   const [isCameraOpen, setIsCameraOpen] = useState<boolean>(false);
@@ -173,6 +174,7 @@ export default function AvatarEditModal({
   const closeModal = () => {
     setPreview(undefined);
     setIsProcessing(false);
+    setIsDeleting(false);
     setSelectedFile(undefined);
     setIsCameraOpen(false);
     setCroppedAreaPixels(null);
@@ -261,14 +263,14 @@ export default function AvatarEditModal({
   };
 
   const deleteAvatar = async () => {
-    setIsProcessing(true);
+    setIsDeleting(true);
     await handleDelete(
       () => {
-        setIsProcessing(false);
+        setIsDeleting(false);
         setPreview(undefined);
         closeModal();
       },
-      () => setIsProcessing(false),
+      () => setIsDeleting(false),
     );
   };
 
@@ -502,7 +504,7 @@ export default function AvatarEditModal({
                       closeModal();
                       dragProps.setFileDropError("");
                     }}
-                    disabled={isProcessing}
+                    disabled={isProcessing || isDeleting}
                   >
                     {t("cancel")}
                   </Button>
@@ -510,7 +512,7 @@ export default function AvatarEditModal({
                     <Button
                       variant="destructive"
                       onClick={deleteAvatar}
-                      disabled={isProcessing}
+                      disabled={isProcessing || isDeleting}
                     >
                       {t("delete")}
                     </Button>
@@ -526,7 +528,7 @@ export default function AvatarEditModal({
                       (!croppedAreaPixels && !showCroppedPreview)
                     }
                   >
-                    {isProcessing ? (
+                    {isProcessing || isDeleting ? (
                       <CareIcon
                         icon="l-spinner"
                         className="animate-spin text-lg"
@@ -539,9 +541,11 @@ export default function AvatarEditModal({
                     <span>
                       {isProcessing
                         ? `${t("uploading")}...`
-                        : showCroppedPreview
-                          ? `${t("upload")}`
-                          : `${t("crop")}`}
+                        : isDeleting
+                          ? `${t("deleting")}...`
+                          : showCroppedPreview
+                            ? `${t("upload")}`
+                            : `${t("crop")}`}
                     </span>
                   </Button>
                 </div>

--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -470,6 +470,7 @@ export default function AvatarEditModal({
                       id="upload-cover-image"
                       variant="primary"
                       className="w-full"
+                      disabled={isProcessing || isDeleting}
                       asChild
                     >
                       <label className="cursor-pointer">
@@ -484,6 +485,7 @@ export default function AvatarEditModal({
                           accept="image/*"
                           className="hidden"
                           onChange={onSelectFile}
+                          disabled={isProcessing || isDeleting}
                         />
                       </label>
                     </Button>
@@ -530,6 +532,7 @@ export default function AvatarEditModal({
                     disabled={
                       (!!imageUrl && !preview) ||
                       isProcessing ||
+                      isDeleting ||
                       !selectedFile ||
                       (!croppedAreaPixels && !showCroppedPreview)
                     }
@@ -583,7 +586,11 @@ export default function AvatarEditModal({
                   />
                 </div>
                 <div className="flex flex-col gap-2 pt-4 sm:flex-row">
-                  <Button variant="primary" onClick={handleSwitchCamera}>
+                  <Button
+                    variant="primary"
+                    onClick={handleSwitchCamera}
+                    disabled={isProcessing || isDeleting}
+                  >
                     <CareIcon icon="l-camera-change" className="text-lg" />
                     {`${t("switch")} ${t("camera")}`}
                   </Button>
@@ -593,6 +600,7 @@ export default function AvatarEditModal({
                       captureImage();
                       setIsCameraOpen(false);
                     }}
+                    disabled={isProcessing || isDeleting}
                   >
                     <CareIcon icon="l-capture" className="text-lg" />
                     {t("capture")}
@@ -606,7 +614,7 @@ export default function AvatarEditModal({
                       setPreview(undefined);
                       closeModal();
                     }}
-                    disabled={isProcessing}
+                    disabled={isProcessing || isDeleting}
                   >
                     {t("close")}
                   </Button>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12745
- Showing deleting transition over the delete utton. 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.

https://github.com/user-attachments/assets/32f83cd6-325c-489e-822a-1e8b6a638313


- [x] Request for Peer Reviews
- [] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved avatar modal with separate visual feedback for avatar deletion and other processing actions. The delete button and related UI elements now clearly indicate when an avatar is being deleted, enhancing user clarity during asynchronous operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->