### PR TITLE
Added fe filter and fixed preview

### DIFF
--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +26,7 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
-  const [, setSelectedConcept] = useState<any | null>(null);
+  const [autocompleteOpen, setAutocompleteOpen] = useState(false);
 
   const { data: searchQuery, isFetching } = useQuery({
     queryKey: ["valueset", "preview_all", valueset.compose],
@@ -46,7 +47,6 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
     enabled: open,
   });
 
-  // 🔍 Frontend filtering of full result list
   const filteredResults = useMemo(() => {
     if (!searchQuery?.results) return [];
     const lower = search.toLowerCase();
@@ -81,9 +81,15 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
           value={search}
           onChange={(value) => {
             setSearch(value);
-            const match = filteredResults.find((opt) => opt.code === value);
+
+            const match = filteredResults.find(
+              (opt) =>
+                opt.code?.toLowerCase() === value.toLowerCase() ||
+                opt.display?.toLowerCase() === value.toLowerCase(),
+            );
+
             if (match) {
-              setSelectedConcept(match);
+              setAutocompleteOpen(false); // close dropdown
             }
           }}
           onSearch={setSearch}
@@ -94,7 +100,6 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
           className="px-1 mt-6"
         />
 
-        {/* Full list rendered */}
         <div className="mt-4 px-1 text-sm text-gray-700 border-t pt-2 space-y-2">
           {filteredResults.map((item) => (
             <div key={item.code} className="border-b pb-2">

--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Autocomplete from "@/components/ui/autocomplete";
@@ -25,15 +25,16 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
+  const [, setSelectedConcept] = useState<any | null>(null);
 
   const { data: searchQuery, isFetching } = useQuery({
-    queryKey: ["valueset", "preview_search", search, valueset.compose],
-    queryFn: query.debounced(valuesetApi.preview_search, {
-      queryParams: { search, count: 20 },
+    queryKey: ["valueset", "preview_all", valueset.compose],
+    queryFn: query(valuesetApi.preview_search, {
+      queryParams: { count: 1000 },
       body: {
         ...valueset,
         name: valueset.name,
-        slug: valueset.slug,
+        ...(valueset.slug?.match(/^[-\w]+$/) ? { slug: valueset.slug } : {}),
         compose: valueset.compose.include[0]?.system
           ? valueset.compose
           : {
@@ -44,6 +45,18 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
     }),
     enabled: open,
   });
+
+  // 🔍 Frontend filtering of full result list
+  const filteredResults = useMemo(() => {
+    if (!searchQuery?.results) return [];
+    const lower = search.toLowerCase();
+    return searchQuery.results.filter(
+      (item) =>
+        item.code?.toLowerCase().includes(lower) ||
+        item.display?.toLowerCase().includes(lower) ||
+        item.system?.toLowerCase().includes(lower),
+    );
+  }, [search, searchQuery]);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -57,15 +70,22 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
             {t("valueset_preview_description")}
           </p>
         </SheetHeader>
+
         <Autocomplete
           options={mergeAutocompleteOptions(
-            searchQuery?.results?.map((option) => ({
+            filteredResults.map((option) => ({
               label: option.display || "",
               value: option.code,
-            })) ?? [],
+            })),
           )}
           value={search}
-          onChange={setSearch}
+          onChange={(value) => {
+            setSearch(value);
+            const match = filteredResults.find((opt) => opt.code === value);
+            if (match) {
+              setSelectedConcept(match);
+            }
+          }}
           onSearch={setSearch}
           placeholder={t("search_concept")}
           noOptionsMessage={
@@ -73,6 +93,25 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
           }
           className="px-1 mt-6"
         />
+
+        {/* Full list rendered */}
+        <div className="mt-4 px-1 text-sm text-gray-700 border-t pt-2 space-y-2">
+          {filteredResults.map((item) => (
+            <div key={item.code} className="border-b pb-2">
+              <p>
+                <strong>Code:</strong> {item.code}
+              </p>
+              <p>
+                <strong>Display:</strong> {item.display}
+              </p>
+              {item.system && (
+                <p>
+                  <strong>System:</strong> {item.system}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
## Proposed Changes

- Fixes #12741
- Loads all concepts on opening the Valueset Preview using backend API
- Implements frontend filtering of the fetched concepts (search is now local)
- Closes autocomplete dropdown when a value is selected
<img width="1920" height="1080" alt="Screenshot (229)" src="https://github.com/user-attachments/assets/14075131-ba3f-400a-9088-e1dbc3cee145" />
<img width="1920" height="1080" alt="Screenshot (230)" src="https://github.com/user-attachments/assets/a97b549e-51c3-4db4-94e5-7e028d862159" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full list display of filtered results below the search input, showing code, display, and system details.

* **Improvements**
  * Enhanced search functionality with faster, client-side filtering across larger datasets.
  * Autocomplete suggestions now reflect filtered results based on code, display, or system fields.
  * Improved selection handling within the search interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->