### PR TITLE
Fix: Allow administering medicine at the same time as it was added #12693

### DIFF
--- a/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
+++ b/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
@@ -69,21 +69,19 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
     const startTime = startOfMinute(
       new Date(administrationRequest.occurrence_period_start),
     );
-    const roundedDate = startOfMinute(date);
+    date = startOfMinute(date);
 
-    if (roundedDate > now) {
+    if (date > now) {
       return t(
         isStartTime ? "start_time_future_error" : "end_time_future_error",
       );
     }
 
     if (isStartTime) {
-      return roundedDate < authoredOn
-        ? t("start_time_before_authored_error")
-        : "";
+      return date < authoredOn ? t("start_time_before_authored_error") : "";
     }
 
-    return roundedDate < startTime ? t("end_time_before_start_error") : "";
+    return date < startTime ? t("end_time_before_start_error") : "";
   };
 
   // Validate and notify parent whenever times change

--- a/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
+++ b/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
@@ -63,22 +63,35 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
   const [startTimeError, setStartTimeError] = useState("");
   const [endTimeError, setEndTimeError] = useState("");
 
-  const validateDateTime = (date: Date, isStartTime: boolean): string => {
-    const now = new Date();
-    const authoredOn = new Date(medication.authored_on);
-    const startTime = new Date(administrationRequest.occurrence_period_start);
+  const roundToNearestMinute = (date: Date) => {
+    const rounded = new Date(date);
+    rounded.setSeconds(0);
+    rounded.setMilliseconds(0);
+    return rounded;
+  };
 
-    if (date > now) {
+  const validateDateTime = (date: Date, isStartTime: boolean): string => {
+    const now = roundToNearestMinute(new Date());
+    const authoredOn = roundToNearestMinute(new Date(medication.authored_on));
+    const startTime = roundToNearestMinute(
+      new Date(administrationRequest.occurrence_period_start),
+    );
+
+    const roundedDate = roundToNearestMinute(date);
+
+    if (roundedDate > now) {
       return t(
         isStartTime ? "start_time_future_error" : "end_time_future_error",
       );
     }
 
     if (isStartTime) {
-      return date < authoredOn ? t("start_time_before_authored_error") : "";
+      return roundedDate < authoredOn
+        ? t("start_time_before_authored_error")
+        : "";
     }
 
-    return date < startTime ? t("end_time_before_start_error") : "";
+    return roundedDate < startTime ? t("end_time_before_start_error") : "";
   };
 
   // Validate and notify parent whenever times change

--- a/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
+++ b/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
@@ -1,4 +1,4 @@
-import { format, formatDistanceToNow } from "date-fns";
+import { format, formatDistanceToNow, startOfMinute } from "date-fns";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -63,21 +63,13 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
   const [startTimeError, setStartTimeError] = useState("");
   const [endTimeError, setEndTimeError] = useState("");
 
-  const roundToNearestMinute = (date: Date) => {
-    const rounded = new Date(date);
-    rounded.setSeconds(0);
-    rounded.setMilliseconds(0);
-    return rounded;
-  };
-
   const validateDateTime = (date: Date, isStartTime: boolean): string => {
-    const now = roundToNearestMinute(new Date());
-    const authoredOn = roundToNearestMinute(new Date(medication.authored_on));
-    const startTime = roundToNearestMinute(
+    const now = startOfMinute(new Date());
+    const authoredOn = startOfMinute(new Date(medication.authored_on));
+    const startTime = startOfMinute(
       new Date(administrationRequest.occurrence_period_start),
     );
-
-    const roundedDate = roundToNearestMinute(date);
+    const roundedDate = startOfMinute(date);
 
     if (roundedDate > now) {
       return t(


### PR DESCRIPTION
…2693

## Proposed Changes

- Fixes #12693 
- Round occurrence_period_start and authored_on to the nearest minute before comparing
- Prevent false validation errors when administering at the same time as prescribing

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and time validation to ensure consistency by ignoring seconds and milliseconds during comparisons. This prevents minor discrepancies from affecting medication administration form validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->