### PR TITLE
Fix: Vitals response with encounter history selection

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -439,7 +439,6 @@
   "add_new_beds": "Add New Bed(s)",
   "add_new_facility": "Add New Facility",
   "add_new_location": "Add New Location",
-  "shift_key": "shift",
   "add_new_medications": "Add New Medications",
   "add_new_patient": "Add New Patient",
   "add_new_user": "Add New User",
@@ -1844,6 +1843,7 @@
   "enter_year_of_birth_to_verify": "Enter year of birth to verify",
   "enter_your_valid_email_address_to_receive_the_discharge_summary": "Enter your valid email address to receive the discharge summary",
   "entered": "Entered",
+  "entered_by": "Entered by",
   "entered_in_error": "Entered in Error",
   "entered_in_error_warning": "This action cannot be undone. The appointment will be marked as entered in error and removed from the system.",
   "entity_count_one": "{{count}} {{entity}}",
@@ -2759,6 +2759,7 @@
   "no_consultation_updates": "No consultation updates",
   "no_contact_points_added": "No contact points added",
   "no_country_found": "No country found",
+  "no_data_available": "No data available",
   "no_data_found": "No data found",
   "no_definitions_found": "No definitions found",
   "no_deleted_observations": "No Deleted Observation",
@@ -4220,6 +4221,7 @@
   "sgst": "SGST",
   "shared_by": "Shared By",
   "shift": "Shift Patient",
+  "shift_key": "shift",
   "shifting": "Shifting",
   "shifting_approval_facility": "Shifting approval facility",
   "shifting_approving_facility": "Shifting approving facility",
@@ -4956,7 +4958,5 @@
   "you_have_unsaved_changes_what_would_you_like_to_do": "You have unsaved changes. What would you like to do?",
   "you_need_at_least_a_location_to_create_an_assest": "You need at least a location to create an assest.",
   "zoom_in": "Zoom In",
-  "zoom_out": "Zoom Out",
-  "no_data_available": "No data available",
-  "entered_by": "Entered by"
+  "zoom_out": "Zoom Out"
 }

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -4956,5 +4956,7 @@
   "you_have_unsaved_changes_what_would_you_like_to_do": "You have unsaved changes. What would you like to do?",
   "you_need_at_least_a_location_to_create_an_assest": "You need at least a location to create an assest.",
   "zoom_in": "Zoom In",
-  "zoom_out": "Zoom Out"
+  "zoom_out": "Zoom Out",
+  "no_data_available": "No data available",
+  "entered_by": "Entered by"
 }

--- a/src/components/Common/Charts/ObservationHistoryTable.tsx
+++ b/src/components/Common/Charts/ObservationHistoryTable.tsx
@@ -18,6 +18,7 @@ import query from "@/Utils/request/query";
 import { Code } from "@/types/base/code/code";
 import { ObservationWithUser } from "@/types/emr/observation";
 import patientApi from "@/types/emr/patient/patientApi";
+import { useTranslation } from "react-i18next";
 
 interface PaginatedResponse<T> {
   count: number;
@@ -50,6 +51,7 @@ export const ObservationHistoryTable = ({
   codes,
 }: ObservationHistoryTableProps) => {
   const { ref, inView } = useInView();
+  const { t } = useTranslation();
 
   const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery<
     PaginatedResponse<ObservationWithUser>
@@ -57,7 +59,8 @@ export const ObservationHistoryTable = ({
     queryKey: [
       "infinite-observations",
       patientId,
-      codes.map((c) => c.code).join(","),
+      encounterId,
+      codes.map((c) => c.code),
     ],
     queryFn: async ({ pageParam = 0 }) => {
       const response = await query(patientApi.listObservations, {
@@ -97,7 +100,7 @@ export const ObservationHistoryTable = ({
   if (!data?.pages[0]?.results.length) {
     return (
       <div className="flex h-[200px] items-center justify-center text-gray-500">
-        No data available
+        {t("no_data_available")}
       </div>
     );
   }
@@ -107,11 +110,11 @@ export const ObservationHistoryTable = ({
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Time</TableHead>
-            <TableHead>Code</TableHead>
-            <TableHead>Value</TableHead>
-            <TableHead>Entered By</TableHead>
-            <TableHead>Notes</TableHead>
+            <TableHead>{t("time")}</TableHead>
+            <TableHead>{t("code")}</TableHead>
+            <TableHead>{t("value")}</TableHead>
+            <TableHead>{t("entered_by")}</TableHead>
+            <TableHead>{t("notes")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/components/Patient/vitals/list.tsx
+++ b/src/components/Patient/vitals/list.tsx
@@ -96,7 +96,7 @@ export const VitalsList = ({
       "infinite-observations",
       patientId,
       encounterId,
-      filteredVitalCodes.map((c) => c.code).join(","),
+      filteredVitalCodes.map((c) => c.code),
     ],
     queryFn: async ({ pageParam = 0 }) => {
       const response = await query(patientApi.listObservations, {

--- a/src/components/Patient/vitals/list.tsx
+++ b/src/components/Patient/vitals/list.tsx
@@ -95,6 +95,7 @@ export const VitalsList = ({
     queryKey: [
       "infinite-observations",
       patientId,
+      encounterId,
       filteredVitalCodes.map((c) => c.code).join(","),
     ],
     queryFn: async ({ pageParam = 0 }) => {


### PR DESCRIPTION
## Proposed Changes
- Vitals response are not corresponding to encounter selection due to appropriate query key
- Added encounterId as querykey 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensures vitals and observation history are cached per encounter to prevent data from appearing mixed when switching encounters; improves consistency when loading more pages or refreshing.
- **New Features**
  - Adds localization support and two new UI strings ("Entered by", "No data available") so table headers and messages are translated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->