### PR TITLE
Supply Delivery create status fix

### DIFF
--- a/src/pages/Facility/services/inventory/ReceiveStock.tsx
+++ b/src/pages/Facility/services/inventory/ReceiveStock.tsx
@@ -27,7 +27,6 @@ import Page from "@/components/Common/Page";
 
 import useAppHistory from "@/hooks/useAppHistory";
 
-import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import { ProductSearch } from "@/pages/Facility/services/inventory/ProductSearch";
 import { SupplierSelect } from "@/pages/Facility/services/inventory/SupplierSelect";
@@ -42,6 +41,7 @@ import supplyDeliveryApi from "@/types/inventory/supplyDelivery/supplyDeliveryAp
 import { SupplyRequestRead } from "@/types/inventory/supplyRequest/supplyRequest";
 import { Organization } from "@/types/organization/organization";
 
+import batchApi from "@/types/base/batch/batchApi";
 import { ProductKnowledgeSelect } from "./ProductKnowledgeSelect";
 import { ReceiveStockTable } from "./ReceiveStockTable";
 import { SupplyRequestSelect } from "./SupplyRequestSelect";
@@ -98,7 +98,7 @@ export function ReceiveStock({
   });
 
   const batchRequest = useMutation({
-    mutationFn: mutate(routes.batchRequest),
+    mutationFn: mutate(batchApi.batchRequest),
     onSuccess: () => {
       toast.success(t("stock_received"));
       form.reset();
@@ -123,7 +123,7 @@ export function ReceiveStock({
             destination: locationId,
             supplied_item: entry.supplied_item?.id,
             supplied_item_quantity: entry.supplied_item_quantity,
-            status: SupplyDeliveryStatus.completed,
+            status: SupplyDeliveryStatus.in_progress,
             supplied_item_type: SupplyDeliveryType.product,
           } satisfies SupplyDeliveryCreate,
         })),


### PR DESCRIPTION
- Status updated to in-progress for receive stock to match BE change

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New supply deliveries now start as “In Progress” instead of being marked complete, ensuring accurate status tracking during receipt.

* **Chores**
  * Updated the batch request integration to use a unified API for inventory receiving operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->