### PR TITLE
fixed slug error

### DIFF
--- a/src/components/ValueSet/ValueSetEditor.tsx
+++ b/src/components/ValueSet/ValueSetEditor.tsx
@@ -1,9 +1,9 @@
+import { FormSkeleton } from "@/components/Common/SkeletonLoading";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { navigate } from "raviger";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-
-import { FormSkeleton } from "@/components/Common/SkeletonLoading";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
@@ -25,6 +25,9 @@ interface ValueSetEditorProps {
 export function ValueSetEditor({ slug, onSuccess }: ValueSetEditorProps) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
+  const [serverErrors, setServerErrors] = useState<Record<string, string[]>>(
+    {},
+  );
   // Fetch existing valueset if we're editing
   const { data: existingValueset, isLoading } = useQuery({
     queryKey: ["valueset", slug],
@@ -41,6 +44,11 @@ export function ValueSetEditor({ slug, onSuccess }: ValueSetEditorProps) {
       toast.success(t("valueset_created"));
       queryClient.invalidateQueries({ queryKey: ["valuesets"] });
       onSuccess?.(data);
+    },
+    onError: (error: { response?: { data?: Record<string, string[]> } }) => {
+      if (error.response?.data) {
+        setServerErrors(error.response.data);
+      }
     },
   });
 
@@ -88,6 +96,7 @@ export function ValueSetEditor({ slug, onSuccess }: ValueSetEditorProps) {
           onSubmit={handleSubmit}
           isSubmitting={createMutation.isPending || updateMutation.isPending}
           isSystemDefined={existingValueset?.is_system_defined}
+          serverErrors={serverErrors}
         />
       )}
     </div>

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon, TrashIcon } from "@radix-ui/react-icons";
+import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as z from "zod";
@@ -44,6 +45,7 @@ interface ValueSetFormProps {
   onSubmit: (data: ValuesetFormType) => void;
   isSubmitting?: boolean;
   isSystemDefined?: boolean;
+  serverErrors?: Record<string, string[]>;
 }
 
 function ConceptFields({
@@ -304,6 +306,7 @@ export function ValueSetForm({
   onSubmit,
   isSubmitting,
   isSystemDefined,
+  serverErrors,
 }: ValueSetFormProps) {
   const { t } = useTranslation();
   const valuesetFormSchema = z.object({
@@ -381,6 +384,17 @@ export function ValueSetForm({
       },
     },
   });
+
+  useEffect(() => {
+    if (serverErrors) {
+      Object.entries(serverErrors).forEach(([field, messages]) => {
+        form.setError(field as keyof ValuesetFormType, {
+          type: "server",
+          message: messages.join(", "),
+        });
+      });
+    }
+  }, [serverErrors, form]);
 
   return (
     <Form {...form}>


### PR DESCRIPTION
## Proposed Changes

Fixes #13501 
- Added an onError handler to the createMutation in ValueSetEditor.tsx to handle API errors.
- Used a useState hook to store server errors and passed them as a prop to the ValueSetForm component.
- Implemented a useEffect hook in ValueSetForm.tsx to display server-side validation errors directly under the slug input field.



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Server-side validation errors are now displayed in the Value Set form, mapped to the relevant fields with clear messages.
  - Improved feedback during create/update flows without changing existing client-side validation behavior.

- Bug Fixes
  - Resolved silent failures during Value Set creation by capturing API validation errors and showing them in the form.
  - Ensures users are informed of server-side issues instead of proceeding without visible error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->