### PR TITLE
fixed the cypress unit issue in observation

### DIFF
--- a/cypress/e2e/facility_spec/settings_spec/labs_spec/observation.cy.ts
+++ b/cypress/e2e/facility_spec/settings_spec/labs_spec/observation.cy.ts
@@ -59,9 +59,7 @@ const METHODS = [
 
 const UNITS = [
   "percent",
-  "percent /100",
   "percent of slope",
-  "percent 0to3Hours",
   "percent Abnormal",
   "percent Activity",
   "percent BasalActivity",


### PR DESCRIPTION
## Proposed Changes

Fixes cypress issue in observation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed two obsolete unit options from lab observation unit selection: “percent /100” and “percent 0to3Hours,” ensuring only valid units are available and reducing user confusion.

* **Tests**
  * Updated end-to-end tests to align with the revised unit list, maintaining coverage and reliability for the lab observation settings workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->