### PR TITLE
fixed #13367: Adds the missing DialogTitle component

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -722,6 +722,7 @@
   "authorize_shift_delete": "Authorize shift delete",
   "auto_fill_slot_duration": "Auto-fill slot duration",
   "auto_generated_for_care": "Auto Generated for Care",
+  "autocomplete_options": "Autocomplete Options",
   "autofilled_fields": "Autofilled Fields",
   "availabilities": "Availabilities",
   "availability": "Availability",

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -18,7 +18,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 
 import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
 
@@ -219,8 +224,13 @@ export default function Autocomplete({
           </SheetTrigger>
           <SheetContent
             side="bottom"
+            aria-describedby={undefined}
             className="h-[50vh] px-0 pt-2 pb-0 rounded-t-lg"
           >
+            <SheetTitle className="sr-only">
+              {t("autocomplete_options")}
+            </SheetTitle>
+
             <div className="absolute inset-x-0 top-0 h-1.5 w-12 mx-auto rounded-full bg-gray-300 mt-2" />
             <div className="mt-6 h-full">
               <Command>{commandContent}</Command>


### PR DESCRIPTION
## Proposed Changes

Fixes #13367 
- Added "autocomplete_options" in public/locale/en.json
- Added Missing SheetTitle in SheetContent
- made aria-describedby = {undefined}


https://github.com/user-attachments/assets/7e65945a-1199-48fc-937b-41c11c654037



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved mobile autocomplete accessibility with a screen-reader-only title, ensuring clearer announcements without changing the visible UI.
  - Added a localized label for “Autocomplete Options” used for accessibility.

- Chores
  - Updated English translations to include the new “Autocomplete Options” entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->