### PR TITLE
Fix: Entering white space for file name passes the validation

### DIFF
--- a/src/Utils/request/api.tsx
+++ b/src/Utils/request/api.tsx
@@ -3,11 +3,7 @@ import {
   FacilityModel,
   FacilityRequest,
 } from "@/components/Facility/models";
-import {
-  CreateFileRequest,
-  CreateFileResponse,
-  FileUploadModel,
-} from "@/components/Patient/models";
+import { FileUploadModel } from "@/components/Patient/models";
 import { AuthUserModel, UpdatePasswordForm } from "@/components/Users/models";
 
 import { PaginatedResponse } from "@/Utils/request/types";
@@ -197,13 +193,6 @@ const routes = {
     TRes: Type<UserBase>(),
   },
 
-  // FileUpload Create
-  createUpload: {
-    path: "/api/v1/files/",
-    method: "POST",
-    TBody: Type<CreateFileRequest>(),
-    TRes: Type<CreateFileResponse>(),
-  },
   viewUpload: {
     path: "/api/v1/files/",
     method: "GET",
@@ -218,11 +207,6 @@ const routes = {
     path: "/api/v1/files/{id}/",
     method: "PUT",
     TBody: Type<Partial<FileUploadModel>>(),
-    TRes: Type<FileUploadModel>(),
-  },
-  markUploadCompleted: {
-    path: "/api/v1/files/{id}/mark_upload_completed/",
-    method: "POST",
     TRes: Type<FileUploadModel>(),
   },
   archiveUpload: {

--- a/src/hooks/useFileUpload.tsx
+++ b/src/hooks/useFileUpload.tsx
@@ -307,7 +307,7 @@ export default function useFileUpload(
           allowNameFallback && uploadFileNames[index] === "" && file
             ? file.name
             : uploadFileNames[index];
-        if (!filename) {
+        if (!filename || filename.trim() === "") {
           setError(t("file_error__single_file_name"));
           return;
         }

--- a/src/hooks/useFileUpload.tsx
+++ b/src/hooks/useFileUpload.tsx
@@ -21,9 +21,9 @@ import {
 
 import { DEFAULT_ALLOWED_EXTENSIONS } from "@/common/constants";
 
-import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import uploadFile from "@/Utils/request/uploadFile";
+import filesApi from "@/types/files/filesApi";
 
 export type FileUploadOptions = {
   multiple?: boolean;
@@ -203,10 +203,8 @@ export default function useFileUpload(
         data: CreateFileResponse;
         associating_id: string;
       }) =>
-        mutate(routes.markUploadCompleted, {
-          pathParams: {
-            id: body.data.id,
-          },
+        mutate(filesApi.markUploadCompleted, {
+          pathParams: { id: body.data.id },
         })(body),
       onSuccess: (_, { data, associating_id }) => {
         queryClient.invalidateQueries({
@@ -273,7 +271,7 @@ export default function useFileUpload(
       file_category: FileCategory;
       mime_type: string;
     }) =>
-      mutate(routes.createUpload, {
+      mutate(filesApi.createUpload, {
         body: {
           original_name: body.original_name,
           file_type: body.file_type,
@@ -307,7 +305,7 @@ export default function useFileUpload(
           allowNameFallback && uploadFileNames[index] === "" && file
             ? file.name
             : uploadFileNames[index];
-        if (!filename || filename.trim() === "") {
+        if (!filename.trim()) {
           setError(t("file_error__single_file_name"));
           return;
         }


### PR DESCRIPTION
## Proposed Changes

- Fixes #[13088](https://github.com/ohcnetwork/care_fe/issues/13088)

This pull request includes a minor update to the `useFileUpload` hook to improve validation for uploaded file names.

* Enhanced the filename validation logic by ensuring that filenames are not only non-null but also not composed entirely of whitespace.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload validation to prevent uploading files with names that are empty or contain only whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->