### PR TITLE
fix: Inconsistent width of Valueset Input

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ChoiceQuestion.tsx
@@ -2,6 +2,8 @@ import { t } from "i18next";
 import { memo } from "react";
 import { toast } from "sonner";
 
+import { cn } from "@/lib/utils";
+
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import RadioInput from "@/components/ui/RadioInput";
@@ -123,7 +125,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
       <>
         {questionnaireResponse.values.map((value, idx) => {
           return (
-            <div key={idx} className="flex items-center gap-2 mb-2">
+            <div key={idx} className="flex items-center mb-2">
               <div className="flex-1">
                 <ValueSetSelect
                   system={question.answer_value_set!}
@@ -151,7 +153,7 @@ export const ChoiceQuestion = memo(function ChoiceQuestion({
           );
         })}
 
-        <div>
+        <div className={cn(questionnaireResponse.values.length && "mr-9")}>
           <ValueSetSelect
             closeOnSelect={false}
             system={question.answer_value_set}

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -240,7 +240,7 @@ export default function ValueSetSelect({
       >
         {!hideTrigger && (
           <PopoverTrigger asChild disabled={disabled}>
-            <div className="w-full px-0!">
+            <div className="w-full">
               <Button
                 type="button"
                 variant="outline"


### PR DESCRIPTION
## Proposed Changes

- Fix the Inconsistent width of Valueset Input selection
- Screenshot :
<img width="930" height="349" alt="image" src="https://github.com/user-attachments/assets/8bfcef54-734e-4f22-adfb-eb97543356e4" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and spacing for choice questions in questionnaires.
  * Adjusted button and wrapper styling for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->