### PR TITLE
Fix: Applied disabled button styling in Manage tags and added padding to address fie…

### DIFF
--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -203,12 +203,18 @@ export const Demography = (props: PatientProps) => {
         />,
         {
           label: t("current_address"),
-          value: <ClickableAddress address={patientData.address || ""} />,
+          value: (
+            <div className="pr-4">
+              <ClickableAddress address={patientData.address || ""} />
+            </div>
+          ),
         },
         {
           label: t("permanent_address"),
           value: (
-            <ClickableAddress address={patientData.permanent_address || ""} />
+            <div className="pr-4">
+              <ClickableAddress address={patientData.permanent_address || ""} />
+            </div>
           ),
         },
         ...getGeoOrgDetails(patientData.geo_organization),

--- a/src/components/Tags/TagAssignmentSheet.tsx
+++ b/src/components/Tags/TagAssignmentSheet.tsx
@@ -511,7 +511,11 @@ export default function TagAssignmentSheet({
             >
               {t("cancel")}
             </Button>
-            <Button onClick={handleSave} disabled={isLoadingTags || !canWrite}>
+            <Button
+              variant="primary"
+              onClick={handleSave}
+              disabled={isLoadingTags || !canWrite}
+            >
               {isLoadingTags ? (
                 <>
                   <Loader2 className="mr-2 size-4 animate-spin" />


### PR DESCRIPTION
…lds in Demography page

## Proposed Changes

Fixes #13290 
- Made the Save button in Manage tags to use the same disabled state styling 
- Added right padding to Current Address and Permanent Address in the patient details view

<img width="312" height="388" alt="image" src="https://github.com/user-attachments/assets/e4499864-b16f-4dc0-9ce4-19d51ca394e2" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added horizontal padding to the current and permanent address fields in patient demography details for improved layout.
  * Updated the "Save" button in tag assignment to use the primary style for better visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->