### PR TITLE
Fix country flag not updating after first selection (#13314)

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -52,6 +52,8 @@ function PhoneInput({
       inputComponent={InputComponent}
       defaultCountry={careConfig.defaultCountry.code}
       smartCaret={true}
+      international={true}
+      countryCallingCodeEditable={false}
       /**
        * Handles the onChange event.
        *

--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -40,8 +40,8 @@ import {
 import tagConfigApi from "@/types/emr/tagConfig/tagConfigApi";
 
 const tagConfigSchema = z.object({
-  slug: z.string().min(1, "Slug is required"),
-  display: z.string().min(1, "Display name is required"),
+  slug: z.string().trim().min(1, "Slug is required"),
+  display: z.string().trim().min(1, "Display name is required"),
   category: z.nativeEnum(TagCategory, {
     required_error: "Category is required",
   }),

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -46,12 +46,12 @@ import patientIdentifierConfigApi from "@/types/patient/patientIdentifierConfig/
 const formSchema = z.object({
   config: z.object({
     use: z.nativeEnum(PatientIdentifierUse),
-    description: z.string().min(1, "Description is required"),
-    system: z.string().min(1, "System is required"),
+    description: z.string().trim().min(1, "Description is required"),
+    system: z.string().trim().min(1, "System is required"),
     required: z.boolean(),
     unique: z.boolean(),
     regex: z.string(),
-    display: z.string().min(1, "Display is required"),
+    display: z.string().trim().min(1, "Display is required"),
     default_value: z.string().optional(),
     retrieve_config: z.object({
       retrieve_with_dob: z.boolean().optional(),


### PR DESCRIPTION
Fixes #13314 

After Fix :

[screen-capture (2).webm](https://github.com/user-attachments/assets/0fa0a2e1-a715-4bb3-bab2-f13ebc3c433e)

The Fix :
The fix involved adding two props to the component. The international prop is the primary fix, telling the component to always work with international formats and to intelligently swap the country code when the flag changes. The countryCallingCodeEditable={false} prop prevents the user from accidentally deleting the country code, which improves the user experience.

Tested Environments
- Chrome
- FireFox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved phone number input to support international formats and prevent editing of the country calling code.

* **Bug Fixes**
  * Enhanced form validation to trim whitespace from input fields, ensuring that fields with only spaces are correctly flagged as empty in tag configuration and patient identifier configuration forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->