### PR TITLE
Fixed whitespace bypasses validation in config forms

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3388,6 +3388,7 @@
   "print_selected": "Print Selected",
   "print_this_response": "Print this response",
   "priority": "Priority",
+  "priority_non_negative": "Priority must be non-negative",
   "prn_prescription": "PRN Prescription",
   "prn_prescriptions": "PRN Prescriptions",
   "prn_reason": "PRN Reason",

--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -39,24 +39,6 @@ import {
 } from "@/types/emr/tagConfig/tagConfig";
 import tagConfigApi from "@/types/emr/tagConfig/tagConfigApi";
 
-const tagConfigSchema = z.object({
-  slug: z.string().min(1, "Slug is required"),
-  display: z.string().min(1, "Display name is required"),
-  category: z.nativeEnum(TagCategory, {
-    required_error: "Category is required",
-  }),
-  description: z.string().optional(),
-  priority: z.number().min(0, "Priority must be non-negative"),
-  status: z.nativeEnum(TagStatus, {
-    required_error: "Status is required",
-  }),
-  resource: z.nativeEnum(TagResource, {
-    required_error: "Resource is required",
-  }),
-});
-
-type TagConfigFormValues = z.infer<typeof tagConfigSchema>;
-
 interface TagConfigFormProps {
   configId?: string;
   parentId?: string;
@@ -74,6 +56,24 @@ export default function TagConfigForm({
   const queryClient = useQueryClient();
   const isEditing = Boolean(configId);
   const isCreatingChild = Boolean(parentId);
+
+  const tagConfigSchema = z.object({
+    slug: z.string().trim().min(1, t("field_required")),
+    display: z.string().trim().min(1, t("field_required")),
+    category: z.nativeEnum(TagCategory, {
+      required_error: t("field_required"),
+    }),
+    description: z.string().optional(),
+    priority: z.number().min(0, t("priority_non_negative")),
+    status: z.nativeEnum(TagStatus, {
+      required_error: t("field_required"),
+    }),
+    resource: z.nativeEnum(TagResource, {
+      required_error: t("field_required"),
+    }),
+  });
+
+  type TagConfigFormValues = z.infer<typeof tagConfigSchema>;
 
   // Fetch parent tag data when creating a child
   const { data: parentTag } = useQuery({

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -43,26 +43,6 @@ import {
 } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import patientIdentifierConfigApi from "@/types/patient/patientIdentifierConfig/patientIdentifierConfigApi";
 
-const formSchema = z.object({
-  config: z.object({
-    use: z.nativeEnum(PatientIdentifierUse),
-    description: z.string().min(1, "Description is required"),
-    system: z.string().min(1, "System is required"),
-    required: z.boolean(),
-    unique: z.boolean(),
-    regex: z.string(),
-    display: z.string().min(1, "Display is required"),
-    default_value: z.string().optional(),
-    retrieve_config: z.object({
-      retrieve_with_dob: z.boolean().optional(),
-      retrieve_with_year_of_birth: z.boolean().optional(),
-      retrieve_with_otp: z.boolean().optional(),
-    }),
-  }),
-  status: z.nativeEnum(PatientIdentifierConfigStatus),
-  facility: z.string().optional().nullable(),
-});
-
 interface PatientIdentifierConfigFormProps {
   facilityId?: string;
   configId?: string;
@@ -76,6 +56,26 @@ export default function PatientIdentifierConfigForm({
 }: PatientIdentifierConfigFormProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+
+  const formSchema = z.object({
+    config: z.object({
+      use: z.nativeEnum(PatientIdentifierUse),
+      description: z.string().trim().min(1, t("field_required")),
+      system: z.string().trim().min(1, t("field_required")),
+      required: z.boolean(),
+      unique: z.boolean(),
+      regex: z.string(),
+      display: z.string().trim().min(1, t("field_required")),
+      default_value: z.string().optional(),
+      retrieve_config: z.object({
+        retrieve_with_dob: z.boolean().optional(),
+        retrieve_with_year_of_birth: z.boolean().optional(),
+        retrieve_with_otp: z.boolean().optional(),
+      }),
+    }),
+    status: z.nativeEnum(PatientIdentifierConfigStatus),
+    facility: z.string().optional().nullable(),
+  });
 
   const { data: config, isLoading } = useQuery({
     queryKey: ["patientIdentifierConfig", configId, facilityId],


### PR DESCRIPTION
## Proposed Changes

Fixes #13312 
- added .trim() so that any extra spaces at the start or end of the input are automatically removed before validation.
- added  added i18n translation for validation strings

[screen-capture.webm](https://github.com/user-attachments/assets/be081573-8bd9-4404-b50b-82edf5380df7)

[screen-capture (1).webm](https://github.com/user-attachments/assets/fa0b3601-9326-45ef-9a4d-c5263144a764)



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new validation message ("Priority must be non-negative") to English locale.

* **Refactor**
  * Validation schemas moved into component scope and updated to trim inputs before checking.
  * All validation error messages now use localized translations.

* **Behavior**
  * Admin tag form now accepts an optional facility context, enabling facility-scoped behavior in the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->