### PR TITLE
Fixed 404 GET calls being made when facilityId is undefined

### DIFF
--- a/src/Routers/routes/FacilityRoutes.tsx
+++ b/src/Routers/routes/FacilityRoutes.tsx
@@ -56,21 +56,31 @@ const FacilityRoutes: AppRoutes = {
     />
   ),
 
-  "/facility/:facilityId/patient/:patientId/diagnostic_reports/:diagnosticReportId":
-    ({ facilityId, patientId, diagnosticReportId }) => (
+  ...[
+    "/facility/:facilityId/patient/:patientId/diagnostic_reports/:diagnosticReportId",
+    "/organization/organizationId/patient/:patientId/diagnostic_reports/:diagnosticReportId",
+  ].reduce((acc: AppRoutes, path) => {
+    acc[path] = ({ facilityId, patientId, diagnosticReportId }) => (
       <DiagnosticReportView
         patientId={patientId}
         facilityId={facilityId}
         diagnosticReportId={diagnosticReportId}
       />
-    ),
-  "/facility/:facilityId/patient/:patientId/diagnostic_reports/:diagnosticReportId/print":
-    ({ patientId, diagnosticReportId }) => (
+    );
+    return acc;
+  }, {}),
+  ...[
+    "/facility/:facilityId/patient/:patientId/diagnostic_reports/:diagnosticReportId/print",
+    "/organization/organizationId/patient/:patientId/diagnostic_reports/:diagnosticReportId/print",
+  ].reduce((acc: AppRoutes, path) => {
+    acc[path] = ({ patientId, diagnosticReportId }) => (
       <DiagnosticReportPrint
         patientId={patientId}
         diagnosticReportId={diagnosticReportId}
       />
-    ),
+    );
+    return acc;
+  }, {}),
   "/facility/:facilityId/billing/accounts": ({ facilityId }) => (
     <AccountList facilityId={facilityId} />
   ),

--- a/src/Routers/routes/PatientRoutes.tsx
+++ b/src/Routers/routes/PatientRoutes.tsx
@@ -63,16 +63,24 @@ const PatientRoutes: AppRoutes = {
       locationId={locationId}
     />
   ),
-  "/facility/:facilityId/patient/:patientId/encounter/:encounterId/consents/:consentId":
-    ({ facilityId, patientId, encounterId, consentId }) => (
-      <EncounterProvider
-        encounterId={encounterId}
-        patientId={patientId}
-        facilityId={facilityId}
-      >
-        <ConsentDetailPage consentId={consentId} />
-      </EncounterProvider>
-    ),
+  ...[
+    "/facility/:facilityId/patient/:patientId/encounter/:encounterId/consents/:consentId",
+    "/organization/organizationId/patient/:patientId/encounter/:encounterId/consents/:consentId",
+  ].reduce((acc: AppRoutes, path) => {
+    acc[path] = ({ facilityId, patientId, encounterId, consentId }) => {
+      return (
+        <EncounterProvider
+          encounterId={encounterId}
+          patientId={patientId}
+          facilityId={facilityId}
+        >
+          <ConsentDetailPage consentId={consentId} />
+        </EncounterProvider>
+      );
+    };
+    return acc;
+  }, {}),
+
   "/facility/:facilityId/patients/verify": () => <VerifyPatient />,
   "/patient/:id": ({ id }) => <PatientHome id={id} page="demography" />,
   "/patient/:id/update": ({ id }) => <PatientRegistration patientId={id} />,

--- a/src/pages/Encounters/ConsentDetail.tsx
+++ b/src/pages/Encounters/ConsentDetail.tsx
@@ -1,12 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import {
-  AlertCircle,
-  ArrowLeft,
-  ChevronLeft,
-  Download,
-  FileText,
-} from "lucide-react";
+import { AlertCircle, ChevronLeft, Download, FileText } from "lucide-react";
 import { Link } from "raviger";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -18,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 
+import BackButton from "@/components/Common/BackButton";
 import Loading from "@/components/Common/Loading";
 import Page from "@/components/Common/Page";
 import ConsentFormSheet from "@/components/Consent/ConsentFormSheet";
