### PR TITLE
fix: 13657 Cross icon overlaps text in button in Inward Purchase Entr…

### DIFF
--- a/src/pages/Facility/services/inventory/ReceiveStock.tsx
+++ b/src/pages/Facility/services/inventory/ReceiveStock.tsx
@@ -174,8 +174,10 @@ export function ReceiveStock({
               `/facility/${facilityId}/locations/${locationId}/external_supply/inward_entry`,
             )
           }
+          className="flex items-center gap-2"
         >
           <X className="size-4" />
+          <span className="hidden sm:inline">{t("close")}</span>
         </Button>
       </div>
       <Separator className="my-1" />


### PR DESCRIPTION

## Proposed Changes

Fixes #13657
- Added flex alignment and spacing to the button
- Made text hidden on small screens and visible from sm: breakpoint upwards
- Ensures better readability and responsive design

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Close button in Receive Stock to include a text label alongside the X icon for clearer actions.
  * The label is localized and only appears on small screens and larger; it remains hidden on extra-small screens to preserve space.
  * No behavioral changes—clicking still closes the view as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->