### PR TITLE
Fix: Sheet over Sheet Invalidate issue

### DIFF
--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -804,7 +804,12 @@ function ActivityDefinitionFormContent({
                         createForm={(onSuccess) => (
                           <CreateSpecimenDefinition
                             facilityId={facilityId}
-                            onSuccess={onSuccess}
+                            onSuccess={() => {
+                              queryClient.invalidateQueries({
+                                queryKey: ["specimenDefinitions"],
+                              });
+                              onSuccess();
+                            }}
                           />
                         )}
                       />
@@ -867,7 +872,12 @@ function ActivityDefinitionFormContent({
                           <div className="py-2">
                             <ObservationDefinitionForm
                               facilityId={facilityId}
-                              onSuccess={onSuccess}
+                              onSuccess={() => {
+                                queryClient.invalidateQueries({
+                                  queryKey: ["observationDefinitions"],
+                                });
+                                onSuccess();
+                              }}
                             />
                           </div>
                         )}
@@ -916,7 +926,12 @@ function ActivityDefinitionFormContent({
                           <div className="py-2">
                             <ChargeItemDefinitionForm
                               facilityId={facilityId}
-                              onSuccess={onSuccess}
+                              onSuccess={() => {
+                                queryClient.invalidateQueries({
+                                  queryKey: ["chargeItemDefinitions"],
+                                });
+                                onSuccess();
+                              }}
                             />
                           </div>
                         )}


### PR DESCRIPTION
## Proposed Changes

Enhance: Invalidate queries on success for specimen, observation, and charge item definitions in ActivityDefinitionForm



https://github.com/user-attachments/assets/897ad07e-5cc3-46fb-a7ef-61b5105c17e2


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data freshness by ensuring that lists of specimen, observation, and charge item definitions are updated immediately after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->