### PR TITLE
Labeling the PRs based on the changes in src/types/**

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+"Type Changes":
+  - all:
+    - changed-files:
+      - any-glob-to-any-file:
+        - src/types/**

--- a/.github/workflows/labeling-pr.yml
+++ b/.github/workflows/labeling-pr.yml
@@ -13,10 +13,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with: 
+          ref: ${{ github.event.pull_request.base.ref }} # Check out base branch for safety
 
       - name: Label PR for type changes
         uses: actions/labeler@v5
         with:
-          # repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: ./.github/labeler.yml
           sync-labels: true

--- a/.github/workflows/labeling-pr.yml
+++ b/.github/workflows/labeling-pr.yml
@@ -1,0 +1,22 @@
+name: Label Type Changes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label-type-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Label PR for type changes
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: ./.github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/labeling-pr.yml
+++ b/.github/workflows/labeling-pr.yml
@@ -1,7 +1,7 @@
 name: Label Type Changes
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -17,6 +17,6 @@ jobs:
       - name: Label PR for type changes
         uses: actions/labeler@v5
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: ./.github/labeler.yml
           sync-labels: true


### PR DESCRIPTION
## Proposed Changes

closes https://github.com/ohcnetwork/care_fe/issues/12980

Create a workflow that adds a new label (Type Changes) to any PRs that contains changes to files in src/types/**.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] create a workflow file in the .github/workflows folder
- [x] create a labeler.yml in the .github/ folder
- [x] Here a github token secret is required as secret which give the permission for writing the label to the PR.
- [x] And sync-labels, is set true so that if changes are removed in later commits then label get remove automatically.
- [x] And it is checkout the base repo's main branch for safety reasons.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated labeling for pull requests that modify files in the `src/types/` directory.
  * Added a workflow to automatically apply and synchronize the "Type Changes" label on relevant pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->