### PR TITLE
Minor Fix: Sync selected tags when sheet opens or closes

### DIFF
--- a/src/components/Questionnaire/ManageQuestionnaireTagsSheet.tsx
+++ b/src/components/Questionnaire/ManageQuestionnaireTagsSheet.tsx
@@ -197,7 +197,7 @@ export default function ManageQuestionnaireTagsSheet({ form, trigger }: Props) {
     if (tags) {
       setSelectedTags(tags);
     }
-  }, [tags]);
+  }, [tags, open]);
 
   // Simple merge of selected tags with available tags
   const tagOptions = useMemo(() => {


### PR DESCRIPTION
### Issue:

https://github.com/user-attachments/assets/03647b6b-a4a4-4c2e-9684-913e65acf861


### Fix:


https://github.com/user-attachments/assets/45ac06fc-d32b-446e-b4f8-1bf712dbfaeb



- the selectedTags state updates correctly when the sheet is opened or closed by adding open to the useEffect dependency array

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag selection behavior so that selected tags are now correctly reset each time the sheet is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->