### PR TITLE
Adjusted responsiveness of button in Patient Name Dropdown

### DIFF
--- a/src/pages/Facility/services/serviceRequests/components/PatientHeader.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/PatientHeader.tsx
@@ -119,7 +119,7 @@ export function PatientHeader({
                 </div>
               </div>
             </div>
-            <DialogFooter className="sm:justify-start mt-4">
+            <DialogFooter>
               <DialogClose asChild>
                 <Button
                   type="button"

--- a/src/pages/Facility/services/serviceRequests/components/PatientHeader.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/PatientHeader.tsx
@@ -8,6 +8,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogFooter,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
@@ -55,7 +56,7 @@ export function PatientHeader({
             </span>
           </div>
         </DialogTrigger>
-        <DialogContent className="p-0 max-w-sm w-full rounded-t-2xl fixed bottom-0 left-1/2 -translate-x-1/2 m-0 shadow-2xl bg-white border-none animate-slide-up">
+        <DialogContent className="mb-8 rounded-lg p-4 w-[calc(100vw-2.5rem)] sm:w-[calc(100%-2rem)] max-w-3xl">
           {/* Drag handle */}
           <div className="w-12 h-1.5 bg-gray-300 rounded-full mx-auto mt-3 mb-2" />
           <div className="px-6 pb-6 pt-2 flex flex-col gap-4">
@@ -117,11 +118,13 @@ export function PatientHeader({
                 </div>
               </div>
             </div>
-            <DialogClose asChild>
-              <button className="mt-4 w-full py-2 rounded-full bg-primary-100 hover:bg-primary-200 text-primary-900 font-semibold shadow transition-colors text-base">
-                {t("close")}
-              </button>
-            </DialogClose>
+            <DialogFooter className="sm:justify-start mt-4">
+              <DialogClose asChild>
+                <button className="mt-4 w-full py-2 rounded-full bg-primary-100 hover:bg-primary-200 text-primary-900 font-semibold shadow transition-colors text-base">
+                  {t("close")}
+                </button>
+              </DialogClose>
+            </DialogFooter>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/pages/Facility/services/serviceRequests/components/PatientHeader.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/PatientHeader.tsx
@@ -4,6 +4,7 @@ import { formatPhoneNumberIntl } from "react-phone-number-input";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogClose,
@@ -56,7 +57,7 @@ export function PatientHeader({
             </span>
           </div>
         </DialogTrigger>
-        <DialogContent className="mb-8 rounded-lg p-4 w-[calc(100vw-2.5rem)] sm:w-[calc(100%-2rem)] max-w-3xl">
+        <DialogContent className="mb-8 rounded-lg p-4">
           {/* Drag handle */}
           <div className="w-12 h-1.5 bg-gray-300 rounded-full mx-auto mt-3 mb-2" />
           <div className="px-6 pb-6 pt-2 flex flex-col gap-4">
@@ -120,9 +121,13 @@ export function PatientHeader({
             </div>
             <DialogFooter className="sm:justify-start mt-4">
               <DialogClose asChild>
-                <button className="mt-4 w-full py-2 rounded-full bg-primary-100 hover:bg-primary-200 text-primary-900 font-semibold shadow transition-colors text-base">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="w-full rounded-full"
+                >
                   {t("close")}
-                </button>
+                </Button>
               </DialogClose>
             </DialogFooter>
           </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #13269 
- Made the DialogClose to be inside DialogFooter
- Made the close button to be a Button component

<img width="460" height="813" alt="close button" src="https://github.com/user-attachments/assets/d7a5d398-7234-426b-9560-5170c4f11071" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the mobile dialog in the Patient Header to a rounded, compact, responsive container for improved readability and spacing.
  * Moved the Close action into a dedicated footer with a full-width, rounded secondary button for clearer and more consistent interaction on small screens.
  * Preserved titles and core content while refining padding and responsive width to avoid a full-bleed, bottom-sheet appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->