### PR TITLE
Fix: Calender first row having diffrent h compare to other

### DIFF
--- a/src/CAREUI/interactive/Calendar.tsx
+++ b/src/CAREUI/interactive/Calendar.tsx
@@ -89,7 +89,7 @@ export default function Calendar(props: Props) {
 
         {calendarDays.map((date, index) => {
           if (!date) {
-            return <div key={`empty-${index}`} className="min-h-[80px]" />;
+            return <div key={`empty-${index}`} className="min-h-16" />;
           }
 
           const isToday = date.toDateString() === new Date().toDateString();


### PR DESCRIPTION
## Proposed Changes

Update minimum height for empty calendar days from 80px to 16 (improves layout consistency)

**ISSUE**
<img width="1070" height="701" alt="image" src="https://github.com/user-attachments/assets/e0679388-aba2-4a70-9898-9d0aaaa6f5a5" />


**FIX**
<img width="1070" height="701" alt="image" src="https://github.com/user-attachments/assets/a26d6d9b-66a1-4a92-b4f8-2c2cfc6852e6" />


@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of empty calendar day slots for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->