### PR TITLE
fix:Questionnaire response list corresponding to Encounter

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -506,6 +506,7 @@ export default function QuestionnaireResponsesList({
       patientId,
       qParams.page,
       questionnaireId,
+      encounter?.id,
     ],
     queryFn: query.paginated(patientApi.getQuestionnaireResponses, {
       pathParams: { patientId },


### PR DESCRIPTION
## Proposed Changes
- fix:Questionnaire response list corresponding to Encounter

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Questionnaire responses now reliably update when switching encounters in Consultation Details, preventing stale or mismatched data from appearing.
  * Improved cache handling ensures the correct responses are shown for each selected encounter without manual refresh.
  * Navigating between encounters triggers a fresh fetch so the UI consistently reflects the current encounter’s questionnaire responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->