### PR TITLE
Expand upto child location if search matches in Location select

### DIFF
--- a/src/components/Location/LocationMultiSelect.tsx
+++ b/src/components/Location/LocationMultiSelect.tsx
@@ -37,19 +37,14 @@ function LocationTreeNode({
   searchQuery,
   visited = new Set(),
 }: LocationTreeNodeProps) {
-  if (visited.has(location.id)) {
-    return null;
-  }
-  const nextVisited = new Set(visited);
-  nextVisited.add(location.id);
-
   const isExpanded = expandedLocations.has(location.id);
+  const isVisited = visited.has(location.id);
   const isSelected = selectedLocationIds.includes(location.id);
   const Icon =
     LocationTypeIcons[location.form as keyof typeof LocationTypeIcons];
 
   // Only fetch children when expanded
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+
   const { data: children, isLoading } = useQuery({
     queryKey: ["locations", facilityId, "children", location.id, "kind"],
     queryFn: query(locationApi.list, {
@@ -62,8 +57,14 @@ function LocationTreeNode({
     }),
 
     staleTime: 5 * 60 * 1000,
+    enabled: isExpanded && !isVisited,
   });
 
+  if (isVisited) {
+    return null;
+  }
+  const nextVisited = new Set(visited);
+  nextVisited.add(location.id);
   const hasChildren = children?.results && children.results.length > 0;
 
   // Filter children based on search query

--- a/src/components/Location/LocationMultiSelect.tsx
+++ b/src/components/Location/LocationMultiSelect.tsx
@@ -351,7 +351,7 @@ export default function LocationMultiSelect({
         <input
           type="text"
           placeholder={t("search_locations")}
-          className="w-full rounded-md border border-input bg-background pl-8 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="w-full rounded-md border border-input bg-background pl-8 py-2 text-sm ring-offset-background focus:ring-primary-500 focus:border-primary-500 focus-visible:outline-none dark:focus-visible:ring-gray-300"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
         />

--- a/src/components/Location/LocationMultiSelect.tsx
+++ b/src/components/Location/LocationMultiSelect.tsx
@@ -23,6 +23,7 @@ interface LocationTreeNodeProps {
   level?: number;
   facilityId: string;
   searchQuery: string;
+  visited?: Set<string>;
 }
 
 function LocationTreeNode({
@@ -34,7 +35,11 @@ function LocationTreeNode({
   level = 0,
   facilityId,
   searchQuery,
+  visited = new Set(),
 }: LocationTreeNodeProps) {
+  const nextVisited = new Set(visited);
+  nextVisited.add(location.id);
+
   const isExpanded = expandedLocations.has(location.id);
   const isSelected = selectedLocationIds.includes(location.id);
   const Icon =
@@ -54,6 +59,10 @@ function LocationTreeNode({
 
     staleTime: 5 * 60 * 1000,
   });
+
+  if (visited.has(location.id)) {
+    return null;
+  }
 
   const hasChildren = children?.results && children.results.length > 0;
 
@@ -133,6 +142,7 @@ function LocationTreeNode({
               level={level}
               facilityId={facilityId}
               searchQuery={searchQuery}
+              visited={nextVisited}
             />
           ))}
         </div>

--- a/src/components/Location/LocationMultiSelect.tsx
+++ b/src/components/Location/LocationMultiSelect.tsx
@@ -37,6 +37,9 @@ function LocationTreeNode({
   searchQuery,
   visited = new Set(),
 }: LocationTreeNodeProps) {
+  if (visited.has(location.id)) {
+    return null;
+  }
   const nextVisited = new Set(visited);
   nextVisited.add(location.id);
 
@@ -46,6 +49,7 @@ function LocationTreeNode({
     LocationTypeIcons[location.form as keyof typeof LocationTypeIcons];
 
   // Only fetch children when expanded
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { data: children, isLoading } = useQuery({
     queryKey: ["locations", facilityId, "children", location.id, "kind"],
     queryFn: query(locationApi.list, {
@@ -59,10 +63,6 @@ function LocationTreeNode({
 
     staleTime: 5 * 60 * 1000,
   });
-
-  if (visited.has(location.id)) {
-    return null;
-  }
 
   const hasChildren = children?.results && children.results.length > 0;
 

--- a/src/components/Location/LocationMultiSelect.tsx
+++ b/src/components/Location/LocationMultiSelect.tsx
@@ -2,7 +2,7 @@
 // This doesn't account for nested locations.
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronRight, Plus, Search, X } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
@@ -243,6 +243,24 @@ export default function LocationMultiSelect({
     return map;
   }, [allLocations?.results]);
 
+  useEffect(() => {
+    if (!allLocations?.results) return;
+
+    if (!searchQuery) {
+      setExpandedLocations(new Set());
+      return;
+    }
+
+    const matchedPaths = findMatchingPaths(allLocations.results, searchQuery);
+    const expanded = new Set<string>();
+
+    for (const path of matchedPaths) {
+      path.forEach((id) => expanded.add(id));
+    }
+
+    setExpandedLocations(expanded);
+  }, [searchQuery, allLocations?.results]);
+
   const handleToggleExpand = (locationId: string) => {
     setExpandedLocations((prev) => {
       const next = new Set(prev);
@@ -266,6 +284,37 @@ export default function LocationMultiSelect({
   const handleRemove = (locationId: string) => {
     onChange(value.filter((id) => id !== locationId));
   };
+
+  function findMatchingPaths(
+    allLocations: LocationList[],
+    searchQuery: string,
+  ): string[][] {
+    const results: string[][] = [];
+    const parentMap = new Map<string, string | null>();
+
+    for (const loc of allLocations) {
+      const parentId =
+        typeof loc.parent === "object" ? loc.parent?.id : loc.parent;
+
+      parentMap.set(loc.id, (parentId ?? null) as string | null);
+    }
+
+    for (const loc of allLocations) {
+      if (loc.name.toLowerCase().includes(searchQuery.toLowerCase())) {
+        const path: string[] = [];
+        let currentId: string | null = loc.id;
+
+        while (currentId) {
+          path.unshift(currentId);
+          currentId = parentMap.get(currentId) || null;
+        }
+
+        results.push(path);
+      }
+    }
+
+    return results;
+  }
 
   return (
     <div className="h-full flex flex-col gap-2">

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -250,7 +250,7 @@ export default function ValueSetSelect({
                   !value?.display && "text-gray-400",
                 )}
               >
-                <span className="truncate block max-w-full">
+                <span>
                   {value?.display || placeholder}
                   {value?.display && showCode && (
                     <span className="text-xs ml-1">({value?.code})</span>

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -250,7 +250,7 @@ export default function ValueSetSelect({
                   !value?.display && "text-gray-400",
                 )}
               >
-                <span>
+                <span className="truncate block max-w-full">
                   {value?.display || placeholder}
                   {value?.display && showCode && (
                     <span className="text-xs ml-1">({value?.code})</span>


### PR DESCRIPTION
## Proposed Changes

- Fixes #13093 
- Added findMatchingPaths utility to build the full path using a parentMap.
- Added useEffect hook to reset the expanded state when search is cleared
- Fixed focus state of search input




https://github.com/user-attachments/assets/a7466fe4-0f0d-406b-a0dd-82d40a6ddd53





@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented potential infinite loops when displaying locations with cyclic parent-child relationships.

* **New Features**
  * Automatically expands all ancestor nodes in the location selector when searching, making it easier to find and view matching locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->