### PR TITLE
fix: Update form submission button states to disable when no changes are made in tag config and patient identifier config forms

### DIFF
--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -403,7 +403,7 @@ export default function TagConfigForm({
         )}
 
         <div className="flex justify-end space-x-2">
-          <Button type="submit" disabled={isLoading}>
+          <Button type="submit" disabled={isLoading || !form.formState.isDirty}>
             {isLoading
               ? t("saving")
               : isEditing

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -558,7 +558,7 @@ export default function PatientIdentifierConfigForm({
             <Button
               type="submit"
               className="w-full mt-6"
-              disabled={isCreating || isUpdating}
+              disabled={!form.formState.isDirty || isCreating || isUpdating}
             >
               {isCreating || isUpdating ? (
                 <span className="flex items-center gap-2">


### PR DESCRIPTION

## Proposed Changes

- Fixes #13115
- used `useDirty` to track the changes and triggers the button disabled logic


https://github.com/user-attachments/assets/2e29914c-eb16-48be-9ffb-2d3d7cf3a9df


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Submit buttons in forms are now disabled unless changes have been made, preventing accidental submissions when no edits are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->