### PR TITLE
Allow Diagnostic Report without Specimen Definition

### DIFF
--- a/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
@@ -43,7 +43,6 @@ import FileUploadDialog from "@/components/Files/FileUploadDialog";
 
 import useFileUpload from "@/hooks/useFileUpload";
 
-import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { Code } from "@/types/base/code/code";
@@ -65,6 +64,8 @@ import {
   ObservationDefinitionReadSpec,
 } from "@/types/emr/observationDefinition/observationDefinition";
 import { SpecimenRead, SpecimenStatus } from "@/types/emr/specimen/specimen";
+import { SpecimenDefinitionRead } from "@/types/emr/specimenDefinition/specimenDefinition";
+import filesApi from "@/types/files/filesApi";
 
 interface DiagnosticReportFormProps {
   patientId: string;
@@ -75,6 +76,7 @@ interface DiagnosticReportFormProps {
   activityDefinition?: {
     diagnostic_report_codes?: Code[];
     category?: string;
+    specimen_requirements?: SpecimenDefinitionRead[];
   };
   specimens: SpecimenRead[];
 }
@@ -135,7 +137,7 @@ export function DiagnosticReportForm({
 
   // Check if all required specimens are collected
   const hasCollectedSpecimens =
-    activityDefinition?.category !== "laboratory" ||
+    activityDefinition?.specimen_requirements?.length === 0 ||
     specimens.some((specimen) => specimen.status === SpecimenStatus.available);
 
   // Fetch the full diagnostic report to get observations
@@ -154,7 +156,7 @@ export function DiagnosticReportForm({
   const { data: files = { results: [], count: 0 }, refetch: refetchFiles } =
     useQuery({
       queryKey: ["files", "diagnostic_report", fullReport?.id],
-      queryFn: query(routes.viewUpload, {
+      queryFn: query(filesApi.viewUpload, {
         queryParams: {
           file_type: "diagnostic_report",
           associating_id: fullReport?.id,

--- a/src/types/files/filesApi.ts
+++ b/src/types/files/filesApi.ts
@@ -1,0 +1,44 @@
+import {
+  CreateFileRequest,
+  CreateFileResponse,
+  FileUploadModel,
+} from "@/components/Patient/models";
+
+import { HttpMethod, Type } from "@/Utils/request/api";
+import { PaginatedResponse } from "@/Utils/request/types";
+
+export default {
+  createUpload: {
+    path: "/api/v1/files/",
+    method: HttpMethod.POST,
+    TBody: Type<CreateFileRequest>(),
+    TRes: Type<CreateFileResponse>(),
+  },
+  viewUpload: {
+    path: "/api/v1/files/",
+    method: HttpMethod.GET,
+    TRes: Type<PaginatedResponse<FileUploadModel>>(),
+  },
+  retrieveUpload: {
+    path: "/api/v1/files/{id}/",
+    method: HttpMethod.GET,
+    TRes: Type<FileUploadModel>(),
+  },
+  editUpload: {
+    path: "/api/v1/files/{id}/",
+    method: HttpMethod.PUT,
+    TBody: Type<Partial<FileUploadModel>>(),
+    TRes: Type<FileUploadModel>(),
+  },
+  markUploadCompleted: {
+    path: "/api/v1/files/{id}/mark_upload_completed/",
+    method: HttpMethod.POST,
+    TRes: Type<FileUploadModel>(),
+  },
+  archiveUpload: {
+    path: "/api/v1/files/{id}/archive/",
+    method: HttpMethod.POST,
+    TRes: Type<FileUploadModel>(),
+    TBody: Type<{ archive_reason: string }>(),
+  },
+};


### PR DESCRIPTION
Allow Diagnostic Report without Specimen Definition in SR

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new file management capabilities, including uploading, viewing, editing, marking as completed, and archiving files.
* **Bug Fixes**
  * Improved specimen requirement checks in diagnostic report forms to ensure required specimens are accurately validated.
* **Chores**
  * Updated internal file retrieval logic to use a dedicated file API for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->