### PR TITLE
Fix: Update password button enabled prematurely 

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2709,6 +2709,7 @@
   "new_password": "New Password",
   "new_password_confirmation": "Confirm New Password",
   "new_password_same_as_old": "Your new password <strong>must not match the old password </strong> ",
+  "new_password_same_as_old_plain": "Your new password must not match the old password",
   "new_password_validation": "New password is not valid.",
   "new_section": "New Section",
   "new_service_request": "New Request",

--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -65,6 +65,7 @@ export default function UserResetPassword({
 
   const form = useForm({
     resolver: zodResolver(PasswordSchema),
+    mode: "onSubmit",
     defaultValues: {
       old_password: "",
       new_password_1: "",
@@ -225,7 +226,7 @@ export default function UserResetPassword({
               </Button>
               <Button
                 type="submit"
-                disabled={!form.formState.isDirty || isPending}
+                disabled={!form.formState.isValid || isPending}
                 variant="primary"
               >
                 {isPending && (

--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -66,7 +66,6 @@ export default function UserResetPassword({
   const form = useForm({
     mode: "onSubmit",
     resolver: zodResolver(PasswordSchema),
-    mode: "onSubmit",
     defaultValues: {
       old_password: "",
       new_password_1: "",

--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -64,6 +64,7 @@ export default function UserResetPassword({
     });
 
   const form = useForm({
+    mode: "onSubmit",
     resolver: zodResolver(PasswordSchema),
     defaultValues: {
       old_password: "",
@@ -89,6 +90,11 @@ export default function UserResetPassword({
     };
     resetPassword(form);
   };
+
+  const allFieldsFilled =
+    form.watch("old_password") &&
+    form.watch("new_password_1") &&
+    form.watch("new_password_2");
 
   return (
     <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow-sm sm:rounded-lg sm:px-6 sm:py-6">
@@ -225,7 +231,7 @@ export default function UserResetPassword({
               </Button>
               <Button
                 type="submit"
-                disabled={!form.formState.isDirty || isPending}
+                disabled={!allFieldsFilled || isPending}
                 variant="primary"
               >
                 {isPending && (

--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -91,6 +91,11 @@ export default function UserResetPassword({
     resetPassword(form);
   };
 
+  const allFieldsFilled =
+    form.watch("old_password") &&
+    form.watch("new_password_1") &&
+    form.watch("new_password_2");
+
   return (
     <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow-sm sm:rounded-lg sm:px-6 sm:py-6">
       {!isEditing && (
@@ -226,7 +231,7 @@ export default function UserResetPassword({
               </Button>
               <Button
                 type="submit"
-                disabled={!form.formState.isValid || isPending}
+                disabled={!allFieldsFilled || isPending}
                 variant="primary"
               >
                 {isPending && (

--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -22,8 +22,8 @@ import { PasswordInput } from "@/components/ui/input-password";
 import { ValidationHelper } from "@/components/Users/UserFormValidations";
 import { UpdatePasswordForm } from "@/components/Users/models";
 
+import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
-import authApi from "@/types/auth/authApi";
 import { UserReadMinimal } from "@/types/user/user";
 
 export default function UserResetPassword({
@@ -59,12 +59,12 @@ export default function UserResetPassword({
       path: ["new_password_2"],
     })
     .refine((values) => values.new_password_1 !== values.old_password, {
-      message: t("new_password_same_as_old"),
+      message: t("new_password_same_as_old_plain"),
       path: ["new_password_1"],
     });
 
   const form = useForm({
-    mode: "onSubmit",
+    mode: "onChange",
     resolver: zodResolver(PasswordSchema),
     defaultValues: {
       old_password: "",
@@ -72,8 +72,8 @@ export default function UserResetPassword({
       new_password_2: "",
     },
   });
-  const { mutate: updatePassword, isPending } = useMutation({
-    mutationFn: mutate(authApi.updatePassword),
+  const { mutate: resetPassword, isPending } = useMutation({
+    mutationFn: mutate(routes.updatePassword),
     onSuccess: () => {
       toast.success(t("password_updated"));
       form.reset();
@@ -88,13 +88,8 @@ export default function UserResetPassword({
       username: userData.username,
       new_password: formData.new_password_1,
     };
-    updatePassword(form);
+    resetPassword(form);
   };
-
-  const allFieldsFilled =
-    form.watch("old_password") &&
-    form.watch("new_password_1") &&
-    form.watch("new_password_2");
 
   return (
     <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow-sm sm:rounded-lg sm:px-6 sm:py-6">
@@ -231,7 +226,7 @@ export default function UserResetPassword({
               </Button>
               <Button
                 type="submit"
-                disabled={!allFieldsFilled || isPending}
+                disabled={!form.formState.isValid || isPending}
                 variant="primary"
               >
                 {isPending && (

--- a/src/components/Users/UserResetPassword.tsx
+++ b/src/components/Users/UserResetPassword.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
 


### PR DESCRIPTION
## Proposed Changes

Fixes [#13542 ](https://github.com/ohcnetwork/care_fe/issues/13542)

- Enable "Update Password" button only when all three fields (Current, New, Confirm) are filled.
- Updated form mode to onSubmit to control when validation messages appear.

https://github.com/user-attachments/assets/b9420896-203b-4043-ab43-ef71cab80e54

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset Password form now requires all password fields to be valid before enabling Submit, preventing partial submissions.
  * Validation runs in real time as you edit fields for faster feedback.
  * New-password-equals-old is now a blocking validation and shows an updated plain-text translated warning.
  * Submit button disables when the form is invalid and shows a loading spinner while the request is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->