### PR TITLE
tag selector mobile fix

### DIFF
--- a/src/components/ui/multi-filter/tagFilter.tsx
+++ b/src/components/ui/multi-filter/tagFilter.tsx
@@ -74,7 +74,7 @@ function TreeViewItem({
   });
 
   const isSelected = selectedTags.some((t) => t.id === tag.id);
-  const isRootLevel = tag.has_children && (children?.results?.length ?? 0) > 0;
+  const isRootLevel = tag.has_children;
   const allChildrenSelected =
     children?.results?.every((childTag: TagConfig) =>
       selectedTags.some((t) => t.id === childTag.id),


### PR DESCRIPTION
## Proposed Changes

- adjusted root level check for tag selector (test on mobile)

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Parent groups in the multi-filter now display as expandable whenever they have child items, even if those children haven’t loaded yet.
  - Expand/collapse controls and chevrons are shown consistently for all parent groups.
  - Root-level gating is applied uniformly, improving predictability.
  - Enhances navigation and discoverability in the filter panel by preventing missing or hidden controls before data loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->