### PR TITLE
Fix : Reset Search Field Automatically on Search Box Closes For Shadcn

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -108,7 +108,14 @@ const CountrySelect = ({
     setOpen(false);
   };
   return (
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover
+      open={open}
+      modal
+      onOpenChange={(open) => {
+        setOpen(open);
+        open && setSearchValue("");
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           type="button"


### PR DESCRIPTION
## Proposed Changes

- Fixes #12972

- Fixes from https://github.com/omeralpi/shadcn-phone-input/pull/84

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.



https://github.com/user-attachments/assets/21f27995-c96c-4c37-bad5-84480de9775f


- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * The country selection popover in the phone input now clears the search field each time it is opened, improving usability when selecting a country.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->