### PR TITLE
changed from <p> to <div> and no hydration error

### DIFF
--- a/src/components/ValueSet/ValueSetList.tsx
+++ b/src/components/ValueSet/ValueSetList.tsx
@@ -148,7 +148,7 @@ const RenderCard = ({
                   <h3 className="text-left text-xs font-medium uppercase tracking-wider text-gray-500">
                     {t("description")}
                   </h3>
-                  <p className="max-w-md text-sm text-gray-900 break-words whitespace-normal">
+                  <div className="max-w-md text-sm text-gray-900 break-words whitespace-normal">
                     <ExpandableText>
                       <ExpandableTextContent>
                         {valueset.description}
@@ -157,7 +157,7 @@ const RenderCard = ({
                         {t("read_more")}
                       </ExpandableTextExpandButton>
                     </ExpandableText>
-                  </p>
+                  </div>
                 </div>
 
                 <div className="mt-4 flex justify-end">


### PR DESCRIPTION
## Proposed Changes
Just converted \<p>\</p> to \<div>\</div>, which results in no hydration error.
Fixes #13249 
view :
<img width="1917" height="988" alt="Screenshot 2025-08-05 061849" src="https://github.com/user-attachments/assets/a07b0b4b-30d1-43b1-9cc5-42af46e45af1" />


Fixes #issue_number
- No hydration error
- No console errors

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the description section markup for improved structure without changing appearance or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->