### PR TITLE
multi practitioner select: limit avatar display to 5

### DIFF
--- a/src/pages/Appointments/components/MultiPractitionerSelect.tsx
+++ b/src/pages/Appointments/components/MultiPractitionerSelect.tsx
@@ -40,6 +40,8 @@ interface MultiPractitionerSelectorProps {
   clearSelection?: string;
 }
 
+const MULTI_SELECT_SHOW_LIMIT = 5;
+
 export const MultiPractitionerSelector = ({
   facilityId,
   selected,
@@ -72,7 +74,7 @@ export const MultiPractitionerSelector = ({
       <div className="order-last sm:order-first">
         {selected && selected.length > 0 && (
           <div className="flex items-center gap-1">
-            {selected.map((user) => (
+            {selected.slice(0, MULTI_SELECT_SHOW_LIMIT).map((user) => (
               <Fragment key={user.id}>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -103,7 +105,13 @@ export const MultiPractitionerSelector = ({
             role="combobox"
             className="size-8! rounded-full"
           >
-            <CareIcon icon="l-plus" className="size-4" />
+            {selected && selected.length > MULTI_SELECT_SHOW_LIMIT ? (
+              <span className="text-xs text-gray-500">
+                +{selected.length - MULTI_SELECT_SHOW_LIMIT}
+              </span>
+            ) : (
+              <CareIcon icon="l-plus" className="size-4" />
+            )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="p-0" align="start">


### PR DESCRIPTION
## Proposed Changes

- Limit display to 5, so it doesn't overflow

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the practitioner selection display to show up to five selected practitioners as avatars.
  * When more than five practitioners are selected, a "+N" indicator now shows how many additional practitioners are selected.
  * The plus icon remains visible only when the selected count is within the display limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->