### PR TITLE
Minor Fix: Add Parentheses around for duration unit code

### DIFF
--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -748,7 +748,7 @@ function ProductKnowledgeFormContent({
                                           <span>
                                             {t(`unit_${duration.code}`)}
                                             <span className="text-sm ml-1">
-                                              {duration.code}
+                                              ({duration.code})
                                             </span>
                                           </span>
                                         </SelectItem>

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -747,7 +747,7 @@ function ProductKnowledgeFormContent({
                                         >
                                           <span>
                                             {t(`unit_${duration.code}`)}
-                                            <span className="text-sm ml-1">
+                                            <span className="text-sm ml-1 text-gray-500">
                                               ({duration.code})
                                             </span>
                                           </span>


### PR DESCRIPTION
## Before 

<img width="357" height="288" alt="Screenshot 2025-09-07 at 8 00 18 PM" src="https://github.com/user-attachments/assets/18dab149-e340-4248-8be2-965ae66c6c76" />

## After


<img width="357" height="288" alt="Screenshot 2025-09-07 at 11 04 46 PM" src="https://github.com/user-attachments/assets/527c1f97-e33d-4063-8c48-95b2c0ed6b2c" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved unit display in Storage Guidelines on the Product Knowledge form (Facility > Settings). Stability duration units now show the translated unit name with the unit code in parentheses (e.g., “Days (d)”), improving clarity for end-users. No changes to data, APIs, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->