### PR TITLE
Adds support for HSN code in product knowledge

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3439,6 +3439,7 @@
   "product_details": "Product Details",
   "product_is_already_in_the_list": "Product is already added in the list",
   "product_knowledge": "Product Knowledge",
+  "product_knowledge_alternate_identifier": "HSN Code",
   "product_knowledge_created_successfully": "Product knowledge created successfully",
   "product_knowledge_description": "Base information about this product",
   "product_knowledge_names_description": "Alternative names for the product",

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -59,6 +59,7 @@ const formSchema = z.object({
   slug: z.string().min(1, "Slug is required"),
   product_type: z.nativeEnum(ProductKnowledgeType),
   status: z.nativeEnum(ProductKnowledgeStatus),
+  alternate_identifier: z.string().optional(),
   code: codeSchema.nullable(),
   names: z
     .array(
@@ -171,6 +172,7 @@ function ProductKnowledgeFormContent({
         slug: existingData.slug,
         product_type: existingData.product_type,
         status: existingData.status,
+        alternate_identifier: existingData.alternate_identifier,
         code: existingData.code?.code ? existingData.code : null,
         names: existingData.names || [],
         storage_guidelines: existingData.storage_guidelines || [],
@@ -449,6 +451,21 @@ function ProductKnowledgeFormContent({
                             )}
                           </SelectContent>
                         </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="alternate_identifier"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-col">
+                        <FormLabel>
+                          {t("product_knowledge_alternate_identifier")}
+                        </FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
@@ -65,6 +65,12 @@ function ProductKnowledgeCard({
                 {product.code.system} | {product.code.code}
               </p>
             )}
+            {product.alternate_identifier && (
+              <p className="mt-1 text-sm text-gray-500">
+                {t("product_knowledge_alternate_identifier")}:{" "}
+                {product.alternate_identifier}
+              </p>
+            )}
           </div>
           <Button
             variant="outline"
@@ -219,6 +225,9 @@ export default function ProductKnowledgeList({
                   <TableHeader className="bg-gray-100">
                     <TableRow>
                       <TableHead>{t("name")}</TableHead>
+                      <TableHead>
+                        {t("product_knowledge_alternate_identifier")}
+                      </TableHead>
                       <TableHead>{t("product_type")}</TableHead>
                       <TableHead>{t("status")}</TableHead>
                       <TableHead>{t("actions")}</TableHead>
@@ -229,6 +238,9 @@ export default function ProductKnowledgeList({
                       <TableRow key={product.id} className="divide-x">
                         <TableCell className="font-medium">
                           {product.name}
+                        </TableCell>
+                        <TableCell>
+                          {product.alternate_identifier || "-"}
                         </TableCell>
                         <TableCell>
                           <Badge

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeView.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeView.tsx
@@ -172,6 +172,14 @@ export default function ProductKnowledgeView({
               <p className="text-sm text-gray-500">{t("slug")}</p>
               <p className="text-gray-700">{product.slug}</p>
             </div>
+            <div>
+              <p className="text-sm text-gray-500">
+                {t("product_knowledge_alternate_identifier")}
+              </p>
+              <p className="text-gray-700">
+                {product.alternate_identifier || "-"}
+              </p>
+            </div>
           </CardContent>
         </Card>
 
@@ -246,14 +254,16 @@ export default function ProductKnowledgeView({
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="grid gap-6">
-                <div>
-                  <p className="mb-2 text-sm text-gray-500">
-                    {t("dosage_form")}
-                  </p>
-                  <div className="rounded-lg border bg-gray-50/50 p-3">
-                    <CodeDisplay code={product.definitional.dosage_form} />
+                {product.definitional.dosage_form && (
+                  <div>
+                    <p className="mb-2 text-sm text-gray-500">
+                      {t("dosage_form")}
+                    </p>
+                    <div className="rounded-lg border bg-gray-50/50 p-3">
+                      <CodeDisplay code={product.definitional.dosage_form} />
+                    </div>
                   </div>
-                </div>
+                )}
                 {product.definitional.intended_routes &&
                   product.definitional.intended_routes.length > 0 && (
                     <div>

--- a/src/types/inventory/productKnowledge/productKnowledge.ts
+++ b/src/types/inventory/productKnowledge/productKnowledge.ts
@@ -70,6 +70,7 @@ export interface ProductDefinition {
 export interface ProductKnowledgeBase {
   id: string;
   slug: string;
+  alternate_identifier?: string;
   product_type: ProductKnowledgeType;
   status: ProductKnowledgeStatus;
   code?: Code;


### PR DESCRIPTION
## Proposed Changes

- Adds HSN code (alt. identifier) in  product knowledge

<img width="1335" height="579" alt="image" src="https://github.com/user-attachments/assets/817c186c-aa5a-4494-b5cb-a1e3a8b68666" />

<img width="1330" height="577" alt="image" src="https://github.com/user-attachments/assets/a3f15294-285f-432f-b821-00314f52a26a" />

<img width="1335" height="648" alt="image" src="https://github.com/user-attachments/assets/daabd9aa-dcd4-4e27-a6ec-ec291393bca9" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an optional “Alternate Identifier (HSN Code)” field to Product Knowledge: input in the form, display in the list (new column) and detail view.
  * Added translation for the new label.
* Bug Fixes
  * Detail view now hides the Dosage Form section when no value is available, preventing empty blocks from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->