### PR TITLE
fix: 13657 Cross icon overlaps text in button in Inward Purchase Entries page in mobile view

### DIFF
--- a/src/pages/Facility/services/inventory/ReceiveStock.tsx
+++ b/src/pages/Facility/services/inventory/ReceiveStock.tsx
@@ -98,6 +98,7 @@ export function ReceiveStock({
   });
 
   const batchRequest = useMutation({
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     mutationFn: mutate(routes.batchRequest),
     onSuccess: () => {
       toast.success(t("stock_received"));
@@ -174,8 +175,10 @@ export function ReceiveStock({
               `/facility/${facilityId}/locations/${locationId}/external_supply/inward_entry`,
             )
           }
+          className="flex items-center gap-2"
         >
           <X className="size-4" />
+          <span className="hidden sm:inline">{t("close")}</span>
         </Button>
       </div>
       <Separator className="my-1" />


### PR DESCRIPTION


## Proposed Changes

Fixes #13657

Tagging: @ohcnetwork/care-fe-code-reviewers

-Added flex alignment and spacing to the button
-Made text hidden on small screens and visible from sm: breakpoint upwards
-Ensures better readability and responsive design

Fixes #13657 

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Close button in the Receive Stock header to include a text label alongside the icon. The label is responsive: hidden on extra-small screens and shown on small and larger screens. Spacing and alignment have been refined for a cleaner, more readable layout. This improves clarity and discoverability of the action across devices. There are no changes to navigation behavior or workflows; interactions remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->