### PR TITLE
fix: Add zod validation in charge item definitions form

### DIFF
--- a/src/pages/Facility/settings/billing/discount/discount-components/DiscountMonetaryComponentForm.tsx
+++ b/src/pages/Facility/settings/billing/discount/discount-components/DiscountMonetaryComponentForm.tsx
@@ -41,7 +41,8 @@ const formSchema = z
       .refine((val) => !val || Number(val) >= 0, {
         message: "Amount must be greater than or equal to 0",
       })
-      .optional(),
+      .optional()
+      .nullable(),
     title: z.string().min(1, { message: "field_required" }),
   })
   .refine((data) => data.factor != null || data.amount != null, {

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -67,7 +67,8 @@ const priceComponentSchema = z.object({
     .refine((val) => !val || Number(val) > 0, {
       message: "Amount must be greater than 0",
     })
-    .optional(),
+    .optional()
+    .nullable(),
 });
 
 interface ChargeItemDefinitionFormProps {

--- a/src/types/base/monetaryComponent/monetaryComponent.ts
+++ b/src/types/base/monetaryComponent/monetaryComponent.ts
@@ -12,7 +12,7 @@ export interface MonetaryComponent {
   monetary_component_type: MonetaryComponentType;
   code?: Code;
   factor?: number;
-  amount?: string;
+  amount?: string | null;
 }
 
 export interface MonetaryComponentRead extends MonetaryComponent {


### PR DESCRIPTION
## Proposed Changes

Fixes #13148

https://github.com/user-attachments/assets/151b7b57-b827-4166-a737-1b14d686c83f



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation to accept empty or null values for the amount field in discount and charge item forms.

* **Refactor**
  * Updated internal data handling to support null values for monetary amounts, ensuring better compatibility with various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->