### PR TITLE
feat: add app update option to user menu in sidebar

### DIFF
--- a/src/components/ui/sidebar/nav-user.tsx
+++ b/src/components/ui/sidebar/nav-user.tsx
@@ -1,5 +1,5 @@
 import { CaretSortIcon } from "@radix-ui/react-icons";
-import { BadgeCheck, LogOut } from "lucide-react";
+import { BadgeCheck, LogOut, RefreshCw } from "lucide-react";
 import { navigate } from "raviger";
 import { useTranslation } from "react-i18next";
 
@@ -22,6 +22,7 @@ import { NavigationLink } from "@/components/ui/sidebar/nav-main";
 
 import { Avatar } from "@/components/Common/Avatar";
 
+import { useAppUpdates } from "@/hooks/useAppUpdates";
 import useAuthUser, { useAuthContext } from "@/hooks/useAuthUser";
 import { useCareApps } from "@/hooks/useCareApps";
 import { usePatientSignOut } from "@/hooks/usePatientSignOut";
@@ -39,6 +40,7 @@ export function FacilityNavUser({
   const { isMobile, open } = useSidebar();
   const { signOut } = useAuthContext();
   const careApps = useCareApps();
+  const { newVersion, updateApp } = useAppUpdates();
   const pluginNavItems = careApps
     .filter((c) => !!c.userNavItems)
     .flatMap((c) => c.userNavItems) as NavigationLink[];
@@ -92,6 +94,18 @@ export function FacilityNavUser({
                 </div>
               </div>
             </DropdownMenuLabel>
+            {newVersion && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  data-cy="user-menu-update"
+                  onClick={updateApp}
+                >
+                  <RefreshCw />
+                  {t("update")}
+                </DropdownMenuItem>
+              </>
+            )}
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem

--- a/src/components/ui/sidebar/nav-user.tsx
+++ b/src/components/ui/sidebar/nav-user.tsx
@@ -40,7 +40,7 @@ export function FacilityNavUser({
   const { isMobile, open } = useSidebar();
   const { signOut } = useAuthContext();
   const careApps = useCareApps();
-  const { newVersion, updateApp } = useAppUpdates();
+  const { newVersion, updateApp } = useAppUpdates(false, undefined, true);
   const pluginNavItems = careApps
     .filter((c) => !!c.userNavItems)
     .flatMap((c) => c.userNavItems) as NavigationLink[];
@@ -102,7 +102,7 @@ export function FacilityNavUser({
                   onClick={updateApp}
                 >
                   <RefreshCw />
-                  {t("update")}
+                  {t("update_available")}
                 </DropdownMenuItem>
               </>
             )}

--- a/src/hooks/useAppUpdates.tsx
+++ b/src/hooks/useAppUpdates.tsx
@@ -10,6 +10,7 @@ const APP_UPDATED_KEY = "app-updated";
 export const useAppUpdates = (
   silentlyAutoUpdate?: boolean,
   onDismissUpdateToast?: () => void,
+  hideUpdateToast?: boolean,
 ) => {
   const [newVersion, setNewVersion] = useState<string>();
   const [appUpdated, setAppUpdated] = useState(false);
@@ -57,7 +58,7 @@ export const useAppUpdates = (
   if (newVersion && silentlyAutoUpdate) updateApp();
 
   useEffect(() => {
-    if (newVersion && !silentlyAutoUpdate) {
+    if (newVersion && !silentlyAutoUpdate && !hideUpdateToast) {
       toast(t("software_update"), {
         description: t("a_new_version_of_care_is_available"),
         duration: Infinity,
@@ -72,7 +73,7 @@ export const useAppUpdates = (
         },
       });
     }
-  }, [newVersion, isUpdating]);
+  }, [newVersion, isUpdating, hideUpdateToast]);
 
   useEffect(() => {
     if (appUpdated) {


### PR DESCRIPTION
## Proposed Changes

Just added the update button to user menu in sidebar

<img width="1498" height="836" alt="image" src="https://github.com/user-attachments/assets/37aab3cd-d5cf-4dc9-a1a3-c67605ca637d" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Update" option to the user navigation menu, allowing users to update the app when a new version is available.
  * Introduced an option to control update notification toasts for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->