### PR TITLE
add support for disabling clear filters

### DIFF
--- a/src/components/ui/multi-filter/MultiFilter.tsx
+++ b/src/components/ui/multi-filter/MultiFilter.tsx
@@ -52,17 +52,22 @@ export default function MultiFilter({
   const [openStates, setOpenStates] = useState<Record<string, boolean>>({});
   const { t } = useTranslation();
 
-  const totalSelectedCount = Object.values(selectedFilters).reduce(
+  const nonClearableFilterCount = Object.values(selectedFilters).reduce(
     (sum, filterState) => {
+      if (filterState.filter.disableClear) {
+        return sum;
+      }
       if (Array.isArray(filterState.selected)) {
-        return sum + filterState.selected.length;
+        if (filterState.selected.length === 0) {
+          return sum;
+        }
       }
       return sum + 1;
     },
     0,
   );
 
-  const hasAnyFilters = totalSelectedCount > 0;
+  const hasAnyFilters = nonClearableFilterCount > 0;
 
   const handleFilterSelect = (filterKey: string) => {
     setActiveFilter(filterKey);

--- a/src/components/ui/multi-filter/filterConfigs.tsx
+++ b/src/components/ui/multi-filter/filterConfigs.tsx
@@ -42,25 +42,27 @@ export const encounterStatusFilter = (
       label: t(value),
       color: ENCOUNTER_STATUS_FILTER_COLORS[value],
     })),
-    undefined,
-    (selected: FilterValues) => {
-      const selectedStatus = selected as string[];
-      if (typeof selectedStatus[0] === "string") {
-        const option = selectedStatus[0];
-        const color = ENCOUNTER_STATUS_FILTER_COLORS[option as EncounterStatus];
-        return (
-          <GenericSelectedBadge
-            selectedValue={option}
-            selectedLength={selectedStatus.length}
-            className={color}
-          />
-        );
-      }
-      return <></>;
+    {
+      renderSelected: (selected: FilterValues) => {
+        const selectedStatus = selected as string[];
+        if (typeof selectedStatus[0] === "string") {
+          const option = selectedStatus[0];
+          const color =
+            ENCOUNTER_STATUS_FILTER_COLORS[option as EncounterStatus];
+          return (
+            <GenericSelectedBadge
+              selectedValue={option}
+              selectedLength={selectedStatus.length}
+              className={color}
+            />
+          );
+        }
+        return <></>;
+      },
+      getOperations: () => customOperations || [{ label: "is" }],
+      mode,
+      icon: <CircleDashed className="w-4 h-4" />,
     },
-    () => customOperations || [{ label: "is" }],
-    mode,
-    <CircleDashed className="w-4 h-4" />,
   );
 export const encounterClassFilter = (
   key: string = "encounter_class",
@@ -76,24 +78,25 @@ export const encounterClassFilter = (
       label: t(`encounter_class__${value}`),
       color: ENCOUNTER_CLASS_FILTER_COLORS[value as EncounterClass],
     })),
-    undefined,
-    (selected: FilterValues) => {
-      const selectedClass = selected as string[];
-      if (typeof selectedClass[0] === "string") {
-        const option = selectedClass[0];
-        const color = ENCOUNTER_CLASS_FILTER_COLORS[option as EncounterClass];
-        return (
-          <GenericSelectedBadge
-            selectedValue={`encounter_class__${option}`}
-            selectedLength={selectedClass.length}
-            className={color}
-          />
-        );
-      }
-      return <></>;
+    {
+      renderSelected: (selected: FilterValues) => {
+        const selectedClass = selected as string[];
+        if (typeof selectedClass[0] === "string") {
+          const option = selectedClass[0];
+          const color = ENCOUNTER_CLASS_FILTER_COLORS[option as EncounterClass];
+          return (
+            <GenericSelectedBadge
+              selectedValue={`encounter_class__${option}`}
+              selectedLength={selectedClass.length}
+              className={color}
+            />
+          );
+        }
+        return <></>;
+      },
+      getOperations: () => customOperations || [{ label: "is" }],
+      mode,
     },
-    () => customOperations || [{ label: "is" }],
-    mode,
   );
 
 export const encounterPriorityFilter = (
@@ -111,38 +114,35 @@ export const encounterPriorityFilter = (
       label: t(`encounter_priority__${value}`),
       color: ENCOUNTER_PRIORITY_FILTER_COLORS[value as EncounterPriority],
     })),
