### PR TITLE
fix icon misalignment

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -249,7 +249,7 @@ export default function Autocomplete({
             <span className="sr-only">{t("clear")}</span>
           </Button>
         ) : (
-          <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+          <CaretSortIcon className="absolute right-3 top-1/2 ml-2 size-4 shrink-0 opacity-50" />
         )}
       </div>
     );
@@ -300,7 +300,7 @@ export default function Autocomplete({
           <span className="sr-only">{t("clear")}</span>
         </Button>
       ) : (
-        <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+        <CaretSortIcon className="absolute right-3 top-1/2 ml-2 size-4 shrink-0 opacity-50" />
       )}
     </div>
   );


### PR DESCRIPTION
## Proposed Changes

Fixes #13566
<img width="629" height="93" alt="image" src="https://github.com/user-attachments/assets/2b4999f8-30b6-499e-8497-bc0f2383cd3f" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed the caret icon alignment in the Autocomplete component, ensuring it is properly centered vertically on both mobile and desktop. This resolves minor visual misalignment and improves readability.

- Style
  - Refined icon positioning and spacing within the Autocomplete input for a cleaner, more consistent appearance across breakpoints. No changes to behavior or public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->