### PR TITLE
Prescription - Pass facility id for permission check

### DIFF
--- a/src/components/Medicine/PrescriptionView.tsx
+++ b/src/components/Medicine/PrescriptionView.tsx
@@ -36,6 +36,7 @@ export default function PrescriptionView({
     queryKey: ["prescription", patientId, prescriptionId],
     queryFn: query(prescriptionApi.get, {
       pathParams: { patientId, id: prescriptionId! },
+      queryParams: { facility: facilityId },
     }),
     enabled: !!patientId && !!prescriptionId,
   });

--- a/src/pages/Encounters/PrintPrescription.tsx
+++ b/src/pages/Encounters/PrintPrescription.tsx
@@ -24,6 +24,7 @@ export const PrintPrescription = (props: {
     queryKey: ["prescription", patientId, prescriptionId],
     queryFn: query(prescriptionApi.get, {
       pathParams: { patientId, id: prescriptionId! },
+      queryParams: { facility: facilityId },
     }),
     enabled: !!prescriptionId,
   });

--- a/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
@@ -231,6 +231,7 @@ export default function MedicationDispenseList({
     queryKey: ["prescription", patientId, prescriptionId],
     queryFn: query(prescriptionApi.get, {
       pathParams: { patientId, id: prescriptionId },
+      queryParams: { facility: facilityId },
     }),
   });
 
@@ -261,6 +262,7 @@ export default function MedicationDispenseList({
     }) => {
       return mutate(prescriptionApi.update, {
         pathParams: { patientId, id: prescription.id },
+        queryParams: { facility: facilityId },
       })({ ...prescription, status: newStatus });
     },
     onSuccess: () => {


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensured prescriptions are filtered by the selected facility in Prescription View and Print Prescription.
  - Medication Dispense List now fetches and updates prescriptions within the current facility context.
  - Prevents cross-facility mix-ups, ensuring accurate data display and actions per facility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->