### PR TITLE
prevent base price input overflow in mobile view

### DIFF
--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -605,10 +605,10 @@ export function ChargeItemDefinitionForm({
           </CardHeader>
           <CardContent className="space-y-6">
             {/* Base Price and MRP */}
-            <div className="p-4 bg-gray-50 rounded-lg border">
+            {/* <div className="p-4 bg-gray-50 rounded-lg border">
               <div className="space-y-4">
                 {/* MRP */}
-                {/* <div className="flex items-center justify-between">
+            {/* <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium text-gray-900">{t("mrp")}</h4>
                     <p className="text-sm text-gray-600">
@@ -623,40 +623,40 @@ export function ChargeItemDefinitionForm({
                     />
                   </div>
                 </div> */}
-
-                {/* Base Price */}
-                <FormField
-                  control={form.control}
-                  name="price_components.0.amount"
-                  render={({ field }) => (
-                    <FormItem className="flex items-center justify-between gap-2">
-                      <FormLabel className="font-medium text-gray-900 text-xl">
-                        {t("base_price")}
-                      </FormLabel>
-                      <div className="flex flex-col items-end gap-2">
-                        <FormControl className="w-48">
-                          <MonetaryAmountInput
-                            {...field}
-                            value={field.value ?? 0}
-                            onChange={(e) =>
-                              field.onChange(String(e.target.value))
-                            }
-                            placeholder="0.00"
-                          />
-                        </FormControl>
-                        <FormMessage>
-                          {
-                            form.formState.errors.price_components?.[0]?.amount
-                              ?.message
-                          }
-                        </FormMessage>
-                      </div>
-                    </FormItem>
-                  )}
-                />
+            {/* Base Price */}
+            <div className="rounded-lg border p-4 bg-gray-50 space-y-2">
+              <div>
+                <h4 className="text-lg font-medium text-gray-900">
+                  Base Price
+                </h4>
+                <p className="text-sm text-gray-600">
+                  Enter the base service cost before discounts or taxes.
+                </p>
               </div>
-            </div>
 
+              <FormField
+                control={form.control}
+                name="price_components.0.amount"
+                render={({ field }) => (
+                  <FormItem className="w-full space-y-1">
+                    <FormControl>
+                      <MonetaryAmountInput
+                        {...field}
+                        value={field.value ?? 0}
+                        onChange={(e) => field.onChange(String(e.target.value))}
+                        placeholder="0.00"
+                      />
+                    </FormControl>
+                    <FormMessage>
+                      {
+                        form.formState.errors.price_components?.[0]?.amount
+                          ?.message
+                      }
+                    </FormMessage>
+                  </FormItem>
+                )}
+              />
+            </div>
             {/* Discounts */}
             <MonetaryComponentSelectionSection
               title={t("discounts")}

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -627,10 +627,10 @@ export function ChargeItemDefinitionForm({
             <div className="rounded-lg border p-4 bg-gray-50 space-y-2">
               <div>
                 <h4 className="text-lg font-medium text-gray-900">
-                  Base Price
+                  {t("base_price")}
                 </h4>
                 <p className="text-sm text-gray-600">
-                  Enter the base service cost before discounts or taxes.
+                  {t("base_price_explanation")}
                 </p>
               </div>
 


### PR DESCRIPTION
## Proposed Changes

- Fixes  #13111
-fixed overflow of base price in mobile view

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the layout and styling of the base price input section for improved clarity and simplicity.
  * Removed the MRP input field and its related information from the pricing components card.

* **Style**
  * Adjusted spacing and stacking of elements in the pricing section for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->