### PR TITLE
Fix: 2FA Dialog Retains Previous Error Message After Closing #13478

### DIFF
--- a/src/components/Users/TwoFactorAuth.tsx
+++ b/src/components/Users/TwoFactorAuth.tsx
@@ -236,7 +236,7 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
         open={showPasswordDialog}
         onOpenChange={(open) => {
           closePasswordDialog();
-          if (!open) setSetupPasswordError(""); // Clear error on close
+          if (!open) setSetupPasswordError("");
         }}
         onSubmit={(password) => setupTOTP({ password })}
         title={t("confirm_password")}
@@ -253,7 +253,7 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
           open={showSetupDialog}
           onOpenChange={(open) => {
             closeSetupDialog();
-            if (!open) setVerificationError(""); // Clear error on close
+            if (!open) setVerificationError("");
           }}
           setupData={setupData}
           onVerify={(code) => verifyTOTP({ code })}
@@ -280,7 +280,7 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
         open={showDisableDialog}
         onOpenChange={(open) => {
           closeDisableDialog();
-          if (!open) setDisableError(""); // Clear error on close
+          if (!open) setDisableError("");
         }}
         onSubmit={(password) => disableTOTP({ password })}
         title={t("disable_two_factor_authentication")}
@@ -302,7 +302,7 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
         open={showRegenerateConfirm}
         onOpenChange={(open) => {
           closeRegenerateConfirm();
-          if (!open) setRegeneratePasswordError(""); // Clear error on close
+          if (!open) setRegeneratePasswordError("");
         }}
         onSubmit={(password) => regenerateBackupCodes({ password })}
         title={t("regenerate_backup_codes")}

--- a/src/components/Users/TwoFactorAuth.tsx
+++ b/src/components/Users/TwoFactorAuth.tsx
@@ -251,7 +251,10 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
       {setupData && (
         <TOTPSetupDialog
           open={showSetupDialog}
-          onOpenChange={closeSetupDialog}
+          onOpenChange={(open) => {
+            closeSetupDialog();
+            if (!open) setVerificationError(""); // Clear error on close
+          }}
           setupData={setupData}
           onVerify={(code) => verifyTOTP({ code })}
           verificationError={verificationError}

--- a/src/components/Users/TwoFactorAuth.tsx
+++ b/src/components/Users/TwoFactorAuth.tsx
@@ -234,7 +234,10 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
       {/* Password Dialog for Setup */}
       <PasswordDialog
         open={showPasswordDialog}
-        onOpenChange={closePasswordDialog}
+        onOpenChange={(open) => {
+          closePasswordDialog();
+          if (!open) setSetupPasswordError(""); // Clear error on close
+        }}
         onSubmit={(password) => setupTOTP({ password })}
         title={t("confirm_password")}
         description={t("please_enter_current_password")}
@@ -272,7 +275,10 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
       {/* Password Dialog for Disable */}
       <PasswordDialog
         open={showDisableDialog}
-        onOpenChange={closeDisableDialog}
+        onOpenChange={(open) => {
+          closeDisableDialog();
+          if (!open) setDisableError(""); // Clear error on close
+        }}
         onSubmit={(password) => disableTOTP({ password })}
         title={t("disable_two_factor_authentication")}
         description={t("disable_2fa_confirmation")}
@@ -291,7 +297,10 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
       {/* Password Dialog for Regenerate */}
       <PasswordDialog
         open={showRegenerateConfirm}
-        onOpenChange={closeRegenerateConfirm}
+        onOpenChange={(open) => {
+          closeRegenerateConfirm();
+          if (!open) setRegeneratePasswordError(""); // Clear error on close
+        }}
         onSubmit={(password) => regenerateBackupCodes({ password })}
         title={t("regenerate_backup_codes")}
         description={t("regenerate_backup_codes_warning")}

--- a/src/components/Users/TwoFactorAuth.tsx
+++ b/src/components/Users/TwoFactorAuth.tsx
@@ -253,7 +253,10 @@ export const TwoFactorAuth = ({ userData }: userChildProps) => {
           open={showSetupDialog}
           onOpenChange={(open) => {
             closeSetupDialog();
-            if (!open) setVerificationError("");
+            if (!open) {
+              setVerificationError("");
+              setSetupData(null);
+            }
           }}
           setupData={setupData}
           onVerify={(code) => verifyTOTP({ code })}


### PR DESCRIPTION
Fixes #13478

**Proposed Changes**
- Clear error messages (`setupPasswordError`, `disableError`, `regeneratePasswordError`) when dialogs are closed.
- Ensures a fresh state whenever the user reopens the dialog.

https://github.com/user-attachments/assets/135b751a-1b0b-4304-ad0e-8796795fae8f

Tagging: @ohcnetwork/care-fe-code-reviewers

**Merge Checklist**
-  [x] Add specs that demonstrate the bug or test the new feature.
-  [x] Update product documentation. (Not applicable for UI alignment changes)
-  [x] Ensure that UI text is placed in I18n files.
-  [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
-  [x] Request peer reviews.
-  [x] Complete QA on mobile devices.
-  [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Two-Factor Authentication dialogs now clear related error messages when closed (setup password, TOTP verification, disable, and regenerate flows).
  * TOTP setup also resets in-progress setup data when closed.
  * Opening behavior unchanged; errors/data are cleared only on close to avoid stale messages on reopen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->