### PR TITLE
Patient Index Search: Fix auto identifier config sort and phone number auto-fill in patient registration

### DIFF
--- a/src/components/Common/SearchInput.tsx
+++ b/src/components/Common/SearchInput.tsx
@@ -208,6 +208,12 @@ export default function SearchInput({
     [onSearch, safeOptions, onFieldChange],
   );
 
+  useEffect(() => {
+    if (selectedOption) {
+      setSearchValue(selectedOption.value);
+    }
+  }, [selectedOption?.value]);
+
   const unselectedOptions = safeOptions.filter(
     (option) => option.key !== selectedOption?.key,
   );

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -89,19 +89,20 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
   }
 
   // Build search options
-  const searchOptions =
-    facility?.patient_instance_identifier_configs
-      ?.sort((a, _b) => (a.config.auto_maintained ? -1 : 1))
-      .map((c) => ({
-        key: c.id,
-        type:
-          c.config.system === "system.care.ohc.network/patient-phone-number"
-            ? ("phone" as const)
-            : ("text" as const),
-        placeholder: t("search_by_identifier", { name: c.config.display }),
-        value: "",
-        display: c.config.display,
-      })) || [];
+  const searchOptions = [
+    ...(facility?.patient_instance_identifier_configs || []),
+  ]
+    .sort((a) => (a.config.auto_maintained ? -1 : 1))
+    .map((c) => ({
+      key: c.id,
+      type:
+        c.config.system === "system.care.ohc.network/patient-phone-number"
+          ? ("phone" as const)
+          : ("text" as const),
+      placeholder: t("search_by_identifier", { name: c.config.display }),
+      value: "",
+      display: c.config.display,
+    }));
 
   // Track identifier search state
   const [identifierSearch, setIdentifierSearch] = useState<{

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { navigate } from "raviger";
-import { useCallback, useState } from "react";
+import { navigate, useQueryParams } from "raviger";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatPhoneNumberIntl } from "react-phone-number-input";
 import { toast } from "sonner";
@@ -46,12 +46,16 @@ import { FacilityRead } from "@/types/facility/facility";
 import { PatientIdentifierConfig } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import { TFunction } from "i18next";
 
+const PHONE_NUMBER_CONFIG_SYSTEM =
+  "system.care.ohc.network/patient-phone-number";
+
 export default function PatientIndex({ facilityId }: { facilityId: string }) {
   useShortcutSubContext();
   const [yearOfBirth, setYearOfBirth] = useState("");
   const [selectedPatient, setSelectedPatient] = useState<
     PartialPatientModel | PatientRead | null
   >(null);
+  const [qParams] = useQueryParams();
   const [verificationOpen, setVerificationOpen] = useState(false);
   const { t } = useTranslation();
   const { hasPermission } = usePermissions();
@@ -107,6 +111,23 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
     }
   };
 
