### PR TITLE
fix: exclude 'show-shortcuts' action from displayed items and update dependencies

### DIFF
--- a/src/components/Facility/ShortcutCommandDialog.tsx
+++ b/src/components/Facility/ShortcutCommandDialog.tsx
@@ -75,6 +75,10 @@ export function ShortcutCommandDialog({
 
       const items: ActionItem[] = contextActions
         .filter((action) => {
+          if (action.action === "show-shortcuts") {
+            return false;
+          }
+
           // Only include actions if the corresponding element exists on the page
           const element = document.querySelector(
             `[data-shortcut-id='${action.action}']`,
@@ -96,7 +100,8 @@ export function ShortcutCommandDialog({
     });
 
     return actionGroups;
-  }, [subContext]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subContext, open]);
 
   const handleSelect = useCallback(
     (actionId: string) => {


### PR DESCRIPTION


## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the self-referential “Show shortcuts” entry from the shortcuts dialog to prevent confusion and accidental activation.
  * Improved the stability of the shortcuts list when opening/closing the dialog, ensuring the displayed actions remain accurate and relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->