### PR TITLE
fix checkbox misalignment

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -543,7 +543,6 @@ export default function PatientRegistration(
                                 }
                               }}
                               data-cy="same-phone-number-checkbox"
-                              className="mt-2"
                             />
                           </FormControl>
                           <FormLabel>


### PR DESCRIPTION
## Proposed Changes

Fixes #13383 
- Remove unnecessary margin class from the same phone number checkbox in PatientRegistration component

<img width="732" height="140" alt="image" src="https://github.com/user-attachments/assets/a9686fed-893b-489a-b9ff-cead70ba386d" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing for the “Same phone number” checkbox in the Patient Registration form by removing an extra top margin, resulting in cleaner alignment with adjacent fields.
  * Visual-only refinement; no changes to interaction, validation, or data behavior. Improves consistency across screen sizes and reduces unnecessary whitespace for a tighter, more cohesive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->