### PR TITLE
Fix: Page Crash for edit patient detail page via org route

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -58,7 +58,7 @@ import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { dateQueryString } from "@/Utils/utils";
 import validators from "@/Utils/validators";
-import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
+import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
 import GovtOrganizationSelector from "@/pages/Organization/components/GovtOrganizationSelector";
 import {
   BloodGroupChoices,
@@ -93,7 +93,7 @@ export default function PatientRegistration(
   const { t } = useTranslation();
   const { goBack } = useAppHistory();
   const defaultCountry = careConfig.defaultCountry.name;
-  const { facility } = useCurrentFacility();
+  const { facility } = useCurrentFacilitySilently();
 
   const [suppressDuplicateWarning, setSuppressDuplicateWarning] =
     useState(!!patientId);
@@ -376,7 +376,7 @@ export default function PatientRegistration(
   });
 
   useEffect(() => {
-    if (patientQuery.data && facility) {
+    if (patientQuery.data) {
       form.reset({
         _selected_levels: [
           patientQuery.data.geo_organization as unknown as Organization,
@@ -407,17 +407,24 @@ export default function PatientRegistration(
         )?.id,
         deceased_datetime: null,
         tags: [], // This is only used for create patient
-        identifiers: facility.patient_instance_identifier_configs.map(
-          (identifierConfig) => {
-            const identifier = patientQuery.data.instance_identifiers?.find(
-              (i) => i.config.id === identifierConfig.id,
-            );
-            return {
-              config: identifierConfig.id,
-              value: identifier?.value,
-            };
-          },
-        ),
+        identifiers: facility
+          ? facility.patient_instance_identifier_configs.map(
+              (identifierConfig) => {
+                const identifier = patientQuery.data.instance_identifiers?.find(
+                  (i) => i.config.id === identifierConfig.id,
+                );
+                return {
+                  config: identifierConfig.id,
+                  value: identifier?.value,
+                };
+              },
+            )
+          : patientQuery.data.instance_identifiers.map((identifierConfig) => {
+              return {
+                config: identifierConfig.config.id,
+                value: identifierConfig.value,
+              };
+            }),
       } as unknown as z.infer<typeof formSchema>);
     } else if (facility) {
       form.setValue(


### PR DESCRIPTION
## Proposed Changes

- Fixes #13481
- used useCurrentFacilitySilently instead
- Made changes according to  above


https://github.com/user-attachments/assets/76cdb5f1-e1a2-4f38-a879-ceb409915cc6




Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Patient registration and edit forms now initialize reliably even if facility context isn’t available.
  - Existing patient identifiers are correctly pre-filled, preventing empty or incomplete fields.
  - Reduces instances of blocked or unresponsive forms during patient workflows.

- Improvements
  - More resilient handling of patient identifiers across varying facility configurations.
  - Smoother new/edit patient flows with fewer interruptions and reduced loading noise.
  - Better consistency in form data population, leading to a more predictable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->