### PR TITLE
Add patient identifier and tags in encounter header; accounts in encounter properties and move external identifier to sidebar

### DIFF
--- a/src/components/Facility/ConsultationDetails/OverviewSideBar.tsx
+++ b/src/components/Facility/ConsultationDetails/OverviewSideBar.tsx
@@ -28,6 +28,7 @@ interface Props {
 }
 
 export default function SideOverview({ encounter, canEdit }: Props) {
+  const { t } = useTranslation();
   const { selectedEncounterId, currentEncounterId } = useEncounter();
   const readOnly = selectedEncounterId !== currentEncounterId;
 
@@ -42,6 +43,14 @@ export default function SideOverview({ encounter, canEdit }: Props) {
         {!readOnly && canEdit && <Questionnaires encounter={encounter} />}
         <Locations canEdit={canEdit} encounter={encounter} />
         <DepartmentsAndTeams canEdit={canEdit} encounter={encounter} />
+        <div className="flex md:flex-col gap-0.5 items-center md:items-start">
+          <span className="text-xs text-gray-600 w-32 md:w-auto">
+            {t("hospital_identifier")}:{" "}
+          </span>
+          <span className="text-sm font-semibold">
+            {encounter.external_identifier || "--"}
+          </span>
+        </div>
         <AuditLogs encounter={encounter} />
       </div>
     </div>

--- a/src/pages/Encounters/EncounterHeader.tsx
+++ b/src/pages/Encounters/EncounterHeader.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ExternalLink } from "lucide-react";
 import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
@@ -35,6 +36,7 @@ export function EncounterHeader() {
   const readOnly = selectedEncounterId !== currentEncounterId;
 
   const { patient, facility } = encounter;
+  const tags = [...patient.instance_tags, ...patient.facility_tags];
 
   return (
     <Card className="p-2 md:p-4 flex flex-col md:flex-row md:justify-between gap-6">
@@ -77,6 +79,33 @@ export function EncounterHeader() {
                 ? formatDateTime(encounter.period.end)
                 : t("ongoing")}
             </span>
+          </div>
+          {patient.instance_identifiers.map((identifier) => (
+            <div
+              key={identifier.config.id}
+              className="flex md:flex-col gap-0.5 items-center md:items-start"
+            >
+              <span className="text-xs text-gray-600 w-32 md:w-auto">
+                {identifier.config.config.display}:{" "}
+              </span>
+              <span className="text-sm font-semibold">{identifier.value}</span>
+            </div>
+          ))}
+          <div className="flex md:flex-col gap-0.5 items-center md:items-start">
+            <span className="text-xs text-gray-600 w-32 md:w-auto">
+              {t("tags")}:{" "}
+            </span>
+            {tags.length ? (
+              <div className="flex flex-wrap gap-1">
+                {tags.map((tag) => (
+                  <Badge key={tag.id} variant="secondary" size="sm">
+                    {tag.display}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <span className="text-sm font-semibold">--</span>
+            )}
           </div>
         </div>
         <div className="md:hidden">

--- a/src/pages/Encounters/EncounterHeader.tsx
+++ b/src/pages/Encounters/EncounterHeader.tsx
@@ -78,13 +78,6 @@ export function EncounterHeader() {
                 : t("ongoing")}
             </span>
           </div>
-          <div className="flex md:flex-col gap-0.5 items-center md:items-start">
-            <span className="text-xs text-gray-600 w-32 md:w-auto">
-              {t("hospital_identifier")}:{" "}
-            </span>
-            {/* TODO: implement this once we have it */}
-            <span className="text-sm font-semibold">--</span>
-          </div>
         </div>
         <div className="md:hidden">
           <EncounterProperties encounter={encounter} canEdit={false} />

--- a/src/pages/Encounters/EncounterProperties.tsx
+++ b/src/pages/Encounters/EncounterProperties.tsx
@@ -14,6 +14,7 @@ import {
 
 import { LocationSheet } from "@/components/Location/LocationSheet";
 import { LocationTree } from "@/components/Location/LocationTree";
+import { AccountSheetButton } from "@/components/Patient/AccountSheet";
 import LinkDepartmentsSheet from "@/components/Patient/LinkDepartmentsSheet";
 import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
 
@@ -36,7 +37,7 @@ export default function EncounterProperties({ encounter, canEdit }: Props) {
   const EncounterClassIcon = ENCOUNTER_CLASS_ICONS[encounter.encounter_class];
 
   return (
-    <div className="flex flex-wrap md:flex-col gap-2">
+    <div className="flex flex-wrap md:flex-col gap-3">
       <div className="hidden md:flex flex-col gap-1">
         <span className="text-xs font-medium">{t("status")}: </span>
         <div>
@@ -170,6 +171,26 @@ export default function EncounterProperties({ encounter, canEdit }: Props) {
           )}
         </div>
       </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-xs font-medium">{t("account")}: </span>
+        <div className="flex flex-wrap gap-2">
+          <AccountSheetButton
+            encounter={encounter}
+            trigger={
+              <div className="flex items-center gap-1">
+                <Badge variant="secondary" size="sm">
+                  <span>{t("accounts")}</span>
+                </Badge>
+                <Button variant="ghost" size="xs">
+                  <PenIcon />
+                </Button>
+              </div>
+            }
+            canWrite={canEdit}
+          />
+        </div>
+      </div>
     </div>
   );
 }
@@ -236,14 +257,14 @@ const LocationPropertyBadge = ({
         facilityId={encounter.facility.id}
         encounter={encounter}
         trigger={
-          <div className="group flex items-center gap-1">
+          <div className="flex items-center gap-1">
             <Badge variant="secondary" size="sm" className="cursor-pointer">
               <MapPinIcon className="size-3" />
               {t("no_location_associated")}
             </Badge>
-            <div className="group-hover:opacity-100 opacity-0 transition-opacity duration-200 ease-in-out">
-              <Edit2Icon className="size-3" />
-            </div>
+            <Button variant="ghost" size="xs">
+              <Edit2Icon className="size-4" />
+            </Button>
           </div>
         }
         history={encounter.location_history}

--- a/src/pages/Encounters/tabs/EncounterOverviewTab.tsx
+++ b/src/pages/Encounters/tabs/EncounterOverviewTab.tsx
@@ -35,10 +35,6 @@ const actionLinks = [
     href: "questionnaire/symptom",
     label: "Add Symptoms",
   },
-  {
-    href: "questionnaire/charge_item",
-    label: "Add Charge Item",
-  },
 ];
 
 export const EncounterOverviewTab = () => {

--- a/src/types/emr/encounter/encounter.ts
+++ b/src/types/emr/encounter/encounter.ts
@@ -11,7 +11,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 
 import { CareTeamResponse } from "@/types/careTeam/careTeam";
-import { Patient } from "@/types/emr/patient/patient";
+import { PatientRead } from "@/types/emr/patient/patient";
 import { TagConfig } from "@/types/emr/tagConfig/tagConfig";
 import { FacilityOrganization } from "@/types/facilityOrganization/facilityOrganization";
 import { LocationAssociationStatus } from "@/types/location/association";
@@ -202,7 +202,7 @@ export type LocationHistory = {
 
 export interface Encounter {
   id: string;
-  patient: Patient;
+  patient: PatientRead;
   facility: {
     id: string;
     name: string;


### PR DESCRIPTION
## Proposed Changes

- Added patient tags and identifiers to encounter header
- Add accounts to encounter properties
- Moved hospital identifier from encounter header to sidebar

<img width="893" height="201" alt="image" src="https://github.com/user-attachments/assets/fbc31d57-d5f0-4370-9143-67a65dc6ac48" />


<img width="578" height="524" alt="image" src="https://github.com/user-attachments/assets/5c65ed24-2f8f-46c4-88fb-5c48f6bea0b7" />

<img width="412" height="373" alt="image" src="https://github.com/user-attachments/assets/c0e3235d-3fe5-4d85-b594-c5c36cb28cd9" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new section in the sidebar to display the hospital identifier for the encounter.
  * Introduced an "account" section in the encounter properties, allowing users to view and edit accounts related to the encounter.
  * Added patient instance identifiers display in the encounter header.
  * Updated tags display in the encounter header with visual badges.

* **Improvements**
  * Updated the layout and spacing in the encounter properties for better visual consistency.
  * Improved the location badge UI for a more consistent editing experience.

* **Bug Fixes**
  * Removed the "Add Charge Item" action link from the encounter overview tab to streamline user options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->