### PR TITLE
fix service card link

### DIFF
--- a/src/pages/Facility/services/FacilityServices.tsx
+++ b/src/pages/Facility/services/FacilityServices.tsx
@@ -62,7 +62,7 @@ export default function FacilityServicesPage({
               <ServiceCard
                 key={service.id}
                 service={service}
-                facilityId={facilityId}
+                link={`/facility/${facilityId}/services/${service.id}`}
               />
             ))}
           </div>

--- a/src/pages/Facility/settings/healthcareService/HealthcareServiceList.tsx
+++ b/src/pages/Facility/settings/healthcareService/HealthcareServiceList.tsx
@@ -97,7 +97,7 @@ export default function HealthcareServiceList({
               <ServiceCard
                 key={service.id}
                 service={service}
-                facilityId={facilityId}
+                link={`/facility/${facilityId}/settings/healthcare_services/${service.id}`}
               />
             ))}
           </div>

--- a/src/pages/Facility/settings/healthcareService/ServiceCard.tsx
+++ b/src/pages/Facility/settings/healthcareService/ServiceCard.tsx
@@ -14,10 +14,10 @@ type DuoToneIconName = keyof typeof duoToneIcons;
 
 interface Props {
   service: HealthcareServiceReadSpec;
-  facilityId: string;
+  link: string;
 }
 
-export function ServiceCard({ service, facilityId }: Props) {
+export function ServiceCard({ service, link }: Props) {
   const { t } = useTranslation();
   const getIconName = (name: string): DuoToneIconName =>
     `d-${name}` as DuoToneIconName;
@@ -51,11 +51,7 @@ export function ServiceCard({ service, facilityId }: Props) {
             </div>
           </div>
           <Button
-            onClick={() =>
-              navigate(
-                `/facility/${facilityId}/settings/healthcare_services/${service.id}`,
-              )
-            }
+            onClick={() => navigate(link)}
             variant="outline"
             size="sm"
             className="px-3 text-xs whitespace-nowrap w-full md:w-auto"


### PR DESCRIPTION
## Proposed Changes

- fix link for service card

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Service cards now use direct links to service detail pages, providing consistent URLs across Facility Services and Healthcare Service Settings.
  - Navigation now routes directly via provided links instead of constructing URLs on click, reducing potential routing issues.
  - Improves deep-linking and sharing: users can bookmark or share precise service pages more reliably.
  - No visual changes; users will experience smoother, more predictable navigation to service details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->