### PR TITLE
fix: billing tab highlighting issue

### DIFF
--- a/src/components/ui/sidebar/facility/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility/facility-nav.tsx
@@ -137,7 +137,7 @@ function generateFacilityLinks(
         },
         {
           name: t("billing"),
-          url: `${baseUrl}/settings/billing/discount_codes`,
+          url: `${baseUrl}/settings/billing`,
         },
         {
           name: t("charge_item_definitions"),

--- a/src/pages/Facility/settings/billing/layout.tsx
+++ b/src/pages/Facility/settings/billing/layout.tsx
@@ -1,5 +1,5 @@
 import { Menu } from "lucide-react";
-import { Link, useRoutes } from "raviger";
+import { ActiveLink, Link, navigate, useFullPath, useRoutes } from "raviger";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
@@ -21,6 +21,7 @@ import { TaxCodeSettings } from "@/pages/Facility/settings/billing/tax/tax-codes
 import { TaxComponentSettings } from "@/pages/Facility/settings/billing/tax/tax-components/TaxComponentSettings";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 
+import { useEffect } from "react";
 import { InformationalCodeSettings } from "./informational/InformationalCodeSettings";
 import { BillingSettings } from "./settings/BillingSettings";
 
@@ -89,6 +90,24 @@ export function BillingSettingsLayout() {
     basePath: `/facility/${facilityId}/settings/billing`,
     routeProps: { facilityId },
   });
+  const fullPath = useFullPath();
+
+  useEffect(() => {
+    const baseBillingPath = `/facility/${facilityId}/settings/billing`;
+    if (fullPath === baseBillingPath || fullPath === `${baseBillingPath}/`) {
+      navigate(`${baseBillingPath}/discount_codes`);
+    }
+  }, [fullPath, facilityId]);
+
+  const subpath = () => {
+    const idx = fullPath.indexOf("/settings/billing");
+    if (idx !== -1) {
+      let suffix = fullPath.substring(idx + "/settings/billing".length);
+      if (!suffix || suffix === "/") return "/settings";
+      return suffix.startsWith("/") ? suffix : `/${suffix}`;
+    }
+    return "/settings";
+  };
 
   return (
     <div className="container flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10">
@@ -134,16 +153,18 @@ export function BillingSettingsLayout() {
                 </h4>
                 <div className="space-y-1">
                   {category.items.map((item) => (
-                    <Link
+                    <ActiveLink
                       key={item.href}
                       href={`/billing${item.href}`}
                       className={cn(
                         buttonVariants({ variant: "ghost" }),
                         "w-full justify-start",
+                        subpath() === item.href &&
+                          "bg-white text-green-700 shadow",
                       )}
                     >
                       {item.title}
-                    </Link>
+                    </ActiveLink>
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #12964


https://github.com/user-attachments/assets/958477e3-e784-495d-b27e-ddb4fc2dbc03



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Billing settings navigation with active-state highlighting across desktop and mobile, making the current section clearly visible.
  * Clicking “Billing” now routes to the Billing landing path and automatically redirects to the default “Discount Codes” subsection.
  * Navigation is now path-aware, ensuring the correct menu item is highlighted based on the current URL.
  * Simplified Billing submenu link to the Billing root for a cleaner URL, while preserving access to all subsections via the sidebar and dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->