### PR TITLE
fix: Corrected Slot Info Text

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -4119,7 +4119,7 @@
   "session_expired_message": "It looks like your session timed out for a moment. Take a quick breather, then log in again to continue.",
   "session_expired_msg": "It appears that your session has expired. This could be due to inactivity. Please login again to continue.",
   "session_slots_info": "{{slots}} slots of {{minutes}} mins.",
-  "session_slots_info_striked": " {{intended_slots}} slotsăr  {{actual_slots}} slots of {{minutes}} mins.",
+  "session_slots_info_striked": " <s>{{intended_slots}} slots</s>  {{actual_slots}} slots of {{minutes}} mins.",
   "session_title": "Session Title",
   "session_title_placeholder": "IP Rounds",
   "session_type": "Session Type",

--- a/public/locale/ml.json
+++ b/public/locale/ml.json
@@ -2576,7 +2576,7 @@
   "sending": "അയയ്ക്കുന്നു",
   "session_capacity": "സെഷൻ ശേഷി",
   "session_slots_info": "{slots}} സ്ലോട്ടുകൾ {{minutes}} മിനിറ്റ് വീതം.",
-  "session_slots_info_striked": "<s>{{intended_slots}} സ്ലോട്ടുകൾ</s>",
+  "session_slots_info_striked": "<s>{{intended_slots}} സ്ലോട്ടുകൾ</s>   {{actual_slots}} സ്ലോട്ടുകൾ {{minutes}} മിനിറ്റ് വീതം.",
   "session_title": "സെഷൻ ശീർഷകം",
   "session_title_placeholder": "IP റൗണ്ടുകൾ",
   "session_type": "സെഷൻ തരം",

--- a/public/locale/ml.json
+++ b/public/locale/ml.json
@@ -2576,7 +2576,7 @@
   "sending": "അയയ്ക്കുന്നു",
   "session_capacity": "സെഷൻ ശേഷി",
   "session_slots_info": "{slots}} സ്ലോട്ടുകൾ {{minutes}} മിനിറ്റ് വീതം.",
-  "session_slots_info_striked": "<s>{{intended_slots}} സ്ലോട്ടുകൾ</s>   {{actual_slots}} സ്ലോട്ടുകൾ {{minutes}} മിനിറ്റ് വീതം.",
+  "session_slots_info_striked": "<s>{{intended_slots}} സ്ലോട്ടുകൾ</s>",
   "session_title": "സെഷൻ ശീർഷകം",
   "session_title_placeholder": "IP റൗണ്ടുകൾ",
   "session_type": "സെഷൻ തരം",


### PR DESCRIPTION
## Proposed Changes

- Fixes #13092 
- Corrected the slot info text in the schedule template when an exception is added.

<img width="1919" height="899" alt="Screenshot 2025-07-28 133035" src="https://github.com/user-attachments/assets/a0bd9129-79a8-49d1-b3bc-9bbd9074b619" />

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected formatting of the session slot information message in English and Malayalam to display intended and actual slot counts with proper strikethrough and duration details.

* **New Features**
  * Enhanced session slot information in Malayalam to include both actual slot count and duration per slot for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->