### PR TITLE
improved overflow handling in CommandGroup

### DIFF
--- a/src/components/Questionnaire/ValueSetSearchContent.tsx
+++ b/src/components/Questionnaire/ValueSetSearchContent.tsx
@@ -192,14 +192,16 @@ export default function ValueSetSearchContent({
           </TabsList>
         </Tabs>
       </div>
-      <CommandInput
-        ref={inputRef}
-        placeholder={placeholder}
-        className="outline-hidden border-none ring-0 shadow-none"
-        onValueChange={onSearchChange}
-        value={search}
-        autoFocus
-      />
+      <div className="border-b border-gray-200">
+        <CommandInput
+          ref={inputRef}
+          placeholder={placeholder}
+          className="outline-hidden border-none ring-0 shadow-none"
+          onValueChange={onSearchChange}
+          value={search}
+          autoFocus
+        />
+      </div>
       <CommandList className="h-75 overflow-hidden">
         <CommandEmpty>
           {search.length < 3 ? (
@@ -261,7 +263,7 @@ export default function ValueSetSearchContent({
               "border-gray-200",
             )}
           >
-            <CommandGroup>
+            <CommandGroup className="h-75 overflow-auto">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-normal text-gray-700 p-1">
                   {t("starred")}


### PR DESCRIPTION
## Proposed Changes

There was a noscroll issue in the started items. The started Items was not having scroll.

fix:
<img width="759" height="613" alt="image" src="https://github.com/user-attachments/assets/61e6d870-a4cf-4d9f-8ae4-910a35f4f38c" />

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a bottom border below the input field for improved visual separation.
  * Updated the starred items list to have a fixed height and vertical scrolling for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->