### PR TITLE
Receive Stock shortcuts

### DIFF
--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -41,6 +41,13 @@
     { "key": "d", "action": "dispense-button", "description": "Dispense Medication", "when": "always" }
   ],
 
+"facility:pharmacy:supply-delivery": [
+    { "key": "shift+enter", "action": "mark-as-received", "description": "Mark as Received", "when": "always" },
+    { "key": "w", "action": "proceed-without-marking", "description": "Proceed without Marking", "when": "always" },
+    { "key": "enter", "action": "proceed-with-marking", "description": "Proceed with Marking", "when": "always" }
+
+  ],
+
   "facility:billing:invoice": [
     { "key": "c", "action": "create-invoice", "description": "Create Invoice", "when": "always" },
     { "key": "o", "action": "other-charge-items", "description": "Other Charge Items", "when": "always" },

--- a/src/pages/Facility/services/inventory/internalTransfer/ReceiveItem.tsx
+++ b/src/pages/Facility/services/inventory/internalTransfer/ReceiveItem.tsx
@@ -101,7 +101,7 @@ export default function ReceiveItem({
 }: Props) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  useShortcutSubContext("supply-delivery");
+  useShortcutSubContext("facility:pharmacy:supply-delivery");
   const [isReceivingAbandonedItem, setIsReceivingAbandonedItem] =
     useState(false);
   const [nextDeliveryUrl, setNextDeliveryUrl] = useState<string>("");
@@ -429,34 +429,33 @@ export default function ReceiveItem({
   return (
     <Page title={t("to_receive")} hideTitleOnPage>
       <div className="max-w-8xl container mx-auto flex flex-row gap-8">
-        {mode === "external" && (
-          <div
-            className={cn("grid gap-8 hidden md:grid grid-cols-[300px_1fr]")}
-          >
-            <SupplyDeliveryList
-              facilityId={facilityId}
-              locationId={locationId}
-              selectedDelivery={delivery}
-              onSelectDelivery={(deliveryId) => {
+        <div className={cn("grid gap-8 hidden md:grid grid-cols-[300px_1fr]")}>
+          <SupplyDeliveryList
+            facilityId={facilityId}
+            locationId={locationId}
+            selectedDelivery={delivery}
+            mode={mode}
+            onSelectDelivery={(deliveryId) => {
+              const { deliveryId: _, ...cleanParams } = qParams;
+              navigate(
+                makeUrl(
+                  mode === "external"
+                    ? `/facility/${facilityId}/locations/${locationId}/external_supply/deliveries/${deliveryId}`
+                    : `/facility/${facilityId}/locations/${locationId}/internal_transfers/to_receive/${deliveryId}`,
+                  { ...cleanParams, deliveryId },
+                ),
+              );
+            }}
+            onSetNextDeliveryUrl={(url) => {
+              if (url) {
                 const { deliveryId: _, ...cleanParams } = qParams;
-                navigate(
-                  makeUrl(
-                    `/facility/${facilityId}/locations/${locationId}/external_supply/deliveries/${deliveryId}`,
-                    { ...cleanParams, deliveryId },
-                  ),
-                );
-              }}
-              onSetNextDeliveryUrl={(url) => {
-                if (url) {
-                  const { deliveryId: _, ...cleanParams } = qParams;
-                  setNextDeliveryUrl(makeUrl(url, { ...cleanParams }));
-                } else {
-                  setNextDeliveryUrl("");
-                }
-              }}
-            />
-          </div>
-        )}
+                setNextDeliveryUrl(makeUrl(url, { ...cleanParams }));
+              } else {
+                setNextDeliveryUrl("");
+              }
+            }}
+          />
+        </div>
         {isLoading || !delivery ? (
           <Skeleton className="h-[calc(100vh-4rem)] w-full" />
         ) : (
@@ -818,9 +817,7 @@ export default function ReceiveItem({
                                           checked={field.value}
                                           onCheckedChange={field.onChange}
                                           id="markAsFullyReceived"
-                                          data-shortcut-id="mark_as_fully_received"
                                         />
-                                        <ShortcutBadge actionId="mark_as_fully_received" />
                                       </div>
                                     </FormControl>
                                   </div>
@@ -863,7 +860,6 @@ export default function ReceiveItem({
                           type="button"
                           disabled={isPending}
                           onClick={() => openDialog("receive")}
-                          data-shortcut-id="mark-as-received"
                         >
                           <ButtonIcon className="size-4" />
                           {buttonText}
@@ -1066,7 +1062,6 @@ export default function ReceiveItem({
                       }
                       setQuantityMismatchDialog({ open: false });
                     }}
-                    data-shortcut-id="proceed-without-marking"
                   >
                     {t("SRD__proceed_without_marking")}
                     <ShortcutBadge actionId="proceed-without-marking" />
@@ -1082,7 +1077,6 @@ export default function ReceiveItem({
                       }
                       setQuantityMismatchDialog({ open: false });
                     }}
-                    data-shortcut-id="proceed-with-marking"
                   >
                     {t("proceed")}
                     <ShortcutBadge actionId="proceed-with-marking" />


### PR DESCRIPTION
## Proposed Changes

- Added back shortcuts missing since conflict merge
- Added switcher for internal flow receive stock

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new keyboard shortcuts for pharmacy supply delivery actions.
  * Improved delivery list to support both internal transfers and external deliveries, including updated UI labels and tailored data display for each mode.

* **Bug Fixes**
  * Addressed navigation and URL handling to ensure accurate mode-specific delivery management.

* **Style**
  * Streamlined UI controls and removed shortcut indicators for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->