### PR TITLE
refactor:  unnecessary FormDescription wrappers around FormField components

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -521,42 +521,38 @@ export default function PatientRegistration(
                         data-cy="patient-phone-input"
                       />
                     </FormControl>
-                    <FormDescription>
-                      <FormField
-                        control={form.control}
-                        name="same_phone_number"
-                        render={({ field }) => (
-                          <FormItem className="flex items-center gap-2">
-                            <FormControl>
-                              <Checkbox
-                                checked={field.value}
-                                onCheckedChange={(v) => {
-                                  field.onChange(v);
-                                  if (v) {
-                                    form.setValue(
-                                      "emergency_phone_number",
-                                      form.watch("phone_number"),
-                                      { shouldValidate: true },
-                                    );
-                                  } else {
-                                    form.setValue(
-                                      "emergency_phone_number",
-                                      "",
-                                      { shouldValidate: true },
-                                    );
-                                  }
-                                }}
-                                data-cy="same-phone-number-checkbox"
-                                className="mt-2"
-                              />
-                            </FormControl>
-                            <FormLabel>
-                              {t("use_phone_number_for_emergency")}
-                            </FormLabel>
-                          </FormItem>
-                        )}
-                      />
-                    </FormDescription>
+                    <FormField
+                      control={form.control}
+                      name="same_phone_number"
+                      render={({ field }) => (
+                        <FormItem className="flex items-center gap-2">
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value}
+                              onCheckedChange={(v) => {
+                                field.onChange(v);
+                                if (v) {
+                                  form.setValue(
+                                    "emergency_phone_number",
+                                    form.watch("phone_number"),
+                                    { shouldValidate: true },
+                                  );
+                                } else {
+                                  form.setValue("emergency_phone_number", "", {
+                                    shouldValidate: true,
+                                  });
+                                }
+                              }}
+                              data-cy="same-phone-number-checkbox"
+                              className="mt-2"
+                            />
+                          </FormControl>
+                          <FormLabel>
+                            {t("use_phone_number_for_emergency")}
+                          </FormLabel>
+                        </FormItem>
+                      )}
+                    />
                     <FormMessage />
                   </FormItem>
                 )}
@@ -856,35 +852,31 @@ export default function PatientRegistration(
                         data-cy="current-address-input"
                       />
                     </FormControl>
-                    <FormDescription>
-                      <FormField
-                        control={form.control}
-                        name="same_address"
-                        render={({ field }) => (
-                          <FormItem className="flex items-center gap-2">
-                            <FormControl>
-                              <Checkbox
-                                checked={field.value}
-                                onCheckedChange={(v) => {
-                                  field.onChange(v);
-                                  if (v) {
-                                    form.setValue(
-                                      "permanent_address",
-                                      form.getValues("address"),
-                                      { shouldValidate: true },
-                                    );
-                                  }
-                                }}
-                                data-cy="same-address-checkbox"
-                              />
-                            </FormControl>
-                            <FormLabel>
-                              {t("use_address_as_permanent")}
-                            </FormLabel>
-                          </FormItem>
-                        )}
-                      />
-                    </FormDescription>
+                    <FormField
+                      control={form.control}
+                      name="same_address"
+                      render={({ field }) => (
+                        <FormItem className="flex items-center gap-2">
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value}
+                              onCheckedChange={(v) => {
+                                field.onChange(v);
+                                if (v) {
+                                  form.setValue(
+                                    "permanent_address",
+                                    form.getValues("address"),
+                                    { shouldValidate: true },
+                                  );
+                                }
+                              }}
+                              data-cy="same-address-checkbox"
+                            />
+                          </FormControl>
+                          <FormLabel>{t("use_address_as_permanent")}</FormLabel>
+                        </FormItem>
+                      )}
+                    />
                     <FormMessage />
                   </FormItem>
                 )}


### PR DESCRIPTION

## Proposed Changes
Fixes 
<img width="813" height="851" alt="image" src="https://github.com/user-attachments/assets/24da0dcf-0876-4e14-970c-f29c50234b52" />
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Patient Registration form structure by streamlining the “Same phone number” and “Same address” checkboxes, keeping their behavior unchanged.

* **Style**
  * Minor layout and spacing adjustments in the Patient Registration form for clearer presentation of the related fields.

* **Bug Fixes**
  * Ensured consistent validation and value syncing when toggling the “Same phone number” option; no changes to existing behavior for “Same address.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->