### PR TITLE
Set PopoverTrigger default type to "button" to prevent accidental form submission 

### DIFF
--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -481,6 +481,7 @@ export default function ValueSetSelect({
           <PopoverTrigger asChild disabled={disabled}>
             <div className={cn(value?.display ? "w-full" : "mr-11")}>
               <Button
+                type="button"
                 variant="outline"
                 role="combobox"
                 className={cn(


### PR DESCRIPTION

## Proposed Changes

This PR addresses an issue where the PopoverTrigger component (often rendered as a <button>) defaults to type="submit", which can unintentionally trigger form submissions when used inside a <form>. Fix: Explicitly sets type="button" for PopoverTrigger to avoid unintended form submissions.


![image](https://github.com/user-attachments/assets/fa74f711-aa44-4ea4-8c7a-2e17fa53665c)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a button in the value set selection to prevent unintended form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->