### PR TITLE
fix: make Add Patient Identifier Config button responsive on mobile

### DIFF
--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigList.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigList.tsx
@@ -136,7 +136,7 @@ export default function PatientIdentifierConfigList({
           <h1 className="text-2xl font-bold text-gray-700">
             {t("patient_identifier_config")}
           </h1>
-          <div className="mb-6 flex items-center justify-between">
+          <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
               <p className="text-gray-600 text-sm">
                 {facilityId
@@ -172,7 +172,7 @@ export default function PatientIdentifierConfigList({
               }}
             >
               <SheetTrigger asChild>
-                <Button onClick={handleAdd}>
+                <Button onClick={handleAdd} className="w-full md:w-auto">
                   <CareIcon icon="l-plus" className="mr-2" />
                   {t("add_patient_identifier_config")}
                 </Button>


### PR DESCRIPTION
## Proposed Changes

- Fixes #13027 

<img width="679" height="732" alt="Screenshot 2025-07-22 111900" src="https://github.com/user-attachments/assets/c16b5c31-c043-4488-be96-42d69c7b52f5" />

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and responsiveness of the page header and "Add Patient Identifier Config" button for better display on different screen sizes. The button now expands to full width on small screens and adjusts automatically on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->