### PR TITLE
fixes allergies not displayed in timeline view (clinical history)

### DIFF
--- a/src/components/Patient/allergy/list.tsx
+++ b/src/components/Patient/allergy/list.tsx
@@ -115,6 +115,7 @@ export function AllergyList({
       const year = format(allergy.created_date, "yyyy");
       acc[year] ??= {};
       acc[year][dateStr] ??= [];
+      acc[year][dateStr].push(allergy);
       return acc;
     }, {} as GroupedAllergies);
 


### PR DESCRIPTION
- fixes #12918
- accidentally caused by #12853

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the grouping of allergies by year and date when viewing the timeline, ensuring allergies are accurately displayed under their respective dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->