### PR TITLE
Fixes encounter switching with files tab due to filters cache restoration

### DIFF
--- a/src/components/Files/DischargeSummarySubTab.tsx
+++ b/src/components/Files/DischargeSummarySubTab.tsx
@@ -73,6 +73,7 @@ export const DischargeTab = ({
   const queryClient = useQueryClient();
   const { qParams, updateQuery, Pagination } = useFilters({
     limit: 15,
+    disableCache: true,
   });
 
   const { mutate: generateDischargeSummary, isPending: isGenerating } =

--- a/src/components/Files/DrawingSubTab.tsx
+++ b/src/components/Files/DrawingSubTab.tsx
@@ -143,7 +143,7 @@ export const DrawingPage = ({
   const facilityIdExists = !!subpathMatch?.facilityId;
   const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
     limit: 15,
-    cacheBlacklist: ["name"],
+    disableCache: true,
   });
   const { data: patientData } = useQuery({
     queryKey: ["patient", patientId],

--- a/src/components/Files/FileSubTab.tsx
+++ b/src/components/Files/FileSubTab.tsx
@@ -77,6 +77,7 @@ export const FilesPage = ({
   const { hasPermission } = usePermissions();
   const { qParams, updateQuery, Pagination } = useFilters({
     limit: 15,
+    disableCache: true,
   });
   // const queryClient = useQueryClient();
   const { canViewClinicalData } = getPermissions(

--- a/src/hooks/useFilters.tsx
+++ b/src/hooks/useFilters.tsx
@@ -73,6 +73,14 @@ export default function useFilters({
   const removeFilter = (param: string) => removeFilters([param]);
 
   useEffect(() => {
+    if (disableCache) {
+      // Clean-up any existing cache if present for this path.
+      FiltersCache.invalidate();
+
+      // Skip cache restoration logic for this usage.
+      return;
+    }
+
     const qParamKeys = Object.keys(qParams);
 
     // If we navigate to a path that has query params set on mount,


### PR DESCRIPTION


## Proposed Changes

- Fixes encounter switching with files tab due to filters cache restoration

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable filter caching in various file-related tabs, ensuring filter settings are not retained between sessions.

* **Bug Fixes**
  * Improved filter behavior by preventing unintended restoration of previous filter states when caching is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->