### PR TITLE
fix: update reschedule appointment warning text for clarity

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3690,7 +3690,7 @@
   "requirements": "Requirements",
   "reschedule": "Reschedule",
   "reschedule_appointment": "Reschedule Appointment",
-  "reschedule_appointment_warning": "<strong>Enter the reason for rescheduling.</strong> You are about to create a new appointment by clicking Continue. This action cannot be undone. The current appointment will be marked as Rescheduled, and the patient will be notified.",
+  "reschedule_appointment_warning": "You are about to create a new appointment by clicking Continue. This action cannot be undone. The current appointment will be marked as Rescheduled with above note, and the patient will be notified.",
   "reschedule_appointment_with": "Reschedule Appointment with",
   "rescheduled": "Rescheduled",
   "rescheduling": "Rescheduling...",

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -16,7 +16,7 @@ import { addDays, differenceInYears, format, isBefore } from "date-fns";
 import { BanIcon, Loader2, PrinterIcon } from "lucide-react";
 import { navigate } from "raviger";
 import { useEffect, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { formatPhoneNumberIntl } from "react-phone-number-input";
 import { toast } from "sonner";
 
@@ -551,12 +551,7 @@ const AppointmentActions = ({
                   <Alert variant="destructive">
                     <AlertTitle>{t("warning")}</AlertTitle>
                     <AlertDescription>
-                      <Trans
-                        i18nKey="reschedule_appointment_warning"
-                        components={{
-                          strong: <strong className="font-bold" />,
-                        }}
-                      />
+                      {t("reschedule_appointment_warning")}
                     </AlertDescription>
                   </Alert>
                 </AlertDialogDescription>
@@ -572,7 +567,7 @@ const AppointmentActions = ({
                     setIsRescheduleReasonOpen(false);
                     setIsRescheduleOpen(true);
                   }}
-                  disabled={oldNote === appointment.note || !oldNote.trim()}
+                  disabled={!oldNote.trim()}
                 >
                   {t("continue")}
                 </AlertDialogAction>


### PR DESCRIPTION
fix: update reschedule appointment warning text for clarity in en.json and simplify translation usage in AppointmentDetail.tsx

<img width="752" height="502" alt="image" src="https://github.com/user-attachments/assets/d7ef65ab-9eb2-4db7-a603-e955ef8e6044" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the reschedule appointment warning message for improved clarity and consistency in language.
* **Bug Fixes**
  * Simplified the logic for enabling the "Continue" button when rescheduling an appointment, ensuring it is only disabled if the note is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->