### PR TITLE
Fix: Camera Switch fails After First Switch in Mobile

### DIFF
--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -126,8 +126,8 @@ export default function AvatarEditModal({
   }, [isCameraOpen]);
 
   const handleSwitchCamera = useCallback(() => {
-    setConstraint(
-      constraint.facingMode === "user"
+    setConstraint((prevConstraint) =>
+      prevConstraint.facingMode === "user"
         ? VideoConstraints.environment
         : VideoConstraints.user,
     );


### PR DESCRIPTION
## Proposed Changes

- Fixes #13003
- Change the logic of `handleSwitchCamera` function a bit.
- It uses `useCallback` and an `empty dependency array`, which  created a stale closure. where the function only ever had access to the initial constraint state. As a result, after the first switch, it would always see facingMode as "user" and couldn't toggle back.
- So , The `handleSwitchCamera `function has been updated to use the functional update form of useState. By passing a function to setConstraint, we can safely access the previous state (prevConstraint) and ensure the toggle logic is always based on the most current state value.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera switching reliability when editing your avatar, ensuring smoother toggling between front and rear cameras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->