### PR TITLE
fixed activity definition form

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1163,7 +1163,7 @@
   "copy_phone_number": "Copy Phone Number",
   "copying_is_not_allowed": "Copying is not allowed",
   "could_not_load_page": "We are facing some difficulties showing the Page you were looking for. Our Engineers have been notified and we'll make sure that this is resolved on the fly!",
-  "counseling": "Counseling",
+  "counselling": "Counselling",
   "countries_travelled": "Countries travelled",
   "cover_image_deleted": "Cover Image Deleted",
   "cover_image_updated": "Cover Image Updated",

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -286,7 +286,7 @@ function ActivityDefinitionFormContent({
             kind: existingData.kind,
             code: existingData.code,
             body_site: existingData.body_site,
-            diagnostic_report_codes: existingData.diagnostic_report_codes,
+            diagnostic_report_codes: existingData.diagnostic_report_codes || [],
             specimen_requirements:
               existingData.specimen_requirements?.map((s) => ({
                 value: s.id,

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -106,6 +106,7 @@ export default function ActivityDefinitionView({
     updateActivityDefinition({
       ...definition,
       status: "retired",
+      diagnostic_report_codes: definition.diagnostic_report_codes || [],
     });
   };
 

--- a/src/types/emr/activityDefinition/activityDefinition.ts
+++ b/src/types/emr/activityDefinition/activityDefinition.ts
@@ -22,7 +22,7 @@ export enum Category {
   laboratory = "laboratory",
   imaging = "imaging",
   surgical_procedure = "surgical_procedure",
-  counseling = "counseling",
+  counselling = "counselling",
 }
 
 export enum Kind {


### PR DESCRIPTION
## Proposed Changes

- fixed activity definition form

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured form fields related to diagnostic report codes always initialize with an array, preventing issues when editing activity definitions.
  * Included diagnostic report codes when retiring activity definitions to maintain data consistency.

* **Style**
  * Updated English localization to use "counselling" instead of "counseling" for improved consistency.

* **Refactor**
  * Renamed category references from "counseling" to "counselling" throughout the app for consistent terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->