### PR TITLE
fixes structured type not getting cleared when type is unstructured

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1613,6 +1613,14 @@ function QuestionEditor({
     onChange({ ...question, [field]: value, ...additionalFields });
   };
 
+  // Clear structured type if not structured, voluntarily doing this way, so that
+  // form is made dirty and user's can simply open and save the form to clear the error.
+  useEffect(() => {
+    if (question.structured_type && question.type !== "structured") {
+      updateField("structured_type", undefined);
+    }
+  }, [question.structured_type, question.type]);
+
   const toggleSubQuestionExpanded = (
     questionLinkId: string,
     allowCollapse: boolean = true,


### PR DESCRIPTION
## Proposed Changes

- fixes structured type not getting cleared when type is unstructured

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically clears the “Structured type” field when a question is switched away from Structured, preventing stale values.
  * Resolves a validation issue that previously blocked saving after changing the question type; the form now updates correctly and can be saved.
  * Improves questionnaire editor reliability and reduces user confusion during type changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->