### PR TITLE
Update whitespace handling in QuestionnaireResponsesList

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -338,7 +338,7 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
                           className="py-1 pr-0 align-top"
                           colSpan={response.note ? 1 : 2}
                         >
-                          <div className="text-sm font-medium break-words whitespace-normal">
+                          <div className="text-sm font-medium break-words whitespace-pre-wrap">
                             {values.map((val, idx) => (
                               <React.Fragment key={idx}>
                                 {idx > 0 && ", "}

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -169,7 +169,7 @@ function QuestionGroup({
           className="py-1 pr-0 align-top"
           colSpan={response.note ? 1 : 2}
         >
-          <div className="text-sm font-medium break-words whitespace-normal">
+          <div className="text-sm font-medium break-words whitespace-pre-wrap">
             {values.map((val, idx) => (
               <React.Fragment key={idx}>
                 {idx > 0 && ", "}


### PR DESCRIPTION
Update whitespace handling in QuestionnaireResponsesList for better text formatting

## Proposed Changes
**issue**
![image](https://github.com/user-attachments/assets/992f00b8-d605-416b-8d33-0ae983c37ebb)

**fix**
![image](https://github.com/user-attachments/assets/a1f21f6d-ec47-4a60-a4e6-487067449882)
@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved display of questionnaire response values to better preserve whitespace and line breaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->