### PR TITLE
fix : Handle back propagation with select inside the EntitySelectionSheet

### DIFF
--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -156,6 +156,22 @@ export function EntitySelectionSheet({
         <SheetContent
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
+          onInteractOutside={(event) => {
+            const target = event.target as Node;
+            const currentTarget = event.currentTarget as Node;
+
+            const selectContent = document.querySelector(
+              '[data-slot="select-content"]',
+            );
+
+            // Prevent the Sheet from closing if the click is inside the select dropdown or inside the Sheet
+            if (
+              selectContent?.contains(target) ||
+              currentTarget.contains(target)
+            ) {
+              event.preventDefault();
+            }
+          }}
         >
           {selectedEntity ? (
             <div className="flex flex-col h-auto min-h-[50vh] max-h-[80vh] sm:max-h-[70vh] md:max-h-[60vh]">

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -154,7 +154,7 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
-          className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden !pointer-events-auto"
+          className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden pointer-events-auto"
           side="bottom"
           onInteractOutside={(event) => {
             // Try to get the real click/tap target from Radix's originalEvent
@@ -168,7 +168,6 @@ export function EntitySelectionSheet({
               return;
             }
 
-            // Prevent sheet close if click is inside sheet content
             const sheetContent = document.getElementById("sheet-content");
             if (sheetContent && sheetContent.contains(target)) {
               event.preventDefault();

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -17,6 +17,8 @@
 import { ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { cn } from "@/lib/utils";
+
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -154,8 +156,9 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
-          // style={{ pointerEvents: "auto" }}
-          className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
+          className={cn(
+            "px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden disabled:pointer-events-none",
+          )}
           side="bottom"
           onInteractOutside={(event) => {
             const target = (event.detail?.originalEvent?.target ??

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -160,22 +160,25 @@ export function EntitySelectionSheet({
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
-            const target = event.target as Element | null;
-            if (!target) return;
-
-            // Dropdown / select content check
+            const target = event.target as EventTarget | null;
+            if (!(target instanceof Element)) return;
+            // 1) If the tap/click is inside any portal content (select/combobox/popover), don't close the Sheet
             if (
-              target.closest('[role="combobox"]') ||
-              target.closest('[data-slot="select-trigger"]') ||
-              target.closest('[data-slot="popover-trigger"]')
+              target.closest(
+                '[data-slot="select-content"], [data-slot="combobox-content"], [data-slot="popover-content"]',
+              )
             ) {
               event.preventDefault();
               return;
             }
-            // Click inside the sheet
-            if (sheetRef.current?.contains(target)) {
+            // 2) If any of those portal contents are currently open, block the Sheet from closing
+            //    so overlay/back press closes the inner dropdown/popover first.
+            if (
+              document.querySelector(
+                '[data-slot="select-content"][data-state="open"], [data-slot="combobox-content"][data-state="open"], [data-slot="popover-content"][data-state="open"]',
+              )
+            ) {
               event.preventDefault();
-              return;
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -160,14 +160,19 @@ export function EntitySelectionSheet({
           side="bottom"
           onInteractOutside={(event) => {
             const target = event.target as Element | null;
-
             if (!target) return;
 
-            if (
-              target.closest('[data-slot="select-content"]') ||
-              sheetRef.current?.contains(target)
-            ) {
+            // Dropdown / select content check
+            if (target.closest('[data-slot="select-content"]')) {
               event.preventDefault();
+              event.stopPropagation();
+              return;
+            }
+
+            // Click inside the sheet
+            if (sheetRef.current?.contains(target)) {
+              event.preventDefault();
+              event.stopPropagation();
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -154,7 +154,8 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
-          className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden pointer-events-auto"
+          id="sheet-content"
+          className='px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden [&[data-slot="sheet-content"][data-state="open"]]:pointer-events-auto'
           side="bottom"
           onInteractOutside={(event) => {
             // Try to get the real click/tap target from Radix's originalEvent

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -156,23 +156,22 @@ export function EntitySelectionSheet({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
           ref={sheetRef}
+          id="sheet-content"
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
-          onInteractOutside={(event) => {
+          onPointerDownOutside={(event) => {
             const target = event.target as Element | null;
             if (!target) return;
 
-            // Dropdown / select content check
+            // If inside Radix select dropdown (portal content)
             if (target.closest('[data-slot="select-content"]')) {
               event.preventDefault();
-              event.stopPropagation();
               return;
             }
 
-            // Click inside the sheet
+            // If inside sheet content
             if (sheetRef.current?.contains(target)) {
               event.preventDefault();
-              event.stopPropagation();
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -154,8 +154,8 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
-          id="sheet-content"
-          className='px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden [&[data-slot="sheet-content"][data-state="open"]]:pointer-events-auto'
+          style={{ pointerEvents: "auto" }}
+          className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
             // Try to get the real click/tap target from Radix's originalEvent

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -154,7 +154,7 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
-          className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
+          className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden !pointer-events-auto"
           side="bottom"
           onInteractOutside={(event) => {
             // Try to get the real click/tap target from Radix's originalEvent

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -137,28 +137,51 @@ export function EntitySelectionSheet({
     if (!target) return;
 
     // Check if the interaction is inside Radix select dropdown (portal content)
+    // This handles both the old and new Radix UI implementations
     if (
       target.closest('[data-slot="select-content"]') ||
-      target.closest("[data-radix-select-content]")
+      target.closest("[data-radix-select-content]") ||
+      target.closest('[role="listbox"]') ||
+      target.closest('[role="option"]')
     ) {
       event.preventDefault();
       return;
     }
 
-    // Check if the interaction is inside any other common portal content
-    const portalSelectors = [
+    // Check if the interaction is inside any other Radix portal content
+    const radixPortalSelectors = [
       "[data-radix-dropdown-menu-content]",
       "[data-radix-popover-content]",
       "[data-radix-tooltip-content]",
       "[data-radix-dialog-content]",
       "[data-radix-combobox-content]",
-      "[data-portal]",
-      ".select-portal",
-      ".dropdown-portal",
-      ".popover-portal",
+      "[data-radix-select-viewport]",
+      "[data-radix-popper-content-wrapper]",
     ];
 
-    if (portalSelectors.some((selector) => target.closest(selector))) {
+    if (radixPortalSelectors.some((selector) => target.closest(selector))) {
+      event.preventDefault();
+      return;
+    }
+
+    // Check for popover content (like date pickers)
+    if (
+      target.closest('[data-slot="popover-content"]') ||
+      target.closest('[aria-haspopup="dialog"]') ||
+      target.closest(".react-datepicker") ||
+      target.closest(".DayPicker")
+    ) {
+      event.preventDefault();
+      return;
+    }
+
+    // Additional check: if clicking on a combobox trigger or select trigger,
+    // prevent closing to allow the dropdown to open
+    if (
+      target.closest('[role="combobox"]') ||
+      target.closest('[data-slot="select-trigger"]') ||
+      target.closest('[data-slot="popover-trigger"]')
+    ) {
       event.preventDefault();
       return;
     }

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -14,7 +14,7 @@
  * the appropriate props.
  *
  */
-import { ReactNode, useCallback, useRef, useState } from "react";
+import { ReactNode, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -132,69 +132,6 @@ export function EntitySelectionSheet({
     setSelectedEntity(null);
   };
 
-  const handleInteractOutside = useCallback((event: Event) => {
-    const target = event.target as Element | null;
-    if (!target) return;
-
-    // Check if the interaction is inside Radix select dropdown (portal content)
-    // This handles both the old and new Radix UI implementations
-    if (
-      target.closest('[data-slot="select-content"]') ||
-      target.closest("[data-radix-select-content]") ||
-      target.closest('[role="listbox"]') ||
-      target.closest('[role="option"]')
-    ) {
-      event.preventDefault();
-      return;
-    }
-
-    // Check if the interaction is inside any other Radix portal content
-    const radixPortalSelectors = [
-      "[data-radix-dropdown-menu-content]",
-      "[data-radix-popover-content]",
-      "[data-radix-tooltip-content]",
-      "[data-radix-dialog-content]",
-      "[data-radix-combobox-content]",
-      "[data-radix-select-viewport]",
-      "[data-radix-popper-content-wrapper]",
-    ];
-
-    if (radixPortalSelectors.some((selector) => target.closest(selector))) {
-      event.preventDefault();
-      return;
-    }
-
-    // Check for popover content (like date pickers)
-    if (
-      target.closest('[data-slot="popover-content"]') ||
-      target.closest('[aria-haspopup="dialog"]') ||
-      target.closest(".react-datepicker") ||
-      target.closest(".DayPicker")
-    ) {
-      event.preventDefault();
-      return;
-    }
-
-    // Additional check: if clicking on a combobox trigger or select trigger,
-    // prevent closing to allow the dropdown to open
-    if (
-      target.closest('[role="combobox"]') ||
-      target.closest('[data-slot="select-trigger"]') ||
-      target.closest('[data-slot="popover-trigger"]')
-    ) {
-      event.preventDefault();
-      return;
-    }
-
-    // Check if the interaction is inside the sheet content itself
-    if (sheetRef.current?.contains(target)) {
-      event.preventDefault();
-      return;
-    }
-
-    // Allow the sheet to close for genuine outside interactions
-  }, []);
-
   return (
     <>
       {system === "system-medication" ? (
@@ -222,7 +159,25 @@ export function EntitySelectionSheet({
           id="sheet-content"
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
-          onInteractOutside={handleInteractOutside}
+          onInteractOutside={(event) => {
+            const target = event.target as Element | null;
+            if (!target) return;
+
+            // Dropdown / select content check
+            if (
+              target.closest('[role="combobox"]') ||
+              target.closest('[data-slot="select-trigger"]') ||
+              target.closest('[data-slot="popover-trigger"]')
+            ) {
+              event.preventDefault();
+              return;
+            }
+            // Click inside the sheet
+            if (sheetRef.current?.contains(target)) {
+              event.preventDefault();
+              return;
+            }
+          }}
         >
           {selectedEntity ? (
             <div className="flex flex-col h-auto min-h-[50vh] max-h-[80vh] sm:max-h-[70vh] md:max-h-[60vh]">

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -159,25 +159,15 @@ export function EntitySelectionSheet({
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
-            const target = event.target as Node;
+            const target = event.target as Element | null;
 
-            // Select dropdown content
-            const selectContent = document.querySelector(
-              '[data-slot="select-content"]',
-            );
+            if (!target) return;
 
-            // If click/touch is inside the dropdown
-            if (selectContent && selectContent.contains(target)) {
+            if (
+              target.closest('[data-slot="select-content"]') ||
+              sheetRef.current?.contains(target)
+            ) {
               event.preventDefault();
-              event.stopPropagation();
-              return;
-            }
-
-            // If click/touch is inside the sheet
-            if (sheetRef.current?.contains(target)) {
-              event.preventDefault();
-              event.stopPropagation();
-              return;
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -164,13 +164,20 @@ export function EntitySelectionSheet({
             if (!target) return;
 
             // Prevent sheet close if click is inside dropdown menu
-            if (target.closest('[data-slot="select-content"]')) {
+            if (
+              target.closest('[data-slot="select-content"]') ||
+              target.closest('[data-slot="sheet-overlay"]')
+            ) {
               event.preventDefault();
               return;
             }
 
             const sheetContent = document.getElementById("sheet-content");
-            if (sheetContent && sheetContent.contains(target)) {
+            const sheetOverlay = document.getElementById("sheet-overlay");
+            if (
+              (sheetContent && sheetContent.contains(target)) ||
+              (sheetOverlay && sheetOverlay.contains(target))
+            ) {
               event.preventDefault();
               return;
             }

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -158,18 +158,18 @@ export function EntitySelectionSheet({
           side="bottom"
           onInteractOutside={(event) => {
             const target = event.target as Node;
-            const currentTarget = event.currentTarget as Node;
-
             const selectContent = document.querySelector(
               '[data-slot="select-content"]',
             );
-
+            const sheetContent = document.getElementById("sheet-content");
             // Prevent the Sheet from closing if the click is inside the select dropdown or inside the Sheet
-            if (
-              selectContent?.contains(target) ||
-              currentTarget.contains(target)
-            ) {
+            if (selectContent?.contains(target)) {
               event.preventDefault();
+            }
+
+            if (sheetContent?.contains(target)) {
+              event.preventDefault();
+              return;
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -14,7 +14,7 @@
  * the appropriate props.
  *
  */
-import { ReactNode, useRef, useState } from "react";
+import { ReactNode, useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -132,6 +132,46 @@ export function EntitySelectionSheet({
     setSelectedEntity(null);
   };
 
+  const handleInteractOutside = useCallback((event: Event) => {
+    const target = event.target as Element | null;
+    if (!target) return;
+
+    // Check if the interaction is inside Radix select dropdown (portal content)
+    if (
+      target.closest('[data-slot="select-content"]') ||
+      target.closest("[data-radix-select-content]")
+    ) {
+      event.preventDefault();
+      return;
+    }
+
+    // Check if the interaction is inside any other common portal content
+    const portalSelectors = [
+      "[data-radix-dropdown-menu-content]",
+      "[data-radix-popover-content]",
+      "[data-radix-tooltip-content]",
+      "[data-radix-dialog-content]",
+      "[data-radix-combobox-content]",
+      "[data-portal]",
+      ".select-portal",
+      ".dropdown-portal",
+      ".popover-portal",
+    ];
+
+    if (portalSelectors.some((selector) => target.closest(selector))) {
+      event.preventDefault();
+      return;
+    }
+
+    // Check if the interaction is inside the sheet content itself
+    if (sheetRef.current?.contains(target)) {
+      event.preventDefault();
+      return;
+    }
+
+    // Allow the sheet to close for genuine outside interactions
+  }, []);
+
   return (
     <>
       {system === "system-medication" ? (
@@ -159,21 +199,7 @@ export function EntitySelectionSheet({
           id="sheet-content"
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
-          onPointerDownOutside={(event) => {
-            const target = event.target as Element | null;
-            if (!target) return;
-
-            // If inside Radix select dropdown (portal content)
-            if (target.closest('[data-slot="select-content"]')) {
-              event.preventDefault();
-              return;
-            }
-
-            // If inside sheet content
-            if (sheetRef.current?.contains(target)) {
-              event.preventDefault();
-            }
-          }}
+          onInteractOutside={handleInteractOutside}
         >
           {selectedEntity ? (
             <div className="flex flex-col h-auto min-h-[50vh] max-h-[80vh] sm:max-h-[70vh] md:max-h-[60vh]">

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -14,7 +14,7 @@
  * the appropriate props.
  *
  */
-import { ReactNode, useRef, useState } from "react";
+import { ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -104,7 +104,6 @@ export function EntitySelectionSheet({
 }: EntitySelectionSheetProps) {
   const { t } = useTranslation();
   const [selectedEntity, setSelectedEntity] = useState<Code | null>(null);
-  const sheetRef = useRef<HTMLDivElement>(null);
 
   const handleSelect = (code: Code) => {
     setSelectedEntity(code);
@@ -155,30 +154,25 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
-          ref={sheetRef}
-          id="sheet-content"
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
-            const target = event.target as EventTarget | null;
-            if (!(target instanceof Element)) return;
-            // 1) If the tap/click is inside any portal content (select/combobox/popover), don't close the Sheet
-            if (
-              target.closest(
-                '[data-slot="select-content"], [data-slot="combobox-content"], [data-slot="popover-content"]',
-              )
-            ) {
+            // Try to get the real click/tap target from Radix's originalEvent
+            const target = (event.detail?.originalEvent?.target ??
+              event.target) as Element | null;
+            if (!target) return;
+
+            // Prevent sheet close if click is inside dropdown menu
+            if (target.closest('[data-slot="select-content"]')) {
               event.preventDefault();
               return;
             }
-            // 2) If any of those portal contents are currently open, block the Sheet from closing
-            //    so overlay/back press closes the inner dropdown/popover first.
-            if (
-              document.querySelector(
-                '[data-slot="select-content"][data-state="open"], [data-slot="combobox-content"][data-state="open"], [data-slot="popover-content"][data-state="open"]',
-              )
-            ) {
+
+            // Prevent sheet close if click is inside sheet content
+            const sheetContent = document.getElementById("sheet-content");
+            if (sheetContent && sheetContent.contains(target)) {
               event.preventDefault();
+              return;
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -14,7 +14,7 @@
  * the appropriate props.
  *
  */
-import { ReactNode, useState } from "react";
+import { ReactNode, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -104,6 +104,7 @@ export function EntitySelectionSheet({
 }: EntitySelectionSheetProps) {
   const { t } = useTranslation();
   const [selectedEntity, setSelectedEntity] = useState<Code | null>(null);
+  const sheetRef = useRef<HTMLDivElement>(null);
 
   const handleSelect = (code: Code) => {
     setSelectedEntity(code);
@@ -157,19 +158,15 @@ export function EntitySelectionSheet({
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
-            const target = event.target as Node;
-            const selectContent = document.querySelector(
-              '[data-slot="select-content"]',
-            );
-            const sheetContent = document.getElementById("sheet-content");
-            // Prevent the Sheet from closing if the click is inside the select dropdown or inside the Sheet
-            if (selectContent?.contains(target)) {
-              event.preventDefault();
-            }
+            const target = event.target as Element | null;
 
-            if (sheetContent?.contains(target)) {
+            if (!target) return;
+
+            if (
+              target.closest('[data-slot="select-content"]') ||
+              sheetRef.current?.contains(target)
+            ) {
               event.preventDefault();
-              return;
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -158,28 +158,37 @@ export function EntitySelectionSheet({
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
-            // Try to get the real click/tap target from Radix's originalEvent
             const target = (event.detail?.originalEvent?.target ??
               event.target) as Element | null;
             if (!target) return;
 
-            // Prevent sheet close if click is inside dropdown menu
-            if (
-              target.closest('[data-slot="select-content"]') ||
-              target.closest('[data-slot="sheet-overlay"]')
-            ) {
+            const selectContent = document.querySelector(
+              '[data-slot="select-content"]',
+            );
+            const datePickerPopup = document.querySelector(
+              '[data-slot="datepicker-popup"]',
+            );
+
+            if (selectContent || datePickerPopup) {
               event.preventDefault();
+              if (selectContent) {
+                const trigger = document.querySelector(
+                  '[data-slot="select-trigger"]',
+                ) as HTMLElement | null;
+                trigger?.click(); // closes select
+              }
+              if (datePickerPopup) {
+                const trigger = document.querySelector(
+                  '[data-slot="datepicker-trigger"]',
+                ) as HTMLElement | null;
+                trigger?.click(); // closes date picker
+              }
               return;
             }
 
             const sheetContent = document.getElementById("sheet-content");
-            const sheetOverlay = document.getElementById("sheet-overlay");
-            if (
-              (sheetContent && sheetContent.contains(target)) ||
-              (sheetOverlay && sheetOverlay.contains(target))
-            ) {
+            if (sheetContent && sheetContent.contains(target)) {
               event.preventDefault();
-              return;
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -154,7 +154,7 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
-          style={{ pointerEvents: "auto" }}
+          // style={{ pointerEvents: "auto" }}
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
@@ -162,26 +162,18 @@ export function EntitySelectionSheet({
               event.target) as Element | null;
             if (!target) return;
 
-            const selectContent = document.querySelector(
+            const openSelect = document.querySelector(
               '[data-slot="select-content"]',
             );
-            const datePickerPopup = document.querySelector(
-              '[data-slot="datepicker-popup"]',
-            );
 
-            if (selectContent || datePickerPopup) {
+            if (openSelect) {
               event.preventDefault();
-              if (selectContent) {
+
+              if (openSelect) {
                 const trigger = document.querySelector(
                   '[data-slot="select-trigger"]',
                 ) as HTMLElement | null;
-                trigger?.click(); // closes select
-              }
-              if (datePickerPopup) {
-                const trigger = document.querySelector(
-                  '[data-slot="datepicker-trigger"]',
-                ) as HTMLElement | null;
-                trigger?.click(); // closes date picker
+                trigger?.click();
               }
               return;
             }
@@ -189,6 +181,7 @@ export function EntitySelectionSheet({
             const sheetContent = document.getElementById("sheet-content");
             if (sheetContent && sheetContent.contains(target)) {
               event.preventDefault();
+              return;
             }
           }}
         >

--- a/src/components/Questionnaire/EntitySelectionSheet.tsx
+++ b/src/components/Questionnaire/EntitySelectionSheet.tsx
@@ -155,18 +155,29 @@ export function EntitySelectionSheet({
       )}
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
+          ref={sheetRef}
           className="px-0 pt-2 pb-0 rounded-t-3xl sm:max-w-md sm:mx-auto [&>button:first-child]:hidden"
           side="bottom"
           onInteractOutside={(event) => {
-            const target = event.target as Element | null;
+            const target = event.target as Node;
 
-            if (!target) return;
+            // Select dropdown content
+            const selectContent = document.querySelector(
+              '[data-slot="select-content"]',
+            );
 
-            if (
-              target.closest('[data-slot="select-content"]') ||
-              sheetRef.current?.contains(target)
-            ) {
+            // If click/touch is inside the dropdown
+            if (selectContent && selectContent.contains(target)) {
               event.preventDefault();
+              event.stopPropagation();
+              return;
+            }
+
+            // If click/touch is inside the sheet
+            if (sheetRef.current?.contains(target)) {
+              event.preventDefault();
+              event.stopPropagation();
+              return;
             }
           }}
         >


### PR DESCRIPTION
## Proposed Changes

- Fixes #12222 

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents the sheet from closing when interacting with embedded overlays (dropdowns, comboboxes, popovers, date pickers); those overlays are now handled separately so the sheet remains open.
  * Improves detection of true outside clicks/taps and pointer interactions so embedded controls behave correctly while genuine outside interactions still close the sheet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->