### PR TITLE
fix: Truncate description of Tag Config Table

### DIFF
--- a/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
+++ b/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
@@ -231,10 +231,10 @@ export default function TagConfigTable({
                   onClick={() => onView(config.id)}
                 >
                   <TableCell className="font-medium">
-                    <div className="flex flex-col">
+                    <div className="flex flex-col max-w-md text-sm break-words whitespace-normal">
                       <span>{config.display}</span>
                       {config.description && (
-                        <span className="text-sm truncate max-w-md text-gray-500">
+                        <span className="text-gray-500">
                           {config.description}
                         </span>
                       )}

--- a/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
+++ b/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
@@ -239,7 +239,7 @@ export default function TagConfigTable({
               {sortedConfigs.map((config: TagConfig) => (
                 <TableRow key={config.id} className="divide-x hover:bg-gray-50">
                   <TableCell className="font-medium">
-                    <div className="flex flex-col max-w-md text-sm break-words whitespace-normal">
+                    <div className="flex flex-col text-sm break-words whitespace-normal">
                       <span>{config.display}</span>
                       {config.description && (
                         <ExpandableText>

--- a/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
+++ b/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
@@ -18,6 +18,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  ExpandableText,
+  ExpandableTextContent,
+  ExpandableTextExpandButton,
+} from "@/components/ui/expandable-text";
 
 import {
   CardGridSkeleton,
@@ -92,7 +97,14 @@ function TagConfigCard({
               {t(config.resource)} | {t("priority")}: {config.priority}
             </p>
             {config.description && (
-              <p className="mt-2 text-sm text-gray-600">{config.description}</p>
+              <ExpandableText>
+                <ExpandableTextContent className="mt-2 text-sm text-gray-600">
+                  {config.description}
+                </ExpandableTextContent>
+                <ExpandableTextExpandButton>
+                  {t("read_more")}
+                </ExpandableTextExpandButton>
+              </ExpandableText>
             )}
           </div>
           <div className="flex items-center gap-2">
@@ -228,15 +240,19 @@ export default function TagConfigTable({
                 <TableRow
                   key={config.id}
                   className="divide-x cursor-pointer hover:bg-gray-50"
-                  onClick={() => onView(config.id)}
                 >
                   <TableCell className="font-medium">
                     <div className="flex flex-col max-w-md text-sm break-words whitespace-normal">
                       <span>{config.display}</span>
                       {config.description && (
-                        <span className="text-gray-500">
-                          {config.description}
-                        </span>
+                        <ExpandableText>
+                          <ExpandableTextContent className="text-gray-500">
+                            {config.description}
+                          </ExpandableTextContent>
+                          <ExpandableTextExpandButton>
+                            {t("read_more")}
+                          </ExpandableTextExpandButton>
+                        </ExpandableText>
                       )}
                     </div>
                   </TableCell>

--- a/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
+++ b/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
@@ -237,10 +237,7 @@ export default function TagConfigTable({
             </TableHeader>
             <TableBody className="bg-white">
               {sortedConfigs.map((config: TagConfig) => (
-                <TableRow
-                  key={config.id}
-                  className="divide-x cursor-pointer hover:bg-gray-50"
-                >
+                <TableRow key={config.id} className="divide-x hover:bg-gray-50">
                   <TableCell className="font-medium">
                     <div className="flex flex-col max-w-md text-sm break-words whitespace-normal">
                       <span>{config.display}</span>

--- a/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
+++ b/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
@@ -231,12 +231,12 @@ export default function TagConfigTable({
                   onClick={() => onView(config.id)}
                 >
                   <TableCell className="font-medium">
-                    <div>
-                      <div>{config.display}</div>
+                    <div className="flex flex-col">
+                      <span>{config.display}</span>
                       {config.description && (
-                        <div className="text-sm text-gray-500">
+                        <span className="text-sm truncate max-w-md text-gray-500">
                           {config.description}
-                        </div>
+                        </span>
                       )}
                     </div>
                   </TableCell>


### PR DESCRIPTION
## Proposed Changes

- Fixes #12990

<img width="1384" height="764" alt="Screenshot 2025-07-21 at 11 29 29 AM" src="https://github.com/user-attachments/assets/99e13e34-70bb-4703-a073-f568dc63dfb3" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable text for tag descriptions in both mobile and desktop views, allowing users to expand and read more.
  * Introduced a dedicated "View" button with an eye icon for accessing tag details in the desktop table view.

* **Style**
  * Enhanced layout and text formatting for display and description fields in the tag configuration table for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->