### PR TITLE
Created a reusable component to display linkable address text and integrated it into the AppointmentDetails page

### DIFF
--- a/src/components/Common/ClickableAddress.tsx
+++ b/src/components/Common/ClickableAddress.tsx
@@ -1,0 +1,17 @@
+import { Markdown } from "@/components/ui/markdown";
+
+export const ClickableAddress = ({ address }: { address: string }) => {
+  return (
+    <div
+      className="[&_a]:text-sky-600 [&_a]:underline [&_a]:hover:text-sky-300 break-words overflow-wrap-anywhere"
+      onClick={(e) => {
+        if (e.target instanceof HTMLAnchorElement && e.target.href) {
+          e.preventDefault();
+          window.open(e.target.href, "_blank", "noopener,noreferrer");
+        }
+      }}
+    >
+      <Markdown content={address || ""} prose={false} />
+    </div>
+  );
+};

--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -8,8 +8,8 @@ import { formatPhoneNumberIntl } from "react-phone-number-input";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Button } from "@/components/ui/button";
-import { Markdown } from "@/components/ui/markdown";
 
+import { ClickableAddress } from "@/components/Common/ClickableAddress";
 import { PatientProps } from "@/components/Patient/PatientDetailsTab";
 import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
 
@@ -48,20 +48,6 @@ export const Demography = (props: PatientProps) => {
       section.scrollIntoView();
     }
   };
-
-  const renderClickableAddress = (address: string) => (
-    <div
-      className="[&_a]:text-sky-600 [&_a]:underline [&_a]:hover:text-sky-300 break-words overflow-wrap-anywhere"
-      onClick={(e) => {
-        if (e.target instanceof HTMLAnchorElement && e.target.href) {
-          e.preventDefault();
-          window.open(e.target.href, "_blank", "noopener,noreferrer");
-        }
-      }}
-    >
-      <Markdown content={address || ""} prose={false} />
-    </div>
-  );
 
   const handleEditClick = (sectionId: string) => {
     if (sectionId === "tags") {
@@ -217,11 +203,13 @@ export const Demography = (props: PatientProps) => {
         />,
         {
           label: t("current_address"),
-          value: renderClickableAddress(patientData.address || ""),
+          value: <ClickableAddress address={patientData.address || ""} />,
         },
         {
           label: t("permanent_address"),
-          value: renderClickableAddress(patientData.permanent_address || ""),
+          value: (
+            <ClickableAddress address={patientData.permanent_address || ""} />
+          ),
         },
         ...getGeoOrgDetails(patientData.geo_organization),
       ],

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
 
+import { ClickableAddress } from "@/components/Common/ClickableAddress";
 import Loading from "@/components/Common/Loading";
 import Page from "@/components/Common/Page";
 import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
@@ -372,7 +373,7 @@ const AppointmentDetails = ({
               </p>
             </div>
           </div>
-          <div className="flex items-center space-x-4 text-sm">
+          <div className="flex items-center space-x-4 text-sm ">
             <MobileIcon className="size-5 text-gray-600" />
             <div>
               <p className="font-medium">
@@ -398,13 +399,17 @@ const AppointmentDetails = ({
               </p>
             </div>
           </div>
-          <div className="flex items-center space-x-4 text-sm">
-            <DrawingPinIcon className="size-5 text-gray-600" />
-            <div>
-              <p className="font-medium">
-                {appointment.patient.address || t("no_address_provided")}
+          <div className="flex flex-row items-start gap-4 text-sm">
+            <DrawingPinIcon className="size-5 text-gray-600 mt-1" />
+            <div className="min-w-0 flex-1">
+              <p className="font-medium break-words">
+                <ClickableAddress
+                  address={
+                    appointment.patient.address || t("no_address_provided")
+                  }
+                />
               </p>
-              <p className="text-gray-600">
+              <p className="text-gray-600 break-words">
                 {stringifyNestedObject(appointment.patient.geo_organization)}
               </p>
               <p className="text-gray-600">

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -373,7 +373,7 @@ const AppointmentDetails = ({
               </p>
             </div>
           </div>
-          <div className="flex items-center space-x-4 text-sm ">
+          <div className="flex items-center space-x-4 text-sm">
             <MobileIcon className="size-5 text-gray-600" />
             <div>
               <p className="font-medium">


### PR DESCRIPTION
## Proposed Changes

- Refactored address display into a reusable linkable text component and reused it in the AppointmentDetails page.
- Screenshot :
<img width="982" height="845" alt="image" src="https://github.com/user-attachments/assets/3d3cb6f7-6953-419a-85f4-9d5a052aed30" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a standardized clickable address component for displaying addresses with enhanced styling and link handling.

* **Refactor**
  * Replaced custom address rendering in patient demography and appointment details with the new clickable address component for consistency and improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->