### PR TITLE
Fix: Build fail due to syntax error in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -178,7 +178,7 @@ const config = [
           callees: {
             exclude: [".*"],
           },
-        },
+        })
       ],
       "i18next-no-undefined-translation-keys/no-undefined-translation-keys": [
         dynamicRules({


### PR DESCRIPTION
## Proposed Changes

Fix: Build fail due to syntax error in eslint

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Fixed a minor syntax issue in the project's linting configuration related to i18n rule handling.
  * Improves reliability and consistency of local and CI lint checks, reducing developer tooling noise.
  * No changes to app behavior, UI, or performance.
  * Maintenance-only change; no impact on end-user features or content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->