### PR TITLE
Fix whitespace bypass in required fields validation in config forms (#13312)

### DIFF
--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -40,8 +40,8 @@ import {
 import tagConfigApi from "@/types/emr/tagConfig/tagConfigApi";
 
 const tagConfigSchema = z.object({
-  slug: z.string().min(1, "Slug is required"),
-  display: z.string().min(1, "Display name is required"),
+  slug: z.string().trim().min(1, "Slug is required"),
+  display: z.string().trim().min(1, "Display name is required"),
   category: z.nativeEnum(TagCategory, {
     required_error: "Category is required",
   }),

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -46,12 +46,12 @@ import patientIdentifierConfigApi from "@/types/patient/patientIdentifierConfig/
 const formSchema = z.object({
   config: z.object({
     use: z.nativeEnum(PatientIdentifierUse),
-    description: z.string().min(1, "Description is required"),
-    system: z.string().min(1, "System is required"),
+    description: z.string().trim().min(1, "Description is required"),
+    system: z.string().trim().min(1, "System is required"),
     required: z.boolean(),
     unique: z.boolean(),
     regex: z.string(),
-    display: z.string().min(1, "Display is required"),
+    display: z.string().trim().min(1, "Display is required"),
     default_value: z.string().optional(),
     retrieve_config: z.object({
       retrieve_with_dob: z.boolean().optional(),


### PR DESCRIPTION
### Summary
This PR fixes an issue where users could bypass the required field validation in configuration forms by entering only whitespace characters. The validation now trims input and correctly detects empty values, preventing invalid form submissions.

### Changes made:
- Updated validation logic in TagConfigForm and PatientIdentifierConfigForm components.
- Added trimming of input fields before validation.
- Ensured required fields cannot be submitted with only spaces.

Patient Identifier Config
[
[screen-capture.webm](https://github.com/user-attachments/assets/0c4c5370-7feb-48ec-a7db-1cf6494736f4)
](url)

Tag config
[screen-capture (1).webm](https://github.com/user-attachments/assets/68d0059b-57fd-4d45-a8fb-7e9770acbbe7)


### Issue:
Closes #13312

### Testing:
- Manually tested form submission with whitespace-only input.
- Verified error messages appear as expected.
- Confirmed valid input still submits successfully.

---

Please review and let me know if any changes are needed. Thanks!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation by trimming whitespace from input fields before checking minimum length in tag configuration and patient identifier configuration forms. This prevents entries with only spaces from being accepted as valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->