### PR TITLE
Fix css for autocomplete component in valueset preview

### DIFF
--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -57,22 +57,25 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
             {t("valueset_preview_description")}
           </p>
         </SheetHeader>
-        <Autocomplete
-          options={mergeAutocompleteOptions(
-            searchQuery?.results?.map((option) => ({
-              label: option.display || "",
-              value: option.code,
-            })) ?? [],
-          )}
-          value={search}
-          onChange={setSearch}
-          onSearch={setSearch}
-          placeholder={t("search_concept")}
-          noOptionsMessage={
-            searchQuery && !isFetching ? t("no_results_found") : t("searching")
-          }
-          className="px-1 mt-6"
-        />
+        <div className="px-1 mt-6">
+          <Autocomplete
+            options={mergeAutocompleteOptions(
+              searchQuery?.results?.map((option) => ({
+                label: option.display || "",
+                value: option.code,
+              })) ?? [],
+            )}
+            value={search}
+            onChange={setSearch}
+            onSearch={setSearch}
+            placeholder={t("search_concept")}
+            noOptionsMessage={
+              searchQuery && !isFetching
+                ? t("no_results_found")
+                : t("searching")
+            }
+          />
+        </div>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
## Proposed Changes

Fixes #13529 
- Removed css inside autocomplete component
- Surrounded autocomplete with div and shifted css here

![Capture 35](https://github.com/user-attachments/assets/99f79c5e-7dfb-4463-8a17-0b412d9fa48a)


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted spacing around the Autocomplete in the Value Set preview: reduced horizontal padding and top margin for a more compact, consistent layout.
  - Layout-only change; no impact on interactions, data fetching, or performance.
  - Improves visual alignment and reduces excess whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->