### PR TITLE
service req: deletion logic fix, layout adj for obs w/ components

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2572,6 +2572,7 @@
   "mark_this_transfer_as_complete_question": "Are you sure you want to mark this transfer as complete? The Origin facility will no longer have access to this patient",
   "mark_transfer_complete_confirmation": "Are you sure you want to mark this transfer as complete? The Origin facility will no longer have access to this patient",
   "markdown_supported": "You can use markdown to format your facility description",
+  "marked_for_deletion": "Marked for deletion. Click save results to delete.",
   "max_dosage_24_hrs": "Max. dosage in 24 hrs.",
   "max_dosage_in_24hrs_gte_base_dosage_error": "Max. dosage in 24 hours must be greater than or equal to base dosage",
   "max_size_for_image_uploaded_should_be": "Max size for image uploaded should be {{maxSize}}.",

--- a/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
@@ -37,7 +37,6 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { Avatar } from "@/components/Common/Avatar";
-import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import { FileListTable } from "@/components/Files/FileListTable";
 import FileUploadDialog from "@/components/Files/FileUploadDialog";
 
@@ -99,6 +98,7 @@ interface ObservationValue {
   value: string;
   unit: string;
   isNormal: boolean;
+  status: ObservationStatus;
   components: Record<string, ComponentValue>;
 }
 
