### PR TITLE
removed PatientInfoCardQuickActions plugin component

### DIFF
--- a/src/components/Encounter/EncounterCommandDialog.tsx
+++ b/src/components/Encounter/EncounterCommandDialog.tsx
@@ -383,11 +383,11 @@ export function EncounterCommandDialog({
           {useCareApps().some(
             (plugin) => plugin.components?.PatientInfoCardActions,
           ) && (
-            <CommandGroup heading={t("plugin_actions")} className="px-2">
+            <CommandGroup heading={t("plugin_actions")} className="px-0">
               <PLUGIN_Component
                 __name="PatientInfoCardActions"
                 encounter={encounter}
-                className="rounded-md cursor-pointer hover:bg-gray-100 flex justify-between aria-selected:bg-gray-100 w-full py-2"
+                className="rounded-md cursor-pointer text-gray-600 hover:bg-gray-100 flex justify-baseline aria-selected:bg-gray-100 w-full p-2"
               />
             </CommandGroup>
           )}

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -41,7 +41,6 @@ import {
   PatientDeceasedInfo,
   PatientHeader,
 } from "@/pages/Facility/services/serviceRequests/PatientHeader";
-import { PLUGIN_Component } from "@/PluginEngine";
 import { EncounterDiagnosticReportsTab } from "./tabs/diagnostic-reports";
 import { EncounterNotesTab } from "./tabs/notes";
 import { EncounterServiceRequestTab } from "./tabs/service-requests";
@@ -191,12 +190,6 @@ export const EncounterShow = (props: Props) => {
             <>
               {canWriteSelectedEncounter && selectedEncounter && (
                 <div className="flex flex-col items-end justify-center gap-4">
-                  <PLUGIN_Component
-                    __name="PatientInfoCardQuickActions"
-                    encounter={selectedEncounter}
-                    className="w-full lg:w-auto bg-primary-700 text-white hover:bg-primary-600"
-                  />
-
                   <EncounterCommandDialog
                     encounter={selectedEncounter}
                     open={actionsOpen}

--- a/src/pages/Encounters/tabs/overview/summary-panel-actions.tab.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-actions.tab.tsx
@@ -69,7 +69,7 @@ export const SummaryPanelActionsTab = () => {
             encounter={selectedEncounter}
             className={cn(
               buttonVariants({ variant: "outline" }),
-              "justify-start sm:@sm:justify-center sm:@sm:flex-1",
+              "justify-start sm:@sm:justify-center sm:@sm:flex-1 w-full",
             )}
           />
         )}

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -34,11 +34,6 @@ export type PatientInfoCardActionsComponentType = React.FC<{
   className?: string;
 }>;
 
-export type PatientInfoCardQuickActionsComponentType = React.FC<{
-  encounter: EncounterRead;
-  className?: string;
-}>;
-
 export type PatientInfoCardMarkAsCompleteComponentType = React.FC<{
   encounter: EncounterRead;
 }>;
@@ -66,7 +61,6 @@ export type SupportedPluginComponents = {
   Scribe: ScribeComponentType;
   PatientHomeActions: PatientHomeActionsComponentType;
   PatientInfoCardActions: PatientInfoCardActionsComponentType;
-  PatientInfoCardQuickActions: PatientInfoCardQuickActionsComponentType;
   PatientInfoCardMarkAsComplete: PatientInfoCardMarkAsCompleteComponentType;
   FacilityHomeActions: FacilityHomeActionsComponentType;
   PatientRegistrationForm: PatientRegistrationFormComponentType;


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- removed PatientInfoCardQuickActions plugin component
- Changed doctor connect plug component as PatientInfoCardActions https://github.com/ohcnetwork/care_doctor_connect_fe/pull/17

Tagging: @ohcnetwork/care-fe-code-reviewers

<img width="398" height="609" alt="image" src="https://github.com/user-attachments/assets/975eb6b4-d6c0-44b2-a9c5-24eb01a8e246" />
<img width="874" height="316" alt="image" src="https://github.com/user-attachments/assets/bb628bb3-e2b7-49de-a586-a56b882d2f35" />


## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Tweaked spacing, alignment, and text color for Patient Info Card actions to improve readability.
  - Reduced padding in plugin actions and ensured full‑width layout for better responsiveness.
  - Preserved hover and selected state visuals for consistency.

- Refactor
  - Removed legacy Patient Info Card quick actions from the Encounter view; the actions area now focuses on the command dialog trigger for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->