### PR TITLE
UI Fix: Move See Details button to bottom in Product Knowledge page

### DIFF
--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
@@ -66,19 +66,20 @@ function ProductKnowledgeCard({
               </p>
             )}
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() =>
-              navigate(
-                `/facility/${facilityId}/settings/product_knowledge/${product.id}`,
-              )
-            }
-          >
-            <CareIcon icon="l-edit" className="size-4" />
-            {t("see_details")}
-          </Button>
         </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto block"
+          onClick={() =>
+            navigate(
+              `/facility/${facilityId}/settings/product_knowledge/${product.id}`,
+            )
+          }
+        >
+          <CareIcon icon="l-edit" className="size-4" />
+          {t("see_details")}
+        </Button>
       </CardContent>
     </Card>
   );

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { navigate } from "raviger";
+import { Link, navigate } from "raviger";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -67,19 +67,14 @@ function ProductKnowledgeCard({
             )}
           </div>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="ml-auto block"
-          onClick={() =>
-            navigate(
-              `/facility/${facilityId}/settings/product_knowledge/${product.id}`,
-            )
-          }
+        <Link
+          href={`/facility/${facilityId}/settings/product_knowledge/${product.id}`}
         >
-          <CareIcon icon="l-edit" className="size-4" />
-          {t("see_details")}
-        </Button>
+          <Button variant="outline" size="sm" className="ml-auto block">
+            <CareIcon icon="l-edit" className="size-4" />
+            {t("see_details")}
+          </Button>
+        </Link>
       </CardContent>
     </Card>
   );
@@ -252,18 +247,14 @@ export default function ProductKnowledgeList({
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() =>
-                              navigate(
-                                `/facility/${facilityId}/settings/product_knowledge/${product.id}`,
-                              )
-                            }
+                          <Link
+                            href={`/facility/${facilityId}/settings/product_knowledge/${product.id}`}
                           >
-                            <CareIcon icon="l-edit" className="size-4" />
-                            {t("see_details")}
-                          </Button>
+                            <Button variant="outline" size="sm">
+                              <CareIcon icon="l-edit" className="size-4" />
+                              {t("see_details")}
+                            </Button>
+                          </Link>
                         </TableCell>
                       </TableRow>
                     ))}

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
@@ -66,12 +66,14 @@ function ProductKnowledgeCard({
             )}
           </div>
         </div>
-        <Link href={`/product_knowledge/${product.id}`}>
-          <Button variant="outline" size="sm" className="ml-auto block">
-            <CareIcon icon="l-edit" className="size-4" />
-            {t("see_details")}
+        <div className="flex justify-end">
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/product_knowledge/${product.id}`}>
+              <CareIcon icon="l-edit" className="size-4" />
+              {t("see_details")}
+            </Link>
           </Button>
-        </Link>
+        </div>
       </CardContent>
     </Card>
   );
@@ -244,12 +246,12 @@ export default function ProductKnowledgeList({
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          <Link href={`/product_knowledge/${product.id}`}>
-                            <Button variant="outline" size="sm">
+                          <Button asChild variant="outline" size="sm">
+                            <Link href={`/product_knowledge/${product.id}`}>
                               <CareIcon icon="l-edit" className="size-4" />
                               {t("see_details")}
-                            </Button>
-                          </Link>
+                            </Link>
+                          </Button>
                         </TableCell>
                       </TableRow>
                     ))}

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
@@ -38,7 +38,6 @@ import productKnowledgeApi from "@/types/inventory/productKnowledge/productKnowl
 
 function ProductKnowledgeCard({
   product,
-  facilityId,
 }: {
   product: ProductKnowledgeBase;
   facilityId: string;
@@ -67,9 +66,7 @@ function ProductKnowledgeCard({
             )}
           </div>
         </div>
-        <Link
-          href={`/facility/${facilityId}/settings/product_knowledge/${product.id}`}
-        >
+        <Link href={`/product_knowledge/${product.id}`}>
           <Button variant="outline" size="sm" className="ml-auto block">
             <CareIcon icon="l-edit" className="size-4" />
             {t("see_details")}
@@ -247,9 +244,7 @@ export default function ProductKnowledgeList({
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          <Link
-                            href={`/facility/${facilityId}/settings/product_knowledge/${product.id}`}
-                          >
+                          <Link href={`/product_knowledge/${product.id}`}>
                             <Button variant="outline" size="sm">
                               <CareIcon icon="l-edit" className="size-4" />
                               {t("see_details")}


### PR DESCRIPTION
## Proposed Changes

Fixes #13381  
- Moved the `See Details` button to bottom right using tailwind classes

<img width="352" height="703" alt="image" src="https://github.com/user-attachments/assets/e8021914-9176-4ddb-be53-4f11501d17b6" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Repositioned the “See Details” button in Product Knowledge cards to its own row below the product header, improving visual hierarchy and readability.
  - Enhanced alignment and spacing for a cleaner layout, especially on smaller screens, reducing header crowding.

- **Bug Fixes**
  - Standardized the “See Details” control across card, mobile and table views and updated its target to a unified product knowledge page, ensuring consistent navigation.

- **Refactor**
  - Simplified product card usage by removing the facility context requirement, streamlining component invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->