### PR TITLE
fix: Prevent passing null value when no diagnostic report codes are present in Activity Definition 

### DIFF
--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -286,7 +286,7 @@ function ActivityDefinitionFormContent({
             kind: existingData.kind,
             code: existingData.code,
             body_site: existingData.body_site,
-            diagnostic_report_codes: existingData.diagnostic_report_codes,
+            diagnostic_report_codes: existingData.diagnostic_report_codes || [],
             specimen_requirements:
               existingData.specimen_requirements?.map((s) => ({
                 value: s.id,

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -103,10 +103,13 @@ export default function ActivityDefinitionView({
 
   const handleDelete = () => {
     if (!definition) return;
-    updateActivityDefinition({
+
+    const payload = {
       ...definition,
       status: "retired",
-    });
+      diagnostic_report_codes: definition.diagnostic_report_codes || [],
+    };
+    updateActivityDefinition(payload);
   };
 
   if (isLoading) {

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -104,12 +104,11 @@ export default function ActivityDefinitionView({
   const handleDelete = () => {
     if (!definition) return;
 
-    const payload = {
+    updateActivityDefinition({
       ...definition,
       status: "retired",
       diagnostic_report_codes: definition.diagnostic_report_codes || [],
-    };
-    updateActivityDefinition(payload);
+    });
   };
 
   if (isLoading) {


### PR DESCRIPTION
## Proposed Changes

- Fixes #12860
- Prevent passing null value to the backend when no diagnostic report codes are present in activity definition
- Passed an empty array instead of null value


https://github.com/user-attachments/assets/82d6e9c9-313c-4304-895d-8d83553d27fa


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form reliability by ensuring the diagnostic report codes field always initializes as an array, preventing potential errors when editing activity definitions.
  * Enhanced stability when retiring an activity definition by guaranteeing diagnostic report codes are set to an empty array if not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->