### PR TITLE
Add expiry in lot dropdown during dispense

### DIFF
--- a/src/components/Consumable/DispenseDrawer.tsx
+++ b/src/components/Consumable/DispenseDrawer.tsx
@@ -685,7 +685,7 @@ export default function DispenseDrawer({
                                                         key={
                                                           lot.selectedInventoryId
                                                         }
-                                                        className="flex items-center justify-between w-full bg-gray-50 px-px py-px border-gray-200 border-1 rounded-sm text-gray-950"
+                                                        className="flex items-center justify-between w-full bg-gray-50 px-px py-px border-gray-200 border-1 rounded-sm text-gray-950 gap-1"
                                                       >
                                                         <span className="font-medium text-sm ml-1">
                                                           {
@@ -715,6 +715,33 @@ export default function DispenseDrawer({
                                                             .display ||
                                                             t("units")}
                                                         </Badge>
+                                                        {selectedInventory
+                                                          ?.product
+                                                          .expiration_date && (
+                                                          <Badge
+                                                            variant={
+                                                              selectedInventory.status ===
+                                                                "active" &&
+                                                              new Date(
+                                                                selectedInventory.product.expiration_date,
+                                                              ) >= new Date()
+                                                                ? "primary"
+                                                                : "destructive"
+                                                            }
+                                                          >
+                                                            {t("expiry")}:{" "}
+                                                            {selectedInventory
+                                                              .product
+                                                              .expiration_date
+                                                              ? formatDate(
+                                                                  selectedInventory
+                                                                    .product
+                                                                    .expiration_date,
+                                                                  "dd/MM/yyyy",
+                                                                )
+                                                              : "-"}
+                                                          </Badge>
+                                                        )}
                                                       </div>
                                                     );
                                                   },
@@ -780,7 +807,7 @@ export default function DispenseDrawer({
                                                       checked={isSelected}
                                                       className="mr-2"
                                                     />
-                                                    <div className="flex-1 flex items-center justify-between">
+                                                    <div className="flex-1 flex items-center justify-between gap-1">
                                                       <span>
                                                         {
                                                           inv.product.batch
@@ -803,6 +830,30 @@ export default function DispenseDrawer({
                                                           .base_unit.display ||
                                                           t("units")}
                                                       </Badge>
+                                                      {inv.product
+                                                        ?.expiration_date && (
+                                                        <Badge
+                                                          variant={
+                                                            inv.status ===
+                                                              "active" &&
+                                                            new Date(
+                                                              inv.product.expiration_date,
+                                                            ) >= new Date()
+                                                              ? "primary"
+                                                              : "destructive"
+                                                          }
+                                                        >
+                                                          {t("expiry")}:{" "}
+                                                          {inv.product
+                                                            .expiration_date
+                                                            ? formatDate(
+                                                                inv.product
+                                                                  .expiration_date,
+                                                                "dd/MM/yyyy",
+                                                              )
+                                                            : "-"}
+                                                        </Badge>
+                                                      )}
                                                     </div>
                                                   </div>
                                                 );

--- a/src/pages/Facility/services/inventory/internalTransfer/SupplyDeliveryCreate.tsx
+++ b/src/pages/Facility/services/inventory/internalTransfer/SupplyDeliveryCreate.tsx
@@ -37,8 +37,6 @@ import Page from "@/components/Common/Page";
 
 import useAppHistory from "@/hooks/useAppHistory";
 
-import mutate from "@/Utils/request/mutate";
-import query from "@/Utils/request/query";
 import Autocomplete from "@/components/ui/autocomplete";
 import { InventoryRead } from "@/types/inventory/product/inventory";
 import inventoryApi from "@/types/inventory/product/inventoryApi";
@@ -51,6 +49,9 @@ import {
 import supplyDeliveryApi from "@/types/inventory/supplyDelivery/supplyDeliveryApi";
 import supplyRequestApi from "@/types/inventory/supplyRequest/supplyRequestApi";
 import locationApi from "@/types/location/locationApi";
+import mutate from "@/Utils/request/mutate";
+import query from "@/Utils/request/query";
+import { formatDate } from "date-fns";
 
 const supplyDeliveryItemSchema = z.object({
   supplied_inventory_item: z.string().min(1, "Inventory item is required"),
@@ -115,7 +116,7 @@ export default function SupplyDeliveryCreate({
 
   const inventoryItemOptions =
     inventoryItems?.results.map((item: InventoryRead) => ({
-      label: `${item.product.product_knowledge.name} (${t("lot")} #${item.product.batch?.lot_number})`,
+      label: `${t("lot")} #${item.product.batch?.lot_number} ${item.product.expiration_date ? `(${t("expiry")} ${formatDate(item.product.expiration_date, "dd/MM/yyyy")})` : ""}`,
       value: item.id,
     })) || [];
 

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -1802,10 +1802,10 @@ export default function MedicationBillForm({ patientId }: Props) {
                                           <PopoverTrigger asChild>
                                             <Button
                                               variant="outline"
-                                              className="w-auto min-w-40 justify-between h-auto min-h-[40px] p-2 border-gray-300 border"
+                                              className="w-auto min-w-40 justify-between h-auto min-h-[40px] p-1 border-gray-300 border"
                                               type="button"
                                             >
-                                              <div className="flex flex-col items-start gap-1 w-full">
+                                              <div className="flex flex-col items-start gap-1 w-full p-1">
                                                 {(() => {
                                                   const selectedLots = form
                                                     .watch(
@@ -1843,7 +1843,7 @@ export default function MedicationBillForm({ patientId }: Props) {
                                                           key={
                                                             lot.selectedInventoryId
                                                           }
-                                                          className="flex items-center gap-2 w-full bg-gray-50 px-2 border-gray-200 border-1 text-gray-950"
+                                                          className="flex items-center gap-2 w-full bg-gray-50 px-2 py-1 border-gray-200 border-1 text-gray-950"
                                                         >
                                                           <span className="font-medium text-sm">
                                                             {"Lot #" +
@@ -1872,6 +1872,33 @@ export default function MedicationBillForm({ patientId }: Props) {
                                                                 .display
                                                             }
                                                           </Badge>
+                                                          {selectedInventory
+                                                            ?.product
+                                                            .expiration_date && (
+                                                            <Badge
+                                                              variant={
+                                                                selectedInventory.status ===
+                                                                  "active" &&
+                                                                new Date(
+                                                                  selectedInventory.product.expiration_date,
+                                                                ) >= new Date()
+                                                                  ? "primary"
+                                                                  : "destructive"
+                                                              }
+                                                            >
+                                                              {t("expiry")}:{" "}
+                                                              {selectedInventory
+                                                                .product
+                                                                .expiration_date
+                                                                ? formatDate(
+                                                                    selectedInventory
+                                                                      .product
+                                                                      .expiration_date,
+                                                                    "dd/MM/yyyy",
+                                                                  )
+                                                                : "-"}
+                                                            </Badge>
+                                                          )}
                                                           {selectedInventory
                                                             ?.location.id !==
                                                             locationId && (
@@ -1984,6 +2011,30 @@ export default function MedicationBillForm({ patientId }: Props) {
                                                               .base_unit.display
                                                           }
                                                         </Badge>
+                                                        {inv.product
+                                                          ?.expiration_date && (
+                                                          <Badge
+                                                            variant={
+                                                              inv.status ===
+                                                                "active" &&
+                                                              new Date(
+                                                                inv.product.expiration_date,
+                                                              ) >= new Date()
+                                                                ? "primary"
+                                                                : "destructive"
+                                                            }
+                                                          >
+                                                            {t("expiry")}:{" "}
+                                                            {inv.product
+                                                              .expiration_date
+                                                              ? formatDate(
+                                                                  inv.product
+                                                                    .expiration_date,
+                                                                  "dd/MM/yyyy",
+                                                                )
+                                                              : "-"}
+                                                          </Badge>
+                                                        )}
                                                         {inv?.location.id !==
                                                           locationId && (
                                                           <Badge variant="secondary">


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added expiry badges across inventory selections, lists, and dropdowns, showing “expiry: dd/MM/yyyy” when available.
  - Badges use colors to indicate status: primary for active/non-expired items, destructive for expired or inactive items.
  - Inventory option labels now include formatted expiry dates alongside lot information.

- Style
  - Adjusted gap spacing and minor padding to improve layout and accommodate new badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->