### PR TITLE
Fix : Reset Search Field Automatically on Search Box Closes

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -104,7 +104,14 @@ const CountrySelect = ({
   const [searchValue, setSearchValue] = React.useState("");
 
   return (
-    <Popover modal>
+    <Popover
+      modal
+      onOpenChange={(open) => {
+        if (!open) {
+          setSearchValue("");
+        }
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           type="button"


### PR DESCRIPTION
## Proposed Changes

- Fixes #12593

- Used the popover's onOpenChange to reset the search state

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.

https://github.com/user-attachments/assets/d2109c6b-88e6-4510-a4aa-c418ad4b02a2


- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the country selection dropdown by clearing the search field each time the dropdown is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->