### PR TITLE
Display today's appointments by default in the list

### DIFF
--- a/care.config.ts
+++ b/care.config.ts
@@ -84,7 +84,7 @@ const careConfig = {
      */
     defaultDateFilter: env.REACT_APPOINTMENTS_DEFAULT_DATE_FILTER
       ? parseInt(env.REACT_APPOINTMENTS_DEFAULT_DATE_FILTER)
-      : 7,
+      : 0,
 
     // Kill switch in-case the heatmap API doesn't scale as expected
     useAvailabilityStatsAPI: boolean(


### PR DESCRIPTION
## Proposed Changes
- Load today's appointments as the default in the appoinment list 
- Screenshot :
<img width="770" height="578" alt="image" src="https://github.com/user-attachments/assets/38d4f656-716b-4729-b12f-a3a1ee7e8ab6" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the default appointments view to show only today's appointments instead of the upcoming week, unless otherwise configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->