### PR TITLE
fix: add country option to government organization types in localization

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -287,6 +287,7 @@
   "SRD__select_product_placeholder": "Select product",
   "SYSTEM__govt_org_type__block_panchayat": "Block Panchayat",
   "SYSTEM__govt_org_type__corporation": "Corporation",
+  "SYSTEM__govt_org_type__country": "Country",
   "SYSTEM__govt_org_type__default": "State",
   "SYSTEM__govt_org_type__district": "District",
   "SYSTEM__govt_org_type__district_panchayat": "District Panchayat",


### PR DESCRIPTION
## Proposed Changes

Fixes #13715 
- Add country option to government organization types in localization


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English localization for the “Country” government organization type, enabling the UI to display the correct label where applicable.

* **Chores**
  * Updated localization resources to include the new “Country” entry.
  * No other translations were altered; no impact on behavior or performance.
  * This change affects display text only and does not modify workflows or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->