### PR TITLE
Fixes unnecessary extra page in diagnostic report print

### DIFF
--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
@@ -153,7 +153,7 @@ export default function DiagnosticReportPrint({
       <PrintPreview
         title={`${t("diagnostic_report")} - ${report.code?.display || "diagnostic_report"}`}
       >
-        <div className="min-h-screen py-8 max-w-4xl mx-auto">
+        <div className="py-8 max-w-4xl mx-auto">
           {/* Header with Facility Name and Logo */}
           <div className="flex justify-between items-start pb-6 border-b border-gray-200">
             <div className="space-y-4 flex-1">


### PR DESCRIPTION
## Proposed Changes
- Remove unnecessary page in Diagnostic report print page

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Diagnostic Report print view layout to no longer force full-screen height. The page now adapts to the content’s natural height, reducing unnecessary blank space on shorter reports.
  * Preserved existing padding and width for consistent readability.
  * Improves on-screen viewing and printed output by avoiding excessive vertical whitespace while maintaining the current visual structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->