### PR TITLE
add time of death to encounter

### DIFF
--- a/src/pages/Encounters/EncounterHeader.tsx
+++ b/src/pages/Encounters/EncounterHeader.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { ChevronDown, ExternalLink } from "lucide-react";
 import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
@@ -117,6 +118,15 @@ export function EncounterHeader() {
         <div className="md:hidden">
           <EncounterProperties encounter={encounter} canEdit={false} />
         </div>
+        {patient.deceased_datetime && (
+          <Badge variant="destructive" className="w-fit sm:self-center">
+            <h3 className="text-sm font-normal">
+              {t("time_of_death")}
+              {": "}
+              {dayjs(patient.deceased_datetime).format("DD MMM YYYY, hh:mm A")}
+            </h3>
+          </Badge>
+        )}
       </div>
 
       {!readOnly && (


### PR DESCRIPTION
## Proposed Changes

- adding time of death to encounter page (will need to be adjusted for future to fit with new design)

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "time of death" badge to the encounter header, which appears when relevant and displays the date and time in a user-friendly format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->