### PR TITLE
Always show encounter history selector

### DIFF
--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -27,10 +27,7 @@ import { EncounterObservationsTab } from "@/pages/Encounters/tabs/EncounterObser
 import { EncounterOverviewTab } from "@/pages/Encounters/tabs/EncounterOverviewTab";
 import { EncounterPlotsTab } from "@/pages/Encounters/tabs/EncounterPlotsTab";
 import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
-import {
-  EncounterRead,
-  inactiveEncounterStatus,
-} from "@/types/emr/encounter/encounter";
+import { EncounterRead } from "@/types/emr/encounter/encounter";
 import { PatientRead } from "@/types/emr/patient/patient";
 
 import { EncounterDiagnosticReportsTab } from "./tabs/EncounterDiagnosticReportsTab";
@@ -126,9 +123,7 @@ export const EncounterShow = (props: Props) => {
     <Page title={t("encounter")} className="block" hideTitleOnPage>
       <EncounterHeader />
       <div className="flex flex-col lg:flex-row gap-6 lg:gap-2 mt-4 h-[calc(100vh-10rem)]">
-        {!inactiveEncounterStatus.includes(currentEncounter.status) && (
-          <EncounterHistorySelector />
-        )}
+        <EncounterHistorySelector />
         <div className="w-full overflow-x-auto">
           <div className="w-full border-b-2 border-secondary-200 ">
             <div className="overflow-x-auto sm:flex sm:items-baseline">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Encounter history selector is now always visible, regardless of encounter status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->