### PR TITLE
Fixed status param incosistency in Appointments Page

### DIFF
--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -1090,7 +1090,7 @@ function AppointmentRow(props: {
             </SelectTrigger>
             <SelectContent>
               {getStatusGroups(t).map((group) => (
-                <SelectItem key={group.label} value={group.label}>
+                <SelectItem key={group.label} value={group.statuses.join(",")}>
                   <div className="flex items-center">{group.label}</div>
                 </SelectItem>
               ))}

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -1067,7 +1067,10 @@ function AppointmentRow(props: {
             <TabsList>
               {getStatusGroups(t).map((group) => {
                 return (
-                  <TabsTrigger key={group.label} value={group.label}>
+                  <TabsTrigger
+                    key={group.label}
+                    value={group.statuses.join(",")}
+                  >
                     {group.label}
                   </TabsTrigger>
                 );


### PR DESCRIPTION
## Proposed Changes

Fixes #13683 
- Sending `status` value instead of `label` in `List` tab-view of Appointments Page

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Status tabs now use canonical, comma-separated status values to drive filtering, ensuring consistent behavior across locales and when grouping multiple statuses.
  * Multi-status groups now apply all underlying statuses at once for more precise appointment lists.

* **Bug Fixes**
  * Fixed cases where selecting a status tab did not apply the correct filter.
  * Improved reliability when sharing or bookmarking filtered appointment views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->