### PR TITLE
fix: made tag search debounced

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -348,7 +348,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
 
   const { data: availableTags, isLoading: isLoadingAvailableTags } = useQuery({
     queryKey: ["questionnaireTags", tagSearchQuery],
-    queryFn: query(questionnaireApi.tags.list, {
+    queryFn: query.debounced(questionnaireApi.tags.list, {
       queryParams: {
         name: tagSearchQuery || undefined,
       },

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -348,7 +348,7 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
 
   const { data: availableTags, isLoading: isLoadingAvailableTags } = useQuery({
     queryKey: ["tags", tagSearchQuery],
-    queryFn: query(questionnaireApi.tags.list, {
+    queryFn: query.debounced(questionnaireApi.tags.list, {
       queryParams: {
         name: tagSearchQuery || undefined,
       },


### PR DESCRIPTION
## Proposed Changes

Fixes #13454 
- Changed queryFn to be debounced
- Tag searches are now debounced instead of making an api call for every key press

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.

https://github.com/user-attachments/assets/38b17f0d-01ac-4e3d-8c05-959e02ebd946


- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Tag search in the Questionnaire Editor now uses debounced requests, reducing unnecessary network calls while typing.
  * Smoother, more responsive search results with less flicker, especially on slower or unstable networks.
  * More consistent behavior when typing quickly; outcomes remain unchanged but with lower data usage and fewer rapid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->