### PR TITLE
Allow rendering for stock with no charge items

### DIFF
--- a/src/pages/Facility/services/inventory/ReceiveStockTable.tsx
+++ b/src/pages/Facility/services/inventory/ReceiveStockTable.tsx
@@ -47,7 +47,7 @@ export function ReceiveStockTable({
 
   const getUnitInformation = (entry: any) => {
     const priceComponents: MonetaryComponent[] =
-      entry.supplied_item?.charge_item_definition.price_components;
+      entry.supplied_item?.charge_item_definition?.price_components ?? [];
     const tax = priceComponents
       ?.filter(
         (component) =>


### PR DESCRIPTION
## Proposed Changes

Fixes #13298 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved occasional errors in the Receive Stock table when some items lacked pricing details, ensuring calculations (taxes, discounts, totals) run reliably.
  * Improved stability to prevent crashes or freezes during stock receiving, especially with incomplete or partial item data.
  * Enhanced user experience by maintaining consistent display of amounts even when pricing information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->