### PR TITLE
fix: add ref to SelectTrigger components across multiple forms

### DIFF
--- a/src/components/Users/UserForm.tsx
+++ b/src/components/Users/UserForm.tsx
@@ -361,7 +361,7 @@ export default function UserForm({
                   defaultValue={field.value}
                 >
                   <FormControl>
-                    <SelectTrigger data-cy="user-type-select">
+                    <SelectTrigger data-cy="user-type-select" ref={field.ref}>
                       <SelectValue placeholder={t("select_user_type")} />
                     </SelectTrigger>
                   </FormControl>
@@ -737,7 +737,7 @@ export default function UserForm({
                   defaultValue={field.value}
                 >
                   <FormControl>
-                    <SelectTrigger data-cy="gender-select">
+                    <SelectTrigger data-cy="gender-select" ref={field.ref}>
                       <SelectValue placeholder={t("select_gender")} />
                     </SelectTrigger>
                   </FormControl>

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -252,7 +252,7 @@ function RuleFields({
                       disabled={disabled}
                     >
                       <FormControl>
-                        <SelectTrigger>
+                        <SelectTrigger ref={field.ref}>
                           <SelectValue placeholder={t("select_system")} />
                         </SelectTrigger>
                       </FormControl>
@@ -455,7 +455,7 @@ export function ValueSetForm({
                 disabled={isSystemDefined}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger ref={field.ref}>
                     <SelectValue placeholder={t("select_status")} />
                   </SelectTrigger>
                 </FormControl>

--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -252,7 +252,7 @@ export default function TagConfigForm({
                 disabled={isLoading}
               >
                 <FormControl>
-                  <SelectTrigger className="capitalize">
+                  <SelectTrigger className="capitalize" ref={field.ref}>
                     <SelectValue placeholder={t("select_category")}>
                       {t(field.value)}
                     </SelectValue>
@@ -283,7 +283,7 @@ export default function TagConfigForm({
                 disabled={isLoading || isEditing}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger ref={field.ref}>
                     <SelectValue placeholder={t("select_resource")}>
                       {t(field.value)}
                     </SelectValue>
@@ -336,7 +336,7 @@ export default function TagConfigForm({
                 disabled={isLoading}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger ref={field.ref}>
                     <SelectValue placeholder={t("select_status")}>
                       {t(field.value)}
                     </SelectValue>

--- a/src/pages/Encounters/ReportBuilder/HeaderBuilder.tsx
+++ b/src/pages/Encounters/ReportBuilder/HeaderBuilder.tsx
@@ -76,9 +76,11 @@ const AlignmentInput = ({
         <FormItem>
           <FormLabel>{t("alignment")}</FormLabel>
           <Select value={field.value} onValueChange={field.onChange}>
-            <SelectTrigger>
-              <SelectValue placeholder={t("alignment")} />
-            </SelectTrigger>
+            <FormControl>
+              <SelectTrigger ref={field.ref}>
+                <SelectValue placeholder={t("alignment")} />
+              </SelectTrigger>
+            </FormControl>
             <SelectContent>
               {HEADER_ALIGNMENT_OPTIONS.map((option) => (
                 <SelectItem key={option.id} value={option.id}>

--- a/src/pages/Encounters/ReportBuilder/LayoutBuilder.tsx
+++ b/src/pages/Encounters/ReportBuilder/LayoutBuilder.tsx
@@ -309,7 +309,7 @@ export default function LayoutBuilder({ form }: LayoutBuilderProps) {
                     onValueChange={handlePageNumberingAlignChange}
                     disabled={!pageNumberingEnabled}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger className="w-full" ref={field.ref}>
                       <SelectValue placeholder={t("select_alignment")} />
                     </SelectTrigger>
                     <SelectContent>
@@ -341,7 +341,7 @@ export default function LayoutBuilder({ form }: LayoutBuilderProps) {
                   <FormLabel>{t("font_family")}</FormLabel>
                   <FormControl>
                     <Select value={field.value} onValueChange={field.onChange}>
-                      <SelectTrigger>
+                      <SelectTrigger ref={field.ref}>
                         <SelectValue placeholder={t("select_font")} />
                       </SelectTrigger>
                       <SelectContent>
@@ -366,7 +366,7 @@ export default function LayoutBuilder({ form }: LayoutBuilderProps) {
                   <FormLabel>{t("font_size")}</FormLabel>
                   <FormControl>
                     <Select value={field.value} onValueChange={field.onChange}>
-                      <SelectTrigger>
+                      <SelectTrigger ref={field.ref}>
                         <SelectValue placeholder={t("select_size")} />
                       </SelectTrigger>
                       <SelectContent>

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -264,7 +264,7 @@ export function PaymentReconciliationSheet({
                       defaultValue={field.value}
                     >
                       <FormControl>
-                        <SelectTrigger>
+                        <SelectTrigger ref={field.ref}>
                           <SelectValue
                             placeholder={t("select_payment_method")}
                           />
@@ -314,7 +314,7 @@ export function PaymentReconciliationSheet({
                       defaultValue={field.value}
                     >
                       <FormControl>
-                        <SelectTrigger>
+                        <SelectTrigger ref={field.ref}>
                           <SelectValue
                             placeholder={t("select_reconciliation_type")}
                           />

--- a/src/pages/Facility/billing/account/AccountSheet.tsx
+++ b/src/pages/Facility/billing/account/AccountSheet.tsx
@@ -219,7 +219,7 @@ export function AccountSheet({
                         onValueChange={field.onChange}
                         disabled={isCreating}
                       >
-                        <SelectTrigger>
+                        <SelectTrigger ref={field.ref}>
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -246,7 +246,7 @@ export function AccountSheet({
                         value={field.value}
                         onValueChange={field.onChange}
                       >
-                        <SelectTrigger>
+                        <SelectTrigger ref={field.ref}>
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>

--- a/src/pages/Facility/billing/account/components/EditChargeItemSheet.tsx
+++ b/src/pages/Facility/billing/account/components/EditChargeItemSheet.tsx
@@ -221,7 +221,7 @@ export function EditChargeItemSheet({
                             defaultValue={field.value}
                           >
                             <FormControl>
-                              <SelectTrigger>
+                              <SelectTrigger ref={field.ref}>
                                 <SelectValue placeholder={t("select_status")} />
                               </SelectTrigger>
                             </FormControl>

--- a/src/pages/Facility/services/inventory/SupplyRequestForm.tsx
+++ b/src/pages/Facility/services/inventory/SupplyRequestForm.tsx
@@ -409,7 +409,7 @@ export default function SupplyRequestForm({
                             defaultValue={field.value}
                           >
                             <FormControl>
-                              <SelectTrigger>
+                              <SelectTrigger ref={field.ref}>
                                 <SelectValue placeholder={t("select_status")} />
                               </SelectTrigger>
                             </FormControl>
@@ -541,7 +541,10 @@ export default function SupplyRequestForm({
                           defaultValue={field.value}
                         >
                           <FormControl>
-                            <SelectTrigger className="border border-gray-400">
+                            <SelectTrigger
+                              className="border border-gray-400"
+                              ref={field.ref}
+                            >
                               <SelectValue placeholder={t("select_intent")} />
                             </SelectTrigger>
                           </FormControl>

--- a/src/pages/Facility/settings/billing/discount/discount-components/DiscountMonetaryComponentForm.tsx
+++ b/src/pages/Facility/settings/billing/discount/discount-components/DiscountMonetaryComponentForm.tsx
@@ -198,7 +198,7 @@ export function DiscountMonetaryComponentForm({
                       value={valueType}
                       onValueChange={handleValueTypeChange}
                     >
-                      <SelectTrigger className="flex-1">
+                      <SelectTrigger className="flex-1" ref={_field.ref}>
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -515,7 +515,7 @@ export function ChargeItemDefinitionForm({
                         defaultValue={field.value}
                       >
                         <FormControl>
-                          <SelectTrigger>
+                          <SelectTrigger ref={field.ref}>
                             <SelectValue placeholder={t("select_status")} />
                           </SelectTrigger>
                         </FormControl>

--- a/src/pages/Facility/settings/devices/components/DeviceForm.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceForm.tsx
@@ -247,7 +247,10 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                 <FormLabel aria-required>{t("status")}</FormLabel>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <FormControl>
-                    <SelectTrigger data-cy="device-status-select">
+                    <SelectTrigger
+                      data-cy="device-status-select"
+                      ref={field.ref}
+                    >
                       <SelectValue placeholder={t("select_status")} />
                     </SelectTrigger>
                   </FormControl>
@@ -272,7 +275,10 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                 <FormLabel aria-required>{t("availability_status")}</FormLabel>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <FormControl>
-                    <SelectTrigger data-cy="device-availability-status-select">
+                    <SelectTrigger
+                      data-cy="device-availability-status-select"
+                      ref={field.ref}
+                    >
                       <SelectValue
                         placeholder={t("select_availability_status")}
                       />
@@ -494,7 +500,10 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                       }}
                     >
                       <FormControl>
-                        <SelectTrigger className="h-[42px] md:h-[38px]">
+                        <SelectTrigger
+                          className="h-[42px] md:h-[38px]"
+                          ref={field.ref}
+                        >
                           <SelectValue
                             placeholder={t("select_contact_system")}
                           />

--- a/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
+++ b/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
@@ -284,7 +284,7 @@ function HealthcareServiceFormContent({
                           onValueChange={field.onChange}
                           value={field.value}
                         >
-                          <SelectTrigger>
+                          <SelectTrigger ref={field.ref}>
                             <SelectValue
                               placeholder={t("select_internal_type")}
                             />

--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -297,6 +297,7 @@ export default function LocationForm({
                   <SelectTrigger
                     className="w-full"
                     data-cy="location-form-options"
+                    ref={field.ref}
                   >
                     <SelectValue />
                   </SelectTrigger>
@@ -348,7 +349,7 @@ export default function LocationForm({
                 <FormLabel>{t("number_of_beds")}</FormLabel>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <FormControl>
-                    <SelectTrigger data-cy="bed-counts-select">
+                    <SelectTrigger data-cy="bed-counts-select" ref={field.ref}>
                       <SelectValue placeholder={t("select_number_of_beds")} />
                     </SelectTrigger>
                   </FormControl>
@@ -507,7 +508,7 @@ export default function LocationForm({
                 <FormLabel>{t("status")}</FormLabel>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <FormControl>
-                    <SelectTrigger data-cy="location-status">
+                    <SelectTrigger data-cy="location-status" ref={field.ref}>
                       <SelectValue />
                     </SelectTrigger>
                   </FormControl>
@@ -532,7 +533,7 @@ export default function LocationForm({
                 <FormLabel>{t("operational_status")}</FormLabel>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <FormControl>
-                    <SelectTrigger data-cy="operational-status">
+                    <SelectTrigger data-cy="operational-status" ref={field.ref}>
                       <SelectValue />
                     </SelectTrigger>
                   </FormControl>

--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
@@ -355,7 +355,7 @@ function ObservationDefinitionFormContent({
                           defaultValue={field.value}
                         >
                           <FormControl>
-                            <SelectTrigger>
+                            <SelectTrigger ref={field.ref}>
                               <SelectValue placeholder={t("select_status")} />
                             </SelectTrigger>
                           </FormControl>
@@ -383,7 +383,7 @@ function ObservationDefinitionFormContent({
                           defaultValue={field.value}
                         >
                           <FormControl>
-                            <SelectTrigger>
+                            <SelectTrigger ref={field.ref}>
                               <SelectValue placeholder={t("select_category")} />
                             </SelectTrigger>
                           </FormControl>
@@ -414,7 +414,7 @@ function ObservationDefinitionFormContent({
                             defaultValue={field.value}
                           >
                             <FormControl>
-                              <SelectTrigger>
+                              <SelectTrigger ref={field.ref}>
                                 <SelectValue
                                   placeholder={t("select_data_type")}
                                 />
@@ -677,7 +677,7 @@ function ObservationDefinitionFormContent({
                                     defaultValue={field.value}
                                   >
                                     <FormControl>
-                                      <SelectTrigger>
+                                      <SelectTrigger ref={field.ref}>
                                         <SelectValue
                                           placeholder={t("select_data_type")}
                                         />

--- a/src/pages/Facility/settings/product/ProductForm.tsx
+++ b/src/pages/Facility/settings/product/ProductForm.tsx
@@ -329,7 +329,7 @@ export function ProductFormContent({
                     defaultValue={field.value}
                   >
                     <FormControl>
-                      <SelectTrigger>
+                      <SelectTrigger ref={field.ref}>
                         <SelectValue placeholder={t("select_status")} />
                       </SelectTrigger>
                     </FormControl>

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -390,7 +390,7 @@ function ProductKnowledgeFormContent({
                           defaultValue={field.value}
                         >
                           <FormControl>
-                            <SelectTrigger>
+                            <SelectTrigger ref={field.ref}>
                               <SelectValue
                                 placeholder={t("select_product_type")}
                               />
@@ -472,7 +472,7 @@ function ProductKnowledgeFormContent({
                           defaultValue={field.value}
                         >
                           <FormControl>
-                            <SelectTrigger>
+                            <SelectTrigger ref={field.ref}>
                               <SelectValue placeholder={t("status")} />
                             </SelectTrigger>
                           </FormControl>
@@ -557,7 +557,7 @@ function ProductKnowledgeFormContent({
                                     defaultValue={field.value}
                                   >
                                     <FormControl>
-                                      <SelectTrigger>
+                                      <SelectTrigger ref={field.ref}>
                                         <SelectValue
                                           placeholder={t("select_name_type")}
                                         />
@@ -731,7 +731,7 @@ function ProductKnowledgeFormContent({
                                     }}
                                   >
                                     <FormControl>
-                                      <SelectTrigger>
+                                      <SelectTrigger ref={field.ref}>
                                         <SelectValue
                                           placeholder={t(
                                             "duration_unit_placeholder",

--- a/src/pages/Facility/settings/specimen-definitions/SpecimenDefinitionForm.tsx
+++ b/src/pages/Facility/settings/specimen-definitions/SpecimenDefinitionForm.tsx
@@ -294,7 +294,7 @@ export function SpecimenDefinitionForm({
                         defaultValue={field.value}
                       >
                         <FormControl>
-                          <SelectTrigger>
+                          <SelectTrigger ref={field.ref}>
                             <SelectValue placeholder={t("select_status")} />
                           </SelectTrigger>
                         </FormControl>
@@ -510,7 +510,7 @@ export function SpecimenDefinitionForm({
                         defaultValue={field.value}
                       >
                         <FormControl>
-                          <SelectTrigger>
+                          <SelectTrigger ref={field.ref}>
                             <SelectValue placeholder={t("select_preference")} />
                           </SelectTrigger>
                         </FormControl>

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -190,7 +190,7 @@ export default function PatientIdentifierConfigForm({
                           onValueChange={field.onChange}
                           value={field.value}
                         >
-                          <SelectTrigger>
+                          <SelectTrigger ref={field.ref}>
                             <SelectValue placeholder={t("select_use")} />
                           </SelectTrigger>
                           <SelectContent>
@@ -533,7 +533,7 @@ export default function PatientIdentifierConfigForm({
                           onValueChange={field.onChange}
                           value={field.value}
                         >
-                          <SelectTrigger>
+                          <SelectTrigger ref={field.ref}>
                             <SelectValue placeholder={t("select_status")} />
                           </SelectTrigger>
                           <SelectContent>


### PR DESCRIPTION
## Proposed Changes

Fixes #13199 
- Added ref to SelectTrigger components across multiple forms.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved validation, focus, and keyboard navigation for select fields across multiple forms (e.g., user management, value sets, admin tag config, report/layout builders, billing and accounts, inventory, discounts, charge item definitions, devices, healthcare services, locations, observations, products, specimen definitions, and patient identifier config).
  - Resolves cases where selects might not receive focus or show error states reliably.
- Style
  - Consistent form control behavior for select inputs, aligning visual validation states and focus handling across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->