### PR TITLE
Hide Action buttons when No Active Account for Account Sheet

### DIFF
--- a/src/components/Patient/AccountSheet.tsx
+++ b/src/components/Patient/AccountSheet.tsx
@@ -66,11 +66,13 @@ export function AccountSheetButton({
     setCreateAccountOpen(true);
   };
 
-  const handleEditAccount = (account: AccountRead) => {
+  const handleEditAccount = (account: AccountRead, e: React.MouseEvent) => {
+    e.stopPropagation();
     setEditingAccount(account);
   };
 
-  const handleViewAccount = (account: AccountRead) => {
+  const handleViewAccount = (account: AccountRead, e: React.MouseEvent) => {
+    e.stopPropagation();
     navigate(
       `/facility/${encounter.facility.id}/billing/account/${account.id}`,
     );
@@ -102,7 +104,7 @@ export function AccountSheetButton({
                     variant="outline"
                     size="sm"
                     className="flex items-center gap-1"
-                    onClick={() => handleViewAccount(accounts[0])}
+                    onClick={(e) => handleViewAccount(accounts[0], e)}
                   >
                     <ExternalLink className="size-4" />
                     {t("more_details")}
@@ -112,7 +114,7 @@ export function AccountSheetButton({
                       variant="outline"
                       size="sm"
                       className="flex items-center gap-1"
-                      onClick={() => handleEditAccount(accounts[0])}
+                      onClick={(e) => handleEditAccount(accounts[0], e)}
                     >
                       <Edit className="size-4" />
                       {t("edit")}

--- a/src/components/Patient/AccountSheet.tsx
+++ b/src/components/Patient/AccountSheet.tsx
@@ -66,13 +66,11 @@ export function AccountSheetButton({
     setCreateAccountOpen(true);
   };
 
-  const handleEditAccount = (account: AccountRead, e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleEditAccount = (account: AccountRead) => {
     setEditingAccount(account);
   };
 
-  const handleViewAccount = (account: AccountRead, e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleViewAccount = (account: AccountRead) => {
     navigate(
       `/facility/${encounter.facility.id}/billing/account/${account.id}`,
     );
@@ -98,33 +96,35 @@ export function AccountSheetButton({
           <SheetHeader className="mb-6">
             <SheetTitle className="text-xl flex items-center justify-start gap-2">
               {t("account")}
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="flex items-center gap-1"
-                  onClick={(e) => handleViewAccount(accounts[0], e)}
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  {t("more_details")}
-                </Button>
-                {canWrite && (
+              {!!accounts.length && (
+                <div className="flex items-center gap-2">
                   <Button
                     variant="outline"
                     size="sm"
                     className="flex items-center gap-1"
-                    onClick={(e) => handleEditAccount(accounts[0], e)}
+                    onClick={() => handleViewAccount(accounts[0])}
                   >
-                    <Edit className="h-4 w-4" />
-                    {t("edit")}
+                    <ExternalLink className="size-4" />
+                    {t("more_details")}
                   </Button>
-                )}
-              </div>
+                  {canWrite && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="flex items-center gap-1"
+                      onClick={() => handleEditAccount(accounts[0])}
+                    >
+                      <Edit className="size-4" />
+                      {t("edit")}
+                    </Button>
+                  )}
+                </div>
+              )}
             </SheetTitle>
           </SheetHeader>
           {isLoading ? (
             <div className="flex justify-center items-center h-40">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              <div className="animate-spin rounded-full size-8 border-b-2 border-primary"></div>
             </div>
           ) : (
             <div className="space-y-5 pr-2 max-h-[calc(100vh-120px)] overflow-y-auto">


### PR DESCRIPTION

## Issue

https://github.com/user-attachments/assets/3b9171f9-7902-4cdd-9b26-0fbb7abdda71




## Fix

![Screenshot 2025-08-03 at 1 20 53 PM](https://github.com/user-attachments/assets/05de4cf0-d00d-4949-9e4f-ad6403e75ba7)



@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved button layout in the account sheet header, showing action buttons only when accounts are available.
  * Updated "more details" button with an outlined style and external link icon.
  * "Edit" button now appears only for users with editing permissions.

* **Style**
  * Adjusted loading spinner to use consistent sizing for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->