### PR TITLE
Increase location sheet per page size

### DIFF
--- a/src/components/Location/LocationSheet.tsx
+++ b/src/components/Location/LocationSheet.tsx
@@ -70,7 +70,7 @@ interface LocationSheetProps {
   defaultTab?: "assign" | "history";
 }
 
-const ITEMS_PER_PAGE = 10;
+const ITEMS_PER_PAGE = 20;
 
 export function LocationSheet({
   history,


### PR DESCRIPTION
## Proposed Changes

- Increase location sheet per page size

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Ensure that UI text is placed in I18n files.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Locations and beds lists now display 20 items per page (up from 10).
  - Pagination aligned to the new page size, resulting in fewer pages and fewer “Load more” actions.
  - “Has more” indicators and next-page loading updated to match the increased page size for smoother browsing.
  - Users can view more results per page without extra clicks; overall navigation remains familiar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->