### PR TITLE
Fix: Update the permission checks for bookings

### DIFF
--- a/src/common/Permissions.tsx
+++ b/src/common/Permissions.tsx
@@ -63,13 +63,12 @@ export const PERMISSION_SUBMIT_QUESTIONNAIRE = "can_submit_questionnaire";
 export const PERMISSION_MANAGE_QUESTIONNAIRE = "can_manage_questionnaire";
 
 // Appointment Permissions
-export const PERMISSION_LIST_USER_BOOKING = "can_list_user_booking";
-export const PERMISSION_WRITE_USER_BOOKING = "can_write_user_booking";
-export const PERMISSION_CREATE_APPOINTMENT = "can_create_appointment";
+export const PERMISSION_LIST_BOOKING = "can_list_booking";
+export const PERMISSION_WRITE_BOOKING = "can_write_booking";
 
 // Schedule Permissions
-export const PERMISSION_WRITE_USER_SCHEDULE = "can_write_user_schedule";
-export const PERMISSION_LIST_USER_SCHEDULE = "can_list_user_schedule";
+export const PERMISSION_WRITE_SCHEDULE = "can_write_schedule";
+export const PERMISSION_LIST_SCHEDULE = "can_list_schedule";
 
 // User Permissions
 export const PERMISSION_CREATE_USER = "can_create_user";
