### PR TITLE
Fixed Charge Item Definition Cell Navigation / Product Knowledge Navigation

### DIFF
--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
@@ -105,15 +105,15 @@ function ChargeItemTableRow({
   const { t } = useTranslation();
 
   return (
-    <TableRow className="hover:bg-gray-50 cursor-pointer">
-      <TableCell
-        className="font-medium cursor-pointer"
-        onClick={() =>
-          navigate(
-            `/facility/${facilityId}/settings/charge_item_definitions/${definition.slug}`,
-          )
-        }
-      >
+    <TableRow
+      className="hover:bg-gray-50 cursor-pointer"
+      onClick={() =>
+        navigate(
+          `/facility/${facilityId}/settings/charge_item_definitions/${definition.slug}`,
+        )
+      }
+    >
+      <TableCell className="font-medium cursor-pointer">
         <div className="flex items-center space-x-3">
           <div>
             <div className="font-medium text-gray-900">{definition.title}</div>

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -157,7 +157,9 @@ function ProductKnowledgeFormContent({
   existingData,
   categorySlug,
   onSuccess = () =>
-    navigate(`/facility/${facilityId}/settings/product_knowledge`),
+    navigate(
+      `/facility/${facilityId}/settings/product_knowledge/categories/${categorySlug}`,
+    ),
 }: {
   facilityId: string;
   slug?: string;
@@ -989,7 +991,9 @@ function ProductKnowledgeFormContent({
                 type="button"
                 variant="outline"
                 onClick={() =>
-                  navigate(`/facility/${facilityId}/settings/product_knowledge`)
+                  navigate(
+                    `/facility/${facilityId}/settings/product_knowledge/categories/${categorySlug}`,
+                  )
                 }
               >
                 {t("cancel")}

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeView.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeView.tsx
@@ -20,12 +20,14 @@ import Page from "@/components/Common/Page";
 import { CardListWithHeaderSkeleton } from "@/components/Common/SkeletonLoading";
 
 import query from "@/Utils/request/query";
+import BackButton from "@/components/Common/BackButton";
 import { Code } from "@/types/base/code/code";
 import {
   PRODUCT_KNOWLEDGE_STATUS_COLORS,
   ProductName,
 } from "@/types/inventory/productKnowledge/productKnowledge";
 import productKnowledgeApi from "@/types/inventory/productKnowledge/productKnowledgeApi";
+import { ArrowLeft } from "lucide-react";
 
 interface Props {
   facilityId: string;
@@ -75,16 +77,10 @@ export default function ProductKnowledgeView({ facilityId, slug }: Props) {
               {t("product_knowledge_not_found")}
             </AlertDescription>
           </Alert>
-          <Button
-            variant="outline"
-            className="mt-4"
-            onClick={() =>
-              navigate(`/facility/${facilityId}/settings/product_knowledge`)
-            }
-          >
-            <CareIcon icon="l-arrow-left" className="mr-2 size-4" />
+          <BackButton>
+            <ArrowLeft />
             {t("back_to_list")}
-          </Button>
+          </BackButton>
         </div>
       </Page>
     );
@@ -93,17 +89,10 @@ export default function ProductKnowledgeView({ facilityId, slug }: Props) {
   return (
     <Page title={product.name} hideTitleOnPage={true}>
       <div className="container mx-auto max-w-3xl space-y-6">
-        <Button
-          variant="outline"
-          size="xs"
-          className="mb-2"
-          onClick={() =>
-            navigate(`/facility/${facilityId}/settings/product_knowledge`)
-          }
-        >
-          <CareIcon icon="l-arrow-left" className="size-4" />
+        <BackButton>
+          <ArrowLeft />
           {t("back")}
-        </Button>
+        </BackButton>
 
         <div className="flex items-center justify-between">
           <div>


### PR DESCRIPTION
## Proposed Changes

Fixes Develop ToDO
- Fixed issue where charge item definition card will only open when clicking on name cell instead of row
- Fixed issue where it navigated user to product knowledge instead of category after category creation

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charge Item Definitions: entire table rows are now clickable to open a charge item’s details.
  * Product Knowledge: after save or cancel, the form redirects back to the relevant category page (category preserved in the URL).

* **Refactor**
  * Product view: back navigation standardized to a shared BackButton with an arrow icon for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->