### PR TITLE
Handle patient fallback in EncounterProvider

### DIFF
--- a/src/pages/Encounters/utils/EncounterProvider.tsx
+++ b/src/pages/Encounters/utils/EncounterProvider.tsx
@@ -88,6 +88,7 @@ export function EncounterProvider({
     queryKey: ["patient", patientId],
     queryFn: query(patientApi.getPatient, {
       pathParams: { id: patientId },
+      silent: true,
     }),
   });
 
@@ -181,7 +182,7 @@ export function EncounterProvider({
         patientId,
         primaryEncounterId,
         selectedEncounterId,
-        patient,
+        patient: patient ?? primaryEncounter?.patient,
         primaryEncounter,
         selectedEncounter,
         isPatientLoading,


### PR DESCRIPTION
## Proposed Changes


This pull request introduces two small but meaningful improvements to the `EncounterProvider` component. The first change ensures that the patient query runs silently, and the second change improves the robustness of the patient data provided to consumers of the context.

- Query Behavior:
  * The patient query now includes the `silent: true` option, which suppresses loading indicators or notifications during data fetching.

- Patient Data Handling:
  * The `patient` value passed to the context now falls back to `primaryEncounter?.patient` if the direct patient data is unavailable, making the context more resilient to missing patient information.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] ~Add specs that demonstrate the bug or test the new feature~
- [ ] ~Update [product documentation](https://docs.ohc.network).~
- [X] Ensure that UI text is placed in I18n files.
- [ ] ~Prepare a screenshot or demo video for the changelog entry and attach it to the issue.~
- [X] Request peer reviews.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of patient details in Encounters by falling back to the encounter’s patient when direct patient data hasn’t loaded yet.
  * Reduced distracting loading errors/toasts when fetching patient information for an encounter.

* **Refactor**
  * Streamlined patient data handling within Encounters to provide a more consistent experience during initial load and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->