### PR TITLE
Show empty appointments when no practitioners are selected

### DIFF
--- a/src/pages/Appointments/components/MultiPractitionerSelect.tsx
+++ b/src/pages/Appointments/components/MultiPractitionerSelect.tsx
@@ -55,7 +55,7 @@ const getColorForTag = (uuid: string) => {
 };
 
 interface MultiPractitionerSelectorProps {
-  selected: NonEmptyArray<UserReadMinimal>;
+  selected: UserReadMinimal[];
   onSelect: (users: UserReadMinimal[]) => void;
   facilityId: string;
 }
@@ -146,8 +146,6 @@ export const MultiPractitionerSelector = ({
   const getItemValue = (user: UserReadMinimal) => {
     return `${formatName(user)} ${user.username}`;
   };
-
-  const hasMultiple = selected && selected.length > 1;
 
   const handleOrganizationClick = (organization: FacilityOrganizationRead) => {
     if (organization.has_children) {
@@ -325,13 +323,9 @@ export const MultiPractitionerSelector = ({
                               key={user.id}
                               value={getItemValue(user)}
                               onSelect={() => {
-                                if (hasMultiple) {
-                                  onSelect(
-                                    selected.filter(
-                                      (s) => s.id !== user.id,
-                                    ) as NonEmptyArray<UserReadMinimal>,
-                                  );
-                                }
+                                onSelect(
+                                  selected.filter((s) => s.id !== user.id),
+                                );
                               }}
                               className="flex items-center gap-2 px-3 py-3 cursor-pointer hover:bg-gray-50"
                             >
@@ -348,7 +342,7 @@ export const MultiPractitionerSelector = ({
                                   {formatName(user)}
                                 </span>
                               </div>
-                              {hasMultiple && <XIcon className="ml-auto" />}
+                              <XIcon className="ml-auto" />
                             </CommandItem>
                           ))}
                           <div className="bg-gray-200 -mx-1 my-1 h-px"></div>


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Support for showing empty appointments when no practitioners where selected
- On mount the authenticated appointments will show

[Screencast from 2025-09-17 20-13-30.webm](https://github.com/user-attachments/assets/d3a64ebb-e47d-4679-bbd2-8eee6d51d4f5)

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Reworked status filter: mobile now uses a Select instead of Tabs; desktop Tabs retained.
  - Removed inline slot-filtering UI.
  - Practitioner filtering now defaults to no selection and auto-selects the signed-in user when enabled without a choice.
  - Multi-practitioner selection can be empty; items can be removed individually at any time.
  - Data loads only when resources are selected, reducing unnecessary fetching.
  - Removed loading skeleton animations for appointment lists.
  - Minor table/header layout and labeling adjustments for practitioner, status, and token columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->