### PR TITLE
Fixes mark as complete via appointment encounter header not setting end date

### DIFF
--- a/src/pages/Encounters/AppointmentEncounterHeader.tsx
+++ b/src/pages/Encounters/AppointmentEncounterHeader.tsx
@@ -175,6 +175,12 @@ export const AppointmentEncounterHeader = ({
           patient: encounter.patient.id,
           facility: encounter.facility.id,
           status: "completed",
+          period: {
+            start: encounter.period.start,
+            end: encounter.period.end
+              ? encounter.period.end
+              : new Date().toISOString(),
+          },
         },
       },
       {


### PR DESCRIPTION


## Proposed Changes

- Fixes mark as complete via appointment encounter header not setting end date

<img width="2047" height="501" alt="image" src="https://github.com/user-attachments/assets/d3f2ee93-3ad3-40ef-8117-7e246ced6a93" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed encounters now always record an end time. If an end time was missing, it is set to the current time; otherwise, the existing end time is preserved.
  * Improves accuracy of encounter durations, timelines, and related reporting.
  * Reduces errors in workflows and integrations that require a defined end time.
  * Enhances consistency for exports, analytics, and billing processes relying on encounter completion data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->