### PR TITLE
Trim white-spaces in remark in create schedule template sheet

### DIFF
--- a/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
@@ -100,7 +100,7 @@ export default function CreateScheduleTemplateSheet({
               z.object({
                 slot_type: z.literal("appointment"),
                 name: z.string().min(1, t("field_required")),
-                reason: z.string(),
+                reason: z.string().trim(),
                 start_time: z
                   .string()
                   .min(1, t("field_required")) as unknown as z.ZodType<Time>,
@@ -122,7 +122,7 @@ export default function CreateScheduleTemplateSheet({
               z.object({
                 slot_type: z.enum(["open", "closed"]),
                 name: z.string().min(1, t("field_required")),
-                reason: z.string(),
+                reason: z.string().trim(),
                 start_time: z
                   .string()
                   .min(1, t("field_required")) as unknown as z.ZodType<Time>,
@@ -206,7 +206,7 @@ export default function CreateScheduleTemplateSheet({
             slot_type: availability.slot_type,
             slot_size_in_minutes: availability.slot_size_in_minutes,
             tokens_per_slot: availability.tokens_per_slot,
-            reason: availability.reason?.trim() ?? "",
+            reason: availability.reason,
             availability: values.weekdays.map((day) => ({
               day_of_week: day,
               start_time: availability.start_time,

--- a/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
@@ -206,7 +206,7 @@ export default function CreateScheduleTemplateSheet({
             slot_type: availability.slot_type,
             slot_size_in_minutes: availability.slot_size_in_minutes,
             tokens_per_slot: availability.tokens_per_slot,
-            reason: availability.reason,
+            reason: availability.reason?.trim() ?? "",
             availability: values.weekdays.map((day) => ({
               day_of_week: day,
               start_time: availability.start_time,

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -567,7 +567,7 @@ const NewAvailabilityCard = ({
         .min(1, t("field_required")) as unknown as z.ZodType<Time>,
       slot_size_in_minutes: z.number().nullable(),
       tokens_per_slot: z.number().nullable(),
-      reason: z.string(),
+      reason: z.string().trim(),
       weekdays: z
         .array(z.number() as unknown as z.ZodType<DayOfWeek>)
         .min(1, t("schedule_weekdays_min_error")),


### PR DESCRIPTION
## Proposed Changes

- Fixes #12888 
- added trim for remark in onSubmit function

https://github.com/user-attachments/assets/b3d5b1bd-babc-4994-af2f-67048ba264b2


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the "reason" field when creating and editing schedule templates to ensure leading and trailing whitespace is trimmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->