### PR TITLE
Made UI responsive for smaller screen for To Dispatch page

### DIFF
--- a/src/pages/Facility/services/inventory/internalTransfer/ToDispatch.tsx
+++ b/src/pages/Facility/services/inventory/internalTransfer/ToDispatch.tsx
@@ -72,7 +72,7 @@ export default function ToDispatch({ facilityId, locationId }: Props) {
         </div>
 
         <Tabs value={currentTab} onValueChange={handleTabChange}>
-          <TabsList className="w-full justify-start border-b border-gray-200 bg-transparent p-0 h-auto rounded-none">
+          <TabsList className="w-full justify-start border-b border-gray-200 bg-transparent p-0 h-auto rounded-none overflow-x-auto">
             <TabsTrigger
               value="requests_to_dispatch"
               className="border-0 border-b-2 border-transparent px-4 py-2 text-gray-600 hover:text-gray-900 data-[state=active]:text-primary-800 data-[state=active]:border-primary-700 data-[state=active]:bg-transparent data-[state=active]:shadow-none rounded-none"

--- a/src/pages/Facility/services/inventory/internalTransfer/ToDispatchSupplyRequestTable.tsx
+++ b/src/pages/Facility/services/inventory/internalTransfer/ToDispatchSupplyRequestTable.tsx
@@ -102,7 +102,7 @@ export default function ToDispatchSupplyRequestTable({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-4">
+      <div className="flex flex-col md:flex-row items-center gap-4">
         <ProductKnowledgeSelect
           value={selectedProduct}
           onChange={(product) => updateQuery({ item: product?.id })}


### PR DESCRIPTION
## Proposed Changes

Fixes #13587 
- Added overflow-x-auto to TabList
- Made the buttons stack in mobile screens


https://github.com/user-attachments/assets/efe13b83-66a9-479d-bf5c-968e3750f06b



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Tab list now supports horizontal scrolling when content overflows, improving usability on smaller screens.
  * Supply request table controls now use a responsive layout: stacked vertically on small screens and arranged horizontally on medium and larger screens for better readability and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->