### PR TITLE
fix: public registration query params

### DIFF
--- a/src/pages/PublicAppointments/PatientSelect.tsx
+++ b/src/pages/PublicAppointments/PatientSelect.tsx
@@ -223,6 +223,12 @@ export default function PatientSelect({
           onClick={() =>
             navigate(
               `/facility/${facilityId}/appointments/${staffId}/patient-registration`,
+              {
+                query: {
+                  slotId,
+                  reason,
+                },
+              },
             )
           }
         >


### PR DESCRIPTION
## Proposed Changes

- Query params missed for patient registration flow in #12413 (was marked as tested accidentally)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When adding a new patient, the registration page now includes the current appointment slot and reason as part of the URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->