### PR TITLE
Fix: Tooltip position for username in User Profile page

### DIFF
--- a/src/components/Users/UserBanner.tsx
+++ b/src/components/Users/UserBanner.tsx
@@ -38,7 +38,7 @@ export default function UserBanner({ userData }: { userData: UserBase }) {
           <TooltipComponent content={userData.username} side="bottom">
             <p
               id="username"
-              className="text-sm font-light leading-relaxed text-secondary-600 truncate w-fit"
+              className="text-sm font-light leading-relaxed text-secondary-600 w-fit"
             >
               {userData.username}
             </p>

--- a/src/components/Users/UserBanner.tsx
+++ b/src/components/Users/UserBanner.tsx
@@ -38,7 +38,7 @@ export default function UserBanner({ userData }: { userData: UserBase }) {
           <TooltipComponent content={userData.username} side="bottom">
             <p
               id="username"
-              className="text-sm font-light leading-relaxed text-secondary-600 truncate"
+              className="text-sm font-light leading-relaxed text-secondary-600 truncate w-fit"
             >
               {userData.username}
             </p>


### PR DESCRIPTION
## Proposed Changes

- Add w-fit to avoid full-width and fix tooltip misalignment

Before 

<img width="414" alt="Screenshot 2025-06-28 at 6 37 09 PM" src="https://github.com/user-attachments/assets/2e03aec1-195c-4824-8c29-d3c3863ecb19" />

After

<img width="414" alt="Screenshot 2025-06-28 at 6 38 02 PM" src="https://github.com/user-attachments/assets/572fbede-1ecf-4846-ba52-6941b67bcb8a" />

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the display of usernames in user banners by adjusting width to fit the content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->