### PR TITLE
Use ShadCN Select for Language Selector in User Profile Page

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2831,6 +2831,7 @@
   "select_investigation": "Select Investigations (all investigations will be selected by default)",
   "select_investigation_groups": "Select Investigation Groups",
   "select_investigations": "Select Investigations",
+  "select_language": "Select Language",
   "select_local_body": "Select Local Body",
   "select_location": "Select Location",
   "select_location_first": "Select Location First",

--- a/src/components/Common/LanguageSelector.tsx
+++ b/src/components/Common/LanguageSelector.tsx
@@ -2,13 +2,19 @@ import careConfig from "@careConfig";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import { keysOf } from "@/Utils/utils";
 import { LANGUAGES } from "@/i18n";
 
-export const LanguageSelector = (props: any) => {
-  const { i18n } = useTranslation();
+export const LanguageSelector = () => {
+  const { t, i18n } = useTranslation();
 
   useEffect(() => {
     document.documentElement.setAttribute("lang", i18n.language);
@@ -27,23 +33,19 @@ export const LanguageSelector = (props: any) => {
   );
 
   return (
-    <div className="relative flex items-center">
-      <select
-        className={cn(
-          props.className,
-          "w-full cursor-pointer appearance-none rounded-md py-2 pl-2 pr-10 focus:border-primary-500 focus:outline-hidden focus:ring-primary-500",
-        )}
-        id="language-selector"
-        name="language"
-        value={i18n.language}
-        onChange={(e: any) => handleLanguage(e.target.value)}
-      >
-        {availableLocales.map((e) => (
-          <option key={e} value={e}>
-            {LANGUAGES[e]}
-          </option>
-        ))}
-      </select>
+    <div className="relative flex items-center w-full">
+      <Select value={i18n.language} onValueChange={handleLanguage}>
+        <SelectTrigger className="focus:border-primary-500 focus:outline-none focus:ring-primary-500">
+          <SelectValue placeholder={t("select_language")} />
+        </SelectTrigger>
+        <SelectContent>
+          {availableLocales.map((lang) => (
+            <SelectItem key={lang} value={lang}>
+              {LANGUAGES[lang]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </div>
   );
 };

--- a/src/components/Common/LanguageSelector.tsx
+++ b/src/components/Common/LanguageSelector.tsx
@@ -33,20 +33,18 @@ export const LanguageSelector = () => {
   );
 
   return (
-    <div className="relative flex items-center w-full">
-      <Select value={i18n.language} onValueChange={handleLanguage}>
-        <SelectTrigger className="focus:border-primary-500 focus:outline-none focus:ring-primary-500">
-          <SelectValue placeholder={t("select_language")} />
-        </SelectTrigger>
-        <SelectContent>
-          {availableLocales.map((lang) => (
-            <SelectItem key={lang} value={lang}>
-              {LANGUAGES[lang]}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <Select value={i18n.language} onValueChange={handleLanguage}>
+      <SelectTrigger>
+        <SelectValue placeholder={t("select_language")} />
+      </SelectTrigger>
+      <SelectContent>
+        {availableLocales.map((lang) => (
+          <SelectItem key={lang} value={lang}>
+            {LANGUAGES[lang]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 };
 

--- a/src/components/Common/LanguageSelector.tsx
+++ b/src/components/Common/LanguageSelector.tsx
@@ -35,7 +35,7 @@ export const LanguageSelector = () => {
   return (
     <div className="relative flex items-center w-full">
       <Select value={i18n.language} onValueChange={handleLanguage}>
-        <SelectTrigger className="focus:border-primary-500 focus:outline-none focus:ring-primary-500">
+        <SelectTrigger>
           <SelectValue placeholder={t("select_language")} />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12736 
- Replaced native <select> element with ShadCN <Select> component for consistent UI
- Moved the placeholder string to en.json
- Applied appropriate styling to match design system

**After**


https://github.com/user-attachments/assets/97f8319b-c404-4771-b49a-3bcf5e008154





@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * The language selector now uses a custom dropdown component with improved styling and localization support.

* **Refactor**
  * Updated the language selector interface for a more consistent and user-friendly experience.

* **Documentation**
  * Added a new localization string for the language selector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->