+  useEffect(() => {
+    if (!facility) {
+      return;
+    }
+
+    const phoneNumberConfig = getPhoneNumberConfig(
+      facility.patient_instance_identifier_configs,
+    );
+
+    if (qParams.phone_number && phoneNumberConfig) {
+      setIdentifierSearch({
+        config: phoneNumberConfig.id,
+        value: qParams.phone_number,
+      });
+    }
+  }, [qParams.phone_number, facility]);
+
   const handleVerify = () => {
     if (!selectedPatient || !yearOfBirth || yearOfBirth.length !== 4) {
       toast.error(t("valid_year_of_birth"));
@@ -153,7 +174,6 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
           <div>
             <div className="space-y-6">
               <SearchInput
-                data-cy="patient-search"
                 options={getSearchOptions(t, facility)}
                 onSearch={handleSearch}
                 className="w-full"
@@ -246,7 +266,6 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
               type="text"
               placeholder={`${t("year_of_birth")} (YYYY)`}
               value={yearOfBirth}
-              data-cy="year-of-birth-input"
               onChange={(e) => {
                 const value = e.target.value;
                 if (/^\d{0,4}$/.test(value)) {
@@ -264,15 +283,10 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
             <Button
               variant="outline"
               onClick={() => setVerificationOpen(false)}
-              data-cy="cancel-verification-button"
             >
               {t("cancel")}
             </Button>
-            <Button
-              className="mb-2"
-              onClick={handleVerify}
-              data-cy="confirm-verification-button"
-            >
+            <Button className="mb-2" onClick={handleVerify}>
               {t("verify")}
             </Button>
           </DialogFooter>
@@ -289,14 +303,24 @@ const getSearchOptions = (t: TFunction, facility?: FacilityRead) => {
 
   const { patient_instance_identifier_configs: configs } = facility;
 
-  // Auto-maintained configs first, then non-auto-maintained configs
+  // Phone number configs first, followed by auto-maintained configs, and then non-auto-maintained configs
   return [
-    ...configs.filter((c) => c.config.auto_maintained),
+    // Phone number configs
+    ...configs.filter(
+      ({ config }) =>
+        config.auto_maintained && config.system === PHONE_NUMBER_CONFIG_SYSTEM,
+    ),
+    // Auto-maintained configs but not phone number configs
+    ...configs.filter(
+      ({ config }) =>
+        config.auto_maintained && config.system !== PHONE_NUMBER_CONFIG_SYSTEM,
+    ),
+    // Non-auto-maintained configs
     ...configs.filter((c) => !c.config.auto_maintained),
   ].map((c) => ({
     key: c.id,
     type:
-      c.config.system === "system.care.ohc.network/patient-phone-number"
+      c.config.system === PHONE_NUMBER_CONFIG_SYSTEM
         ? ("phone" as const)
         : ("text" as const),
     placeholder: t("search_by_identifier", { name: c.config.display }),
@@ -305,13 +329,17 @@ const getSearchOptions = (t: TFunction, facility?: FacilityRead) => {
   }));
 };
 
+const getPhoneNumberConfig = (identifierConfigs: PatientIdentifierConfig[]) => {
+  return identifierConfigs.find(
+    (c) => c.config.system === PHONE_NUMBER_CONFIG_SYSTEM,
+  );
+};
+
 const getPhoneNumberFromIdentifierSearch = (
   identifierConfigs: PatientIdentifierConfig[],
   identifierSearch: { config?: string; value?: string },
 ) => {
-  const phoneNumberConfig = identifierConfigs.find(
-    (c) => c.config.system === "system.care.ohc.network/patient-phone-number",
-  );
+  const phoneNumberConfig = getPhoneNumberConfig(identifierConfigs);
 
   if (phoneNumberConfig && identifierSearch.config === phoneNumberConfig.id) {
     return identifierSearch.value;
@@ -333,23 +361,19 @@ function AddPatientButton({
 }) {
   const { t } = useTranslation();
 
+  const phoneNumber =
+    identifierSearch &&
+    getPhoneNumberFromIdentifierSearch(identifierConfigs, identifierSearch);
+
   return (
     <Button
       variant={outline ? "outline" : "primary_gradient"}
       className="gap-3 group"
       onClick={() =>
         navigate(`/facility/${facilityId}/patient/create`, {
-          query: {
-            phone_number:
-              identifierSearch &&
-              getPhoneNumberFromIdentifierSearch(
-                identifierConfigs,
-                identifierSearch,
-              ),
-          },
+          query: phoneNumber ? { phone_number: phoneNumber } : undefined,
         })
       }
-      data-cy="create-new-patient-button"
       data-shortcut-id="submit-action"
     >
       <CareIcon icon="l-plus" className="size-4" />

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -5,10 +5,6 @@ import { useTranslation } from "react-i18next";
 import { formatPhoneNumberIntl } from "react-phone-number-input";
 import { toast } from "sonner";
 
-import { cn } from "@/lib/utils";
-
-import CareIcon from "@/CAREUI/icons/CareIcon";
-
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -34,6 +30,7 @@ import SearchInput from "@/components/Common/SearchInput";
 import { getPermissions } from "@/common/Permissions";
 import { GENDER_TYPES } from "@/common/constants";
 
+import CareIcon from "@/CAREUI/icons/CareIcon";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import query from "@/Utils/request/query";
 import { usePermissions } from "@/context/PermissionContext";
@@ -45,6 +42,8 @@ import {
   PatientRead,
 } from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
+import { FacilityRead } from "@/types/facility/facility";
+import { TFunction } from "i18next";
 
 export default function PatientIndex({ facilityId }: { facilityId: string }) {
   useShortcutSubContext();
@@ -62,47 +61,6 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
     hasPermission,
     facility?.permissions ?? [],
   );
-
-  const handleCreatePatient = useCallback(() => {
-    navigate(`/facility/${facilityId}/patient/create`, {
-      query: {
-        // queryParams,
-        // phone_number: qParams.value,
-      },
-    });
-  }, [facilityId]);
-
-  function AddPatientButton({ outline }: { outline?: boolean }) {
-    return (
-      <Button
-        variant={outline ? "outline" : "primary_gradient"}
-        className={cn("gap-3 group")}
-        onClick={handleCreatePatient}
-        data-cy="create-new-patient-button"
-        data-shortcut-id="submit-action"
-      >
-        <CareIcon icon="l-plus" className="size-4" />
-        {t("add_new_patient")}
-        <ShortcutBadge actionId="submit-action" className="bg-white" />
-      </Button>
-    );
-  }
-
-  // Build search options
-  const searchOptions = [
-    ...(facility?.patient_instance_identifier_configs || []),
-  ]
-    .sort((a) => (a.config.auto_maintained ? -1 : 1))
-    .map((c) => ({
-      key: c.id,
-      type:
-        c.config.system === "system.care.ohc.network/patient-phone-number"
-          ? ("phone" as const)
-          : ("text" as const),
-      placeholder: t("search_by_identifier", { name: c.config.display }),
-      value: "",
-      display: c.config.display,
-    }));
 
   // Track identifier search state
   const [identifierSearch, setIdentifierSearch] = useState<{
@@ -170,7 +128,7 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
       <div className="container max-w-5xl mx-auto py-6">
         {canCreatePatient && (
           <div className="flex justify-center md:justify-end">
-            <AddPatientButton />
+            <AddPatientButton facilityId={facilityId} />
           </div>
         )}
         <div className="space-y-6 mt-6">
@@ -189,7 +147,7 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
             <div className="space-y-6">
               <SearchInput
                 data-cy="patient-search"
-                options={searchOptions}
+                options={getSearchOptions(t, facility)}
                 onSearch={handleSearch}
                 className="w-full"
                 autoFocus
@@ -211,7 +169,7 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
                           <p className="text-sm text-gray-500 mb-6">
                             {t("no_patient_record_text")}
                           </p>
-                          <AddPatientButton outline />
+                          <AddPatientButton facilityId={facilityId} outline />
                         </div>
                       </div>
                     ) : (
@@ -306,5 +264,52 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+const getSearchOptions = (t: TFunction, facility?: FacilityRead) => {
+  if (!facility) {
+    return [];
+  }
+
+  const { patient_instance_identifier_configs: configs } = facility;
+
+  // Auto-maintained configs first, then non-auto-maintained configs
+  return [
+    ...configs.filter((c) => c.config.auto_maintained),
+    ...configs.filter((c) => !c.config.auto_maintained),
+  ].map((c) => ({
+    key: c.id,
+    type:
+      c.config.system === "system.care.ohc.network/patient-phone-number"
+        ? ("phone" as const)
+        : ("text" as const),
+    placeholder: t("search_by_identifier", { name: c.config.display }),
+    value: "",
+    display: c.config.display,
+  }));
+};
+
+function AddPatientButton({
+  facilityId,
+  outline,
+}: {
+  facilityId: string;
+  outline?: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Button
+      variant={outline ? "outline" : "primary_gradient"}
+      className="gap-3 group"
+      onClick={() => navigate(`/facility/${facilityId}/patient/create`)}
+      data-cy="create-new-patient-button"
+      data-shortcut-id="submit-action"
+    >
+      <CareIcon icon="l-plus" className="size-4" />
+      {t("add_new_patient")}
+      <ShortcutBadge actionId="submit-action" className="bg-white" />
+    </Button>
   );
 }

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import { FacilityRead } from "@/types/facility/facility";
+import { PatientIdentifierConfig } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import { TFunction } from "i18next";
 
 export default function PatientIndex({ facilityId }: { facilityId: string }) {
@@ -128,7 +129,13 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
       <div className="container max-w-5xl mx-auto py-6">
         {canCreatePatient && (
           <div className="flex justify-center md:justify-end">
-            <AddPatientButton facilityId={facilityId} />
+            <AddPatientButton
+              facilityId={facilityId}
+              identifierConfigs={
+                facility?.patient_instance_identifier_configs || []
+              }
+              identifierSearch={identifierSearch}
+            />
           </div>
         )}
         <div className="space-y-6 mt-6">
@@ -169,7 +176,15 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
                           <p className="text-sm text-gray-500 mb-6">
                             {t("no_patient_record_text")}
                           </p>
-                          <AddPatientButton facilityId={facilityId} outline />
+                          <AddPatientButton
+                            facilityId={facilityId}
+                            outline
+                            identifierConfigs={
+                              facility?.patient_instance_identifier_configs ||
+                              []
+                            }
+                            identifierSearch={identifierSearch}
+                          />
                         </div>
                       </div>
                     ) : (
@@ -290,12 +305,31 @@ const getSearchOptions = (t: TFunction, facility?: FacilityRead) => {
   }));
 };
 
+const getPhoneNumberFromIdentifierSearch = (
+  identifierConfigs: PatientIdentifierConfig[],
+  identifierSearch: { config?: string; value?: string },
+) => {
+  const phoneNumberConfig = identifierConfigs.find(
+    (c) => c.config.system === "system.care.ohc.network/patient-phone-number",
+  );
+
+  if (phoneNumberConfig && identifierSearch.config === phoneNumberConfig.id) {
+    return identifierSearch.value;
+  }
+
+  return undefined;
+};
+
 function AddPatientButton({
   facilityId,
   outline,
+  identifierConfigs,
+  identifierSearch,
 }: {
   facilityId: string;
   outline?: boolean;
+  identifierConfigs: PatientIdentifierConfig[];
+  identifierSearch?: { config?: string; value?: string };
 }) {
   const { t } = useTranslation();
 
@@ -303,7 +337,18 @@ function AddPatientButton({
     <Button
       variant={outline ? "outline" : "primary_gradient"}
       className="gap-3 group"
-      onClick={() => navigate(`/facility/${facilityId}/patient/create`)}
+      onClick={() =>
+        navigate(`/facility/${facilityId}/patient/create`, {
+          query: {
+            phone_number:
+              identifierSearch &&
+              getPhoneNumberFromIdentifierSearch(
+                identifierConfigs,
+                identifierSearch,
+              ),
+          },
+        })
+      }
       data-cy="create-new-patient-button"
       data-shortcut-id="submit-action"
     >

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -174,7 +174,7 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
           <div>
             <div className="space-y-6">
               <SearchInput
-                options={getSearchOptions(t, facility)}
+                options={getSearchOptions(t, identifierSearch, facility)}
                 onSearch={handleSearch}
                 className="w-full"
                 autoFocus
@@ -296,7 +296,11 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
   );
 }
 
-const getSearchOptions = (t: TFunction, facility?: FacilityRead) => {
+const getSearchOptions = (
+  t: TFunction,
+  searchIdentifier: { config?: string; value?: string },
+  facility?: FacilityRead,
+) => {
   if (!facility) {
     return [];
   }
@@ -324,7 +328,8 @@ const getSearchOptions = (t: TFunction, facility?: FacilityRead) => {
         ? ("phone" as const)
         : ("text" as const),
     placeholder: t("search_by_identifier", { name: c.config.display }),
-    value: "",
+    value:
+      searchIdentifier.config === c.id ? (searchIdentifier.value ?? "") : "",
     display: c.config.display,
   }));
 };


### PR DESCRIPTION
## Proposed Changes

- Patient Index Search: Ensure original array is not mutated when patient identifiers are sorted
- This happens when component re-renders multiple times due to various reasons, and the sorting is performed multiple times

<img width="1431" height="495" alt="image" src="https://github.com/user-attachments/assets/0980138d-e495-483f-aa8b-60a6639e07c4" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Patient button now carries a detected phone number from query parameters into the create-patient flow when available.

* **Refactor**
  * Patient search options are now generated centrally from facility and identifier settings, prioritizing phone-number configs.
  * Add Patient control consolidated across various UI states for consistent behavior.

* **Bug Fixes**
  * Search input value now reliably syncs with the selected option when it changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->