### PR TITLE
Add History button to all three accordions - Alleriges, diagnosis and symptoms

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -263,9 +263,8 @@ function PrintButton({ item }: { item: QuestionnaireResponse }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="xs">
+        <Button variant="link" size="xs">
           <Printer className="size-4" />
-          {t("print")}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -263,9 +263,9 @@ function PrintButton({ item }: { item: QuestionnaireResponse }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" className="h-7 px-2">
-          <Printer />
-          <span>{t("print")}</span>
+        <Button variant="outline" size="xs">
+          <Printer className="size-4" />
+          {t("print")}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -263,9 +263,9 @@ function PrintButton({ item }: { item: QuestionnaireResponse }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="xs" className="[&_svg]:size-3">
-          <Printer className="size-4" />
-          {t("print")}
+        <Button variant="outline" className="h-7 px-2">
+          <Printer />
+          <span>{t("print")}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/src/components/Patient/EncounterAccordionLayout.tsx
+++ b/src/components/Patient/EncounterAccordionLayout.tsx
@@ -44,7 +44,7 @@ export function EncounterAccordionLayout({
                 {!readOnly && editLink && (
                   <Button variant="link" size="xs">
                     <Link href={editLink}>
-                      <SquarePen className="size-4 text-gray-500" />
+                      <SquarePen className="size-4" />
                     </Link>
                   </Button>
                 )}

--- a/src/components/Patient/EncounterAccordionLayout.tsx
+++ b/src/components/Patient/EncounterAccordionLayout.tsx
@@ -37,11 +37,9 @@ export function EncounterAccordionLayout({
     <Card className={cn("border-none rounded-md", className)}>
       <Accordion defaultValue={title.toLowerCase()} type="single" collapsible>
         <AccordionItem value={title.toLowerCase()}>
-          <AccordionTrigger className="px-4 py-0 hover:no-underline flex items-center gap-1">
+          <AccordionTrigger className="px-2 py-1 hover:no-underline flex items-center gap-2">
             <CardHeader className="w-full flex flex-row items-center justify-between p-0 translate-y-0.5">
-              <CardTitle className="text-lg font-semibold pt-1">
-                {t(title)}:
-              </CardTitle>
+              <CardTitle className="text-lg pt-1">{t(title)}:</CardTitle>
               <div>
                 {!readOnly && editLink && (
                   <Button variant="link" size="xs">

--- a/src/components/Patient/EncounterAccordionLayout.tsx
+++ b/src/components/Patient/EncounterAccordionLayout.tsx
@@ -37,8 +37,8 @@ export function EncounterAccordionLayout({
     <Card className={cn("border-none rounded-md", className)}>
       <Accordion defaultValue={title.toLowerCase()} type="single" collapsible>
         <AccordionItem value={title.toLowerCase()}>
-          <AccordionTrigger className="px-4 py-1 hover:no-underline flex items-center">
-            <CardHeader className="w-full flex flex-row items-center justify-between p-0">
+          <AccordionTrigger className="px-4 py-0 hover:no-underline flex items-center gap-1">
+            <CardHeader className="w-full flex flex-row items-center justify-between p-0 translate-y-0.5">
               <CardTitle className="text-lg font-semibold pt-1">
                 {t(title)}:
               </CardTitle>

--- a/src/components/Patient/EncounterAccordionLayout.tsx
+++ b/src/components/Patient/EncounterAccordionLayout.tsx
@@ -42,15 +42,11 @@ export function EncounterAccordionLayout({
               <CardTitle className="text-lg font-semibold pt-1">
                 {t(title)}:
               </CardTitle>
-              <div className="flex gap-1 items-center">
+              <div>
                 {!readOnly && editLink && (
                   <Button variant="link" size="xs">
-                    <Link
-                      href={editLink}
-                      className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950"
-                    >
-                      <SquarePen className="size-4" />
-                      <span className="underline"> {t("edit")}</span>
+                    <Link href={editLink}>
+                      <SquarePen className="size-4 text-gray-500" />
                     </Link>
                   </Button>
                 )}

--- a/src/components/Patient/EncounterAccordionLayout.tsx
+++ b/src/components/Patient/EncounterAccordionLayout.tsx
@@ -38,8 +38,8 @@ export function EncounterAccordionLayout({
       <Accordion defaultValue={title.toLowerCase()} type="single" collapsible>
         <AccordionItem value={title.toLowerCase()}>
           <AccordionTrigger className="px-2 py-1 hover:no-underline flex items-center gap-2">
-            <CardHeader className="w-full flex flex-row items-center justify-between p-0 translate-y-0.5">
-              <CardTitle className="text-lg pt-1">{t(title)}:</CardTitle>
+            <CardHeader className="w-full flex flex-row items-center justify-between p-0 translate-y-0.5 pl-2">
+              <CardTitle className="text-base pt-1">{t(title)}:</CardTitle>
               <div>
                 {!readOnly && editLink && (
                   <Button variant="link" size="xs">

--- a/src/components/Patient/EncounterAccordionLayout.tsx
+++ b/src/components/Patient/EncounterAccordionLayout.tsx
@@ -1,10 +1,9 @@
+import { SquarePen } from "lucide-react";
 import { Link } from "raviger";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
-
-import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import {
   Accordion,
@@ -35,30 +34,31 @@ export function EncounterAccordionLayout({
   const { t } = useTranslation();
 
   return (
-    <Card className={cn("border-none rounded-sm", className)}>
+    <Card className={cn("border-none rounded-md", className)}>
       <Accordion defaultValue={title.toLowerCase()} type="single" collapsible>
         <AccordionItem value={title.toLowerCase()}>
-          <AccordionTrigger className="p-4 py-2 hover:no-underline flex items-center">
-            <CardHeader className="w-full flex flex-row justify-between p-0 m-0 translate-y-0.5">
-              <CardTitle className="text-base font-semibold">
-                {t(title)}
+          <AccordionTrigger className="px-4 py-1 hover:no-underline flex items-center">
+            <CardHeader className="w-full flex flex-row items-center justify-between p-0">
+              <CardTitle className="text-lg font-semibold pt-1">
+                {t(title)}:
               </CardTitle>
-              {!readOnly && editLink ? (
-                <Button variant="outline" size="xs">
-                  <Link
-                    href={editLink}
-                    className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950"
-                  >
-                    <CareIcon icon="l-pen" className="size-4" />
-                    {t("edit")}
-                  </Link>
-                </Button>
-              ) : (
-                actionButton && actionButton
-              )}
+              <div className="flex gap-1 items-center">
+                {!readOnly && editLink && (
+                  <Button variant="link" size="xs">
+                    <Link
+                      href={editLink}
+                      className="flex items-center gap-1 text-sm hover:text-gray-500 text-gray-950"
+                    >
+                      <SquarePen className="size-4" />
+                      <span className="underline"> {t("edit")}</span>
+                    </Link>
+                  </Button>
+                )}
+                {actionButton && actionButton}
+              </div>
             </CardHeader>
           </AccordionTrigger>
-          <AccordionContent className="p-0">
+          <AccordionContent className="p-0 mt-2">
             <CardContent className="px-2 pb-2">{children}</CardContent>
           </AccordionContent>
         </AccordionItem>

--- a/src/components/Patient/allergy/list.tsx
+++ b/src/components/Patient/allergy/list.tsx
@@ -2,9 +2,9 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import {
   BeakerIcon,
-  Clock,
   CookingPotIcon,
   HeartPulseIcon,
+  History,
   LeafIcon,
 } from "lucide-react";
 import { Link, usePath, usePathParams } from "raviger";
@@ -176,13 +176,11 @@ export function AllergyList({
       className={className}
       editLink={!readOnly ? "questionnaire/allergy_intolerance" : undefined}
       actionButton={
-        <Button variant="outline" size="sm" asChild className="px-1">
+        <Button size="sm" variant={"link"} asChild>
           <Link
             href={`/facility/${facilityId}/patient/${patientId}/history/allergies?sourceUrl=${sourceUrl}`}
-            className="font-semibold"
           >
-            <Clock />
-            <span className="text-sm">{t("allergy_history")}</span>
+            <History className="size-4 text-gray-500" />
           </Link>
         </Button>
       }

--- a/src/components/Patient/allergy/list.tsx
+++ b/src/components/Patient/allergy/list.tsx
@@ -185,7 +185,7 @@ export function AllergyList({
                 : `/patient/${patientId}/history/allergies?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
             }
           >
-            <History className="size-4 text-gray-500" />
+            <History className="size-4" />
           </Link>
         </Button>
       }

--- a/src/components/Patient/allergy/list.tsx
+++ b/src/components/Patient/allergy/list.tsx
@@ -7,7 +7,7 @@ import {
   History,
   LeafIcon,
 } from "lucide-react";
-import { Link, usePath, usePathParams } from "raviger";
+import { Link, usePath } from "raviger";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -19,6 +19,7 @@ import { EncounterAccordionLayout } from "@/components/Patient/EncounterAccordio
 
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
+import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
 import {
   AllergyCategory,
   AllergyIntolerance,
@@ -66,7 +67,7 @@ export function AllergyList({
   const { t } = useTranslation();
 
   const LIMIT = showTimeline ? 30 : 14;
-  const { facilityId } = usePathParams("/facility/:facilityId/*") ?? {};
+  const { facilityId } = useCurrentFacilitySilently();
   const sourceUrl = usePath();
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
@@ -176,9 +177,13 @@ export function AllergyList({
       className={className}
       editLink={!readOnly ? "questionnaire/allergy_intolerance" : undefined}
       actionButton={
-        <Button size="sm" variant={"link"} asChild>
+        <Button size="xs" variant={"link"} asChild>
           <Link
-            href={`/facility/${facilityId}/patient/${patientId}/history/allergies?sourceUrl=${sourceUrl}`}
+            href={
+              facilityId
+                ? `/facility/${facilityId}/patient/${patientId}/history/allergies?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+                : `/patient/${patientId}/history/allergies?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+            }
           >
             <History className="size-4 text-gray-500" />
           </Link>

--- a/src/components/Patient/allergy/list.tsx
+++ b/src/components/Patient/allergy/list.tsx
@@ -2,10 +2,12 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import {
   BeakerIcon,
+  Clock,
   CookingPotIcon,
   HeartPulseIcon,
   LeafIcon,
 } from "lucide-react";
+import { Link, usePath, usePathParams } from "raviger";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -64,7 +66,8 @@ export function AllergyList({
   const { t } = useTranslation();
 
   const LIMIT = showTimeline ? 30 : 14;
-
+  const { facilityId } = usePathParams("/facility/:facilityId/*") ?? {};
+  const sourceUrl = usePath();
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
       queryKey: ["infinite-allergies", patientId, encounterId, encounterStatus],
@@ -172,6 +175,17 @@ export function AllergyList({
       readOnly={readOnly}
       className={className}
       editLink={!readOnly ? "questionnaire/allergy_intolerance" : undefined}
+      actionButton={
+        <Button variant="outline" size="sm" asChild className="px-1">
+          <Link
+            href={`/facility/${facilityId}/patient/${patientId}/history/allergies?sourceUrl=${sourceUrl}`}
+            className="font-semibold"
+          >
+            <Clock />
+            <span className="text-sm">{t("allergy_history")}</span>
+          </Link>
+        </Button>
+      }
     >
       <AllergyTable allergies={allergies} />
       {hasNextPage && (

--- a/src/components/Patient/diagnosis/list.tsx
+++ b/src/components/Patient/diagnosis/list.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { Clock } from "lucide-react";
+import { History } from "lucide-react";
 import { Link, usePath, usePathParams } from "raviger";
 import { useTranslation } from "react-i18next";
 
@@ -153,13 +153,12 @@ export function DiagnosisList({
       className={className}
       editLink={!readOnly ? "questionnaire/diagnosis" : undefined}
       actionButton={
-        <Button variant="outline" size="sm" className="px-1" asChild>
+        <Button variant="link" asChild>
           <Link
             href={`/facility/${facilityId}/patient/${patientId}/history/diagnoses?sourceUrl=${sourceUrl}`}
             className="font-semibold"
           >
-            <Clock />
-            <span className="text-sm">{t("diagnosis_history")}</span>
+            <History className="size-4 text-gray-500" />
           </Link>
         </Button>
       }

--- a/src/components/Patient/diagnosis/list.tsx
+++ b/src/components/Patient/diagnosis/list.tsx
@@ -163,7 +163,7 @@ export function DiagnosisList({
             }
             className="font-semibold"
           >
-            <History className="size-4 text-gray-500" />
+            <History className="size-4" />
           </Link>
         </Button>
       }

--- a/src/components/Patient/diagnosis/list.tsx
+++ b/src/components/Patient/diagnosis/list.tsx
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { History } from "lucide-react";
-import { Link, usePath, usePathParams } from "raviger";
+import { Link, usePath } from "raviger";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,7 @@ import { EncounterAccordionLayout } from "@/components/Patient/EncounterAccordio
 
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
+import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
 import {
   ACTIVE_DIAGNOSIS_CLINICAL_STATUS,
   Diagnosis,
@@ -44,7 +45,7 @@ export function DiagnosisList({
   const { t } = useTranslation();
 
   const LIMIT = showTimeline ? 30 : 14;
-  const { facilityId } = usePathParams("/facility/:facilityId/*") ?? {};
+  const { facilityId } = useCurrentFacilitySilently();
   const sourceUrl = usePath();
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
@@ -153,9 +154,13 @@ export function DiagnosisList({
       className={className}
       editLink={!readOnly ? "questionnaire/diagnosis" : undefined}
       actionButton={
-        <Button variant="link" asChild>
+        <Button variant="link" size="xs" asChild>
           <Link
-            href={`/facility/${facilityId}/patient/${patientId}/history/diagnoses?sourceUrl=${sourceUrl}`}
+            href={
+              facilityId
+                ? `/facility/${facilityId}/patient/${patientId}/history/diagnoses?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+                : `/patient/${patientId}/history/diagnoses?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+            }
             className="font-semibold"
           >
             <History className="size-4 text-gray-500" />

--- a/src/components/Patient/diagnosis/list.tsx
+++ b/src/components/Patient/diagnosis/list.tsx
@@ -1,5 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
+import { Clock } from "lucide-react";
+import { Link, usePath, usePathParams } from "raviger";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -42,7 +44,8 @@ export function DiagnosisList({
   const { t } = useTranslation();
 
   const LIMIT = showTimeline ? 30 : 14;
-
+  const { facilityId } = usePathParams("/facility/:facilityId/*") ?? {};
+  const sourceUrl = usePath();
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
       queryKey: ["infinite-encounter_diagnosis", patientId, encounterId],
@@ -149,6 +152,17 @@ export function DiagnosisList({
       readOnly={readOnly}
       className={className}
       editLink={!readOnly ? "questionnaire/diagnosis" : undefined}
+      actionButton={
+        <Button variant="outline" size="sm" className="px-1" asChild>
+          <Link
+            href={`/facility/${facilityId}/patient/${patientId}/history/diagnoses?sourceUrl=${sourceUrl}`}
+            className="font-semibold"
+          >
+            <Clock />
+            <span className="text-sm">{t("diagnosis_history")}</span>
+          </Link>
+        </Button>
+      }
     >
       <div className="space-y-2">
         {diagnoses.length ? <DiagnosisTable diagnoses={diagnoses} /> : null}

--- a/src/components/Patient/symptoms/list.tsx
+++ b/src/components/Patient/symptoms/list.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { Clock } from "lucide-react";
+import { History } from "lucide-react";
 import { Link, usePath, usePathParams } from "raviger";
 import { useTranslation } from "react-i18next";
 
@@ -148,13 +148,11 @@ export function SymptomsList({
       className={className}
       editLink={!readOnly ? "questionnaire/symptom" : undefined}
       actionButton={
-        <Button variant="outline" size="sm" className="px-1" asChild>
+        <Button variant="link" asChild>
           <Link
             href={`/facility/${facilityId}/patient/${patientId}/history/symptoms?sourceUrl=${sourceUrl}`}
-            className="font-semibold"
           >
-            <Clock />
-            <span className="text-sm">{t("symptom_history")}</span>
+            <History className="size-4 text-gray-500" />
           </Link>
         </Button>
       }

--- a/src/components/Patient/symptoms/list.tsx
+++ b/src/components/Patient/symptoms/list.tsx
@@ -1,5 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
+import { Clock } from "lucide-react";
+import { Link, usePath, usePathParams } from "raviger";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -39,7 +41,8 @@ export function SymptomsList({
   const { t } = useTranslation();
 
   const LIMIT = showTimeline ? 30 : 14;
-
+  const { facilityId } = usePathParams("/facility/:facilityId/*") ?? {};
+  const sourceUrl = usePath();
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
       queryKey: ["infinite-symptoms", patientId, encounterId],
@@ -144,6 +147,17 @@ export function SymptomsList({
       readOnly={readOnly}
       className={className}
       editLink={!readOnly ? "questionnaire/symptom" : undefined}
+      actionButton={
+        <Button variant="outline" size="sm" className="px-1" asChild>
+          <Link
+            href={`/facility/${facilityId}/patient/${patientId}/history/symptoms?sourceUrl=${sourceUrl}`}
+            className="font-semibold"
+          >
+            <Clock />
+            <span className="text-sm">{t("symptom_history")}</span>
+          </Link>
+        </Button>
+      }
     >
       <SymptomTable symptoms={symptoms} />
       {hasNextPage && (

--- a/src/components/Patient/symptoms/list.tsx
+++ b/src/components/Patient/symptoms/list.tsx
@@ -157,7 +157,7 @@ export function SymptomsList({
                 : `/patient/${patientId}/history/symptoms?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
             }
           >
-            <History className="size-4 text-gray-500" />
+            <History className="size-4" />
           </Link>
         </Button>
       }

--- a/src/components/Patient/symptoms/list.tsx
+++ b/src/components/Patient/symptoms/list.tsx
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { History } from "lucide-react";
-import { Link, usePath, usePathParams } from "raviger";
+import { Link, usePath } from "raviger";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,7 @@ import { EncounterAccordionLayout } from "@/components/Patient/EncounterAccordio
 
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
+import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
 import { Symptom } from "@/types/emr/symptom/symptom";
 import symptomApi from "@/types/emr/symptom/symptomApi";
 
@@ -41,7 +42,7 @@ export function SymptomsList({
   const { t } = useTranslation();
 
   const LIMIT = showTimeline ? 30 : 14;
-  const { facilityId } = usePathParams("/facility/:facilityId/*") ?? {};
+  const { facilityId } = useCurrentFacilitySilently();
   const sourceUrl = usePath();
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
@@ -148,9 +149,13 @@ export function SymptomsList({
       className={className}
       editLink={!readOnly ? "questionnaire/symptom" : undefined}
       actionButton={
-        <Button variant="link" asChild>
+        <Button variant="link" size="xs" asChild>
           <Link
-            href={`/facility/${facilityId}/patient/${patientId}/history/symptoms?sourceUrl=${sourceUrl}`}
+            href={
+              facilityId
+                ? `/facility/${facilityId}/patient/${patientId}/history/symptoms?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+                : `/patient/${patientId}/history/symptoms?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+            }
           >
             <History className="size-4 text-gray-500" />
           </Link>


### PR DESCRIPTION
## Proposed Changes


<img width="829" height="417" alt="Screenshot 2025-07-24 at 8 59 35 PM" src="https://github.com/user-attachments/assets/ec1f036e-d0d2-4cd0-8f3e-afd23c3377a7" />



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added "history" action buttons to allergy, diagnosis, and symptoms lists, allowing quick access to each respective history page for the current patient and facility.

* **Style**
  * Updated the appearance and layout of buttons and headers in consultation details and encounter accordion sections for a more polished and consistent user interface.
  * Refined button icon sizing and adjusted accordion header styling for improved readability and visual balance.
  * Simplified print button to icon-only style for a cleaner look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->