### PR TITLE
Fixed edit queue form not being prefilled / invalidated on edit

### DIFF
--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -67,7 +67,7 @@ export function ManageQueuePage({
   });
 
   const { data: queue, isLoading: isQueueLoading } = useQuery({
-    queryKey: ["queue", facilityId, queueId],
+    queryKey: ["tokenQueue", facilityId, queueId],
     queryFn: query(tokenQueueApi.get, {
       pathParams: { facility_id: facilityId, id: queueId },
     }),

--- a/src/pages/Facility/queues/QueueFormSheet.tsx
+++ b/src/pages/Facility/queues/QueueFormSheet.tsx
@@ -107,7 +107,7 @@ export default function QueueFormSheet({
         set_is_primary: queue.is_primary,
       });
     }
-  }, [queue, isEditMode, form]);
+  }, [queue, isEditMode, form, isOpen]);
 
   // Reset form when sheet opens/closes
   useEffect(() => {
@@ -200,9 +200,7 @@ export default function QueueFormSheet({
         ) : (
           <Form {...form}>
             <form
-              onSubmit={form.handleSubmit(onSubmit, (errors) => {
-                console.error("Form validation errors:", errors);
-              })}
+              onSubmit={form.handleSubmit(onSubmit)}
               className="space-y-6 mt-6"
             >
               {/* Queue Name */}


### PR DESCRIPTION
## Proposed Changes

Fixes #13751 
- Changed the invalidateQuery key to the correct key.
- Added isOpen dependency to useEffect in QueueFormSheet so the form gets reset when its opened
- Refactored file by removing console statements

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue data updates more reliably, reducing stale information when viewing facility queues.
  * Editing a queue now correctly refreshes form fields each time the sheet opens.
  * Form submission benefits from streamlined validation handling for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->