### PR TITLE
Enhancement for Card design of Tag config listing page

### DIFF
--- a/src/pages/Admin/TagConfig/TagConfigList.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigList.tsx
@@ -95,7 +95,7 @@ export default function TagConfigList({ facilityId }: TagConfigListProps) {
           <h1 className="text-2xl font-bold text-gray-700">
             {t("tag_config")}
           </h1>
-          <div className="mb-6 flex items-center justify-between">
+          <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
               <p className="text-gray-600 text-sm">
                 {t("manage_tag_config_description")}

--- a/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
+++ b/src/pages/Admin/TagConfig/components/TagConfigTable.tsx
@@ -80,7 +80,7 @@ function TagConfigCard({
       <CardContent className="p-6">
         <div className="mb-4 flex items-start justify-between gap-4">
           <div className="flex-1">
-            <div className="mb-2 flex items-center gap-2">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
               <Badge variant={TAG_STATUS_COLORS[config.status]}>
                 {t(config.status)}
               </Badge>
@@ -92,7 +92,9 @@ function TagConfigCard({
                 </Badge>
               )}
             </div>
-            <h3 className="font-medium text-gray-900">{config.display}</h3>
+            <h3 className="font-medium text-gray-900 text-lg">
+              {config.display}
+            </h3>
             <p className="mt-1 text-sm text-gray-500 capitalize">
               {t(config.resource)} | {t("priority")}: {config.priority}
             </p>
@@ -152,6 +154,7 @@ function TagConfigCard({
             )}
             <Button variant="outline" size="sm">
               <CareIcon icon="l-arrow-right" className="size-4" />
+              {t("view")}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #13310 
- Fixed badge layout to prevent word breaks and improve appearance.
-Reduced tag name font size for better fit on smaller screens.
-Added descriptive "View" text next to the arrow icon for better clarity.
- Button with full width in the next line (For Mobile View)

Screenshots

Before
<img width="1018" height="1632" alt="image" src="https://github.com/user-attachments/assets/47503a0e-88d9-4171-80fe-e0a729a659a8" />

After
<img width="588" height="864" alt="image" src="https://github.com/user-attachments/assets/3b1d13eb-74a5-4954-a327-432aa2db5e33" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive header: description and "Add Tag Config" stack on small screens and align in a spaced row on larger screens.
  * Tag Config cards updated: badges now wrap when space is limited; title displayed larger on its own line.
  * Mobile action button now shows a localized "View" label next to the icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->