### PR TITLE
Fix : Old OTP Value Persists After Changing Phone Number in Patient Login

### DIFF
--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -154,7 +154,7 @@ const Login = (props: LoginProps) => {
       if ("errors" in response) {
         throw response;
       }
-      return response;
+      return response;  
     },
     onSuccess: async (response: { access: string }) => {
       const { access } = response;
@@ -635,6 +635,7 @@ const Login = (props: LoginProps) => {
                                 setOtp("");
                                 setOtpError("");
                                 setOtpValidationError("");
+                                setPhone("");
                               }}
                             >
                               {t("change_phone_number")}

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -154,7 +154,7 @@ const Login = (props: LoginProps) => {
       if ("errors" in response) {
         throw response;
       }
-      return response;  
+      return response;
     },
     onSuccess: async (response: { access: string }) => {
       const { access } = response;

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -635,7 +635,6 @@ const Login = (props: LoginProps) => {
                                 setOtp("");
                                 setOtpError("");
                                 setOtpValidationError("");
-                                setPhone("");
                               }}
                             >
                               {t("change_phone_number")}

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -632,6 +632,7 @@ const Login = (props: LoginProps) => {
                               className="h-auto p-0 text-primary-600"
                               onClick={() => {
                                 setIsOtpSent(false);
+                                setOtp("");
                                 setOtpError("");
                                 setOtpValidationError("");
                               }}


### PR DESCRIPTION
## Proposed Changes

- Fixes #13038
- Reset the otp state.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The OTP input field now clears automatically when changing the phone number during login, enhancing the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->