### PR TITLE
close country dropdown on selection

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -102,9 +102,13 @@ const CountrySelect = ({
   const { t } = useTranslation();
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
   const [searchValue, setSearchValue] = React.useState("");
-
+  const [open, setOpen] = React.useState(false);
+  const handleCountrySelect = (country: RPNInput.Country) => {
+    onChange(country);
+    setOpen(false);
+  };
   return (
-    <Popover modal>
+    <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -159,7 +163,7 @@ const CountrySelect = ({
                       country={value}
                       countryName={label}
                       selectedCountry={selectedCountry}
-                      onChange={onChange}
+                      onChange={handleCountrySelect}
                     />
                   ) : null,
                 )}


### PR DESCRIPTION
## Proposed Changes

- Fixes #12794 
- Used a state variable to control Popover's open/close status.
- State update after selecting country.

https://github.com/user-attachments/assets/f283b907-7415-4aab-9502-1f0e8062a695



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the country selection experience in the phone input by ensuring the country list closes automatically after a country is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->