### PR TITLE
add PatientRegistrationForm plugin component

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -40,6 +40,7 @@ import useAppHistory from "@/hooks/useAppHistory";
 import { tzAwareDateTime } from "@/lib/validators";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import GovtOrganizationSelector from "@/pages/Organization/components/GovtOrganizationSelector";
+import { PLUGIN_Component } from "@/PluginEngine";
 import {
   BloodGroupChoices,
   PatientIdentifierCreate,
@@ -338,6 +339,12 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
                   : ["patient-basics", "additional-details"]
               }
             >
+              <PLUGIN_Component
+                __name="PatientRegistrationForm"
+                form={form}
+                facilityId={facilityId}
+                patientId={patientId}
+              />
               <AccordionItem
                 value="patient-basics"
                 className="bg-white flex flex-col gap-4 p-6 shadow rounded-md"


### PR DESCRIPTION
## Proposed Changes

Adds PatientRegistrationForm plugin component back into patient registration form, it was removed during the redesign implementation. This component is used by ABDM plug for generating or linking Abha Number while registering a patient.

_All necessary changes to ABDM plug has already been made._

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient Registration now supports add-on sections within the form, enabling additional fields to appear alongside existing sections.
  * These optional sections dynamically adapt to the current facility and patient context and are displayed within the existing accordion interface.
  * Enhances customization and extensibility of the registration experience without disrupting current workflows; if no add-ons are available, the form behaves as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->