### PR TITLE
refactor: remove redundant title and hideTitleOnPage from Page #13237

### DIFF
--- a/src/pages/Admin/Roles/RolesIndex.tsx
+++ b/src/pages/Admin/Roles/RolesIndex.tsx
@@ -128,10 +128,9 @@ export default function RolesIndex() {
   };
 
   return (
-    <Page title={t("roles")} hideTitleOnPage>
+    <Page title={t("roles")} className="text-2xl font-bold text-gray-700">
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">{t("roles")}</h1>
           <div className="mb-6 flex items-center justify-between">
             <div>
               <p className="text-gray-600 text-sm">

--- a/src/pages/Admin/TagConfig/TagConfigList.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigList.tsx
@@ -89,12 +89,9 @@ export default function TagConfigList({ facilityId }: TagConfigListProps) {
   };
 
   return (
-    <Page title={t("tag_config")} hideTitleOnPage>
+    <Page title={t("tag_config")} className="text-2xl font-bold text-gray-700">
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">
-            {t("tag_config")}
-          </h1>
           <div className="mb-6 flex items-center justify-between">
             <div>
               <p className="text-gray-600 text-sm">

--- a/src/pages/Admin/TagConfig/TagConfigView.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigView.tsx
@@ -160,7 +160,10 @@ export default function TagConfigView({
   }
 
   return (
-    <Page title={tagConfig.display} hideTitleOnPage>
+    <Page
+      title={tagConfig.display}
+      className="text-2xl font-bold text-gray-900"
+    >
       <div className="container mx-auto space-y-6">
         <Button
           variant="outline"
@@ -178,9 +181,6 @@ export default function TagConfigView({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">
-                {tagConfig.display}
-              </h1>
               <p className="text-gray-600">{tagConfig.slug}</p>
             </div>
           </div>

--- a/src/pages/Admin/organizations/AdminOrganizationList.tsx
+++ b/src/pages/Admin/organizations/AdminOrganizationList.tsx
@@ -103,14 +103,11 @@ export default function AdminOrganizationList({
 
   return (
     <>
-      <Page title={t(organizationType)} hideTitleOnPage className="p-0">
+      <Page title={t(organizationType)} className="p-0">
         <div className="container mx-auto">
-          <div className="flex flex-col sm:flex-row items-start justify-between mb-2 sm:mb-4">
-            <h3>{t(organizationType)}</h3>
-          </div>
           <ResizablePanelGroup
             direction="horizontal"
-            className="min-h-[calc(100vh-14rem)] rounded-lg"
+            className="min-h-[calc(100vh-14rem)] rounded-lg mb-2 sm:mb-4"
           >
             <ResizablePanel
               defaultSize={20}

--- a/src/pages/Encounters/ReportBuilder/index.tsx
+++ b/src/pages/Encounters/ReportBuilder/index.tsx
@@ -51,10 +51,9 @@ export default function ReportBuilderList({
     });
 
   return (
-    <Page title={t("available_templates")} hideTitleOnPage className="p-0">
+    <Page title={t("available_templates")} className="p-0">
       <div className="container mx-auto">
         <div className="flex flex-col sm:flex-row items-start justify-between mb-4 gap-2">
-          <h3>{t("available_templates")}</h3>
           {canManageTemplate && (
             <Button
               variant="outline"

--- a/src/pages/Facility/billing/paymentReconciliation/PaymentReconciliationList.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PaymentReconciliationList.tsx
@@ -24,14 +24,14 @@ export function PaymentReconciliationList({
   const effectiveAccountId = accountId || urlAccountId;
 
   return (
-    <Page title={t("payment_reconciliations")} hideTitleOnPage>
+    <Page
+      title={t("payment_reconciliations")}
+      className="text-2xl font-bold text-gray-700 mb-2"
+    >
       <div className="container mx-auto">
         <div className="mb-4">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-2xl font-bold text-gray-700 mb-2">
-                {t("payment_reconciliations")}
-              </h1>
               <p className="text-gray-600 text-sm">
                 {accountId
                   ? t("view_and_manage_account_payments")

--- a/src/pages/Facility/services/FacilityServices.tsx
+++ b/src/pages/Facility/services/FacilityServices.tsx
@@ -98,10 +98,9 @@ export default function FacilityServicesPage({
   const healthcareServices = response?.results || [];
 
   return (
-    <Page title={t("services")} hideTitleOnPage>
+    <Page title={t("services")} className="text-2xl font-bold text-gray-900">
       <div className="container mx-auto">
         <div className="mb-6">
-          <h1 className="text-2xl font-bold text-gray-900">{t("services")}</h1>
           <p className="mt-1 text-sm text-gray-600">
             {t("discover_healthcare_services")}
           </p>

--- a/src/pages/Facility/services/inventory/ReceiveStock.tsx
+++ b/src/pages/Facility/services/inventory/ReceiveStock.tsx
@@ -157,12 +157,10 @@ export function ReceiveStock({
   return (
     <Page
       title={t("receive_stock")}
-      className="flex flex-col gap-4"
-      hideTitleOnPage
+      className="flex flex-col gap-4 text-2xl font-bold"
     >
       <div className="flex flex-row gap-2 justify-between">
         <div className="flex flex-col gap-1">
-          <h1 className="text-2xl font-bold">{t("receive_stock")}</h1>
           <p className="text-sm text-gray-500">
             {t("receive_stock_description")}
           </p>

--- a/src/pages/Facility/services/inventory/SupplyRequestForm.tsx
+++ b/src/pages/Facility/services/inventory/SupplyRequestForm.tsx
@@ -316,11 +316,8 @@ export default function SupplyRequestForm({
 
   if (isEditMode && isFetching) {
     return (
-      <Page title={title} hideTitleOnPage>
+      <Page title={title} className="text-xl font-semibold text-gray-900 mb-6">
         <div className="container mx-auto max-w-3xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">{title}</h1>
-          </div>
           <FormSkeleton rows={10} />
         </div>
       </Page>
@@ -328,7 +325,7 @@ export default function SupplyRequestForm({
   }
 
   return (
-    <Page title={title} hideTitleOnPage>
+    <Page title={title} className="text-xl font-semibold text-gray-900">
       <div className="container mx-auto max-w-5xl">
         <div className="mb-6 relative">
           <Button
@@ -340,7 +337,6 @@ export default function SupplyRequestForm({
             <X className="size-5" />
             <span className="sr-only">{t("close")}</span>
           </Button>
-          <h1 className="text-xl font-semibold text-gray-900">{title}</h1>
           <p className="mt-1 text-sm text-gray-600">{pageDescription}</p>
         </div>
         <Form {...form}>

--- a/src/pages/Facility/services/inventory/externalSupply/IncomingDeliveries.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/IncomingDeliveries.tsx
@@ -80,14 +80,13 @@ export function IncomingDeliveries({ facilityId, locationId }: Props) {
   const deliveries = response?.results || [];
 
   return (
-    <Page title={t("inward_entry")} hideTitleOnPage>
+    <Page
+      title={t("inward_entry")}
+      className="text-xl font-semibold text-gray-900"
+    >
       <div className="container mx-auto">
         <div className="mb-6">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("inward_entry")}
-            </h1>
-
             <div className="flex flex-row gap-2">
               <Button variant="outline" size="sm" asChild>
                 <Link

--- a/src/pages/Facility/services/inventory/externalSupply/PurchaseOrders.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/PurchaseOrders.tsx
@@ -191,13 +191,13 @@ export function PurchaseOrders({ facilityId, locationId }: Props) {
   );
 
   return (
-    <Page title={t("purchase_orders")} hideTitleOnPage>
+    <Page
+      title={t("purchase_orders")}
+      className="text-xl font-semibold text-gray-900"
+    >
       <div className="space-y-4">
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <div>
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("purchase_orders")}
-            </h1>
             <p className="mt-1 text-sm text-gray-600">
               <Trans
                 i18nKey="raise_dispatch_request"

--- a/src/pages/Facility/services/inventory/internalTransfer/ReceiveItem.tsx
+++ b/src/pages/Facility/services/inventory/internalTransfer/ReceiveItem.tsx
@@ -307,13 +307,11 @@ export default function ReceiveItem({
 
   if (isLoading || !delivery) {
     return (
-      <Page title={t("to_receive")} hideTitleOnPage>
+      <Page
+        title={t("to_receive")}
+        className="text-xl font-semibold text-gray-900 mb-6"
+      >
         <div className="container mx-auto max-w-6xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("to_receive")}
-            </h1>
-          </div>
           <div className="flex justify-center items-center h-64">
             <div className="text-lg">{t("loading")}</div>
           </div>
@@ -371,13 +369,13 @@ export default function ReceiveItem({
   );
 
   return (
-    <Page title={t("to_receive")} hideTitleOnPage>
+    <Page
+      title={t("to_receive")}
+      className="text-xl font-semibold text-gray-900"
+    >
       <div className="max-w-6xl container mx-auto">
         <div className="flex justify-between">
           <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("to_receive")}
-            </h1>
             <div className="text-sm text-gray-600">
               {delivery.status === "in_progress" ? (
                 <>

--- a/src/pages/Facility/services/inventory/internalTransfer/ToDispatch.tsx
+++ b/src/pages/Facility/services/inventory/internalTransfer/ToDispatch.tsx
@@ -46,7 +46,10 @@ export default function ToDispatch({ facilityId, locationId }: Props) {
   };
 
   return (
-    <Page title={t("to_dispatch")} hideTitleOnPage>
+    <Page
+      title={t("to_dispatch")}
+      className="text-xl font-semibold text-gray-900"
+    >
       <div className="space-y-4">
         <div className="flex flex-col">
           <p className="text-sm text-gray-700">
@@ -54,9 +57,6 @@ export default function ToDispatch({ facilityId, locationId }: Props) {
           </p>
 
           <div>
-            <h2 className="text-xl font-semibold text-gray-900">
-              {t("to_dispatch")}
-            </h2>
             <p className="mt-1 text-sm text-gray-600">
               <Trans
                 i18nKey="raise_dispatch_request"

--- a/src/pages/Facility/services/inventory/internalTransfer/ToReceive.tsx
+++ b/src/pages/Facility/services/inventory/internalTransfer/ToReceive.tsx
@@ -39,13 +39,13 @@ export default function ToReceive({ facilityId, locationId }: Props) {
   };
 
   return (
-    <Page title={t("to_receive")} hideTitleOnPage>
+    <Page
+      title={t("to_receive")}
+      className="text-xl font-semibold text-gray-900"
+    >
       <div className="space-y-4">
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-gray-900">
-              {t("to_receive")}
-            </h2>
             <p className="mt-1 text-sm text-gray-600">
               {t("to_receive_description")}
             </p>

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -1241,12 +1241,13 @@ export default function MedicationBillForm({ patientId }: Props) {
   };
 
   return (
-    <Page title={t("bill_medications")} hideTitleOnPage={true} isInsidePage>
+    <Page
+      title={t("bill_medications")}
+      className="text-2xl font-bold whitespace-nowrap"
+      isInsidePage
+    >
       <div>
         <div className="mb-6 flex items-center justify-between flex-wrap gap-2">
-          <h1 className="text-2xl font-bold whitespace-nowrap">
-            {t("bill_medications")}
-          </h1>
           <div className="flex gap-2 justify-end">
             <Button
               variant="outline"

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
@@ -221,7 +221,10 @@ export default function ServiceRequestList({
   };
 
   return (
-    <Page title={t("service_requests")} hideTitleOnPage>
+    <Page
+      title={t("service_requests")}
+      className="text-2xl font-semibold text-gray-900"
+    >
       <SpecimenIDScanDialog
         open={isBarcodeOpen}
         onOpenChange={setBarcodeOpen}
@@ -233,9 +236,6 @@ export default function ServiceRequestList({
           <div className="mb-4">
             <p className="text-sm text-gray-600">{location?.name}</p>
             <div className="flex flex-col sm:flex-row justify-between items-start gap-4 mb-4">
-              <h1 className="text-2xl font-semibold text-gray-900">
-                {t("service_requests")}
-              </h1>
               <Button
                 variant="primary"
                 size="sm"

--- a/src/pages/Facility/services/supply/SupplyDeliveryList.tsx
+++ b/src/pages/Facility/services/supply/SupplyDeliveryList.tsx
@@ -72,16 +72,11 @@ export default function SupplyDeliveryList({
   const deliveries = response?.results || [];
 
   return (
-    <Page title={t("supply_deliveries")} hideTitleOnPage>
+    <Page
+      title={t("supply_deliveries")}
+      className="text-xl font-semibold text-gray-900 mb-6"
+    >
       <div className="container mx-auto">
-        <div className="mb-6">
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("supply_deliveries")}
-            </h1>
-          </div>
-        </div>
-
         <div className="mb-4 flex flex-col gap-4">
           <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
             <div className="flex-1">

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -177,13 +177,11 @@ export default function ActivityDefinitionForm({
 
   if (isEditMode && isFetching) {
     return (
-      <Page title={t("edit_activity_definition")} hideTitleOnPage>
+      <Page
+        title={t("edit_activity_definition")}
+        className="text-xl font-semibold text-gray-900 mb-6"
+      >
         <div className="container mx-auto max-w-3xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("edit_activity_definition")}
-            </h1>
-          </div>
           <div className="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-8">
             <div className="text-center">
               <div className="mb-2 text-sm text-gray-500">{t("loading")}</div>
@@ -463,17 +461,9 @@ function ActivityDefinitionFormContent({
           ? t("edit_activity_definition")
           : t("create_activity_definition")
       }
-      hideTitleOnPage
+      className="text-xl font-semibold text-gray-900 mb-6"
     >
       <div className="container mx-auto max-w-3xl">
-        <div className="mb-6">
-          <h1 className="text-xl font-semibold text-gray-900">
-            {isEditMode
-              ? t("edit_activity_definition")
-              : t("create_activity_definition")}
-          </h1>
-        </div>
-
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* Basic Information Section */}

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionList.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionList.tsx
@@ -119,12 +119,12 @@ export default function ActivityDefinitionList({
   const activityDefinitions = response?.results || [];
 
   return (
-    <Page title={t("activity_definitions")} hideTitleOnPage>
+    <Page
+      title={t("activity_definitions")}
+      className="text-2xl font-bold text-gray-700"
+    >
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">
-            {t("activity_definitions")}
-          </h1>
           <div className="mb-6 flex sm:flex-row sm:items-center sm:justify-between flex-col gap-4">
             <div>
               <p className="text-gray-600 text-sm">

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionsList.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionsList.tsx
@@ -115,12 +115,12 @@ export function ChargeItemDefinitionsList({
   const chargeItemDefinitions = response?.results || [];
 
   return (
-    <Page title={t("charge_item_definitions")} hideTitleOnPage>
+    <Page
+      title={t("charge_item_definitions")}
+      className="text-2xl font-bold text-gray-700"
+    >
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">
-            {t("charge_item_definitions")}
-          </h1>
           <div className="mb-6 flex sm:flex-row sm:items-center sm:justify-between flex-col gap-4">
             <div>
               <p className="text-gray-600 text-sm">

--- a/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
+++ b/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
@@ -86,13 +86,11 @@ export default function HealthcareServiceForm({
 
   if (isEditMode && isFetching) {
     return (
-      <Page title={t("edit_healthcare_service")} hideTitleOnPage>
+      <Page
+        title={t("edit_healthcare_service")}
+        className="text-xl font-semibold text-gray-900 mb-6"
+      >
         <div className="container mx-auto max-w-3xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("edit_healthcare_service")}
-            </h1>
-          </div>
           <div className="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-8">
             <div className="text-center">
               <div className="mb-2 text-sm text-gray-500">
@@ -216,17 +214,9 @@ function HealthcareServiceFormContent({
           ? t("edit_healthcare_service")
           : t("create_healthcare_service")
       }
-      hideTitleOnPage
+      className="text-xl font-semibold text-gray-900 mb-6"
     >
       <div className="container mx-auto max-w-3xl">
-        <div className="mb-6">
-          <h1 className="text-xl font-semibold text-gray-900">
-            {isEditMode
-              ? t("edit_healthcare_service")
-              : t("create_healthcare_service")}
-          </h1>
-        </div>
-
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* Basic Information Section */}

--- a/src/pages/Facility/settings/healthcareService/HealthcareServiceList.tsx
+++ b/src/pages/Facility/settings/healthcareService/HealthcareServiceList.tsx
@@ -102,13 +102,13 @@ export default function HealthcareServiceList({
   const healthcareServices = response?.results || [];
 
   return (
-    <Page title={t("healthcare_services")} hideTitleOnPage>
+    <Page
+      title={t("healthcare_services")}
+      className="text-2xl font-bold text-gray-700"
+    >
       <div className="container mx-auto">
         <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
           <div>
-            <h1 className="text-2xl font-bold text-gray-700">
-              {t("healthcare_services")}
-            </h1>
             <p className="mt-1 text-sm text-gray-600">
               {t("manage_healthcare_services")}
             </p>

--- a/src/pages/Facility/settings/healthcareService/HealthcareServiceShow.tsx
+++ b/src/pages/Facility/settings/healthcareService/HealthcareServiceShow.tsx
@@ -46,13 +46,11 @@ export default function HealthcareServiceShow({
 
   if (isLoading) {
     return (
-      <Page title={t("healthcare_service_details")} hideTitleOnPage>
+      <Page
+        title={t("healthcare_service_details")}
+        className="text-xl font-semibold text-gray-900 mb-6"
+      >
         <div className="container mx-auto max-w-3xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("healthcare_service_details")}
-            </h1>
-          </div>
           <TableSkeleton count={1} />
         </div>
       </Page>
@@ -61,13 +59,11 @@ export default function HealthcareServiceShow({
 
   if (!healthcareService) {
     return (
-      <Page title={t("healthcare_service_details")} hideTitleOnPage>
+      <Page
+        title={t("healthcare_service_details")}
+        className="text-xl font-semibold text-gray-900 mb-6"
+      >
         <div className="container mx-auto max-w-3xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("healthcare_service_details")}
-            </h1>
-          </div>
           <Card>
             <CardContent className="flex h-[200px] items-center justify-center">
               <div className="text-center">
@@ -87,12 +83,12 @@ export default function HealthcareServiceShow({
   }
 
   return (
-    <Page title={t("healthcare_service_details")} hideTitleOnPage>
+    <Page
+      title={t("healthcare_service_details")}
+      className="text-xl font-semibold text-gray-900"
+    >
       <div className="container mx-auto max-w-3xl">
         <div className="mb-6 flex items-center justify-between">
-          <h1 className="text-xl font-semibold text-gray-900">
-            {t("healthcare_service_details")}
-          </h1>
           <div className="flex gap-2">
             <Button
               variant="outline"

--- a/src/pages/Facility/settings/locations/LocationSettings.tsx
+++ b/src/pages/Facility/settings/locations/LocationSettings.tsx
@@ -140,10 +140,9 @@ export default function LocationSettings({
   );
 
   return (
-    <Page title={t("locations")} hideTitleOnPage className="p-0">
+    <Page title={t("locations")} className="p-0">
       <div className="container mx-auto">
         <div className="flex flex-col sm:flex-row items-start justify-between mb-2 sm:mb-4">
-          <h3>{t("locations")}</h3>
           <Tabs
             value={activeTab}
             onValueChange={(value) => setActiveTab(value as "list" | "map")}

--- a/src/pages/Facility/settings/locations/LocationView.tsx
+++ b/src/pages/Facility/settings/locations/LocationView.tsx
@@ -198,7 +198,10 @@ export default function LocationView({
         </BreadcrumbList>
       </Breadcrumb>
 
-      <Page hideTitleOnPage title={location?.name || t("location")}>
+      <Page
+        className="text-xl font-semibold"
+        title={location?.name || t("location")}
+      >
         <div className="space-y-6">
           <div className="flex flex-col justify-between items-start gap-4">
             <div className="flex items-center gap-2 flex-wrap">
@@ -210,7 +213,6 @@ export default function LocationView({
                 </>
               ) : (
                 <>
-                  <h2 className="text-xl font-semibold">{location?.name}</h2>
                   <Badge variant="outline" className="whitespace-nowrap">
                     {t(`location_form__${location?.form}`)}
                   </Badge>

--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
@@ -133,13 +133,12 @@ export default function ObservationDefinitionForm({
 
   if (isEditMode && isFetching) {
     return (
-      <Page title={t("edit_observation_definition")} hideTitleOnPage>
+      <Page
+        title={t("edit_observation_definition")}
+        className="text-xl font-semibold text-gray-900"
+      >
         <div className="container mx-auto max-w-3xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("edit_observation_definition")}
-            </h1>
-          </div>
+          <div className="mb-6" />
           <FormSkeleton rows={10} />
         </div>
       </Page>
@@ -259,17 +258,9 @@ function ObservationDefinitionFormContent({
           ? t("edit_observation_definition")
           : t("create_observation_definition")
       }
-      hideTitleOnPage
+      className="text-xl font-semibold text-gray-900 mb-6"
     >
       <div className="container mx-auto max-w-3xl">
-        <div className="mb-6">
-          <h1 className="text-xl font-semibold text-gray-900">
-            {isEditMode
-              ? t("edit_observation_definition")
-              : t("create_observation_definition")}
-          </h1>
-        </div>
-
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* Basic Information Section */}

--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionList.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionList.tsx
@@ -124,12 +124,12 @@ export default function ObservationDefinitionList({
   const observationDefinitions = response?.results || [];
 
   return (
-    <Page title={t("observation_definitions")} hideTitleOnPage>
+    <Page
+      title={t("observation_definitions")}
+      className="text-2xl font-bold text-gray-700"
+    >
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">
-            {t("observation_definitions")}
-          </h1>
           <div className="mb-6 flex sm:flex-row sm:items-center sm:justify-between flex-col gap-4">
             <div>
               <p className="text-gray-600 text-sm">

--- a/src/pages/Facility/settings/organizations/FacilityOrganizationList.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationList.tsx
@@ -139,11 +139,8 @@ export default function FacilityOrganizationList({
 
   return (
     <>
-      <Page title={t("departments_or_teams")} hideTitleOnPage className="p-0">
+      <Page title={t("departments_or_teams")} className="p-0">
         <div className="container mx-auto">
-          <div className="flex flex-col sm:flex-row items-start justify-between mb-2 sm:mb-4">
-            <h3>{t("departments_or_teams")}</h3>
-          </div>
           <div className="flex">
             <FacilityOrganizationNavbar
               facilityId={facilityId}
@@ -201,12 +198,11 @@ export default function FacilityOrganizationList({
               <Page
                 hideTitleOnPage
                 title={org?.name || ""}
-                className="mx-auto max-w-4xl"
+                className="mx-auto max-w-4xl text-xl font-semibold"
               >
                 {organizationId && org && (
                   <>
                     <div className="flex items-center">
-                      <h2 className="text-xl font-semibold">{org.name}</h2>
                       {org.org_type && (
                         <Badge variant="indigo" className="ml-2 w-auto">
                           {t(`facility_organization_type__${org.org_type}`)}

--- a/src/pages/Facility/settings/product/ProductList.tsx
+++ b/src/pages/Facility/settings/product/ProductList.tsx
@@ -118,10 +118,9 @@ export default function ProductList({ facilityId }: { facilityId: string }) {
   const products = response?.results || [];
 
   return (
-    <Page title={t("products")} hideTitleOnPage>
+    <Page title={t("products")} className="text-2xl font-bold text-gray-700">
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">{t("products")}</h1>
           <div className="mb-6 flex sm:flex-row sm:items-center sm:justify-between flex-col gap-4">
             <div>
               <p className="text-gray-600 text-sm">{t("manage_products")}</p>

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -117,13 +117,11 @@ export default function ProductKnowledgeForm({
 
   if (isEditMode && isFetching) {
     return (
-      <Page title={t("edit_product_knowledge")} hideTitleOnPage>
+      <Page
+        title={t("edit_product_knowledge")}
+        className="text-xl font-semibold text-gray-900"
+      >
         <div className="container mx-auto max-w-3xl">
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-gray-900">
-              {t("edit_product_knowledge")}
-            </h1>
-          </div>
           <FormSkeleton rows={10} />
         </div>
       </Page>
@@ -292,17 +290,9 @@ function ProductKnowledgeFormContent({
       title={
         isEditMode ? t("edit_product_knowledge") : t("create_product_knowledge")
       }
-      hideTitleOnPage
+      className="text-xl font-semibold text-gray-900"
     >
       <div className="container mx-auto max-w-3xl">
-        <div className="mb-6">
-          <h1 className="text-xl font-semibold text-gray-900">
-            {isEditMode
-              ? t("edit_product_knowledge")
-              : t("create_product_knowledge")}
-          </h1>
-        </div>
-
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* Basic Information Section */}

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
@@ -120,12 +120,12 @@ export default function ProductKnowledgeList({
   const products = response?.results || [];
 
   return (
-    <Page title={t("product_knowledge")} hideTitleOnPage>
+    <Page
+      title={t("product_knowledge")}
+      className="text-2xl font-bold text-gray-700"
+    >
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">
-            {t("product_knowledge")}
-          </h1>
           <div className="mb-6 flex sm:flex-row sm:items-center sm:justify-between flex-col gap-4">
             <div>
               <p className="text-gray-600 text-sm">

--- a/src/pages/Facility/settings/specimen-definitions/SpecimenDefinitionsList.tsx
+++ b/src/pages/Facility/settings/specimen-definitions/SpecimenDefinitionsList.tsx
@@ -114,12 +114,12 @@ export function SpecimenDefinitionsList({
   const specimenDefinitions = response?.results || [];
 
   return (
-    <Page title={t("specimen_definitions")} hideTitleOnPage>
+    <Page
+      title={t("specimen_definitions")}
+      className="text-2xl font-bold text-gray-700"
+    >
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">
-            {t("specimen_definitions")}
-          </h1>
           <div className="mb-6 flex sm:items-center sm:justify-between sm:flex-row flex-col gap-4">
             <div>
               <p className="text-gray-600 text-sm">

--- a/src/pages/Patient/History/index.tsx
+++ b/src/pages/Patient/History/index.tsx
@@ -53,18 +53,10 @@ export function ClinicalHistoryPage({
           ? t("patient_clinical_history_page_title", { name: patient?.name })
           : t("loading")
       }
-      hideTitleOnPage
+      className="text-lg font-semibold"
     >
       <div className="flex justify-between items-center bg-gray-100 -mx-3 -mt-8 md:-mt-8 md:-mx-9 px-3 md:px-6 pb-3 pt-2 md:rounded-t-lg">
-        <div>
-          {patient ? (
-            <h5 className="text-lg font-semibold">
-              {t("patient_clinical_history_page_title", { name: patient.name })}
-            </h5>
-          ) : (
-            <Skeleton className="w-20 h-4" />
-          )}
-        </div>
+        <div>{!patient && <Skeleton className="w-20 h-4" />}</div>
         <div>
           <Button variant="outline" onClick={handleClose} size="icon">
             <X className="size-4" />

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigList.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigList.tsx
@@ -130,12 +130,12 @@ export default function PatientIdentifierConfigList({
   };
 
   return (
-    <Page title={t("patient_identifier_config")} hideTitleOnPage>
+    <Page
+      title={t("patient_identifier_config")}
+      className="text-2xl font-bold text-gray-700"
+    >
       <div className="container mx-auto">
         <div className="mb-4">
-          <h1 className="text-2xl font-bold text-gray-700">
-            {t("patient_identifier_config")}
-          </h1>
           <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
               <p className="text-gray-600 text-sm">


### PR DESCRIPTION
## Proposed Changes

Fixes  #13237
- `Refractor` the redundant heading from the `Page component` to avoid UI duplication
- Removed usage of hideTitleOnPage prop
- Removed the `title and hideTitleOnPage props` from the `Page component` where they were no longer necessary.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Consolidated page title styling by removing redundant heading elements from multiple pages and applying consistent styling directly to the page container.
  * Eliminated the use of the page title hiding property, ensuring page titles are now always displayed with unified styles.
  * Improved visual consistency of page titles across various sections, including admin, facility, and settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->