### PR TITLE
fix: limit location switcher to my locations

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -439,6 +439,7 @@
   "add_new_beds": "Add New Bed(s)",
   "add_new_facility": "Add New Facility",
   "add_new_location": "Add New Location",
+  "shift_key": "shift",
   "add_new_medications": "Add New Medications",
   "add_new_patient": "Add New Patient",
   "add_new_user": "Add New User",

--- a/src/components/ui/sidebar/facility/location/location-switcher.tsx
+++ b/src/components/ui/sidebar/facility/location/location-switcher.tsx
@@ -69,6 +69,7 @@ export function LocationSwitcher() {
         setLocation={setLocation}
         open={openDialog}
         setOpen={setOpenDialog}
+        myLocations={true}
       />
       <div className="flex flex-col items-start gap-4">
         <Button variant="ghost" onClick={() => navigate(fallbackUrl)}>
@@ -315,8 +316,8 @@ export function LocationSelectorDialog({
               >
                 <span>{t("done")}</span>
                 <span className="flex text-xs items-center gap-1 p-1 shadow rounded-md bg-green-900">
-                  {"shift"}
-                  {"+"}
+                  {t("shift_key")}
+                  {t("+")}
                   <CareIcon icon="l-corner-down-left" />
                 </span>
               </Button>


### PR DESCRIPTION
## Proposed Changes

- set my locations flag to be true for location switcher (limits locations to what you have access to)

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Location selector now supports a “My locations” view, showing only locations you own when opened from the location switcher.
- Localization
  - Added a new translation for the Shift key.
  - The “Done” button’s keyboard shortcut label now uses localized text (e.g., “Shift +”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->