### PR TITLE
add plugin encounter actions

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3329,6 +3329,7 @@
   "please_upload_a_csv_file": "Please Upload A CSV file",
   "please_upload_a_file": "Please upload a file",
   "please_upload_an_image_file": "Please upload an image file!",
+  "plugin_actions": "Plugin Actions",
   "po_number": "PO Number",
   "policy": "Policy",
   "policy__insurer": "Insurer",

--- a/src/components/Encounter/EncounterCommandDialog.tsx
+++ b/src/components/Encounter/EncounterCommandDialog.tsx
@@ -1,4 +1,18 @@
 import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command";
+import {
+  useEncounterShortcutDisplays,
+  useEncounterShortcuts,
+} from "@/hooks/useEncounterShortcuts";
+import {
   ArrowBigRight,
   Building2,
   CheckCircle2,
@@ -13,24 +27,11 @@ import {
   Users,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
 
-import {
-  CommandDialog,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-  CommandShortcut,
-} from "@/components/ui/command";
-
-import {
-  useEncounterShortcutDisplays,
-  useEncounterShortcuts,
-} from "@/hooks/useEncounterShortcuts";
+import { PLUGIN_Component } from "@/PluginEngine";
 import useQuestionnaireOptions from "@/hooks/useQuestionnaireOptions";
+import { EncounterRead } from "@/types/emr/encounter/encounter";
+import { useTranslation } from "react-i18next";
 
 interface ActionItem {
   id: string;
@@ -46,12 +47,14 @@ interface ActionGroup {
 }
 
 interface EncounterCommandDialogProps {
+  encounter: EncounterRead;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   trigger?: React.ReactNode;
 }
 
 export function EncounterCommandDialog({
+  encounter,
   open,
   onOpenChange,
   trigger,
@@ -376,6 +379,13 @@ export function EncounterCommandDialog({
               <CommandSeparator />
             </div>
           ))}
+          <CommandGroup heading={t("plugin_actions")} className="px-2">
+            <PLUGIN_Component
+              __name="PatientInfoCardActions"
+              encounter={encounter}
+              className="rounded-md cursor-pointer hover:bg-gray-100 flex justify-between aria-selected:bg-gray-100 w-full py-2"
+            />
+          </CommandGroup>
         </CommandList>
       </CommandDialog>
     </>

--- a/src/components/Encounter/EncounterCommandDialog.tsx
+++ b/src/components/Encounter/EncounterCommandDialog.tsx
@@ -29,6 +29,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { PLUGIN_Component } from "@/PluginEngine";
+import { useCareApps } from "@/hooks/useCareApps";
 import useQuestionnaireOptions from "@/hooks/useQuestionnaireOptions";
 import { EncounterRead } from "@/types/emr/encounter/encounter";
 import { useTranslation } from "react-i18next";
@@ -379,13 +380,17 @@ export function EncounterCommandDialog({
               <CommandSeparator />
             </div>
           ))}
-          <CommandGroup heading={t("plugin_actions")} className="px-2">
-            <PLUGIN_Component
-              __name="PatientInfoCardActions"
-              encounter={encounter}
-              className="rounded-md cursor-pointer hover:bg-gray-100 flex justify-between aria-selected:bg-gray-100 w-full py-2"
-            />
-          </CommandGroup>
+          {useCareApps().some(
+            (plugin) => plugin.components?.PatientInfoCardActions,
+          ) && (
+            <CommandGroup heading={t("plugin_actions")} className="px-2">
+              <PLUGIN_Component
+                __name="PatientInfoCardActions"
+                encounter={encounter}
+                className="rounded-md cursor-pointer hover:bg-gray-100 flex justify-between aria-selected:bg-gray-100 w-full py-2"
+              />
+            </CommandGroup>
+          )}
         </CommandList>
       </CommandDialog>
     </>

--- a/src/pages/Encounters/EncounterHeader.tsx
+++ b/src/pages/Encounters/EncounterHeader.tsx
@@ -109,6 +109,7 @@ export function EncounterHeader({
             />
 
             <EncounterCommandDialog
+              encounter={encounter}
               open={actionsOpen}
               onOpenChange={setActionsOpen}
               trigger={

--- a/src/pages/Encounters/tabs/overview/summary-panel-actions.tab.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-actions.tab.tsx
@@ -2,9 +2,11 @@ import { CheckIcon, NotebookPen } from "lucide-react";
 import { navigate } from "raviger";
 import { useTranslation } from "react-i18next";
 
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
+import { cn } from "@/lib/utils";
 import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
+import { PLUGIN_Component } from "@/PluginEngine";
 
 export const SummaryPanelActionsTab = () => {
   const { t } = useTranslation();
@@ -17,6 +19,7 @@ export const SummaryPanelActionsTab = () => {
       manageCareTeam,
       dispenseMedicine,
     },
+    selectedEncounter,
   } = useEncounter();
 
   const actions = [
@@ -59,6 +62,17 @@ export const SummaryPanelActionsTab = () => {
             {action.label}
           </Button>
         ))}
+
+        {selectedEncounter && (
+          <PLUGIN_Component
+            __name="PatientInfoCardActions"
+            encounter={selectedEncounter}
+            className={cn(
+              buttonVariants({ variant: "outline" }),
+              "justify-start sm:@sm:justify-center sm:@sm:flex-1",
+            )}
+          />
+        )}
 
         <div className="sm:@sm:flex-1 flex flex-col gap-2 border-t border-gray-300 border-dashed sm:@sm:border-none pt-3 sm:@sm:pt-0">
           <Button


### PR DESCRIPTION
## Proposed Changes

- Added patient info card actions plugin component that was missed out during encounter ui update

<img width="872" height="908" alt="image" src="https://github.com/user-attachments/assets/043d300b-5f09-45de-a609-d1de796229ff" />

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Request for Peer Reviews
- [x] Completion of QA in Mobile Devices
- [x] Completion of QA in Desktop Devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encounter command dialog and overview actions panel now include a plugin-driven action group that surfaces context-aware patient-info actions for the selected encounter.

* **Localization**
  * Added English translation "Plugin Actions" to support the new action group label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->