### PR TITLE
fix: add trim validation for required patient form fields

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -99,7 +99,7 @@ export default function PatientRegistration(
     () =>
       z
         .object({
-          name: z.string().nonempty(t("name_is_required")),
+          name: z.string().trim().nonempty(t("name_is_required")),
           phone_number: validators().phoneNumber.required,
           same_phone_number: z.boolean(),
           emergency_phone_number: validators().phoneNumber.required,
@@ -125,12 +125,12 @@ export default function PatientRegistration(
             .max(120, t("age_must_be_below_120"))
             .optional(),
           address: enableMinimalPatientRegistration
-            ? z.string().optional()
-            : z.string().nonempty(t("address_is_required")),
+            ? z.string().trim().optional()
+            : z.string().trim().nonempty(t("address_is_required")),
           same_address: z.boolean(),
           permanent_address: enableMinimalPatientRegistration
-            ? z.string().optional()
-            : z.string().nonempty(t("field_required")),
+            ? z.string().trim().optional()
+            : z.string().trim().nonempty(t("field_required")),
           pincode: enableMinimalPatientRegistration
             ? validators().pincode.optional()
             : validators().pincode,


### PR DESCRIPTION
## Proposed Changes

- Fixes #12948 
- added `.trim()` to the name, address and permanent address field for validation



https://github.com/user-attachments/assets/e4dc32a8-7179-4a42-b000-f344d0daf114




@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for patient registration fields by trimming whitespace before checking for non-empty values, ensuring that inputs containing only spaces are not accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->