### PR TITLE
fix: Adjust padding in ValueSetSelect component for improved layout

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -1265,7 +1265,6 @@ const MedicationRequestGridRow: React.FC<MedicationRequestGridRowProps> = ({
           onSelect={(site) => handleUpdateDosageInstruction({ site })}
           placeholder={t("select_site")}
           disabled={disabled || isReadOnly}
-          wrapTextForSmallScreen={true}
           asSheet
         />
       </div>

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -439,7 +439,7 @@ export default function ValueSetSelect({
             variant="outline"
             role="combobox"
             className={cn(
-              "w-full justify-between border border-primary rounded-md px-5",
+              "w-full justify-between border border-primary rounded-md px-2",
               wrapTextForSmallScreen
                 ? "h-auto md:h-9 whitespace-normal text-left md:truncate"
                 : "truncate",
@@ -450,7 +450,7 @@ export default function ValueSetSelect({
             <div className="flex items-center">
               <CareIcon
                 icon="l-plus"
-                className="mr-2 text-5xl text-primary-700 font-normal"
+                className="mr-2 text-primary-700 font-normal"
               />
               <span className="text-primary-700 flex items-center font-semibold text-wrap text-sm md:text-base">
                 {value?.display || placeholder}

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -50,7 +50,6 @@ interface Props {
   disabled?: boolean;
   count?: number;
   searchPostFix?: string;
-  wrapTextForSmallScreen?: boolean;
   hideTrigger?: boolean;
   controlledOpen?: boolean;
   title?: string;
@@ -101,7 +100,6 @@ export default function ValueSetSelect({
   disabled,
   count = 10,
   searchPostFix = "",
-  wrapTextForSmallScreen = false,
   hideTrigger = false,
   controlledOpen = false,
   closeOnSelect = true,
@@ -409,9 +407,7 @@ export default function ValueSetSelect({
             onClick={() => setInternalOpen(true)}
             className={cn(
               "w-full justify-between",
-              wrapTextForSmallScreen
-                ? "h-auto md:h-9 whitespace-normal text-left md:truncate"
-                : "truncate",
+              "h-auto md:h-9 whitespace-normal text-left md:truncate",
               !value?.display && "text-gray-400",
             )}
             disabled={disabled}
@@ -439,10 +435,7 @@ export default function ValueSetSelect({
             variant="outline"
             role="combobox"
             className={cn(
-              "w-full justify-between border border-primary rounded-md px-2",
-              wrapTextForSmallScreen
-                ? "h-auto md:h-9 whitespace-normal text-left md:truncate"
-                : "truncate",
+              "w-full justify-between border border-primary rounded-md px-2 h-auto whitespace-normal text-left",
               !value?.display && "text-gray-400",
             )}
             disabled={disabled}
@@ -485,10 +478,7 @@ export default function ValueSetSelect({
                 variant="outline"
                 role="combobox"
                 className={cn(
-                  "justify-between",
-                  wrapTextForSmallScreen
-                    ? "h-auto md:h-9 whitespace-normal text-left md:truncate"
-                    : "truncate",
+                  "justify-between truncate",
                   !value?.display && "text-gray-400",
                 )}
               >


### PR DESCRIPTION
## Proposed Changes
Fixes the broken UI for the value-set component in mobile view 

**Issue**
![image](https://github.com/user-attachments/assets/4c628bf8-affc-4f7e-af4d-7ae24a56cecd)

**Fix** 
![image](https://github.com/user-attachments/assets/9cd3f2fb-2ccd-43b7-8edf-8075efa7178d)


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist


- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized text wrapping on small screens for better readability.
  * Reduced horizontal padding on the mobile button for a more compact appearance.
  * Decreased the icon size within the button for improved visual balance on mobile devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->