### PR TITLE
Dispense medicine from encounter overview

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1504,6 +1504,7 @@
   "dispatched_quantity": "Dispatched Quantity",
   "dispense": "Dispense",
   "dispense_medications": "Dispense Medications",
+  "dispense_medicine": "Dispense Medicine",
   "dispense_selected": "Dispense Selected",
   "dispense_status_updated": "Medication dispense status updated",
   "dispensed": "Dispensed",

--- a/src/components/Facility/ConsultationDetails/OverviewSideBar.tsx
+++ b/src/components/Facility/ConsultationDetails/OverviewSideBar.tsx
@@ -1,5 +1,6 @@
-import { Building, EditIcon, NotebookPen } from "lucide-react";
+import { Building, EditIcon, NotebookPen, Pill } from "lucide-react";
 import { navigate } from "raviger";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -7,6 +8,7 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { LocationSelectorDialog } from "@/components/ui/sidebar/facility/location/location-switcher";
 
 import { CareTeamSheet } from "@/components/CareTeam/CareTeamSheet";
 import { LocationSheet } from "@/components/Location/LocationSheet";
@@ -20,6 +22,7 @@ import { formatDateTime, formatName } from "@/Utils/utils";
 import EncounterProperties from "@/pages/Encounters/EncounterProperties";
 import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
 import { EncounterRead } from "@/types/emr/encounter/encounter";
+import { LocationList } from "@/types/location/location";
 
 interface Props {
   encounter: EncounterRead;
@@ -78,6 +81,8 @@ const Actions = () => {
             </Button>
 
             <ManageCareTeamButton />
+
+            <DispenseMedicineButton />
           </>
         )}
 
@@ -138,6 +143,38 @@ const ManageCareTeamButton = () => {
       }
       canWrite={canWrite}
     />
+  );
+};
+
+const DispenseMedicineButton = () => {
+  const { t } = useTranslation();
+  const [openDialog, setOpenDialog] = useState(false);
+  const [location, setLocation] = useState<LocationList | undefined>(undefined);
+  const { selectedEncounter } = useEncounter();
+
+  const navigateUrl = (selectedLocation: LocationList) =>
+    `/facility/${selectedEncounter?.facility.id}/locations/${selectedLocation.id}/medication_requests/patient/${selectedEncounter?.patient.id}/bill?encounterId=${selectedEncounter?.id}`;
+
+  return (
+    <>
+      <LocationSelectorDialog
+        facilityId={selectedEncounter?.facility.id || ""}
+        location={location}
+        setLocation={setLocation}
+        open={openDialog}
+        setOpen={setOpenDialog}
+        navigateUrl={navigateUrl}
+        myLocations={true}
+      />
+      <Button
+        variant="outline"
+        className="justify-start"
+        onClick={() => setOpenDialog(true)}
+      >
+        <Pill className="size-4" />
+        {t("dispense_medicine")}
+      </Button>
+    </>
   );
 };
 

--- a/src/components/ui/sidebar/facility/location/location-switcher.tsx
+++ b/src/components/ui/sidebar/facility/location/location-switcher.tsx
@@ -102,18 +102,22 @@ export function LocationSwitcher() {
   );
 }
 
-function LocationSelectorDialog({
+export function LocationSelectorDialog({
   facilityId,
   location,
   setLocation,
   open,
   setOpen,
+  navigateUrl,
+  myLocations = false,
 }: {
   facilityId: string;
   location: LocationList | undefined;
   setLocation: (location: LocationList | undefined) => void;
   open: boolean;
   setOpen: (open: boolean) => void;
+  navigateUrl?: (location: LocationList) => string;
+  myLocations?: boolean;
 }) {
   const { t } = useTranslation();
   const [locationLevel, setLocationLevel] = useState<LocationList[]>([]);
@@ -142,9 +146,8 @@ function LocationSelectorDialog({
         ...(currentParentId !== "" && {
           parent: currentParentId,
         }),
-        ...(currentParentId === "" && {
-          mode: "kind",
-        }),
+        mode: "kind",
+        ...(myLocations && !currentParentId && { mine: true }),
         ordering: "sort_index",
         ...(searchValue && { name: searchValue }),
         limit: resultsPerPage,
@@ -172,9 +175,13 @@ function LocationSelectorDialog({
     setSearchValue("");
     setCurrentPage(1);
     if (newLocation.id !== oldLocationId) {
-      navigate(
-        `/facility/${facilityId}/locations/${newLocation.id}/${subPath}`,
-      );
+      if (navigateUrl) {
+        navigate(navigateUrl(newLocation));
+      } else {
+        navigate(
+          `/facility/${facilityId}/locations/${newLocation.id}/${subPath}`,
+        );
+      }
     }
   };
 
@@ -384,6 +391,7 @@ function LocationCommandItem({
   return (
     <CommandItem
       key={location.id}
+      value={location.id}
       onSelect={() =>
         location.has_children
           ? handleSelect(location)

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -9,7 +9,7 @@ import {
   PlusIcon,
   Shuffle,
 } from "lucide-react";
-import { navigate } from "raviger";
+import { navigate, useQueryParams } from "raviger";
 import React, { useEffect, useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
@@ -695,6 +695,7 @@ export default function MedicationBillForm({ patientId }: Props) {
   const queryClient = useQueryClient();
   const { facilityId } = useCurrentFacility();
   const { locationId } = useCurrentLocation();
+  const [{ encounterId }] = useQueryParams();
   const [productKnowledgeInventoriesMap, setProductKnowledgeInventoriesMap] =
     useState<Record<string, InventoryRead[] | undefined>>({});
   const [isInvoiceSheetOpen, setIsInvoiceSheetOpen] = useState(false);
@@ -1167,7 +1168,8 @@ export default function MedicationBillForm({ patientId }: Props) {
           category: MedicationDispenseCategory.outpatient,
           when_prepared: new Date(),
           dosage_instruction: item.dosageInstructions ?? [],
-          encounter: medication?.encounter ?? defaultEncounterId!,
+          encounter:
+            medication?.encounter ?? defaultEncounterId! ?? encounterId,
           location: locationId,
           authorizing_prescription: medication?.id ?? null,
           item: selectedInventory.id,


### PR DESCRIPTION
<img width="275" height="305" alt="image" src="https://github.com/user-attachments/assets/6d4c935b-6d5b-4e21-87eb-14c1773d06d9" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Dispense Medicine” action in Consultation Overview, including a location selector and guided navigation to the dispensing flow.
  - Enabled selecting a specific location before dispensing via an enhanced location selector dialog.
  - Location selector now supports custom navigation behavior and an option to show only “My Locations.”
  - Medication billing now recognizes encounterId from the URL when available for smoother dispensing.
  - Added English translation for “Dispense Medicine.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->