### PR TITLE
Fix for missing descriptions in sheets and dialogues

### DIFF
--- a/src/components/Common/CriticalActionConfirmationDialog.tsx
+++ b/src/components/Common/CriticalActionConfirmationDialog.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -134,7 +135,7 @@ const CriticalActionConfirmationDialog = ({
           </div>
         </AlertDialogHeader>
         <div className="space-y-3 text-sm text-black">
-          {description}
+          <AlertDialogDescription>{description}</AlertDialogDescription>
           <div>
             <span>
               <Trans

--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -6,6 +6,7 @@ import Autocomplete from "@/components/ui/autocomplete";
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
@@ -53,9 +54,9 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
           <SheetTitle className="text-xl font-semibold">
             {t("valueset_preview")}
           </SheetTitle>
-          <p className="text-sm text-gray-500">
+          <SheetDescription>
             {t("valueset_preview_description")}
-          </p>
+          </SheetDescription>
         </SheetHeader>
         <div className="px-1 mt-6">
           <Autocomplete


### PR DESCRIPTION
## Proposed Changes

Fixes #13700 
- Replaced `<p>` with <SheetDescription> in `ValueSetPreview.tsx`
- Surround `{descprition}` with `<AlertDialogDescprition>`

<img width="1920" height="1080" alt="image_2025-09-18_023404783" src="https://github.com/user-attachments/assets/9e9597db-694c-4b79-9902-9970c354b187" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the Value Set Preview header description to use a standardized sheet description component. This improves typography, spacing, and visual consistency, making the description easier to read. Users will see a cleaner header area within the Value Set preview drawer/sheet. No changes to behavior; no impact on performance or accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->