@@ -138,13 +133,7 @@ export function ConsentDetailPage({ consentId }: ConsentDetailPageProps) {
 
   return (
     <div>
-      <Link
-        href={`/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/consents`}
-        className="flex items-center hover:underline md:px-6"
-      >
-        <ArrowLeft className="size-4" />
-        {t("back")}
-      </Link>
+      <BackButton />
       <Page title="">
         <div className="container mx-auto py-4">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/pages/Encounters/tabs/consents.tsx
+++ b/src/pages/Encounters/tabs/consents.tsx
@@ -20,6 +20,7 @@ import useFilters from "@/hooks/useFilters";
 import query from "@/Utils/request/query";
 import { formatDateTime } from "@/Utils/utils";
 import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
+import { buildEncounterUrl } from "@/pages/Encounters/utils/utils";
 import { ConsentModel } from "@/types/consent/consent";
 import consentApi from "@/types/consent/consentApi";
 
@@ -153,7 +154,11 @@ function ConsentCard({
           className="w-full justify-center items-center gap-2 rounded-t-none"
           onClick={() =>
             navigate(
-              `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/consents/${consentId}`,
+              buildEncounterUrl(
+                patientId,
+                `/encounter/${encounterId}/consents/${consentId}`,
+                facilityId,
+              ),
             )
           }
         >

--- a/src/pages/Encounters/tabs/devices.tsx
+++ b/src/pages/Encounters/tabs/devices.tsx
@@ -57,6 +57,7 @@ export const EncounterDevicesTab = () => {
         limit,
       },
     }),
+    enabled: !!facilityId,
   });
 
   const { mutate: disassociateDevice, isPending: isDisassociating } =

--- a/src/pages/Encounters/tabs/diagnostic-reports.tsx
+++ b/src/pages/Encounters/tabs/diagnostic-reports.tsx
@@ -30,6 +30,7 @@ import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 import query from "@/Utils/request/query";
 import { Badge } from "@/components/ui/badge";
 import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
+import { buildEncounterUrl } from "@/pages/Encounters/utils/utils";
 import { DIAGNOSTIC_REPORT_STATUS_COLORS } from "@/types/emr/diagnosticReport/diagnosticReport";
 import diagnosticReportApi from "@/types/emr/diagnosticReport/diagnosticReportApi";
 
@@ -86,7 +87,11 @@ export const EncounterDiagnosticReportsTab = () => {
                         >
                           <TableCell className="font-medium">
                             <Link
-                              href={`/facility/${facilityId}/patient/${patientId}/diagnostic_reports/${report.id}`}
+                              href={buildEncounterUrl(
+                                patientId,
+                                `/diagnostic_reports/${report.id}`,
+                                facilityId,
+                              )}
                               className="group flex items-start gap-1"
                             >
                               <div>
@@ -129,7 +134,11 @@ export const EncounterDiagnosticReportsTab = () => {
                                       size="icon"
                                       onClick={() =>
                                         navigate(
-                                          `/facility/${facilityId}/patient/${patientId}/diagnostic_reports/${report.id}`,
+                                          buildEncounterUrl(
+                                            patientId,
+                                            `/diagnostic_reports/${report.id}`,
+                                            facilityId,
+                                          ),
                                         )
                                       }
                                     >

--- a/src/pages/Encounters/tabs/service-requests.tsx
+++ b/src/pages/Encounters/tabs/service-requests.tsx
@@ -57,6 +57,7 @@ export const EncounterServiceRequestTab = () => {
         ordering: "-created_date",
       },
     }),
+    enabled: !!facilityId,
   });
 
   const handleClearPriority = () => {
@@ -94,7 +95,7 @@ export const EncounterServiceRequestTab = () => {
             value={qParams.status || ""}
             onValueChange={(value) => updateQuery({ status: value })}
             options={Object.values(Status)}
-            label="status"
+            label={t("status")}
             onClear={handleClearStatus}
           />
         </div>
@@ -104,7 +105,7 @@ export const EncounterServiceRequestTab = () => {
             value={qParams.priority || ""}
             onValueChange={(value) => updateQuery({ priority: value })}
             options={Object.values(Priority)}
-            label="priority"
+            label={t("priority")}
             onClear={handleClearPriority}
           />
         </div>

--- a/src/pages/Encounters/utils/utils.tsx
+++ b/src/pages/Encounters/utils/utils.tsx
@@ -1,0 +1,10 @@
+export const buildEncounterUrl = (
+  patientId: string,
+  subPath: string,
+  facilityId?: string,
+) => {
+  if (facilityId) {
+    return `/facility/${facilityId}/patient/${patientId}${subPath}`;
+  }
+  return `/organization/organizationId/patient/${patientId}${subPath}`;
+};


### PR DESCRIPTION
## Proposed Changes

Fixes #13590
- Changed `Devices` and `Service Requests` tab list call to only be made when `facilityId` is present since there is no organization support from API yet.
- Changed URL to use `organization/organizationId` when navigating to consents / diagnostic reports from Organization instead of `facility/{facilityId}`. This makes it so there is no `undefined` in URL.


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added organization-level routes for consent details and diagnostic report view/print.
  - Introduced a consistent BackButton on the consent detail page.

- Improvements
  - Centralized encounter URL generation for consistent navigation across pages.
  - Updated mobile filter labels to use translations for status and priority.

- Bug Fixes
  - Prevented devices and service requests from fetching before a facility is selected, reducing unnecessary loading and potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->