### PR TITLE
Fix : Questionnaires are submitted even when no edits are made

### DIFF
--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -337,6 +337,7 @@ export function QuestionnaireForm({
 
   const [activeGroupId, setActiveGroupId] = useState<string>();
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(true);
 
   const {
     data: questionnaireData,
@@ -461,6 +462,8 @@ export function QuestionnaireForm({
           },
         ]);
         setIsInitialized(true);
+        // Set a short delay before allowing dirty state changes
+        setTimeout(() => setIsInitializing(false), 500);
       }
     }
   }, [questionnaireData, isInitialized, questionnaireSlug]);
@@ -849,7 +852,7 @@ export function QuestionnaireForm({
                       : formItem,
                   ),
                 );
-                if (!isDirty) {
+                if (!isInitializing && !isDirty) {
                   setIsDirty(true);
                 }
               }}

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -921,7 +921,7 @@ export function QuestionnaireForm({
                 <Button
                   type="submit"
                   onClick={handleSubmit}
-                  disabled={isPending || hasErrors}
+                  disabled={isPending || hasErrors || !isDirty}
                   className="relative"
                 >
                   {isPending ? (


### PR DESCRIPTION
## Proposed Changes

- Fixes #12683

This pull request introduces changes to the `QuestionnaireForm` component to improve initialization handling and ensure proper state management during form interactions. The most important changes include adding an `isInitializing` state, implementing a delay before allowing dirty state changes, and updating conditions for enabling the submit button.

### Initialization Handling Improvements:
* Added a new state variable `isInitializing` to track the initialization phase of the form.
* Introduced a short delay (500ms) after initialization before allowing dirty state changes by using `setTimeout`.

### State Management Enhancements:
* Updated logic to prevent marking the form as dirty during the initialization phase by adding a check for `isInitializing`.
* Modified the submit button's `disabled` condition to include a check for `isDirty`, ensuring the button is only enabled when the form has been modified.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a short initialization phase to the questionnaire form, preventing it from being marked as modified during initial loading.
  * Submit button is now disabled until the form has been changed after initialization, reducing accidental submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->