### PR TITLE
Fix for slug field validation error

### DIFF
--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -104,7 +104,7 @@ export default function TagConfigForm({
     const subscription = form.watch((value, { name }) => {
       if (name === "display") {
         form.setValue("slug", generateSlug(value.display || ""), {
-          shouldValidate: false,
+          shouldValidate: true,
         });
       }
     });

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -409,10 +409,10 @@ export function ChargeItemDefinitionForm({
     if (componentIndex === -1) return;
 
     const newComponents = [...currentComponents];
-    const isFactor = component.factor != null;
     newComponents[componentIndex] = {
       ...component,
-      [isFactor ? "factor" : "amount"]: isFactor ? value : String(value),
+      factor: component.factor != null ? value : undefined,
+      amount: component.factor != null ? undefined : String(value),
     };
 
     form.setValue("price_components", newComponents, { shouldValidate: true });

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -300,7 +300,9 @@ export function ChargeItemDefinitionForm({
 
     const subscription = form.watch((value, { name }) => {
       if (name === "title") {
-        form.setValue("slug", generateSlug(value.title || ""));
+        form.setValue("slug", generateSlug(value.title || ""), {
+          shouldValidate: true,
+        });
       }
     });
 
@@ -376,13 +378,7 @@ export function ChargeItemDefinitionForm({
     if (selected) {
       newComponents = [
         ...currentComponents,
-        {
-          ...component,
-          monetary_component_type: type,
-          factor: component.factor != null ? component.factor : undefined,
-          amount:
-            component.factor != null ? undefined : String(component.amount),
-        },
+        { ...component, monetary_component_type: type },
       ];
     } else {
       newComponents = currentComponents.filter(
@@ -409,8 +405,7 @@ export function ChargeItemDefinitionForm({
     const newComponents = [...currentComponents];
     newComponents[componentIndex] = {
       ...component,
-      factor: component.factor != null ? value : undefined,
-      amount: component.factor != null ? undefined : String(value),
+      [component.factor != null ? "factor" : "amount"]: value,
     };
 
     form.setValue("price_components", newComponents, { shouldValidate: true });

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -403,9 +403,10 @@ export function ChargeItemDefinitionForm({
     if (componentIndex === -1) return;
 
     const newComponents = [...currentComponents];
+    const isFactor = component.factor != null;
     newComponents[componentIndex] = {
       ...component,
-      [component.factor != null ? "factor" : "amount"]: value,
+      [isFactor ? "factor" : "amount"]: isFactor ? value : String(value),
     };
 
     form.setValue("price_components", newComponents, { shouldValidate: true });

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -300,7 +300,6 @@ export function ChargeItemDefinitionForm({
 
     const subscription = form.watch((value, { name }) => {
       if (name === "title") {
-        form.clearErrors("slug");
         form.setValue("slug", generateSlug(value.title || ""), {
           shouldValidate: true,
         });
@@ -379,7 +378,13 @@ export function ChargeItemDefinitionForm({
     if (selected) {
       newComponents = [
         ...currentComponents,
-        { ...component, monetary_component_type: type },
+        {
+          ...component,
+          monetary_component_type: type,
+          factor: component.factor != null ? component.factor : undefined,
+          amount:
+            component.factor != null ? undefined : String(component.amount),
+        },
       ];
     } else {
       newComponents = currentComponents.filter(

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -300,6 +300,7 @@ export function ChargeItemDefinitionForm({
 
     const subscription = form.watch((value, { name }) => {
       if (name === "title") {
+        form.clearErrors("slug");
         form.setValue("slug", generateSlug(value.title || ""), {
           shouldValidate: true,
         });


### PR DESCRIPTION
## Proposed Changes

Fixes #13366 
-Error message on slug field is cleared when title is entered

https://github.com/user-attachments/assets/e85cac67-878f-43eb-945b-bf020d310d4e



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Slug now revalidates automatically when the title/display value changes in create mode for charge item and tag configuration forms, reducing invalid or stale slugs and ensuring required slug validation runs during entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->