### PR TITLE
Made the badges responsive in Purchase Order Page

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/PurchaseOrders.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/PurchaseOrders.tsx
@@ -116,7 +116,7 @@ export function PurchaseOrders({ facilityId, locationId }: Props) {
   const selectedProduct = productKnowledges.find((p) => p.id === qParams.item);
 
   const renderFilters = () => (
-    <div className="flex items-center gap-4">
+    <div className="flex flex-col md:flex-row gap-4">
       <ProductKnowledgeSelect
         value={selectedProduct}
         onChange={(product) => updateQuery({ item: product?.id })}


### PR DESCRIPTION
## Proposed Changes
To make the badges on the top responsive.

Fixes #13557 

<img width="528" height="709" alt="Screenshot 2025-09-01 154840" src="https://github.com/user-attachments/assets/1cf04d77-940f-4432-bc15-3d395d20d8d8" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved the Purchase Orders filter bar with a responsive layout: filters now stack vertically on small screens and align horizontally on medium and larger viewports.
  - Enhances readability and usability on mobile and tablets without altering filter behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->