### PR TITLE
Allow check-in / start consultation upto 24 hours after the slot's start time

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -12,7 +12,7 @@ import {
   PlusCircledIcon,
 } from "@radix-ui/react-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { differenceInYears, format, isSameDay } from "date-fns";
+import { addDays, differenceInYears, format, isBefore } from "date-fns";
 import { BanIcon, Loader2, PrinterIcon } from "lucide-react";
 import { navigate } from "raviger";
 import { useEffect, useState } from "react";
@@ -472,7 +472,13 @@ const AppointmentActions = ({
   const [selectedSlotId, setSelectedSlotId] = useState<string>();
 
   const currentStatus = appointment.status;
-  const isToday = isSameDay(appointment.token_slot.start_datetime, new Date());
+
+  // Allow check-in/start consultation as long as the appointment is before 24 hours ahead of slot's start time
+  const canCheckIn = isBefore(
+    appointment.token_slot.start_datetime,
+    addDays(new Date(), 1),
+  );
+
   const [note, setNote] = useState(appointment.note);
 
   const { mutate: cancelAppointment, isPending: isCancelling } = useMutation({
@@ -670,7 +676,7 @@ const AppointmentActions = ({
       {currentStatus === "booked" && (
         <>
           <Button
-            disabled={!isToday}
+            disabled={!canCheckIn}
             variant="outline_primary"
             onClick={() =>
               updateAppointment({
@@ -688,7 +694,7 @@ const AppointmentActions = ({
 
       {["booked", "checked_in"].includes(currentStatus) && (
         <Button
-          disabled={!isToday}
+          disabled={!canCheckIn}
           variant={
             currentStatus === "checked_in" ? "outline_primary" : "outline"
           }


### PR DESCRIPTION

## Proposed Changes

- Allow check-in / start consultation upto 24 hours after the slot's start time

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of "Check In" and "Start Consultation" button availability based on appointment timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->