@@ -126,12 +126,6 @@ export function DiagnosticReportForm({
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
   const [conclusion, setConclusion] = useState<string>("");
   const queryClient = useQueryClient();
-
-  // Add state for delete confirmation
-  const [deleteConfirmation, setDeleteConfirmation] = useState<{
-    definitionId: string;
-    index: number;
-  } | null>(null);
 
   const isImagingReport = activityDefinition?.category === "imaging";
 
@@ -260,28 +254,6 @@ export function DiagnosticReportForm({
       },
     });
 
-  // Add a new mutation for updating observation status
-  const { mutate: updateObservationStatus, isPending: isUpdatingStatus } =
-    useMutation({
-      mutationFn: mutate(observationApi.upsertObservations, {
-        pathParams: {
-          patient_external_id: patientId,
-          external_id: latestReport?.id || "",
-        },
-      }),
-      onSuccess: () => {
-        toast.success(t("observation_deleted"));
-        queryClient.invalidateQueries({
-          queryKey: ["diagnosticReport", latestReport?.id],
-        });
-      },
-      onError: (err: any) => {
-        toast.error(
-          `Failed to delete observation: ${err.message || "Unknown error"}`,
-        );
-      },
-    });
-
   // Initialize file upload hook
   const fileUpload = useFileUpload({
     type: "diagnostic_report" as any,
@@ -344,6 +316,7 @@ export function DiagnosticReportForm({
               value: obs.value.value || "",
               unit: obs.value.unit?.code || "",
               isNormal: obs.interpretation === "normal",
+              status: obs.status,
               components,
             };
 
@@ -376,6 +349,7 @@ export function DiagnosticReportForm({
           value: "",
           unit: "",
           isNormal: true,
+          status: ObservationStatus.AMENDED,
           components: {},
         };
       }
@@ -399,6 +373,7 @@ export function DiagnosticReportForm({
           value: "",
           unit: "",
           isNormal: true,
+          status: ObservationStatus.AMENDED,
           components: {},
         };
       }
@@ -426,6 +401,7 @@ export function DiagnosticReportForm({
           value: "",
           unit: "",
           isNormal: true,
+          status: ObservationStatus.AMENDED,
           components: {},
         };
       }
@@ -455,6 +431,7 @@ export function DiagnosticReportForm({
           value: "",
           unit: "",
           isNormal: true,
+          status: ObservationStatus.AMENDED,
           components: {},
         };
       }
@@ -493,6 +470,7 @@ export function DiagnosticReportForm({
           value: "",
           unit: "",
           isNormal: true,
+          status: ObservationStatus.AMENDED,
           components: {},
         };
       }
@@ -530,6 +508,7 @@ export function DiagnosticReportForm({
           value: "",
           unit: "",
           isNormal: true,
+          status: ObservationStatus.AMENDED,
           components: {},
         };
       }
@@ -576,6 +555,106 @@ export function DiagnosticReportForm({
     }
   }
 
+  function formatObservationData(
+    obsData: ObservationValue,
+    definitionId: string,
+  ) {
+    const observationDefinition = observationDefinitions.find(
+      (def) => def.id === definitionId,
+    );
+
+    // If it's a component-based observation (like blood pressure), we should check if components have values
+    const hasComponents =
+      observationDefinition?.component &&
+      observationDefinition.component.length > 0;
+    const hasComponentValues =
+      hasComponents &&
+      Object.values(obsData.components).some(
+        (comp) => comp.value.trim() !== "",
+      );
+
+    // For observations marked for deletion, always include them if they have an ID
+    const isMarkedForDeletion =
+      obsData.status === ObservationStatus.ENTERED_IN_ERROR && obsData.id;
+
+    // For regular observations, skip if no value is entered
+    // For component-based observations, check component values
+    // But always include observations marked for deletion
+    if (!isMarkedForDeletion) {
+      if (!hasComponents && !obsData.value.trim()) {
+        return null;
+      }
+
+      if (hasComponents && !hasComponentValues) {
+        return null;
+      }
+    }
+
+    const value: QuestionnaireSubmitResultValue = {
+      value: obsData.value,
+    };
+
+    if (obsData.unit && observationDefinition?.permitted_unit) {
+      value.unit = {
+        code: obsData.unit,
+        system: observationDefinition.permitted_unit.system,
+        display: observationDefinition.permitted_unit.display || obsData.unit,
+      };
+    }
+
+    // Create observation components if they exist and have values
+    const components: ObservationComponent[] = [];
+
+    if (hasComponents && observationDefinition) {
+      observationDefinition.component.forEach(
+        (componentDef: ObservationDefinitionComponentSpec) => {
+          const componentCode = componentDef.code.code;
+          const componentData = obsData.components[componentCode];
+
+          if (componentData && componentData.value.trim()) {
+            const componentValue: QuestionnaireSubmitResultValue = {
+              value: componentData.value,
+            };
+
+            if (componentData.unit && componentDef.permitted_unit) {
+              componentValue.unit = {
+                code: componentData.unit,
+                system: componentDef.permitted_unit.system,
+                display:
+                  componentDef.permitted_unit.display || componentData.unit,
+              };
+            }
+
+            components.push({
+              code: componentDef.code,
+              value: componentValue,
+              interpretation: componentData.isNormal ? "normal" : "abnormal",
+            });
+          }
+        },
+      );
+    }
+
+    return {
+      ...(obsData.id
+        ? { observation_id: obsData.id }
+        : { observation_definition: definitionId }),
+      observation: {
+        status:
+          obsData.status === ObservationStatus.ENTERED_IN_ERROR
+            ? ObservationStatus.ENTERED_IN_ERROR
+            : ObservationStatus.FINAL,
+        subject_type: "patient",
+        value_type: observationDefinition?.permitted_data_type || "float",
+        effective_datetime: new Date().toISOString(),
+        value,
+        encounter: null,
+        interpretation: obsData.isNormal ? "normal" : "abnormal",
+        component: components.length > 0 ? components : undefined,
+      },
+    };
+  }
+
   function handleSubmit() {
     if (!hasReport) {
       // First create a report if none exists
@@ -587,6 +666,10 @@ export function DiagnosticReportForm({
       // Check if all observations have values
       const hasObservationValue = Object.values(observations).some((obsList) =>
         obsList.some((obs) => {
+          // Skip observations marked as deleted
+          if (obs.status === ObservationStatus.ENTERED_IN_ERROR) {
+            return false;
+          }
           const hasMainValue = obs.value.trim() !== "";
           const hasComponentValue = Object.values(obs.components).some(
             (comp) => comp.value.trim() !== "",
@@ -611,96 +694,7 @@ export function DiagnosticReportForm({
         Object.entries(observations)
           .flatMap(([definitionId, obsList]) =>
             obsList.map((obsData) => {
-              const observationDefinition = observationDefinitions.find(
-                (def) => def.id === definitionId,
-              );
-
-              // If it's a component-based observation (like blood pressure), we should check if components have values
-              const hasComponents =
-                observationDefinition?.component &&
-                observationDefinition.component.length > 0;
-              const hasComponentValues =
-                hasComponents &&
-                Object.values(obsData.components).some(
-                  (comp) => comp.value.trim() !== "",
-                );
-
-              // For regular observations, skip if no value is entered
-              // For component-based observations, check component values
-              if (!hasComponents && !obsData.value.trim()) {
-                return null;
-              }
-
-              if (hasComponents && !hasComponentValues) {
-                return null;
-              }
-
-              const value: QuestionnaireSubmitResultValue = {
-                value: obsData.value,
-              };
-
-              if (obsData.unit && observationDefinition?.permitted_unit) {
-                value.unit = {
-                  code: obsData.unit,
-                  system: observationDefinition.permitted_unit.system,
-                  display:
-                    observationDefinition.permitted_unit.display ||
-                    obsData.unit,
-                };
-              }
-
-              // Create observation components if they exist and have values
-              const components: ObservationComponent[] = [];
-
-              if (hasComponents && observationDefinition) {
-                observationDefinition.component.forEach(
-                  (componentDef: ObservationDefinitionComponentSpec) => {
-                    const componentCode = componentDef.code.code;
-                    const componentData = obsData.components[componentCode];
-
-                    if (componentData && componentData.value.trim()) {
-                      const componentValue: QuestionnaireSubmitResultValue = {
-                        value: componentData.value,
-                      };
-
-                      if (componentData.unit && componentDef.permitted_unit) {
-                        componentValue.unit = {
-                          code: componentData.unit,
-                          system: componentDef.permitted_unit.system,
-                          display:
-                            componentDef.permitted_unit.display ||
-                            componentData.unit,
-                        };
-                      }
-
-                      components.push({
-                        code: componentDef.code,
-                        value: componentValue,
-                        interpretation: componentData.isNormal
-                          ? "normal"
-                          : "abnormal",
-                      });
-                    }
-                  },
-                );
-              }
-
-              return {
-                ...(obsData.id
-                  ? { observation_id: obsData.id }
-                  : { observation_definition: definitionId }),
-                observation: {
-                  status: ObservationStatus.FINAL,
-                  subject_type: "patient",
-                  value_type:
-                    observationDefinition?.permitted_data_type || "float",
-                  effective_datetime: new Date().toISOString(),
-                  value,
-                  encounter: null,
-                  interpretation: obsData.isNormal ? "normal" : "abnormal",
-                  component: components.length > 0 ? components : undefined,
-                },
-              };
+              return formatObservationData(obsData, definitionId);
             }),
           )
           .filter(Boolean) as ObservationFromDefinitionCreate[];
@@ -728,59 +722,163 @@ export function DiagnosticReportForm({
   }
 
   function handleDeleteObservation(definitionId: string, index: number) {
-    setDeleteConfirmation({ definitionId, index });
-  }
-
-  function handleConfirmDelete() {
-    if (!deleteConfirmation) return;
-    const { definitionId, index } = deleteConfirmation;
-
     const observationsList = observations[definitionId];
     if (!observationsList || !observationsList[index]) return;
 
     const observation = observationsList[index];
-    if (!observation.id) {
-      // If the observation hasn't been saved yet, just remove it from the state
-      setObservations((prev) => {
-        const updatedList = [...(prev[definitionId] || [])];
-        updatedList.splice(index, 1);
-        return {
-          ...prev,
-          [definitionId]:
-            updatedList.length > 0
-              ? updatedList
-              : [
-                  {
-                    id: "",
-                    value: "",
-                    unit: "",
-                    isNormal: true,
-                    components: {},
-                  },
-                ],
-        };
-      });
-    } else {
-      // If the observation exists in the backend, mark it as entered_in_error
-      const updatePayload: ObservationFromDefinitionCreate = {
-        observation_id: observation.id,
-        observation: {
+    setObservations((prev) => {
+      const updatedList = [...(prev[definitionId] || [])];
+      let newList = [];
+      if (observation.id) {
+        // For existing observations, mark as ENTERED_IN_ERROR
+        const updatedObservation = {
+          ...observation,
           status: ObservationStatus.ENTERED_IN_ERROR,
-          subject_type: "patient",
-          value_type: "string",
-          effective_datetime: new Date().toISOString(),
-          value: observation.value
-            ? { value: observation.value }
-            : { value: "" },
-        },
+        };
+        newList = updatedList.map((obs, i) =>
+          i === index ? updatedObservation : obs,
+        );
+      } else {
+        // For new observations, remove them from the list
+        newList = updatedList.filter((_, i) => i !== index);
+      }
+      return {
+        ...prev,
+        [definitionId]:
+          newList.length > 0
+            ? newList
+            : [
+                {
+                  id: "",
+                  value: "",
+                  unit: "",
+                  isNormal: true,
+                  status: ObservationStatus.AMENDED,
+                  components: {},
+                },
+              ],
       };
+    });
+  }
 
-      updateObservationStatus({
-        observations: [updatePayload],
-      });
-    }
+  function renderObservationInput(
+    definition: ObservationDefinitionReadSpec,
+    observationData: ObservationValue,
+    index: number,
+    numObservations: number,
+  ) {
+    const hasComponents =
+      definition.component && definition.component.length > 0;
+    const isErrored =
+      observationData.status === ObservationStatus.ENTERED_IN_ERROR;
+    return (
+      <div
+        key={index}
+        className={cn(
+          "space-y-1 bg-gray-200/50 p-4 rounded-lg",
+          isErrored && "bg-gray-100",
+        )}
+      >
+        <div className="flex justify-between items-center">
+          <Label className="text-sm font-semibold text-gray-950">
+            {t("observation") + " " + (index + 1)}
+          </Label>
+          {isErrored ? (
+            <span className="text-sm text-red-500">
+              {t("marked_for_deletion")}
+            </span>
+          ) : (
+            numObservations > 1 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive hover:bg-destructive/10 ml-2"
+                onClick={() => handleDeleteObservation(definition.id, index)}
+                disabled={isErrored}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            )
+          )}
+        </div>
 
-    setDeleteConfirmation(null);
+        {/* For blood pressure and similar observations with components, we may or may not need to show the main value field */}
+        {(!hasComponents || definition.permitted_data_type !== "quantity") && (
+          <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4 items-stretch sm:items-center">
+            {definition.permitted_unit && (
+              <div className="w-full sm:w-32">
+                <Label className="text-sm font-medium mb-1 block text-gray-700">
+                  {t("unit")}
+                </Label>
+                <Select
+                  value={observationData.unit}
+                  onValueChange={(unit) =>
+                    handleUnitChange(definition.id, index, unit)
+                  }
+                  disabled={isErrored}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("unit")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={definition.permitted_unit.code}>
+                      {definition.permitted_unit.display ||
+                        definition.permitted_unit.code}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <div className="flex-1">
+              <Label className="text-sm font-medium mb-1 block text-gray-700">
+                {t("result")}
+              </Label>
+              <Input
+                value={observationData.value}
+                onChange={(e) =>
+                  handleValueChange(definition.id, index, e.target.value)
+                }
+                placeholder={t("result_value")}
+                type={
+                  definition.permitted_data_type === "decimal" ||
+                  definition.permitted_data_type === "integer"
+                    ? "number"
+                    : "text"
+                }
+                disabled={isErrored}
+              />
+            </div>
+
+            <div className="flex items-center space-x-2 sm:pt-6">
+              <Checkbox
+                id={`abnormal-checkbox-${definition.id}-${index}`}
+                checked={!observationData.isNormal}
+                onCheckedChange={(checked) =>
+                  handleNormalChange(
+                    definition.id,
+                    index,
+                    !checked, // isNormal is the opposite of checked (isAbnormal)
+                  )
+                }
+                disabled={isErrored}
+              />
+              <Label
+                htmlFor={`abnormal-checkbox-${definition.id}-${index}`}
+                className="text-sm font-medium text-gray-700 cursor-pointer"
+              >
+                {t("abnormal")}
+              </Label>
+            </div>
+          </div>
+        )}
+
+        {/* Render component inputs for multi-component observations */}
+        {hasComponents &&
+          renderComponentInputs(definition, observationData, index)}
+      </div>
+    );
   }
 
   // Helper to render component inputs for multi-component observations like blood pressure
@@ -792,24 +890,11 @@ export function DiagnosticReportForm({
     if (!definition.component || definition.component.length === 0) {
       return null;
     }
+    const isErrored =
+      observationData.status === ObservationStatus.ENTERED_IN_ERROR;
 
     return (
       <div className="space-y-2">
-        <Separator />
-        <div className="flex justify-between items-center">
-          <Label className="text-base font-semibold">
-            {t("observation") + " " + (index + 1)}
-          </Label>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => handleDeleteObservation(definition.id, index)}
-            disabled={isUpdatingStatus}
-          >
-            <Trash2 className="size-4" />
-          </Button>
-        </div>
         {definition.component.map((component, componentIndex) => {
           const componentData = observationData.components[
             component.code.code
@@ -821,7 +906,7 @@ export function DiagnosticReportForm({
 
           return (
             <div key={component.code.code}>
-              <Label className="text-sm/10 font-semibold mb-1 block text-gray-950">
+              <Label className="text-sm/10 mb-1 block text-gray-950">
                 {componentIndex + 1}.{" "}
                 {component.code.display || component.code.code}
               </Label>
@@ -841,6 +926,7 @@ export function DiagnosticReportForm({
                           unit,
                         )
                       }
+                      disabled={isErrored}
                     >
                       <SelectTrigger className="w-full">
                         {componentData.unit ? (
@@ -887,6 +973,7 @@ export function DiagnosticReportForm({
                         ? "number"
                         : "text"
                     }
+                    disabled={isErrored}
                   />
                 </div>
 
@@ -902,10 +989,11 @@ export function DiagnosticReportForm({
                         !checked, // isNormal is the opposite of checked (isAbnormal)
                       )
                     }
+                    disabled={isErrored}
                   />
                   <Label
                     htmlFor={`abnormal-checkbox-${definition.id}-${component.code.code}-${index}`}
-                    className="text-sm font-medium text-gray-950 cursor-pointer"
+                    className="text-sm font-normal text-gray-950 cursor-pointer"
                   >
                     {t("abnormal")}
                   </Label>
@@ -914,6 +1002,7 @@ export function DiagnosticReportForm({
             </div>
           );
         })}
+        <Separator className="mt-4" />
       </div>
     );
   }
@@ -1012,14 +1101,13 @@ export function DiagnosticReportForm({
               <div className="space-y-6">
                 {fullReport.status !== DiagnosticReportStatus.final &&
                   observationDefinitions.map((definition) => {
-                    const hasComponents =
-                      definition.component && definition.component.length > 0;
                     const observationsList = observations[definition.id] || [
                       {
                         id: "",
                         value: "",
                         unit: "",
                         isNormal: true,
+                        status: ObservationStatus.AMENDED,
                         components: {},
                       },
                     ];
@@ -1037,119 +1125,14 @@ export function DiagnosticReportForm({
                               </Label>
                             </div>
 
-                            {observationsList.map((observationData, index) => (
-                              <div key={index} className="space-y-4">
-                                {/* For blood pressure and similar observations with components, we may or may not need to show the main value field */}
-                                {(!hasComponents ||
-                                  definition.permitted_data_type !==
-                                    "quantity") && (
-                                  <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4 items-stretch sm:items-center">
-                                    {definition.permitted_unit && (
-                                      <div className="w-full sm:w-32">
-                                        <Label className="text-sm font-medium mb-1 block text-gray-700">
-                                          {t("unit")}
-                                        </Label>
-                                        <Select
-                                          value={observationData.unit}
-                                          onValueChange={(unit) =>
-                                            handleUnitChange(
-                                              definition.id,
-                                              index,
-                                              unit,
-                                            )
-                                          }
-                                        >
-                                          <SelectTrigger className="w-full">
-                                            <SelectValue
-                                              placeholder={t("unit")}
-                                            />
-                                          </SelectTrigger>
-                                          <SelectContent>
-                                            <SelectItem
-                                              value={
-                                                definition.permitted_unit.code
-                                              }
-                                            >
-                                              {definition.permitted_unit
-                                                .display ||
-                                                definition.permitted_unit.code}
-                                            </SelectItem>
-                                          </SelectContent>
-                                        </Select>
-                                      </div>
-                                    )}
-
-                                    <div className="flex-1">
-                                      <Label className="text-sm font-medium mb-1 block text-gray-700">
-                                        {t("result")}
-                                      </Label>
-                                      <Input
-                                        value={observationData.value}
-                                        onChange={(e) =>
-                                          handleValueChange(
-                                            definition.id,
-                                            index,
-                                            e.target.value,
-                                          )
-                                        }
-                                        placeholder={t("result_value")}
-                                        type={
-                                          definition.permitted_data_type ===
-                                            "decimal" ||
-                                          definition.permitted_data_type ===
-                                            "integer"
-                                            ? "number"
-                                            : "text"
-                                        }
-                                      />
-                                    </div>
-
-                                    <div className="flex items-center space-x-2 sm:pt-6">
-                                      <Checkbox
-                                        id={`abnormal-checkbox-${definition.id}-${index}`}
-                                        checked={!observationData.isNormal}
-                                        onCheckedChange={(checked) =>
-                                          handleNormalChange(
-                                            definition.id,
-                                            index,
-                                            !checked, // isNormal is the opposite of checked (isAbnormal)
-                                          )
-                                        }
-                                      />
-                                      <Label
-                                        htmlFor={`abnormal-checkbox-${definition.id}-${index}`}
-                                        className="text-sm font-medium text-gray-700 cursor-pointer"
-                                      >
-                                        {t("abnormal")}
-                                      </Label>
-                                      <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="sm"
-                                        className="text-destructive hover:text-destructive hover:bg-destructive/10 ml-2"
-                                        onClick={() =>
-                                          handleDeleteObservation(
-                                            definition.id,
-                                            index,
-                                          )
-                                        }
-                                        disabled={isUpdatingStatus}
-                                      >
-                                        <Trash2 className="size-4" />
-                                      </Button>
-                                    </div>
-                                  </div>
-                                )}
-
-                                {/* Render component inputs for multi-component observations */}
-                                {hasComponents &&
-                                  renderComponentInputs(
-                                    definition,
-                                    observationData,
-                                    index,
-                                  )}
-                              </div>
-                            ))}
+                            {observationsList.map((observationData, index) =>
+                              renderObservationInput(
+                                definition,
+                                observationData,
+                                index,
+                                observationsList.length,
+                              ),
+                            )}
 
                             {/* Add button for multiple observations */}
                             <Button
@@ -1159,6 +1142,7 @@ export function DiagnosticReportForm({
                               onClick={() => {
                                 setObservations((prev) => {
                                   const currentList = prev[definition.id] || [];
+
                                   return {
                                     ...prev,
                                     [definition.id]: [
@@ -1168,6 +1152,7 @@ export function DiagnosticReportForm({
                                         value: "",
                                         unit: "",
                                         isNormal: true,
+                                        status: ObservationStatus.AMENDED,
                                         components: {},
                                       },
                                     ],
@@ -1370,19 +1355,6 @@ export function DiagnosticReportForm({
         fileUpload={fileUpload}
         associatingId={fullReport?.id || ""}
         type="diagnostic_report"
-      />
-
-      <ConfirmActionDialog
-        open={deleteConfirmation !== null}
-        onOpenChange={(open) => {
-          if (!open) setDeleteConfirmation(null);
-        }}
-        title={t("delete_observation")}
-        description={t("observation_delete_confirmation")}
-        onConfirm={handleConfirmDelete}
-        confirmText={t("delete")}
-        cancelText={t("cancel")}
-        variant="destructive"
       />
     </Card>
   );


### PR DESCRIPTION
## Proposed Changes

- Adjusted logic for deleting observations
   -  removed existing logic with upsert/only delete locally until user saves (similar to what we do elsewhere, like in allergies)
- added minor styling/layout adjustments for observations with components
- TODO: Once observation interpretation is added, layout need to be cleaned up a bit more.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add multiple results for the same test, each with its own units and abnormal checkbox.
  - Component-based tests get dedicated inputs (e.g., blood pressure).
  - Mark individual results for deletion; marked entries are clearly labeled and inputs disabled.

- Refactor
  - Simplified deletion flow: no confirmation dialog; existing results are marked for deletion and unsaved ones are removed instantly.
  - Consolidated, cleaner result-entry UI with indexed headers for multiple results.
  - New in-app message clarifies when a result is marked for deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->