### PR TITLE
Fix: Show role instead of user type in care team summary panel

### DIFF
--- a/src/pages/Encounters/tabs/overview/summary-panel-details-tab/manage-care-team.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-details-tab/manage-care-team.tsx
@@ -60,7 +60,7 @@ export const ManageCareTeam = () => {
                       {member.member.first_name}
                     </span>
                     <span className="text-xs text-gray-500">
-                      {member.member.user_type}
+                      {member.role.display}
                     </span>
                   </div>
                   {index === 0 && (


### PR DESCRIPTION
## Issue

<img width="326" height="265" alt="Screenshot 2025-08-19 at 2 43 54 AM" src="https://github.com/user-attachments/assets/e0def9cf-85bb-46b6-a7a4-3d98631c8033" />

## Fix
<img width="326" height="265" alt="Screenshot 2025-08-19 at 2 43 40 AM" src="https://github.com/user-attachments/assets/d3c92a62-56bd-4e0d-97f1-b7805a3e586d" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the care team member label in the Encounters summary panel to display the member’s role name instead of user type, improving clarity when identifying team responsibilities.
  * Ensures consistent labeling across member rows without altering avatars, names, badges, or other UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->