### PR TITLE
Added EncounterClassHistory for EncounterClassBadge

### DIFF
--- a/src/pages/Encounters/EncounterProperties.tsx
+++ b/src/pages/Encounters/EncounterProperties.tsx
@@ -11,6 +11,9 @@ import {
 
 import { formatDateTime } from "@/Utils/utils";
 import {
+  ENCOUNTER_CLASS_ICONS,
+  ENCOUNTER_CLASSES_COLORS,
+  ENCOUNTER_STATUS_COLORS,
   ENCOUNTER_STATUS_ICONS,
   EncounterRead,
 } from "@/types/emr/encounter/encounter";
@@ -21,7 +24,11 @@ export const StatusBadge = ({ encounter }: { encounter: EncounterRead }) => {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Badge variant="blue" size="sm" className="cursor-pointer">
+        <Badge
+          variant={ENCOUNTER_STATUS_COLORS[encounter.status]}
+          size="sm"
+          className="cursor-pointer"
+        >
           {React.createElement(ENCOUNTER_STATUS_ICONS[encounter.status], {
             className: "size-3",
           })}
@@ -39,6 +46,50 @@ export const StatusBadge = ({ encounter }: { encounter: EncounterRead }) => {
               </span>
               <span className="font-medium">
                 {t(`encounter_status__${history.status}`)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const EncounterClassBadge = ({
+  encounter,
+}: {
+  encounter: EncounterRead;
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Badge
+          variant={ENCOUNTER_CLASSES_COLORS[encounter.encounter_class]}
+          size="sm"
+          className="cursor-pointer"
+        >
+          {React.createElement(
+            ENCOUNTER_CLASS_ICONS[encounter.encounter_class],
+            {
+              className: "size-3",
+            },
+          )}
+          {t(`encounter_class__${encounter.encounter_class}`)}
+          <ChevronDown className="size-3 opacity-50" />
+        </Badge>
+      </PopoverTrigger>
+      <PopoverContent align={"start"} className="w-auto p-2">
+        <div className="space-y-2">
+          <h4 className="font-medium text-sm">{t("class_history")}</h4>
+          {encounter.encounter_class_history.history.map((history, index) => (
+            <div key={index} className="flex items-center gap-2 text-sm">
+              <span className="text-gray-500">
+                {formatDateTime(history.moved_at)}
+              </span>
+              <span className="font-medium">
+                {t(`encounter_class__${history.status}`)}
               </span>
             </div>
           ))}

--- a/src/pages/Encounters/tabs/overview/summary-panel-details-tab/encounter-details.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-details-tab/encounter-details.tsx
@@ -9,13 +9,12 @@ import { Separator } from "@/components/ui/separator";
 
 import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
 
-import { StatusBadge } from "@/pages/Encounters/EncounterProperties";
-import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
 import {
-  ENCOUNTER_CLASSES_COLORS,
-  ENCOUNTER_CLASS_ICONS,
-  ENCOUNTER_PRIORITY_COLORS,
-} from "@/types/emr/encounter/encounter";
+  EncounterClassBadge,
+  StatusBadge,
+} from "@/pages/Encounters/EncounterProperties";
+import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
+import { ENCOUNTER_PRIORITY_COLORS } from "@/types/emr/encounter/encounter";
 
 export const EncounterDetails = () => {
   const { t } = useTranslation();
@@ -27,8 +26,6 @@ export const EncounterDetails = () => {
     canWriteSelectedEncounter,
   } = useEncounter();
   if (!encounter) return <CardListSkeleton count={1} />;
-
-  const EncounterClassIcon = ENCOUNTER_CLASS_ICONS[encounter.encounter_class];
 
   return (
     <div className="flex flex-wrap gap-2 border bg-gray-100 border-gray-200 rounded-md pt-2 px-1 pb-1">
@@ -54,15 +51,7 @@ export const EncounterDetails = () => {
         <div className="flex flex-col gap-1">
           <span className="text-sm font-medium">{t("encounter_class")}: </span>
           <div>
-            <Badge
-              variant={ENCOUNTER_CLASSES_COLORS[encounter.encounter_class]}
-              size="sm"
-            >
-              <EncounterClassIcon className="size-3" />
-              <span className="whitespace-nowrap">
-                {t(`encounter_class__${encounter.encounter_class}`)}
-              </span>
-            </Badge>
+            <EncounterClassBadge encounter={encounter} />
           </div>
         </div>
         <div className="flex flex-col gap-1">

--- a/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
@@ -11,7 +11,10 @@ import { Separator } from "@/components/ui/separator";
 
 import query from "@/Utils/request/query";
 import { Avatar } from "@/components/Common/Avatar";
-import { StatusBadge } from "@/pages/Encounters/EncounterProperties";
+import {
+  EncounterClassBadge,
+  StatusBadge,
+} from "@/pages/Encounters/EncounterProperties";
 import { OverviewSidebarSheet } from "@/pages/Encounters/tabs/overview/overview-sidebar-sheet";
 import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
 import {
@@ -19,11 +22,7 @@ import {
   AccountStatus,
 } from "@/types/billing/account/Account";
 import accountApi from "@/types/billing/account/accountApi";
-import {
-  ENCOUNTER_CLASSES_COLORS,
-  ENCOUNTER_CLASS_ICONS,
-  ENCOUNTER_PRIORITY_COLORS,
-} from "@/types/emr/encounter/encounter";
+import { ENCOUNTER_PRIORITY_COLORS } from "@/types/emr/encounter/encounter";
 
 export const SummaryPanelEncounterDetails = () => {
   const { t } = useTranslation();
@@ -48,7 +47,6 @@ export const SummaryPanelEncounterDetails = () => {
   });
 
   if (!encounter) return null;
-  const EncounterClassIcon = ENCOUNTER_CLASS_ICONS[encounter.encounter_class];
   return (
     <div className="flex flex-col gap-2">
       <div className="xl:hidden flex flex-col sm:flex-row p-3 bg-white -mt-1 rounded-lg gap-4 shadow">
@@ -69,16 +67,7 @@ export const SummaryPanelEncounterDetails = () => {
                   {t("encounter_class")}:
                 </span>
                 <div>
-                  <Badge
-                    variant={
-                      ENCOUNTER_CLASSES_COLORS[encounter.encounter_class]
-                    }
-                  >
-                    <EncounterClassIcon className="size-3" />
-                    <span className="whitespace-nowrap">
-                      {t(`encounter_class__${encounter.encounter_class}`)}
-                    </span>
-                  </Badge>
+                  <EncounterClassBadge encounter={encounter} />
                 </div>
               </div>
               <div>


### PR DESCRIPTION
## Proposed Changes
- Fix : #13740
- Added Encounter Class History Popup for EncounterClass Badge similar to status history
- Fix encounter status badge color consistency
- Screenshot :
<img width="1814" height="752" alt="image" src="https://github.com/user-attachments/assets/ea17eafc-5649-4394-a8d8-4e2f7df6697d" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added EncounterClassBadge to display encounter class with icon/color and a popover showing class history (dates and statuses).
  - Integrated EncounterClassBadge into encounter details panels for quick, consistent access to class info.

- Improvements
  - Status badges now use status-specific colors for clearer visual cues.
  - Unified badge styling for class and status across encounter views for a more consistent UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->