### PR TITLE
Remove unused shortcuts and related effect in PatientIndex component

### DIFF
--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { navigate } from "raviger";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatPhoneNumberIntl } from "react-phone-number-input";
 import { toast } from "sonner";
@@ -37,7 +37,7 @@ import { GENDER_TYPES } from "@/common/constants";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import query from "@/Utils/request/query";
 import { usePermissions } from "@/context/PermissionContext";
-import { useShortcuts, useShortcutSubContext } from "@/context/ShortcutContext";
+import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import {
   getPartialId,
@@ -47,7 +47,6 @@ import {
 import patientApi from "@/types/emr/patient/patientApi";
 
 export default function PatientIndex({ facilityId }: { facilityId: string }) {
-  const shortcuts = useShortcuts();
   useShortcutSubContext();
   const [yearOfBirth, setYearOfBirth] = useState("");
   const [selectedPatient, setSelectedPatient] = useState<
@@ -58,12 +57,6 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
   const { hasPermission } = usePermissions();
 
   const { facility } = useCurrentFacility();
-
-  // Enable shortcuts to work when this search component is active
-  useEffect(() => {
-    shortcuts.setIgnoreInputFields(true);
-    return () => shortcuts.setIgnoreInputFields(false);
-  }, [shortcuts]);
 
   const { canCreatePatient } = getPermissions(
     hasPermission,


### PR DESCRIPTION
## Proposed Changes

<img width="1205" height="424" alt="image" src="https://github.com/user-attachments/assets/078485b7-012b-4a76-9c33-f5deeee035fd" />

Since we have a global shortcut "p" for print and i was allowing shortcut to work in input field... we were not able to enter the key "p"  

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of keyboard shortcuts on the Patient page. Shortcuts no longer intermittently disable or behave unexpectedly during input interactions, resulting in more predictable navigation without interfering with typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->