### PR TITLE
Update local backend API URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Create a `.env.local` file in the root directory of the project :
 
 ```env
 # Point the frontend to your local backend
-REACT_CARE_API_URL=http://127.0.0.1:8000
+REACT_CARE_API_URL=http://127.0.0.1:9000
 ```
 
 Once you have the local backend running and loaded dummy data, you can use the following credentials to authenticate:


### PR DESCRIPTION
## Proposed Changes


This pull request updates the `README.md` file to reflect a change in the default local backend URL for the frontend environment configuration.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59): Updated the `REACT_CARE_API_URL` in the `.env.local` example to use port `9000` instead of `8000`.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect a new default local backend URL for the frontend environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->