### PR TITLE
fix: adjust message input position for tablet responsiveness

### DIFF
--- a/src/components/Notes/NoteManager.tsx
+++ b/src/components/Notes/NoteManager.tsx
@@ -708,7 +708,7 @@ export function NoteManager({
 
                   {/* Message Input */}
                   {canWrite && (
-                    <div className="border-t border-gray-200 p-3 sm:p-4 bg-white sticky max-sm:bottom-14">
+                    <div className="border-t border-gray-200 p-3 sm:p-4 bg-white sticky bottom-0 max-lg:bottom-14">
                       <form onSubmit={handleSendMessage}>
                         <div className="flex gap-2">
                           <AutoExpandingTextarea


### PR DESCRIPTION
## Proposed Changes

- Fixes #12991 
- Changed `max-sm:bottom-14` to `bottom-0 max-lg:bottom-14`

<img width="700" height="899" alt="Screenshot 2025-07-19 201218" src="https://github.com/user-attachments/assets/dcad4935-2d42-4850-ab95-3b3ce4d42a39" />

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sticky positioning of the message input form for improved responsiveness across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->