### PR TITLE
Fix : Switch to table View for medium size screen in Questionnaire and ValueSet Listing Page 

### DIFF
--- a/src/components/Questionnaire/QuestionnaireList.tsx
+++ b/src/components/Questionnaire/QuestionnaireList.tsx
@@ -75,7 +75,7 @@ const RenderCard = ({
   const navigate = useNavigate();
 
   return (
-    <div className="xl:hidden space-y-4">
+    <div className="md:hidden space-y-4">
       {isLoading ? (
         <CardGridSkeleton count={5} />
       ) : questionnaireList.length === 0 ? (
@@ -156,7 +156,7 @@ const RenderTable = ({
   const { t } = useTranslation();
 
   return (
-    <div className="hidden xl:block overflow-hidden rounded-lg bg-white shadow-sm overflow-x-auto">
+    <div className="hidden md:block overflow-hidden rounded-lg bg-white shadow-sm overflow-x-auto">
       {isLoading ? (
         <TableSkeleton count={5} />
       ) : questionnaireList.length === 0 ? (

--- a/src/components/ValueSet/ValueSetList.tsx
+++ b/src/components/ValueSet/ValueSetList.tsx
@@ -79,7 +79,7 @@ const RenderCard = ({
   const navigate = useNavigate();
 
   return (
-    <div className="lg:hidden space-y-4 px-4">
+    <div className="md:hidden space-y-4 px-4">
       {isLoading ? (
         <CardGridSkeleton count={5} />
       ) : valuesets.length === 0 ? (
@@ -201,7 +201,7 @@ const RenderTable = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
   return (
-    <div className="hidden lg:block overflow-hidden rounded-lg bg-white shadow-sm">
+    <div className="hidden md:block overflow-hidden rounded-lg bg-white shadow-sm">
       {isLoading ? (
         <TableSkeleton count={5} />
       ) : valuesets.length === 0 ? (


### PR DESCRIPTION
## Proposed Changes

Fixes #12695 

## Screenshot 

<img width="1899" height="946" alt="Screenshot 2025-09-01 143206" src="https://github.com/user-attachments/assets/d6b5c0c1-1e22-4f20-b728-c8b71695dd37" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated responsive breakpoints for list views.
  - Questionnaire and ValueSet lists now show a card layout only on small screens.
  - The table layout is displayed from medium screens and larger (appears earlier than before).
  - Behavior is consistent across both lists: cards on small, tables on md+.
  - No changes to data loading, interactions, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->