### PR TITLE
Display single date when start and end dates are the same for Exceptions

### DIFF
--- a/src/pages/Scheduling/ScheduleExceptions.tsx
+++ b/src/pages/Scheduling/ScheduleExceptions.tsx
@@ -131,14 +131,25 @@ const ScheduleExceptionItem = (
                 {formatTimeShort(props.start_time)} -{" "}
                 {formatTimeShort(props.end_time)}
               </span>
-              <span> {t("from")} </span>
-              <span className="font-medium">
-                {format(parseISO(props.valid_from), "EEE, dd MMM yyyy")}
-              </span>
-              <span> {t("to")} </span>
-              <span className="font-medium">
-                {format(parseISO(props.valid_to), "EEE, dd MMM yyyy")}
-              </span>
+              {props.valid_from === props.valid_to ? (
+                <>
+                  <span> {t("on")} </span>
+                  <span className="font-medium">
+                    {format(parseISO(props.valid_from), "EEE, dd MMM yyyy")}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span> {t("from")} </span>
+                  <span className="font-medium">
+                    {format(parseISO(props.valid_from), "EEE, dd MMM yyyy")}
+                  </span>
+                  <span> {t("to")} </span>
+                  <span className="font-medium">
+                    {format(parseISO(props.valid_to), "EEE, dd MMM yyyy")}
+                  </span>
+                </>
+              )}
             </span>
           </div>
         </div>

--- a/src/pages/Scheduling/ScheduleExceptions.tsx
+++ b/src/pages/Scheduling/ScheduleExceptions.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { format, parseISO } from "date-fns";
+import { format, isSameDay, parseISO } from "date-fns";
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -111,7 +111,8 @@ const ScheduleExceptionItem = (
       });
     },
   });
-
+  const fromDate = parseISO(props.valid_from);
+  const toDate = parseISO(props.valid_to);
   return (
     <div
       className={cn(
@@ -131,22 +132,22 @@ const ScheduleExceptionItem = (
                 {formatTimeShort(props.start_time)} -{" "}
                 {formatTimeShort(props.end_time)}
               </span>
-              {props.valid_from === props.valid_to ? (
+              {isSameDay(fromDate, toDate) ? (
                 <>
                   <span> {t("on")} </span>
                   <span className="font-medium">
-                    {format(parseISO(props.valid_from), "EEE, dd MMM yyyy")}
+                    {format(fromDate, "EEE, dd MMM yyyy")}
                   </span>
                 </>
               ) : (
                 <>
                   <span> {t("from")} </span>
                   <span className="font-medium">
-                    {format(parseISO(props.valid_from), "EEE, dd MMM yyyy")}
+                    {format(fromDate, "EEE, dd MMM yyyy")}
                   </span>
                   <span> {t("to")} </span>
                   <span className="font-medium">
-                    {format(parseISO(props.valid_to), "EEE, dd MMM yyyy")}
+                    {format(toDate, "EEE, dd MMM yyyy")}
                   </span>
                 </>
               )}


### PR DESCRIPTION
## Proposed Changes

Fixes #13359 
- Comparing props valid_from and valid_to, if same, show "on" valid_from, else show "from" valid_from "to" valid_to"
- Using JSX and ternary operator to attain this condition
- 
<img width="1920" height="1080" alt="image_2025-08-18_201446162" src="https://github.com/user-attachments/assets/8deae1bd-822c-4683-8fc8-6b44d239414b" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule exceptions now display dates more clearly: single-day exceptions show “on <date>” and multi-day exceptions show “from <date> to <date>”. Time range display, date formatting, and translations remain unchanged. This improves readability without altering actions or data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->