### PR TITLE
fix: Add "structured" to HIDE_REPEATABLE_QUESTION_TYPES in QuestionnaireEditor for improved functionality

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -202,7 +202,12 @@ function LayoutOptionCard({
   );
 }
 
-const HIDE_REPEATABLE_QUESTION_TYPES = ["boolean", "group", "display"];
+const HIDE_REPEATABLE_QUESTION_TYPES = [
+  "boolean",
+  "group",
+  "display",
+  "structured",
+];
 
 function findFirstErrorPath(errors: any, path: number[] = []): number[] | null {
   for (let i = 0; i < errors.length; i++) {

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1969,9 +1969,16 @@ function QuestionEditor({
                   value={type}
                   onValueChange={(val: QuestionType) => {
                     if (val !== "group") {
-                      updateField("type", val, { questions: [] });
+                      updateField("type", val, {
+                        questions: [],
+                        repeats: HIDE_REPEATABLE_QUESTION_TYPES.includes(val)
+                          ? false
+                          : question.repeats,
+                      });
                     } else {
-                      updateField("type", val);
+                      updateField("type", val, {
+                        repeats: false,
+                      });
                     }
                   }}
                 >


### PR DESCRIPTION


## Proposed Changes
Add "structured" to HIDE_REPEATABLE_QUESTION_TYPES in QuestionnaireEditor to hide repeatable questions when the "structured" option is selected.

cc: @nihal467 

@ohcnetwork/care-fe-code-reviewers




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the questionnaire editor to hide the "repeatable" option for "structured" question types, in addition to existing types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->