### PR TITLE
remove old filter button for encounter page

### DIFF
--- a/src/components/ui/multi-filter/date-filter.tsx
+++ b/src/components/ui/multi-filter/date-filter.tsx
@@ -155,6 +155,7 @@ export function RenderDateFilter({
                 }
               }}
               className="w-full"
+              showYearSwitcher={false}
               styles={{
                 day: {
                   width: "2.5rem",

--- a/src/pages/Encounters/EncounterHistorySelector.tsx
+++ b/src/pages/Encounters/EncounterHistorySelector.tsx
@@ -7,10 +7,8 @@ import { useInView } from "react-intersection-observer";
 
 import { cn } from "@/lib/utils";
 
-import CareIcon from "@/CAREUI/icons/CareIcon";
-
 import { Badge } from "@/components/ui/badge";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   HoverCard,
@@ -162,7 +160,6 @@ interface Props {
 const EncounterHistoryList = ({ onSelect }: Props) => {
   const { t } = useTranslation();
   const { ref, inView } = useInView();
-  const [showFilters, setShowFilters] = useState(false);
 
   const [status, setStatus] = useState<string>();
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
@@ -307,15 +304,6 @@ const EncounterHistoryList = ({ onSelect }: Props) => {
             <h2 className="text-xs font-medium text-gray-600 uppercase">
               {t("other_encounters")}
             </h2>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => setShowFilters(!showFilters)}
-              className={cn(showFilters && "bg-gray-100")}
-              title={t("toggle_filters")}
-            >
-              <CareIcon icon="l-filter" className="size-4" />
-            </Button>
           </div>
 
           {/* Filters */}


### PR DESCRIPTION
## Proposed Changes

- Remove old filter button from encounter history selector

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Encounter History filters simplified: collapse/expand toggle removed so filters remain visible permanently; filtering behavior unchanged.
  * Date-range calendar simplified: year-switcher hidden when selecting a custom date range to streamline the calendar header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->