### PR TITLE
fix: limit 100 is set for fetching facility organizations

### DIFF
--- a/src/pages/Appointments/components/MultiPractitionerSelect.tsx
+++ b/src/pages/Appointments/components/MultiPractitionerSelect.tsx
@@ -86,6 +86,7 @@ export const MultiPractitionerSelector = ({
         parent: "",
         ordering: "name",
         active: true,
+        limit: 100,
       },
     }),
     enabled: open,


### PR DESCRIPTION
## Proposed Changes
<img width="406" height="604" alt="image" src="https://github.com/user-attachments/assets/bf13aa49-3bbe-43ac-8776-df4aca9439e6" />
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

~- [ ] Add specs that demonstrate the bug or test the new feature.~
~- [ ] Update [product documentation](https://docs.ohc.network).~
~- [ ] Ensure that UI text is placed in I18n files.~
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading speed and reliability in the practitioner selection flow by limiting the initial root organizations fetched to a manageable number.
  * Reduced risk of timeouts or sluggish UI when opening the multi-practitioner selector.

* **Chores**
  * Optimized data fetching for root organizations to enhance responsiveness without changing visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->