### PR TITLE
Dispense list paid tab - logic fixed

### DIFF
--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -49,6 +49,7 @@ import {
   ChargeItemRead,
   ChargeItemStatus,
 } from "@/types/billing/chargeItem/chargeItem";
+import { InvoiceStatus } from "@/types/billing/invoice/invoice";
 import {
   MedicationDispenseCategory,
   MedicationDispenseRead,
@@ -135,7 +136,9 @@ function MedicationTable({
             const instruction = medication.dosage_instruction[0] ?? {};
             const frequency = instruction?.timing?.code;
             const dosage = instruction?.dose_and_rate?.dose_quantity;
-            const isPaid = medication.charge_item.paid_invoice;
+            const isPaid =
+              medication.charge_item.paid_invoice?.status ===
+              InvoiceStatus.balanced;
             const shouldShowCheckbox = showCheckbox;
 
             return (
@@ -348,8 +351,14 @@ export default function DispensedMedicationList({
   };
 
   const filteredMedications = response?.results?.filter((med) => {
-    if (paymentFilter === "paid") return med.charge_item.paid_invoice;
-    if (paymentFilter === "unpaid") return !med.charge_item.paid_invoice;
+    if (paymentFilter === "paid")
+      return med.charge_item.paid_invoice?.status === InvoiceStatus.balanced;
+    if (paymentFilter === "unpaid")
+      return (
+        !med.charge_item.paid_invoice ||
+        med.charge_item.paid_invoice?.status === InvoiceStatus.issued ||
+        med.charge_item.paid_invoice?.status === InvoiceStatus.draft
+      );
     return true;
   });
 


### PR DESCRIPTION
Dispense Queue -> Patient's Dispense list -> Paid tab was listing unpaid dispenses as it depended on the paid_invoice object (obj is now populated with unpaid invoices as well, so fixed logic)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of medication payment status by refining how paid and unpaid medications are determined in the dispensed medications list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->