@@ -169,12 +168,10 @@ export interface Permissions {
   canManageQuestionnaire: boolean;
 
   // Appointment Permissions
-  /** Permission slug: "can_list_user_booking" */
+  /** Permission slug: "can_list_booking" */
   canViewAppointments: boolean;
-  /** Permission slug: "can_write_user_booking" */
-  canUpdateAppointment: boolean;
-  /** Permission slug: "can_create_appointment" */
-  canCreateAppointment: boolean;
+  /** Permission slug: "can_write_booking" */
+  canWriteAppointment: boolean;
 
   // Schedule Permissions
   /** Permission slug: "can_write_user_schedule" */
@@ -336,25 +333,12 @@ export function getPermissions(
     ),
 
     // Appointments
-    canViewAppointments: hasPermission(
-      PERMISSION_LIST_USER_BOOKING,
-      permissions,
-    ),
-    canUpdateAppointment: hasPermission(
-      PERMISSION_WRITE_USER_BOOKING,
-      permissions,
-    ),
-    canCreateAppointment: hasPermission(
-      PERMISSION_CREATE_APPOINTMENT,
-      permissions,
-    ),
+    canViewAppointments: hasPermission(PERMISSION_LIST_BOOKING, permissions),
+    canWriteAppointment: hasPermission(PERMISSION_WRITE_BOOKING, permissions),
 
     // Schedules and Availability
-    canWriteSchedule: hasPermission(
-      PERMISSION_WRITE_USER_SCHEDULE,
-      permissions,
-    ),
-    canViewSchedule: hasPermission(PERMISSION_LIST_USER_SCHEDULE, permissions),
+    canWriteSchedule: hasPermission(PERMISSION_WRITE_SCHEDULE, permissions),
+    canViewSchedule: hasPermission(PERMISSION_LIST_SCHEDULE, permissions),
 
     // User
     canCreateUser: hasPermission(PERMISSION_CREATE_USER, permissions),

--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -50,7 +50,7 @@ export const PatientHome = (props: {
     hasPermission,
   );
 
-  const { canCreateAppointment } = getPermissions(
+  const { canWriteAppointment } = getPermissions(
     hasPermission,
     patientData?.permissions ?? [],
   );
@@ -72,7 +72,7 @@ export const PatientHome = (props: {
       title={t("patient_details")}
       options={
         <>
-          {facilityId && canCreateAppointment && (
+          {facilityId && canWriteAppointment && (
             <Button asChild variant="primary">
               <Link
                 href={`/facility/${facilityId}/patient/${id}/book-appointment`}

--- a/src/components/ui/sidebar/facility/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility/facility-nav.tsx
@@ -24,7 +24,7 @@ function generateFacilityLinks(
   permissions: {
     canViewAppointments: boolean;
     canListEncounters: boolean;
-    canCreateAppointment: boolean;
+    canWriteAppointment: boolean;
     canCreateEncounter: boolean;
     canViewEncounter: boolean;
   },
@@ -59,7 +59,7 @@ function generateFacilityLinks(
       url: `${baseUrl}/patients`,
       icon: <CareIcon icon="d-patient" />,
       visibility:
-        permissions.canCreateAppointment ||
+        permissions.canWriteAppointment ||
         permissions.canListEncounters ||
         permissions.canCreateEncounter,
       children: [
@@ -213,14 +213,14 @@ export function FacilityNav({ selectedFacility }: FacilityNavProps) {
   const {
     canViewAppointments,
     canListEncounters,
-    canCreateAppointment,
+    canWriteAppointment,
     canCreateEncounter,
     canViewEncounter,
   } = getPermissions(hasPermission, facility?.permissions ?? []);
   const permissions = {
     canViewAppointments,
     canListEncounters,
-    canCreateAppointment,
+    canWriteAppointment,
     canCreateEncounter,
     canViewEncounter,
   };

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -103,8 +103,10 @@ export default function AppointmentDetail(props: Props) {
   const { hasPermission } = usePermissions();
   const { goBack } = useAppHistory();
 
-  const { canViewAppointments, canUpdateAppointment, canCreateAppointment } =
-    getPermissions(hasPermission, facility?.permissions ?? []);
+  const { canViewAppointments, canWriteAppointment } = getPermissions(
+    hasPermission,
+    facility?.permissions ?? [],
+  );
 
   const { data: appointment } = useQuery({
     queryKey: ["appointment", props.appointmentId],
@@ -363,7 +365,7 @@ export default function AppointmentDetail(props: Props) {
               </div>
             )}
 
-            {canUpdateAppointment && (
+            {canWriteAppointment && (
               <>
                 <div className="md:mx-4 mt-4">
                   <AppointmentActions
@@ -371,7 +373,7 @@ export default function AppointmentDetail(props: Props) {
                     appointment={appointment}
                     updateAppointment={updateAppointment}
                     onViewPatient={redirectToPatientPage}
-                    canCreateAppointment={canCreateAppointment}
+                    canWriteAppointment={canWriteAppointment}
                     isUpdating={isUpdating}
                   />
                 </div>
@@ -626,7 +628,7 @@ interface AppointmentActionsProps {
   appointment: AppointmentRead;
   updateAppointment: (data: AppointmentUpdateRequest) => void;
   onViewPatient: () => void;
-  canCreateAppointment: boolean;
+  canWriteAppointment: boolean;
   isUpdating: boolean;
 }
 
@@ -635,7 +637,7 @@ const AppointmentActions = ({
   appointment,
   updateAppointment,
   onViewPatient,
-  canCreateAppointment,
+  canWriteAppointment,
   isUpdating,
 }: AppointmentActionsProps) => {
   const { t } = useTranslation();
@@ -807,7 +809,7 @@ const AppointmentActions = ({
         </div>
 
         {/* Secondary Actions */}
-        {canCreateAppointment && (
+        {canWriteAppointment && (
           <div className="space-y-3">
             <Separator />
 

--- a/src/pages/Patient/VerifyPatient.tsx
+++ b/src/pages/Patient/VerifyPatient.tsx
@@ -44,12 +44,12 @@ export default function VerifyPatient() {
   const { facility, facilityId } = useCurrentFacility();
   const { hasPermission } = usePermissions();
 
-  const { canCreateAppointment, canCreateEncounter, canListEncounters } =
+  const { canWriteAppointment, canCreateEncounter, canListEncounters } =
     getPermissions(hasPermission, facility?.permissions ?? []);
 
-  // For now, using canCreateAppointment as a proxy for token creation permission
+  // For now, using canWriteAppointment as a proxy for token creation permission
   // This can be updated when specific token permissions are available
-  const canCreateToken = canCreateAppointment;
+  const canCreateToken = canWriteAppointment;
 
   const {
     mutate: verifyPatient,
@@ -136,14 +136,14 @@ export default function VerifyPatient() {
             </CardHeader>
           </Card>
 
-          {(canCreateAppointment || canCreateEncounter || canCreateToken) && (
+          {(canWriteAppointment || canCreateEncounter || canCreateToken) && (
             <Card>
               <CardHeader>
                 <CardTitle>{t("quick_actions")}</CardTitle>
                 <CardDescription>
-                  {canCreateAppointment && canCreateEncounter
+                  {canWriteAppointment && canCreateEncounter
                     ? t("quick_actions_description")
-                    : canCreateAppointment
+                    : canWriteAppointment
                       ? t("quick_actions_description_create_appointment")
                       : canCreateEncounter
                         ? t("quick_actions_description_create_encounter")
@@ -151,7 +151,7 @@ export default function VerifyPatient() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="grid gap-4 sm:grid-cols-1 lg:grid-cols-3">
-                {canCreateAppointment && (
+                {canWriteAppointment && (
                   <Button
                     asChild
                     variant="outline"
@@ -269,7 +269,7 @@ export default function VerifyPatient() {
             facilityId={facilityId}
             facilityPermissions={facility?.permissions ?? []}
             canListEncounters={canListEncounters}
-            canCreateAppointment={canCreateAppointment}
+            canWriteAppointment={canWriteAppointment}
             canCreateToken={canCreateToken}
             patientData={patientData}
           />

--- a/src/pages/Patient/home/PatientHomeTabs.tsx
+++ b/src/pages/Patient/home/PatientHomeTabs.tsx
@@ -13,7 +13,7 @@ interface PatientHomeTabsProps {
   facilityId: string;
   facilityPermissions: string[];
   canListEncounters: boolean;
-  canCreateAppointment: boolean;
+  canWriteAppointment: boolean;
   canCreateToken: boolean;
   patientData: PatientRead;
 }
@@ -23,7 +23,7 @@ export default function PatientHomeTabs({
   facilityId,
   facilityPermissions,
   canListEncounters,
-  canCreateAppointment,
+  canWriteAppointment,
   canCreateToken,
   patientData,
 }: PatientHomeTabsProps) {
@@ -36,7 +36,7 @@ export default function PatientHomeTabs({
         <TabsTrigger value="encounters" className="flex items-center gap-2">
           <span>{t("encounters")}</span>
         </TabsTrigger>
-        {canCreateAppointment && (
+        {canWriteAppointment && (
           <TabsTrigger value="appointments" className="flex items-center gap-2">
             <span>{t("appointments")}</span>
           </TabsTrigger>
@@ -57,7 +57,7 @@ export default function PatientHomeTabs({
         />
       </TabsContent>
 
-      {canCreateAppointment && (
+      {canWriteAppointment && (
         <TabsContent value="appointments" className="mt-4">
           <Appointments
             patientData={patientData}


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Renamed permissions according to the new backend changes.
- Replaced canUpdateAppointment and canCreateAppointment with canWriteAppointment.
- Updated all usages accordingly

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
