### PR TITLE
Show Quick Actions for mobile and tablet screen

### DIFF
--- a/src/pages/Encounters/tabs/overview.tsx
+++ b/src/pages/Encounters/tabs/overview.tsx
@@ -37,11 +37,7 @@ export const EncounterOverviewTab = () => {
     <div className="flex gap-3">
       <div className="flex-1 xl:h-[calc(100vh-12rem)] xl:pr-3 overflow-y-auto">
         <div className="flex flex-col gap-6">
-          {canWrite && (
-            <div className="hidden xl:block">
-              <QuickActions />
-            </div>
-          )}
+          {canWrite && <QuickActions />}
           <ClinicalHistoryOverview />
           <div className="xl:hidden">
             <SummaryPanel />

--- a/src/pages/Encounters/tabs/overview/quick-actions.tsx
+++ b/src/pages/Encounters/tabs/overview/quick-actions.tsx
@@ -16,7 +16,10 @@ export const QuickActions = (props: React.ComponentProps<"div">) => {
   const { t } = useTranslation();
 
   return (
-    <div {...props} className={cn("flex gap-3", props.className)}>
+    <div
+      {...props}
+      className={cn("grid gap-3 grid-cols-2 sm:grid-cols-4", props.className)}
+    >
       <QuickAction
         icon={<AllergyIcon className="size-8 text-yellow-700" />}
         title={t("allergy")}


### PR DESCRIPTION

<img width="764" height="484" alt="Screenshot 2025-08-19 at 2 35 16 AM" src="https://github.com/user-attachments/assets/2dfdd869-61d9-451d-9558-9a9333e8d703" />
<img width="326" height="658" alt="Screenshot 2025-08-19 at 2 35 52 AM" src="https://github.com/user-attachments/assets/499205b3-979c-42c6-9012-f91d90b1c46d" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Quick Actions are now visible across all screen sizes (mobile, tablet, desktop) when available, improving accessibility and consistency.
  - Updated Quick Actions to a responsive grid layout (2 columns by default, expanding to 4 on small screens) for clearer organization and faster scanning.
  - Visual spacing and alignment improved without changing the underlying actions or their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->