### PR TITLE
Fix:Appointment detail page redirection and use consistent icon

### DIFF
--- a/src/components/ui/sidebar/facility/location/location-nav.tsx
+++ b/src/components/ui/sidebar/facility/location/location-nav.tsx
@@ -6,7 +6,7 @@ import { NavMain } from "@/components/ui/sidebar/nav-main";
 
 import useCurrentLocation from "@/pages/Facility/locations/utils/useCurrentLocation";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
-import { CalendarIcon } from "lucide-react";
+import { CalendarIcon, Logs } from "lucide-react";
 
 export function LocationNav() {
   const { t } = useTranslation();
@@ -88,12 +88,12 @@ export function LocationNav() {
         {
           name: t("appointments"),
           url: `${baseUrl}/appointments`,
-          icon: <CalendarIcon />,
+          icon: <CareIcon icon="d-calendar" />,
         },
         {
           name: t("queues"),
           url: `${baseUrl}/queues`,
-          icon: <CalendarIcon />,
+          icon: <Logs />,
         },
       ]}
     />

--- a/src/components/ui/sidebar/facility/service/service-nav.tsx
+++ b/src/components/ui/sidebar/facility/service/service-nav.tsx
@@ -5,6 +5,7 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { NavMain } from "@/components/ui/sidebar/nav-main";
 
 import useCurrentService from "@/pages/Facility/services/utils/useCurrentService";
+import { Logs } from "lucide-react";
 
 export function ServiceNav() {
   const { t } = useTranslation();
@@ -29,12 +30,12 @@ export function ServiceNav() {
         {
           name: t("appointments"),
           url: `${baseUrl}/appointments`,
-          icon: <CareIcon icon="l-calender" />,
+          icon: <CareIcon icon="d-calendar" />,
         },
         {
           name: t("queues"),
           url: `${baseUrl}/queues`,
-          icon: <CareIcon icon="l-calender" />,
+          icon: <Logs />,
         },
       ]}
     />

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -678,7 +678,12 @@ function AppointmentColumn(props: {
                 ref={index === appointments.length - 1 ? ref : undefined}
               >
                 <Link
-                  href={`/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${appointment.id}`}
+                  href={
+                    appointment.resource_type ===
+                    SchedulableResourceType.Practitioner
+                      ? `/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${appointment.id}`
+                      : `appointments/${appointment.id}`
+                  }
                   className="text-inherit"
                 >
                   <AppointmentCard

--- a/src/pages/Facility/locations/LocationLayout.tsx
+++ b/src/pages/Facility/locations/LocationLayout.tsx
@@ -3,6 +3,7 @@ import { Redirect, useRoutes } from "raviger";
 import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 
 import { ScheduleHome } from "@/components/Schedule/ScheduleHome";
+import AppointmentDetail from "@/pages/Appointments/AppointmentDetail";
 import AppointmentsPage from "@/pages/Appointments/AppointmentsPage";
 import PrintAppointments from "@/pages/Appointments/components/PrintAppointments";
 import BedsList from "@/pages/Facility/locations/BedsList";
@@ -258,6 +259,11 @@ const getRoutes = (facilityId: string, locationId: string) => ({
       resourceId={locationId}
     />
   ),
+  "/appointments/:appointmentId": ({
+    appointmentId,
+  }: {
+    appointmentId: string;
+  }) => <AppointmentDetail appointmentId={appointmentId} />,
   "/appointments/print": () => (
     <PrintAppointments
       facilityId={facilityId}

--- a/src/pages/Facility/services/ServiceLayout.tsx
+++ b/src/pages/Facility/services/ServiceLayout.tsx
@@ -1,5 +1,6 @@
 import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 import { ScheduleHome } from "@/components/Schedule/ScheduleHome";
+import AppointmentDetail from "@/pages/Appointments/AppointmentDetail";
 import AppointmentsPage from "@/pages/Appointments/AppointmentsPage";
 import PrintAppointments from "@/pages/Appointments/components/PrintAppointments";
 import { ManageQueuePage } from "@/pages/Facility/queues/ManageQueue";
@@ -34,6 +35,11 @@ const getRoutes = (facilityId: string, serviceId: string) => ({
       resourceId={serviceId}
     />
   ),
+  "/appointments/:appointmentId": ({
+    appointmentId,
+  }: {
+    appointmentId: string;
+  }) => <AppointmentDetail appointmentId={appointmentId} />,
   "/appointments/print": () => (
     <PrintAppointments
       facilityId={facilityId}


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Added new routes for location and services correctly redirected to AppointmentDetails page
- Used consistent icons everywhere

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added direct appointment detail routes under Location and Service (/appointments/:appointmentId) for in-context viewing.
  - Appointment links now route conditionally based on resource type for more accurate navigation.

- Style
  - Updated sidebar icons: Appointments now uses a refined calendar icon; Queues now uses a logs icon in both Location and Service navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->