### PR TITLE
fix: autocomplete nested button error

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -187,107 +187,111 @@ export default function Autocomplete({
 
   if (isMobile) {
     return (
-      <Sheet open={open} onOpenChange={setOpen}>
-        <SheetTrigger asChild>
-          <Button
-            aria-invalid={props["aria-invalid"]}
-            title={
-              value
-                ? freeInput
-                  ? inputValue || value
-                  : selectedOption?.label
-                : undefined
-            }
-            variant="outline"
-            ref={ref}
-            role="combobox"
-            aria-expanded={open}
-            className={cn("w-full justify-between", className)}
-            disabled={disabled}
-            data-cy={dataCy}
-            type="button"
+      <div className="relative w-full">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button
+              aria-invalid={props["aria-invalid"]}
+              title={
+                value
+                  ? freeInput
+                    ? inputValue || value
+                    : selectedOption?.label
+                  : undefined
+              }
+              variant="outline"
+              ref={ref}
+              role="combobox"
+              aria-expanded={open}
+              className={cn("w-full justify-between", className)}
+              disabled={disabled}
+              data-cy={dataCy}
+              type="button"
+            >
+              <span className="overflow-hidden">
+                {value
+                  ? freeInput
+                    ? inputValue || value
+                    : selectedOption?.label
+                  : placeholder}
+              </span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent
+            side="bottom"
+            className="h-[50vh] px-0 pt-2 pb-0 rounded-t-lg"
           >
-            <span className="overflow-hidden">
-              {value
-                ? freeInput
-                  ? inputValue || value
-                  : selectedOption?.label
-                : placeholder}
-            </span>
-            {selectedOption && showClearButton ? (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-3 p-0 hover:bg-transparent opacity-50"
-                onClick={handleClear}
-                title={t("clear")}
-              >
-                <Cross2Icon className="size-3" />
-                <span className="sr-only">{t("clear")}</span>
-              </Button>
-            ) : (
-              <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
-            )}
+            <div className="absolute inset-x-0 top-0 h-1.5 w-12 mx-auto rounded-full bg-gray-300 mt-2" />
+            <div className="mt-6 h-full">
+              <Command>{commandContent}</Command>
+            </div>
+          </SheetContent>
+        </Sheet>
+        {selectedOption && showClearButton ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="absolute right-1 top-1/2 -translate-y-1/2 p-0 hover:bg-transparent opacity-50 z-10"
+            onClick={handleClear}
+            title={t("clear")}
+          >
+            <Cross2Icon className="size-3" />
+            <span className="sr-only">{t("clear")}</span>
           </Button>
-        </SheetTrigger>
-        <SheetContent
-          side="bottom"
-          className="h-[50vh] px-0 pt-2 pb-0 rounded-t-lg"
-        >
-          <div className="absolute inset-x-0 top-0 h-1.5 w-12 mx-auto rounded-full bg-gray-300 mt-2" />
-          <div className="mt-6 h-full">
-            <Command>{commandContent}</Command>
-          </div>
-        </SheetContent>
-      </Sheet>
+        ) : (
+          <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+        )}
+      </div>
     );
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
-      <PopoverTrigger asChild className={popoverClassName}>
-        <Button
-          title={selectedOption ? selectedOption.label : undefined}
-          variant="outline"
-          role="combobox"
-          aria-invalid={props["aria-invalid"]}
-          aria-expanded={open}
-          className={cn("w-full justify-between", className)}
-          disabled={disabled}
-          data-cy={dataCy}
-          onClick={() => setOpen(!open)}
-          ref={ref}
-        >
-          <span
-            className={cn(
-              inputValue && "truncate",
-              !selectedOption && "text-gray-500",
-            )}
+    <div className="relative w-full">
+      <Popover open={open} onOpenChange={setOpen} modal={true}>
+        <PopoverTrigger asChild className={popoverClassName}>
+          <Button
+            title={selectedOption ? selectedOption.label : undefined}
+            variant="outline"
+            role="combobox"
+            aria-invalid={props["aria-invalid"]}
+            aria-expanded={open}
+            className={cn("w-full justify-between", className)}
+            disabled={disabled}
+            data-cy={dataCy}
+            onClick={() => setOpen(!open)}
+            ref={ref}
           >
-            {displayText}
-          </span>
-          {selectedOption && showClearButton ? (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-3 p-0 hover:bg-transparent opacity-50"
-              onClick={handleClear}
-              title={t("clear")}
+            <span
+              className={cn(
+                inputValue && "truncate",
+                !selectedOption && "text-gray-500",
+              )}
             >
-              <Cross2Icon className="size-3" />
-              <span className="sr-only">{t("clear")}</span>
-            </Button>
-          ) : (
-            <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
-          )}
+              {displayText}
+            </span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]"
+          align={align}
+        >
+          <Command>{commandContent}</Command>
+        </PopoverContent>
+      </Popover>
+      {selectedOption && showClearButton ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute right-1 top-1/2 -translate-y-1/2 p-0 hover:bg-transparent opacity-50 z-10"
+          onClick={handleClear}
+          title={t("clear")}
+        >
+          <Cross2Icon className="size-3" />
+          <span className="sr-only">{t("clear")}</span>
         </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]"
-        align={align}
-      >
-        <Command>{commandContent}</Command>
-      </PopoverContent>
-    </Popover>
+      ) : (
+        <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION

## Proposed Changes

Fixes #13345 
- Change: Just wrapped in a div 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Desktop autocomplete now opens in an inline popover aligned to the trigger.
  - Optional clear button appears when a value is selected; caret shown otherwise.

- Refactor
  - Unified display text across selected, free-input, and placeholder states with improved truncation.
  - Accessibility upgrades: aria-invalid support and clearer trigger/tooltip text.
  - Mobile flow preserved with clearer trigger rendering.
  - No breaking changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->