### PR TITLE
change from pull request to the pull request target

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,7 +1,7 @@
 name: PR Checklist Validator
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- I have changed the pull_request event to the pull_request_target event
- Here we want to _"comment the PR"_ and _"open/close state of the PR"_ based on the thing that checklist is checked or not. And these two action requires the write action. But for the PRs that are raised from the forked repo, Github Action token only gives the read access to the workflow for safety reason because giving the write access to the forked repo PRs can be risky.
If in some cases, if we want the write access to the PRs of the forked repo, then according to the documentation, "pull_request_target" is required, this give write access, but that can risky but here that will be not the scenario, because we are not checking out the forked code, so I think it will be safe.

Here also in warning section this is written that if checkout step is not there then there will be no risk:
https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated continuous integration workflow that runs on pull requests. The trigger source was adjusted while retaining the same checks, steps, and permissions.
  - No changes to application features, UI, performance, or behavior. Users will not notice any differences.
  - Documentation, tests, and release artifacts remain unchanged.
  - This update only affects how pull request checks are initiated; outcomes and status reporting of checks remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->