### PR TITLE
Fix `TypeError: Cannot read properties of undefined (reading 'match')` in Schedule Create and Edit forms

### DIFF
--- a/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
@@ -101,12 +101,12 @@ export default function CreateScheduleTemplateSheet({
                 slot_type: z.literal("appointment"),
                 name: z.string().min(1, t("field_required")),
                 reason: z.string().trim(),
-                start_time: z
-                  .string()
-                  .min(1, t("field_required")) as unknown as z.ZodType<Time>,
-                end_time: z
-                  .string()
-                  .min(1, t("field_required")) as unknown as z.ZodType<Time>,
+                start_time: z.string().min(1, t("field_required")) as z.ZodType<
+                  Time | undefined
+                >,
+                end_time: z.string().min(1, t("field_required")) as z.ZodType<
+                  Time | undefined
+                >,
                 slot_size_in_minutes: z
                   .number()
                   .min(1, t("number_min_error", { min: 0 })),
@@ -254,11 +254,11 @@ export default function CreateScheduleTemplateSheet({
   const updateSlotDuration = (index: number) => {
     const isAutoFill = form.watch(`availabilities.${index}.is_auto_fill`);
     if (isAutoFill) {
-      const duration = calculateSlotDuration(
-        form.watch(`availabilities.${index}.start_time`),
-        form.watch(`availabilities.${index}.end_time`),
-        form.watch(`availabilities.${index}.num_of_slots`),
-      );
+      const start = form.watch(`availabilities.${index}.start_time`);
+      const end = form.watch(`availabilities.${index}.end_time`);
+      const numOfSlots = form.watch(`availabilities.${index}.num_of_slots`);
+      if (!start || !end) return;
+      const duration = calculateSlotDuration(start, end, numOfSlots);
       form.setValue(`availabilities.${index}.slot_size_in_minutes`, duration);
     }
   };
@@ -696,8 +696,8 @@ export default function CreateScheduleTemplateSheet({
                       name: "",
                       slot_type: "appointment",
                       reason: "",
-                      start_time: "00:00",
-                      end_time: "00:00",
+                      start_time: undefined,
+                      end_time: undefined,
                       tokens_per_slot: null as unknown as number,
                       slot_size_in_minutes: null as unknown as number,
                       is_auto_fill: false,

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -559,12 +559,12 @@ const NewAvailabilityCard = ({
     .object({
       name: z.string().min(1, t("field_required")),
       slot_type: z.enum(["appointment", "open", "closed"]),
-      start_time: z
-        .string()
-        .min(1, t("field_required")) as unknown as z.ZodType<Time>,
-      end_time: z
-        .string()
-        .min(1, t("field_required")) as unknown as z.ZodType<Time>,
+      start_time: z.string().min(1, t("field_required")) as z.ZodType<
+        Time | undefined
+      >,
+      end_time: z.string().min(1, t("field_required")) as z.ZodType<
+        Time | undefined
+      >,
       slot_size_in_minutes: z.number().nullable(),
       tokens_per_slot: z.number().nullable(),
       reason: z.string().trim(),
@@ -691,11 +691,11 @@ const NewAvailabilityCard = ({
   const updateSlotDuration = () => {
     const isAutoFill = form.watch("is_auto_fill");
     if (isAutoFill) {
-      const duration = calculateSlotDuration(
-        form.watch("start_time"),
-        form.watch("end_time"),
-        form.watch("num_of_slots"),
-      );
+      const start = form.watch("start_time");
+      const end = form.watch("end_time");
+      const numOfSlots = form.watch("num_of_slots");
+      if (!start || !end) return;
+      const duration = calculateSlotDuration(start, end, numOfSlots);
       form.setValue("slot_size_in_minutes", duration);
     }
   };

--- a/src/pages/Scheduling/utils.ts
+++ b/src/pages/Scheduling/utils.ts
@@ -164,8 +164,8 @@ export const getFakeTokenNumber = (appointment: Appointment) => {
 };
 
 export const calculateSlotDuration = (
-  startTime: string,
-  endTime: string,
+  startTime: Time,
+  endTime: Time,
   numOfSlots: number = 1,
 ) => {
   const start = parse(startTime, "HH:mm", new Date());


### PR DESCRIPTION


## Proposed Changes

- Fixes #13186


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Ensure that UI text is kept in I18n files.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of start and end time fields in scheduling forms to allow for undefined values and prevent errors when times are missing.
  * Enhanced slot duration calculation logic to avoid processing when required time fields are not set.

* **Refactor**
  * Updated internal logic for time field validation and initialization to support more flexible input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->