### PR TITLE
Replace string icons with CareIcon component in various tables and empty states

### DIFF
--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -11,6 +11,17 @@ export interface EmptyStateProps {
   className?: string;
 }
 
+/**
+ * Empty state component to display when there is no data to show.
+ *
+ * @param icon - Optional icon of your choice it can be Lucide Icon or CareIcon
+ *               eg. `<CareIcon icon="l-user" className="text-primary size-6" />` or
+ *                   `<LucideIcon className="text-primary size-6" />`
+ * @param title - The title of the empty state
+ * @param description - Optional description providing more context
+ * @param action - Optional action element (e.g., button) to prompt user action
+ * @param className - Optional additional class names for styling
+ */
 export function EmptyState({
   icon,
   title,

--- a/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
@@ -61,6 +61,7 @@ import {
 import chargeItemApi from "@/types/billing/chargeItem/chargeItemApi";
 import query from "@/Utils/request/query";
 
+import CareIcon from "@/CAREUI/icons/CareIcon";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import AddChargeItemsBillingSheet from "./AddChargeItemsBillingSheet";
 import EditChargeItemSheet from "./EditChargeItemSheet";
@@ -248,9 +249,8 @@ export function ChargeItemsTable({
         <TableSkeleton count={3} />
       ) : !chargeItems?.results?.length ? (
         <EmptyState
-          icon="l-receipt"
+          icon={<CareIcon icon="l-receipt" className="text-primary size-6" />}
           title={t("no_charge_items")}
-          description={t("no_charge_items")}
         />
       ) : (
         <div className="rounded-md overflow-x-auto border-2 border-white shadow-md">

--- a/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
@@ -206,7 +206,9 @@ export default function PaymentsData({
         <TableSkeleton count={3} />
       ) : !payments?.length ? (
         <EmptyState
-          icon="l-credit-card"
+          icon={
+            <CareIcon icon="l-credit-card" className="text-primary size-6" />
+          }
           title={t("no_payments")}
           description={t("no_payments_description")}
         />

--- a/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
@@ -22,6 +22,7 @@ import {
 
 import useFilters from "@/hooks/useFilters";
 
+import CareIcon from "@/CAREUI/icons/CareIcon";
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
 import {
@@ -111,7 +112,12 @@ export default function MedicationDispenseHistory({
           <TableSkeleton count={5} />
         ) : prescriptionQueue?.results?.length === 0 ? (
           <EmptyState
-            icon="l-prescription-bottle"
+            icon={
+              <CareIcon
+                icon="l-prescription-bottle"
+                className="text-primary size-6"
+              />
+            }
             title={t("no_prescriptions_found")}
             description={t("no_prescriptions_found_description")}
           />

--- a/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
@@ -29,6 +29,7 @@ import {
 
 import useFilters from "@/hooks/useFilters";
 
+import CareIcon from "@/CAREUI/icons/CareIcon";
 import PatientIdentifierFilter from "@/components/Patient/PatientIdentifierFilter";
 import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
 import { tagFilter } from "@/components/ui/multi-filter/filterConfigs";
@@ -292,7 +293,12 @@ export default function MedicationRequestList({
           <TableSkeleton count={5} />
         ) : prescriptionQueue?.results?.length === 0 ? (
           <EmptyState
-            icon="l-prescription-bottle"
+            icon={
+              <CareIcon
+                icon="l-prescription-bottle"
+                className="text-primary size-6"
+              />
+            }
             title={t("no_prescriptions_found")}
             description={t("no_prescriptions_found_description")}
           />


### PR DESCRIPTION
Replace string icons with CareIcon component in various tables and empty states also add JSDoc comment to document the EmptyState component and its props in a structured way.

<img width="395" height="279" alt="image" src="https://github.com/user-attachments/assets/fb73bbf3-a99b-48b7-91b7-f62f844148c2" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved visual consistency of empty states by using CareIcon across billing (payments, charge items) and pharmacy (medication requests/dispense history), with clearer sizing and primary color.
  - Simplified the Charge Items empty state by removing the description, keeping only the title.

- Documentation
  - Added JSDoc for EmptyState component and its props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->