### PR TITLE
Whitespace passes validation in Edit facility details form [ 13832]

### DIFF
--- a/src/components/Facility/FacilityForm.tsx
+++ b/src/components/Facility/FacilityForm.tsx
@@ -57,12 +57,12 @@ export default function FacilityForm({
 
   const facilityFormSchema = z.object({
     facility_type: z.string().min(1, t("facility_type_required")),
-    name: z.string().min(1, t("name_is_required")),
+    name: z.string().trim().min(1, t("name_is_required")),
     description: z.string().trim().default(""),
     features: z.array(z.number()).default([]),
     pincode: validators().pincode,
     geo_organization: z.string().min(1, t("field_required")),
-    address: z.string().min(1, t("address_is_required")),
+    address: z.string().trim().min(1, t("address_is_required")),
     phone_number: validators().phoneNumber.required,
     latitude: validators()
       .coordinates.latitude.transform((val) => (val ? Number(val) : undefined))


### PR DESCRIPTION
## Proposed Changes

Fixes #13832 
- Added validation to prevent whitespace-only input in Facility Name and Address fields within the Edit Facility Details form.

Tagging: @ohcnetwork/care-fe-code-reviewers 


https://github.com/user-attachments/assets/3004041d-587e-4c77-99bb-fe5dec3e226b

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [done ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ done] Complete QA on mobile devices.
- [ done ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation for facility name and address to ignore leading/trailing spaces, preventing whitespace-only inputs from being accepted.
  * Ensures required fields correctly flag empty or space-only entries, leading to more reliable submissions and clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->