### PR TITLE
Fixed Image persisting on modal close

### DIFF
--- a/src/components/Common/AvatarEditModal.tsx
+++ b/src/components/Common/AvatarEditModal.tsx
@@ -232,7 +232,7 @@ export default function AvatarEditModal({
     <Dialog
       open={open}
       onOpenChange={(open) => {
-        if (!open) onOpenChange(false);
+        if (!open) closeModal();
         else onOpenChange(open);
       }}
     >
@@ -396,7 +396,7 @@ export default function AvatarEditModal({
                         />
                         {t("upload_an_image")}
                         <input
-                          title="changeFile"
+                          title={t("change_file")}
                           type="file"
                           accept="image/*"
                           className="hidden"


### PR DESCRIPTION
## Proposed Changes

Fixes #13637 
- Replaced `onOpenChange` function with `closeModal` function when open is `false`

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.

https://github.com/user-attachments/assets/58c1f7aa-6cf5-4451-9695-b24f07d19e72


- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing the Avatar Edit dialog now reliably resets its UI state, preventing stale selections or settings from persisting after reopen.

* **New Features**
  * The file input’s title is now localized, displaying translated text based on your language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->