### PR TITLE
fix: slug text field accepting Underscore

### DIFF
--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -519,7 +519,7 @@ function ActivityDefinitionFormContent({
                             onChange={(e) => {
                               const sanitizedValue = e.target.value
                                 .toLowerCase()
-                                .replace(/[^a-z0-9-]/g, "");
+                                .replace(/[^a-z0-9_-]/g, "");
                               field.onChange(sanitizedValue);
                             }}
                           />

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -509,7 +509,7 @@ export function ChargeItemDefinitionForm({
                           // Only allow lowercase letters, numbers, and hyphens
                           const sanitizedValue = e.target.value
                             .toLowerCase()
-                            .replace(/[^a-z0-9-]/g, "");
+                            .replace(/[^a-z0-9_-]/g, "");
                           field.onChange(sanitizedValue);
                         }}
                       />

--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
@@ -311,7 +311,7 @@ function ObservationDefinitionFormContent({
                             onChange={(e) => {
                               const sanitizedValue = e.target.value
                                 .toLowerCase()
-                                .replace(/[^a-z0-9-]/g, "");
+                                .replace(/[^a-z0-9_-]/g, "");
                               field.onChange(sanitizedValue);
                             }}
                           />

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -358,7 +358,7 @@ function ProductKnowledgeFormContent({
                             onChange={(e) => {
                               const sanitizedValue = e.target.value
                                 .toLowerCase()
-                                .replace(/[^a-z0-9-]/g, "");
+                                .replace(/[^a-z0-9_-]/g, "");
                               field.onChange(sanitizedValue);
                             }}
                           />

--- a/src/pages/Facility/settings/specimen-definitions/SpecimenDefinitionForm.tsx
+++ b/src/pages/Facility/settings/specimen-definitions/SpecimenDefinitionForm.tsx
@@ -281,7 +281,7 @@ export function SpecimenDefinitionForm({
                           onChange={(e) => {
                             const sanitizedValue = e.target.value
                               .toLowerCase()
-                              .replace(/[^a-z0-9-]/g, "");
+                              .replace(/[^a-z0-9_-]/g, "");
                             field.onChange(sanitizedValue);
                           }}
                         />


### PR DESCRIPTION
## Proposed Changes

- Fixes #12959
- add "_" in the slug regex like this: /[^a-z0-9_-]/g.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slug fields in various definition forms now allow underscores (_) in addition to letters, numbers, and hyphens, providing greater flexibility for input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->