### PR TITLE
fix: Highlighted active tab in billings

### DIFF
--- a/src/components/ui/sidebar/facility/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility/facility-nav.tsx
@@ -138,7 +138,7 @@ function generateFacilityLinks(
         },
         {
           name: t("billing"),
-          url: `${baseUrl}/settings/billing/discount_codes`,
+          url: `${baseUrl}/settings/billing`,
         },
         {
           name: t("charge_item_definitions"),

--- a/src/pages/Facility/settings/billing/layout.tsx
+++ b/src/pages/Facility/settings/billing/layout.tsx
@@ -1,6 +1,7 @@
 import { Menu } from "lucide-react";
-import { useRoutes } from "raviger";
+import { ActiveLink, useFullPath, useRoutes } from "raviger";
 import { Link } from "raviger";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
@@ -90,6 +91,18 @@ export function BillingSettingsLayout() {
     basePath: `/facility/${facilityId}/settings/billing`,
     routeProps: { facilityId },
   });
+  const fullPath = useFullPath();
+  const fullPathMap = useMemo(
+    () =>
+      fullPath.split("/").reduce(
+        (acc, part) => ({
+          ...acc,
+          [part]: true,
+        }),
+        {} as Record<string, boolean>,
+      ),
+    [fullPath],
+  );
 
   return (
     <div className="container flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10">
@@ -135,16 +148,23 @@ export function BillingSettingsLayout() {
                 </h4>
                 <div className="space-y-1">
                   {category.items.map((item) => (
-                    <Link
+                    <ActiveLink
                       key={item.href}
                       href={`/billing${item.href}`}
                       className={cn(
                         buttonVariants({ variant: "ghost" }),
                         "w-full justify-start",
                       )}
+                      activeClass={cn(
+                        item.href
+                          .split("/")
+                          .every((part) => fullPathMap[part]) &&
+                          "bg-white text-green-700 shadow",
+                      )}
+                      exactActiveClass="bg-white text-green-700 shadow"
                     >
                       {item.title}
-                    </Link>
+                    </ActiveLink>
                   ))}
                 </div>
               </div>

--- a/src/pages/Facility/settings/billing/layout.tsx
+++ b/src/pages/Facility/settings/billing/layout.tsx
@@ -1,7 +1,7 @@
 import { Menu } from "lucide-react";
-import { ActiveLink, useFullPath, useRoutes } from "raviger";
+import { ActiveLink, navigate, useFullPath, useRoutes } from "raviger";
 import { Link } from "raviger";
-import { useMemo } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
@@ -92,17 +92,23 @@ export function BillingSettingsLayout() {
     routeProps: { facilityId },
   });
   const fullPath = useFullPath();
-  const fullPathMap = useMemo(
-    () =>
-      fullPath.split("/").reduce(
-        (acc, part) => ({
-          ...acc,
-          [part]: true,
-        }),
-        {} as Record<string, boolean>,
-      ),
-    [fullPath],
-  );
+
+  useEffect(() => {
+    const baseBillingPath = `/facility/${facilityId}/settings/billing`;
+    if (fullPath === baseBillingPath || fullPath === `${baseBillingPath}/`) {
+      navigate(`${baseBillingPath}/discount_codes`);
+    }
+  }, [fullPath, facilityId]);
+
+  const subpath = (() => {
+    const idx = fullPath.indexOf("/settings/billing");
+    if (idx !== -1) {
+      let suffix = fullPath.substring(idx + "/settings/billing".length);
+      if (!suffix || suffix === "/") return "/settings";
+      return suffix.startsWith("/") ? suffix : `/${suffix}`;
+    }
+    return "/settings";
+  })();
 
   return (
     <div className="container flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10">
@@ -146,7 +152,7 @@ export function BillingSettingsLayout() {
                 <h4 className="px-2 text-sm uppercase font-bold tracking-tight">
                   {category.category}
                 </h4>
-                <div className="space-y-1">
+                <div className="space-y-1 ">
                   {category.items.map((item) => (
                     <ActiveLink
                       key={item.href}
@@ -154,14 +160,9 @@ export function BillingSettingsLayout() {
                       className={cn(
                         buttonVariants({ variant: "ghost" }),
                         "w-full justify-start",
-                      )}
-                      activeClass={cn(
-                        item.href
-                          .split("/")
-                          .every((part) => fullPathMap[part]) &&
+                        subpath === item.href &&
                           "bg-white text-green-700 shadow",
                       )}
-                      exactActiveClass="bg-white text-green-700 shadow"
                     >
                       {item.title}
                     </ActiveLink>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12964


https://github.com/user-attachments/assets/94548702-5cec-4395-8da4-789da3566d74




@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic redirection to the discount codes page within billing settings.
* **Refactor**
  * Enhanced sidebar navigation with dynamic active link highlighting for billing settings.
  * Updated billing submenu URL to point directly to the billing settings overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->