### PR TITLE
fix : Disable the resource field for child tag in the tag config page 

### DIFF
--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -259,7 +259,7 @@ export default function TagConfigForm({
               <Select
                 onValueChange={field.onChange}
                 value={field.value}
-                disabled={isLoading || isEditing}
+                disabled={isLoading || isEditing || isCreatingChild}
               >
                 <FormControl>
                   <SelectTrigger ref={field.ref}>


### PR DESCRIPTION
## Proposed Changes

Fixes #13707

<img width="1896" height="959" alt="image" src="https://github.com/user-attachments/assets/7f6f10d9-d0cd-4cf2-9343-7a2e5ab32446" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In Tag configuration, the Resource field is now disabled while creating a child tag, matching the existing disabled behavior during loading and editing. This ensures consistent form behavior across create/edit flows, reduces confusion, and prevents accidental changes to the Resource selection during transitional states. No other user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->