### PR TITLE
fix: User Page UI of org breaks in Tablet View

### DIFF
--- a/src/pages/Organization/OrganizationUsers.tsx
+++ b/src/pages/Organization/OrganizationUsers.tsx
@@ -159,7 +159,7 @@ export default function OrganizationUsers({ id, navOrganizationId }: Props) {
                 <CardGridSkeleton count={6} />
               </div>
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
                 {users?.results?.length === 0 ? (
                   <Card className="col-span-full">
                     <CardContent className="p-6 text-center text-gray-500">


### PR DESCRIPTION
## Proposed Changes

Fixes #13492


https://github.com/user-attachments/assets/515ff131-b9a9-434a-91f8-0a9016efff21



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated responsive layout on the Organization Users page: single column on small/medium screens, two columns on large screens (≥1024px), and three columns on extra-large screens.
  * Aligned loaded state with the loading skeleton grid for consistent visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->