### PR TITLE
Show charge item agent in invoice

### DIFF
--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -7,6 +7,7 @@ import {
   CreditCard,
   FileCheck,
   FileText,
+  HandCoins,
   MoreHorizontal,
   Wallet,
 } from "lucide-react";
@@ -55,8 +56,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { TooltipComponent } from "@/components/ui/tooltip";
 
 import AddChargeItemSheet from "@/components/Billing/Invoice/AddChargeItemSheet";
+import { Avatar } from "@/components/Common/Avatar";
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
 import useAppHistory from "@/hooks/useAppHistory";
@@ -501,6 +504,9 @@ export function InvoiceShow({
                       <TableHead className={tableHeadClass}>
                         {t("discount")}
                       </TableHead>
+                      <TableHead className={tableHeadClass}>
+                        <HandCoins className="w-full size-4 justify-center" />
+                      </TableHead>
                       {getApplicableTaxColumns(invoice).map((taxCode) => (
                         <TableHead key={taxCode} className={tableHeadClass}>
                           {t(taxCode)}
@@ -607,6 +613,26 @@ export function InvoiceShow({
                                     </div>
                                   ))}
                               </div>
+                            </TableCell>
+                            <TableCell
+                              className={cn(tableCellClass, "text-center")}
+                            >
+                              {item.commission_agent && (
+                                <div className="flex justify-center">
+                                  <TooltipComponent
+                                    content={`${item.commission_agent.first_name} ${item.commission_agent.last_name}`}
+                                  >
+                                    <Avatar
+                                      name={`${item.commission_agent.first_name} ${item.commission_agent.last_name}`}
+                                      imageUrl={
+                                        item.commission_agent
+                                          .profile_picture_url
+                                      }
+                                      className="size-6"
+                                    />
+                                  </TooltipComponent>
+                                </div>
+                              )}
                             </TableCell>
                             {facilityData &&
                               getApplicableTaxColumns(invoice).map(

--- a/src/types/billing/chargeItem/chargeItem.ts
+++ b/src/types/billing/chargeItem/chargeItem.ts
@@ -2,6 +2,7 @@ import { BatchSuccessResponse } from "@/types/base/batch/batch";
 import { MonetaryComponent } from "@/types/base/monetaryComponent/monetaryComponent";
 import { ChargeItemDefinitionBase } from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
 import { InvoiceRead } from "@/types/billing/invoice/invoice";
+import { UserReadMinimal } from "@/types/user/user";
 
 export enum ChargeItemStatus {
   planned = "planned",
@@ -86,6 +87,7 @@ export interface ChargeItemRead extends ChargeItemBase {
   total_price_components: MonetaryComponent[];
   total_price: string;
   charge_item_definition: ChargeItemDefinitionBase;
+  commission_agent: UserReadMinimal;
 }
 
 export interface ChargeItemBatchResponse {


### PR DESCRIPTION
<img width="737" height="701" alt="image" src="https://github.com/user-attachments/assets/4d39187b-8cca-48b2-9524-9df6a5a3d89f" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a commission agent column to invoice items. Displays the agent’s avatar (when available) with a hover tooltip showing their full name. Column header includes a coin icon for quick recognition.

* **UI Improvements**
  * Updated invoice items table layout to accommodate the new column and maintain consistent spacing.
  * Adjusted the “no items” row colspan for draft invoices to keep empty states properly aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->