### PR TITLE
sticky button added in medication history sheet

### DIFF
--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -465,7 +465,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
           {isLoadingRecords && <Skeleton className="h-8 w-full" />}
         </div>
 
-        <div className="flex flex-col gap-2 p-4 border-t">
+        <div className="sticky bottom-0 bg-white flex flex-col gap-2 p-4 border-t">
           {state.dateGroupedRecords.length > 0 &&
             (isLoadingRecords ? (
               <div className="flex justify-center p-4">


### PR DESCRIPTION
## Proposed Changes

Fixes #13599 

<img width="1601" height="923" alt="Screenshot 2025-09-03 152025" src="https://github.com/user-attachments/assets/16020b6f-8794-478c-8ea2-84b9461a4178" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bottom action panel in HistoricalRecordSelector is now sticky and stays visible while scrolling.
  * Panel displays the count of selected records for the active type.
  * Added a Load More control when additional records are available.
  * Consolidated actions (Cancel and Add Selected) into the sticky panel.
  * Improved loading experience by keeping relevant controls and information accessible during data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->