-    undefined,
-    (selected: FilterValues) => {
-      const selectedPriority = selected as string[];
-      if (typeof selectedPriority[0] === "string") {
-        const option = selectedPriority[0];
-        const color =
-          ENCOUNTER_PRIORITY_FILTER_COLORS[option as EncounterPriority];
-        return (
-          <GenericSelectedBadge
-            selectedValue={`encounter_priority__${option}`}
-            selectedLength={selectedPriority.length}
-            className={color}
-          />
-        );
-      }
-      return <></>;
+    {
+      renderSelected: (selected: FilterValues) => {
+        const selectedPriority = selected as string[];
+        if (typeof selectedPriority[0] === "string") {
+          const option = selectedPriority[0];
+          const color =
+            ENCOUNTER_PRIORITY_FILTER_COLORS[option as EncounterPriority];
+          return (
+            <GenericSelectedBadge
+              selectedValue={`encounter_priority__${option}`}
+              selectedLength={selectedPriority.length}
+              className={color}
+            />
+          );
+        }
+        return <></>;
+      },
+      getOperations: () => customOperations || [{ label: "is" }],
+      mode,
     },
-    () => customOperations || [{ label: "is" }],
-    mode,
   );
 export const dateFilter = (
   key: string = "started_date",
   label?: string,
   dateRangeOptions?: DateRangeOption[],
+  disableClear?: boolean,
 ) =>
