### PR TITLE
Show all facility encounters if not completed

### DIFF
--- a/src/pages/Encounters/EncounterHistorySelector.tsx
+++ b/src/pages/Encounters/EncounterHistorySelector.tsx
@@ -141,7 +141,7 @@ const EncounterHistoryList = ({ onSelect }: Props) => {
           offset: String(pageParam),
           ...(completedEncounterStatus.includes(currentEncounter?.status ?? "")
             ? { patient_filter: patientId, facility: facilityId }
-            : { patient: patientId, facility: facilityId }),
+            : { patient: patientId }),
         },
       })({ signal });
       return response as PaginatedResponse<EncounterRead>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encounter history filtering so that the facility filter is only applied for completed encounters, ensuring more accurate results for ongoing or non-completed encounters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->