### PR TITLE
feat: add period details to encounter completion request

### DIFF
--- a/src/pages/Encounters/AppointmentEncounterHeader.tsx
+++ b/src/pages/Encounters/AppointmentEncounterHeader.tsx
@@ -175,6 +175,12 @@ export const AppointmentEncounterHeader = ({
           patient: encounter.patient.id,
           facility: encounter.facility.id,
           status: "completed",
+          period: {
+            start: encounter.period.start,
+            end: encounter.period.end
+              ? encounter.period.end
+              : new Date().toISOString(),
+          },
         },
       },
       {


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completing an encounter now reliably records an end time. If none is set, the current timestamp is applied.
  * Improves consistency of encounter periods across the app and prevents missing timestamps in summaries, exports, and history views.
  * Enhances reporting accuracy and audit trails by ensuring completed encounters always include both start and end times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->