### PR TITLE
Update Badge padding fix in PatientInfoCard

### DIFF
--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -353,21 +353,19 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                   {props.encounter.current_location ? (
                     <Popover>
                       <PopoverTrigger asChild>
-                        <div>
-                          <Badge
-                            className="capitalize gap-1 py-1 px-3 cursor-pointer hover:bg-secondary-100"
-                            variant="outline"
-                            title={`Current Location: ${props.encounter.current_location.name}`}
-                            data-cy="current-location-badge"
-                          >
-                            <CareIcon
-                              icon="l-location-point"
-                              className="size-4 text-green-600"
-                            />
-                            {props.encounter.current_location.name}
-                            <ChevronDown className="size-3 opacity-50" />
-                          </Badge>
-                        </div>
+                        <Badge
+                          className="capitalize gap-1 py-1 px-3 cursor-pointer hover:bg-secondary-100"
+                          variant="outline"
+                          title={`Current Location: ${props.encounter.current_location.name}`}
+                          data-cy="current-location-badge"
+                        >
+                          <CareIcon
+                            icon="l-location-point"
+                            className="size-4 text-green-600"
+                          />
+                          {props.encounter.current_location.name}
+                          <ChevronDown className="size-3 opacity-50" />
+                        </Badge>
                       </PopoverTrigger>
                       <PopoverContent align={"start"} className="w-auto p-2">
                         <div className="space-y-2 p-2 items-center">

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -186,7 +186,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                   className="flex w-full flex-wrap items-center justify-start gap-2 text-sm text-secondary-900 sm:flex-row sm:text-sm md:pr-10 lg:justify-normal"
                   id="patient-consultationbadges"
                 >
-                  <Popover data-slot="encounter-status-popover">
+                  <Popover>
                     <PopoverTrigger asChild>
                       <Badge
                         className="capitalize gap-1 py-1 px-3 cursor-pointer hover:bg-secondary-100"

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -186,28 +186,26 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                   className="flex w-full flex-wrap items-center justify-start gap-2 text-sm text-secondary-900 sm:flex-row sm:text-sm md:pr-10 lg:justify-normal"
                   id="patient-consultationbadges"
                 >
-                  <Popover>
+                  <Popover data-slot="encounter-status-popover">
                     <PopoverTrigger asChild>
-                      <div>
-                        <Badge
-                          className="capitalize gap-1 py-1 px-2 cursor-pointer hover:bg-secondary-100"
-                          variant="outline"
-                          title={`Encounter Status: ${t(`encounter_status__${props.encounter.status}`)}`}
-                        >
-                          {completedEncounterStatus.includes(
-                            props.encounter.status,
-                          ) || props.encounter.status === "discharged" ? (
-                            <CircleCheck
-                              className="size-4 text-green-300"
-                              fill="green"
-                            />
-                          ) : (
-                            <CircleDashed className="size-4 text-yellow-500" />
-                          )}
-                          {t(`encounter_status__${props.encounter.status}`)}
-                          <ChevronDown className="size-3 opacity-50" />
-                        </Badge>
-                      </div>
+                      <Badge
+                        className="capitalize gap-1 py-1 px-3 cursor-pointer hover:bg-secondary-100"
+                        variant="outline"
+                        title={`Encounter Status: ${t(`encounter_status__${props.encounter.status}`)}`}
+                      >
+                        {completedEncounterStatus.includes(
+                          props.encounter.status,
+                        ) || props.encounter.status === "discharged" ? (
+                          <CircleCheck
+                            className="size-4 text-green-300"
+                            fill="green"
+                          />
+                        ) : (
+                          <CircleDashed className="size-4 text-yellow-500" />
+                        )}
+                        {t(`encounter_status__${props.encounter.status}`)}
+                        <ChevronDown className="size-3 opacity-50" />
+                      </Badge>
                     </PopoverTrigger>
                     <PopoverContent align={"start"} className="w-auto p-2">
                       <div className="space-y-2">
@@ -235,22 +233,20 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
 
                   <Popover>
                     <PopoverTrigger asChild>
-                      <div>
-                        <Badge
-                          className="capitalize gap-1 py-1 px-2 cursor-pointer hover:bg-secondary-100"
-                          variant="outline"
-                          title={`Encounter Class: ${props.encounter.encounter_class}`}
-                        >
-                          <BedSingle
-                            className="size-4 text-blue-400"
-                            fill="#93C5FD"
-                          />
-                          {t(
-                            `encounter_class__${props.encounter.encounter_class}`,
-                          )}
-                          <ChevronDown className="size-3 opacity-50" />
-                        </Badge>
-                      </div>
+                      <Badge
+                        className="capitalize gap-1 py-1 cursor-pointer hover:bg-secondary-100"
+                        variant="outline"
+                        title={`Encounter Class: ${props.encounter.encounter_class}`}
+                      >
+                        <BedSingle
+                          className="size-4 text-blue-400"
+                          fill="#93C5FD"
+                        />
+                        {t(
+                          `encounter_class__${props.encounter.encounter_class}`,
+                        )}
+                        <ChevronDown className="size-3 opacity-50" />
+                      </Badge>
                     </PopoverTrigger>
                     <PopoverContent align={"end"} className="w-auto p-2">
                       <div className="space-y-2">
@@ -276,7 +272,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                     </PopoverContent>
                   </Popover>
                   <Badge
-                    className="capitalize gap-1 py-1 px-2"
+                    className="capitalize gap-1 py-1 px-3"
                     variant="outline"
                     title={`Priority: ${t(
                       `encounter_priority__${props.encounter.priority.toLowerCase()}`,
@@ -290,7 +286,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
 
                   {patient.blood_group && (
                     <Badge
-                      className="capitalize gap-1 py-1 px-2"
+                      className="capitalize gap-1 py-1 px-3"
                       variant="outline"
                       title={`Blood Group: ${patient.blood_group?.replace("_", " ")}`}
                     >
@@ -335,7 +331,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                           )}
                           {encounter.organizations.length === 0 && (
                             <Badge
-                              className="capitalize gap-1 py-1 px-2 cursor-pointer hover:bg-secondary-100"
+                              className="capitalize gap-1 py-1 px-3 cursor-pointer hover:bg-secondary-100"
                               variant="outline"
                             >
                               <Building className="size-4 text-blue-400" />
@@ -359,7 +355,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                       <PopoverTrigger asChild>
                         <div>
                           <Badge
-                            className="capitalize gap-1 py-1 px-2 cursor-pointer hover:bg-secondary-100"
+                            className="capitalize gap-1 py-1 px-3 cursor-pointer hover:bg-secondary-100"
                             variant="outline"
                             title={`Current Location: ${props.encounter.current_location.name}`}
                             data-cy="current-location-badge"
@@ -425,7 +421,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                       </PopoverContent>
                     </Popover>
                   ) : canWrite ? (
-                    <Badge variant="outline">
+                    <Badge variant="outline" className="py-0.5 px-3">
                       <LocationSheet
                         facilityId={props.encounter.facility.id}
                         encounter={encounter}
@@ -447,7 +443,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
                   ) : (
                     <></>
                   )}
-                  <Badge variant="outline">
+                  <Badge variant="outline" className="py-0.5 px-3">
                     <CareTeamSheet
                       encounter={encounter}
                       trigger={
@@ -517,7 +513,7 @@ export default function PatientInfoCard(props: PatientInfoCardProps) {
       <Badge
         key={org.id}
         className={cn(
-          "capitalize gap-1 py-1 px-2 hover:bg-secondary-100 cursor-pointer",
+          "capitalize gap-1 py-1 px-3 hover:bg-secondary-100 cursor-pointer",
         )}
         variant="outline"
         title={`Organization: ${org.name}${org.description ? ` - ${org.description}` : ""}`}


### PR DESCRIPTION
## Proposed Changes

Refactor PatientInfoCard: Update Badge padding for improved spacing and consistency in encounter status and class popovers.Removed the unnecessary div and fixed the py and px of the buttons and badges. 

**Issues**
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/a691b813-2b54-46a3-89d8-1964a9363dc7" />

**Fix**
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/75252633-49b4-44ca-bcac-bf730d18f32e" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved and standardized padding for badges to ensure consistent spacing across the Patient Info Card.
  * Simplified markup by removing unnecessary wrapper elements around badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->