### PR TITLE
Fix filename schema in ConsentFormSheet

### DIFF
--- a/src/components/Consent/ConsentFormSheet.tsx
+++ b/src/components/Consent/ConsentFormSheet.tsx
@@ -78,7 +78,10 @@ const consentFormSchema = (isEdit: boolean) =>
         .array(
           z.object({
             file: z.instanceof(File),
-            name: z.string().min(1, { message: t("enter_file_name") }),
+            name: z
+              .string()
+              .trim()
+              .min(1, { message: t("enter_file_name") }),
           }),
         )
         .default([]),


### PR DESCRIPTION
## Proposed Changes

Fixes #13843 
- Added .trim() to get rid of faulty form submission.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.

https://github.com/user-attachments/assets/80a403b0-6703-446b-9a3f-f3c3f56c1969




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved consent form file name validation by trimming whitespace before checking for content. Names with accidental leading/trailing spaces are accepted as intended, while inputs that are empty or contain only spaces are now correctly flagged. Error messaging remains the same.

- Chores
  - No user-facing changes beyond the validation improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->