### PR TITLE
Set Empty Blood Group to "Unknown" for Old Patients

### DIFF
--- a/src/pages/Encounters/tabs/EncounterOverviewTab.tsx
+++ b/src/pages/Encounters/tabs/EncounterOverviewTab.tsx
@@ -87,11 +87,12 @@ export const EncounterOverviewTab = () => {
                   <Badge variant="destructive">
                     <DropletIcon className="size-4" />
                     <span>
-                      {t(`BLOOD_GROUP_LONG__${patient?.blood_group}`)}
+                      {t(
+                        `BLOOD_GROUP_LONG__${patient?.blood_group || "unknown"}`,
+                      )}
                     </span>
                   </Badge>
                 </div>
-
                 {!!allergies?.results.length && (
                   <div className="flex flex-col items-start gap-1">
                     <span className="text-sm font-medium text-gray-600">


### PR DESCRIPTION
## Proposed Changes
- Previously, blood group wasn’t mandatory for old patients, so some entries were empty. This caused issues with translations. Now, if the blood group is empty, it defaults to "Unknown" to ensure proper display.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices
