### PR TITLE
fix: Add password validation in User Form

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -88,7 +88,7 @@ export default function UserForm({
               t("username_not_valid"),
             ),
       password_setup_method: z.enum(["immediate", "email"]).optional(),
-      password: z.string().optional(),
+      password: isEditMode ? z.string().optional() : z.string().min(8),
       c_password: z.string().optional(),
       first_name: z.string().min(1, t("field_required")),
       last_name: z.string().min(1, t("field_required")),


### PR DESCRIPTION
## Proposed Changes

- Fixes #12529
- Made password required during creating a User and keep it optional in edit mode


https://github.com/user-attachments/assets/705e98c5-6986-4f3a-a0f0-5c289652ced2



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password validation in the user form to require a minimum of 8 characters when creating a new user, while keeping the password optional during user edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->