### PR TITLE
Fix: Update Password button enabled prematurely #13542

### DIFF
--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -65,6 +65,7 @@ export default function UserResetPassword({
 
   const form = useForm({
     resolver: zodResolver(PasswordSchema),
+    mode: "onSubmit",
     defaultValues: {
       old_password: "",
       new_password_1: "",
@@ -225,7 +226,7 @@ export default function UserResetPassword({
               </Button>
               <Button
                 type="submit"
-                disabled={!form.formState.isDirty || isPending}
+                disabled={!form.formState.isValid || isPending}
                 variant="primary"
               >
                 {isPending && (


### PR DESCRIPTION
## Proposed Changes

Fixes #13542
- Enable "Update Password" button only when all three fields (Current, New, Confirm) are filled.
- Updated form mode to `onSubmit` to control when validation messages appear.

https://github.com/user-attachments/assets/9bdb20b7-c562-427f-8564-a4b43eed0116

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reset Password form now validates on submit, avoiding distracting inline errors while typing and providing clearer feedback at submission time.
  * Submit button is disabled until all inputs are valid, reducing accidental or invalid submissions and improving form reliability. Pending/processing state behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->