### PR TITLE
Fix country flag not updating after first selection

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -63,7 +63,12 @@ function PhoneInput({
        *
        * @param {E164Number | undefined} value - The entered value
        */
-      onChange={(value) => onChange?.(value || ("" as RPNInput.Value))}
+      onChange={(value) => {
+        if (value === undefined) {
+          return;
+        }
+        onChange?.(value || ("" as RPNInput.Value));
+      }}
       {...props}
     />
   );

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -52,6 +52,8 @@ function PhoneInput({
       inputComponent={InputComponent}
       defaultCountry={careConfig.defaultCountry.code}
       smartCaret={true}
+      international={true}
+      countryCallingCodeEditable={false}
       /**
        * Handles the onChange event.
        *


### PR DESCRIPTION
## Proposed Changes

Fixes #13314 
- The fix involved adding two props to the component. The international prop is the primary fix, telling the component to always work with international formats and to intelligently swap the country code when the flag changes. The countryCallingCodeEditable={false} prop prevents the user from accidentally deleting the country code, which improves the user experience.
- added 
`
if (value === undefined) {
          return;
        }
`
to  prevent flag reset when input value becomes undefined

[screen-capture (2).webm](https://github.com/user-attachments/assets/426021fa-06be-4b07-98cc-a8625b6b3729)



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Phone number input now uses international formatting by default.
  - Country calling code is locked to prevent accidental edits.

- Bug Fixes
  - Improved change handling in the phone input to avoid unintended value resets when the input is incomplete, resulting in more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->