### PR TITLE
fix : Hide delete button for group question if only one sub-question exists

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1240,6 +1240,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                               }
                               expandPath={expandPath}
                               questionRefs={questionRefs}
+                              totalquestion={rootQuestions.length}
                             />
                           </div>
                         ))}
@@ -1541,6 +1542,7 @@ interface QuestionEditorProps {
   handleEnableWhenDependentClick: (path: string[], targetId: string) => void;
   expandPath?: string[];
   questionRefs: React.RefObject<{ [key: string]: HTMLDivElement | null }>;
+  totalquestion?: number;
 }
 
 function QuestionEditor({
@@ -1566,6 +1568,7 @@ function QuestionEditor({
   handleEnableWhenDependentClick,
   expandPath,
   questionRefs,
+  totalquestion,
 }: QuestionEditorProps): React.ReactElement {
   const { t } = useTranslation();
   const {
@@ -1868,49 +1871,51 @@ function QuestionEditor({
             <ChevronsUpDown className="size-4 text-gray-500" />
           )}
         </CollapsibleTrigger>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="size-8">
-              <CareIcon icon="l-ellipsis-v" className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {!isFirst && (
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onMoveUp?.();
-                }}
-              >
-                <ChevronUp className="mr-2 size-4" />
-                {t("move_up")}
-              </DropdownMenuItem>
-            )}
-            {!isLast && (
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onMoveDown?.();
-                }}
-              >
-                <ChevronDown className="mr-2 size-4" />
-                {t("move_down")}
-              </DropdownMenuItem>
-            )}
+        {!(depth > 0 && totalquestion === 1) && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="size-8">
+                <CareIcon icon="l-ellipsis-v" className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {!isFirst && (
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMoveUp?.();
+                  }}
+                >
+                  <ChevronUp className="mr-2 size-4" />
+                  {t("move_up")}
+                </DropdownMenuItem>
+              )}
+              {!isLast && (
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMoveDown?.();
+                  }}
+                >
+                  <ChevronDown className="mr-2 size-4" />
+                  {t("move_down")}
+                </DropdownMenuItem>
+              )}
 
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete();
-              }}
-              className="text-destructive"
-            >
-              <CareIcon icon="l-trash-alt" className="mr-2 size-4" />
-              {t("delete")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                className="text-destructive"
+              >
+                <CareIcon icon="l-trash-alt" className="mr-2 size-4" />
+                {t("delete")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
 
       <CollapsibleContent>
@@ -2772,6 +2777,7 @@ function QuestionEditor({
                       isLast={idx === (questions?.length || 0) - 1}
                       expandPath={expandPath?.slice(1)}
                       questionRefs={questionRefs}
+                      totalquestion={questions?.length || 0}
                     />
                   </div>
                 ))}

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1240,7 +1240,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                               }
                               expandPath={expandPath}
                               questionRefs={questionRefs}
-                              totalquestion={rootQuestions.length}
+                              totalSiblings={rootQuestions.length}
                             />
                           </div>
                         ))}
@@ -1542,7 +1542,7 @@ interface QuestionEditorProps {
   handleEnableWhenDependentClick: (path: string[], targetId: string) => void;
   expandPath?: string[];
   questionRefs: React.RefObject<{ [key: string]: HTMLDivElement | null }>;
-  totalquestion?: number;
+  totalSiblings?: number;
 }
 
 function QuestionEditor({
@@ -1568,7 +1568,7 @@ function QuestionEditor({
   handleEnableWhenDependentClick,
   expandPath,
   questionRefs,
-  totalquestion,
+  totalSiblings,
 }: QuestionEditorProps): React.ReactElement {
   const { t } = useTranslation();
   const {
@@ -1871,7 +1871,7 @@ function QuestionEditor({
             <ChevronsUpDown className="size-4 text-gray-500" />
           )}
         </CollapsibleTrigger>
-        {!(depth > 0 && totalquestion === 1) && (
+        {!(depth > 0 && totalSiblings === 1) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="icon" className="size-8">
@@ -2777,7 +2777,7 @@ function QuestionEditor({
                       isLast={idx === (questions?.length || 0) - 1}
                       expandPath={expandPath?.slice(1)}
                       questionRefs={questionRefs}
-                      totalquestion={questions?.length || 0}
+                      totalSiblings={questions?.length || 0}
                     />
                   </div>
                 ))}


### PR DESCRIPTION
## Proposed Changes

Fixes #13248 

## Screenshot 

https://github.com/user-attachments/assets/679c81ee-b0bc-49d8-bf00-1c567d2d74df


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Question actions dropdown is hidden for sub-questions when there is only one sibling.
  * Move up/down and delete actions are grouped together in the same dropdown with a separator; delete is now wired to the action.

* **Style**
  * Delete option uses a trash icon and a distinct destructive style for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->