### PR TITLE
fix: pagination for resource category list, filtering for AD list

### DIFF
--- a/src/components/Common/ResourceCategoryList.tsx
+++ b/src/components/Common/ResourceCategoryList.tsx
@@ -25,7 +25,9 @@ import {
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
+import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 import { ResourceCategoryForm } from "@/components/Common/ResourceCategoryForm";
+import useFilters from "@/hooks/useFilters";
 import {
   ResourceCategoryRead,
   ResourceCategoryResourceType,
@@ -194,6 +196,10 @@ export function ResourceCategoryList({
   const [editingCategory, setEditingCategory] = React.useState<string | null>(
     null,
   );
+  const { qParams, Pagination, resultsPerPage } = useFilters({
+    limit: RESULTS_PER_PAGE_LIMIT,
+    disableCache: true,
+  });
 
   // Fetch current category by slug
   const { data: currentCategory } = useQuery({
@@ -207,13 +213,15 @@ export function ResourceCategoryList({
   // Fetch categories for current level
   const { data: categoriesResponse, isLoading: isLoadingCategories } = useQuery(
     {
-      queryKey: ["resourceCategories", facilityId, categorySlug],
+      queryKey: ["resourceCategories", facilityId, categorySlug, qParams],
       queryFn: query(resourceCategoryApi.list, {
         pathParams: { facilityId },
         queryParams: {
           resource_type: resourceType,
           parent: categorySlug || "",
           ordering: "title",
+          limit: resultsPerPage,
+          offset: ((qParams.page ?? 1) - 1) * resultsPerPage,
         },
       }),
     },
@@ -329,6 +337,8 @@ export function ResourceCategoryList({
           onClose={() => setIsCategoryFormOpen(false)}
           onSuccess={handleCategoryFormSuccess}
         />
+
+        <Pagination totalCount={categoriesResponse?.count || 0} />
       </div>
     </TooltipProvider>
   );

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
@@ -276,11 +276,13 @@ export function ActivityDefinitionList({
             {/* classification Filter */}
             <div className="w-full sm:w-auto">
               <FilterSelect
-                value={qParams.category || ""}
-                onValueChange={(value) => updateQuery({ category: value })}
+                value={qParams.classification || ""}
+                onValueChange={(value) =>
+                  updateQuery({ classification: value })
+                }
                 options={Object.values(Classification)}
                 label={t("category")}
-                onClear={() => updateQuery({ category: undefined })}
+                onClear={() => updateQuery({ classification: undefined })}
               />
             </div>
           </div>


### PR DESCRIPTION
## Proposed Changes


- Add pagination for resource category pages
- Fix classification filtering for AD list

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added pagination to the Resource Categories list, with page controls and total count display.

- Improvements
  - Results update immediately when filters change for a smoother browsing experience.

- Bug Fixes
  - Fixed the classification filter in Activity Definitions so it applies correctly and can be cleared independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->