-  createFilterConfig(
-    key,
-    label || t("started_date"),
-    "date",
-    [],
-    undefined,
-    (
+  createFilterConfig(key, label || t("started_date"), "date", [], {
+    renderSelected: (
       selected: FilterValues,
       filter?: FilterConfig,
       onFilterChange?: (filterKey: string, values: FilterValues) => void,
@@ -155,11 +155,13 @@ export const dateFilter = (
         />
       );
     },
-    (selected: FilterValues) => getDateOperations(selected as FilterDateRange),
-    "single",
-    <CalendarFold className="w-4 h-4" />,
+    getOperations: (selected: FilterValues) =>
+      getDateOperations(selected as FilterDateRange),
+    mode: "single",
+    icon: <CalendarFold className="w-4 h-4" />,
     dateRangeOptions,
-  );
+    disableClear,
+  });
 export const tagFilter = (
   key: string = "tags",
   resource: TagResource = TagResource.ENCOUNTER,
@@ -171,21 +173,22 @@ export const tagFilter = (
     label ? t(label) : t("tags", { count: 2 }),
     "tag",
     [],
-    resource,
-    (selected: FilterValues) => {
-      return <SelectedTagBadge selected={selected as TagConfig[]} />;
+    {
+      resource: resource,
+      renderSelected: (selected: FilterValues) => {
+        return <SelectedTagBadge selected={selected as TagConfig[]} />;
+      },
+      getOperations: (selected: FilterValues) => {
+        const selectedTags = selected as TagConfig[];
+        if (selectedTags.length === 1)
+          return [{ label: "includes", value: "all" }];
+        return [
+          { label: "has_all_of", value: "all" },
+          { label: "has_any_of", value: "any" },
+        ];
+      },
+      mode,
+      icon: <Tag className="w-4 h-4" />,
+      operationKey: "tags_behavior",
     },
-    (selected: FilterValues) => {
-      const selectedTags = selected as TagConfig[];
-      if (selectedTags.length === 1)
-        return [{ label: "includes", value: "all" }];
-      return [
-        { label: "has_all_of", value: "all" },
-        { label: "has_any_of", value: "any" },
-      ];
-    },
-    mode,
-    <Tag className="w-4 h-4" />,
-    undefined,
-    "tags_behavior",
   );

--- a/src/components/ui/multi-filter/selectedFilterBar.tsx
+++ b/src/components/ui/multi-filter/selectedFilterBar.tsx
@@ -112,13 +112,15 @@ export function SelectedFilterBar({
         <div className="flex items-center gap-2 px-3 py-2 border-r border-gray-200 whitespace-nowrap">
           {filter.renderSelected?.(selected, filter, onFilterChange)}
         </div>
-        <Button
-          variant="ghost"
-          onClick={clearFilter}
-          className="px-3 py-2 hover:bg-gray-50"
-        >
-          <X className="h-5 w-5 text-gray-600" />
-        </Button>
+        {!filter?.disableClear && (
+          <Button
+            variant="ghost"
+            onClick={clearFilter}
+            className="px-3 py-2 hover:bg-gray-50"
+          >
+            <X className="h-5 w-5 text-gray-600" />
+          </Button>
+        )}
       </div>
       <DropdownMenuContent className="w-[320px] p-0" align="start">
         <FilterRenderer

--- a/src/components/ui/multi-filter/utils/Utils.tsx
+++ b/src/components/ui/multi-filter/utils/Utils.tsx
@@ -55,6 +55,7 @@ export interface BaseFilterConfig {
   ) => React.ReactNode;
   getOperations?: (selected: FilterValues) => Operation[];
   mode?: FilterMode;
+  disableClear?: boolean;
 }
 
 export interface CommandFilterConfig extends BaseFilterConfig {
@@ -127,18 +128,31 @@ export function createFilterConfig(
   label: string,
   type: "command" | "tag" | "date",
   options: FilterOption[],
-  resource?: TagResource,
-  renderSelected?: (
-    selected: FilterValues,
-    filter?: FilterConfig,
-    onFilterChange?: (filterKey: string, values: FilterValues) => void,
-  ) => React.ReactNode,
-  getOperations?: (selected: FilterValues) => Operation[],
-  mode: FilterMode = "single",
-  icon?: React.ReactNode,
-  dateRangeOptions?: DateRangeOption[],
-  operationKey?: string,
+  meta?: {
+    resource?: TagResource;
+    renderSelected?: (
+      selected: FilterValues,
+      filter?: FilterConfig,
+      onFilterChange?: (filterKey: string, values: FilterValues) => void,
+    ) => React.ReactNode;
+    getOperations?: (selected: FilterValues) => Operation[];
+    mode?: FilterMode;
+    icon?: React.ReactNode;
+    dateRangeOptions?: DateRangeOption[];
+    operationKey?: string;
+    disableClear?: boolean;
+  },
 ): FilterConfig {
+  const {
+    resource,
+    renderSelected,
+    getOperations,
+    mode,
+    icon,
+    dateRangeOptions,
+    operationKey,
+    disableClear,
+  } = meta || {};
   const baseConfig: BaseFilterConfig = {
     key,
     label,
@@ -148,6 +162,7 @@ export function createFilterConfig(
     mode: mode || "single",
     icon,
     operationKey,
+    disableClear,
   };
   switch (type) {
     case "date":

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -264,7 +264,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
       "multi",
       t("tags", { count: 2 }),
     ),
-    dateFilter("date", t("date"), shortDateRangeOptions),
+    dateFilter("date", t("date"), shortDateRangeOptions, true),
   ];
 
   const onFilterUpdate = (query: Record<string, unknown>) => {

--- a/src/pages/Encounters/EncounterHistorySelector.tsx
+++ b/src/pages/Encounters/EncounterHistorySelector.tsx
@@ -261,12 +261,16 @@ const EncounterHistoryList = ({ onSelect }: Props) => {
           break;
         case "created_date":
           if (
+            filterValue &&
             typeof filterValue === "object" &&
             "from" in filterValue &&
             "to" in filterValue
           ) {
             setDateFrom(filterValue.from as Date);
             setDateTo(filterValue.to as Date);
+          } else {
+            setDateFrom(undefined);
+            setDateTo(undefined);
           }
           break;
       }

--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -178,7 +178,7 @@ export function EncounterList({
     encounterStatusFilter("status"),
     encounterPriorityFilter("priority"),
     tagFilter("tags", TagResource.ENCOUNTER, "multi", t("tags", { count: 2 })),
-    dateFilter("created_date", t("date"), longDateRangeOptions),
+    dateFilter("created_date", t("date"), longDateRangeOptions, true),
   ];
 
   const onFilterUpdate = (query: Record<string, unknown>) => {


### PR DESCRIPTION
## Proposed Changes

- add support to disable clearing a filter
   - Clicking clear all wouldn't remove the filter
   - Clear all button would be hidden if filters applied are all non clear-able filters
   - Clear (X) button is removed from the selected bar
- minor cleanup with createFilter params

<img width="318" height="139" alt="image" src="https://github.com/user-attachments/assets/88d34e2e-739d-40a3-b3a0-e048ec99d61d" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support for non-clearable filters; “Clear all” now ignores them.
  - Date filters on Appointments and Encounters are set as non-clearable.

- Bug Fixes
  - “Clear” button is hidden for filters that can’t be cleared.
  - Empty selections are no longer counted toward active filters.
  - Improved stability for encounter date filters by safely handling invalid or empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->