### PR TITLE
fix: Chargeitemsection in AppointmentDetails bug

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -649,7 +649,7 @@ const AppointmentDetails = ({
 
       <ChargeItemsSection
         facilityId={facility.id}
-        resourceId={appointment.resource.id}
+        resourceId={appointment.id}
         patientId={appointment.patient.id}
         serviceResourceType={ChargeItemServiceResource.appointment}
         sourceUrl={`/facility/${facility.id}/patient/${appointment.patient.id}/appointments/${appointment.id}`}


### PR DESCRIPTION
## Proposed Changes
- Fix : Use appointmentid instead of resourceid


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charge items in Appointment Details are now correctly associated with the selected appointment, ensuring accurate display and updates.
  * Actions like viewing, adding, or editing charges from an appointment reliably apply to that appointment.
  * Prevents misattribution of charges to unrelated resources, improving consistency across billing workflows and related reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->