### PR TITLE
Make encounter's default date filter configurable

### DIFF
--- a/care.config.ts
+++ b/care.config.ts
@@ -83,6 +83,14 @@ const careConfig = {
     environment: env.REACT_SENTRY_ENVIRONMENT || "staging",
   },
 
+  /**
+   * Relative number of days to show in the encounters page by default.
+   * 0 means today.
+   */
+  encounterDateFilter: env.REACT_ENCOUNTER_DEFAULT_DATE_FILTER
+    ? parseInt(env.REACT_ENCOUNTER_DEFAULT_DATE_FILTER)
+    : 0,
+
   appointments: {
     /**
      * Relative number of days to show in the appointments page by default.

--- a/src/pages/Encounters/EncounterList.tsx
+++ b/src/pages/Encounters/EncounterList.tsx
@@ -33,6 +33,8 @@ import { TagConfig, TagResource } from "@/types/emr/tagConfig/tagConfig";
 import useTagConfigs from "@/types/emr/tagConfig/useTagConfig";
 import query from "@/Utils/request/query";
 import { dateQueryString, dateTimeQueryString } from "@/Utils/utils";
+import careConfig from "@careConfig";
+import { subDays } from "date-fns";
 
 interface EncounterListProps {
   encounters?: EncounterRead[];
@@ -167,10 +169,19 @@ export function EncounterList({
     // Set default date range if no dates are present
     if (!created_date_after && !created_date_before) {
       const today = new Date();
-      updateQuery({
-        created_date_after: dateQueryString(today),
-        created_date_before: dateQueryString(today),
-      });
+      const defaultDays = careConfig.encounterDateFilter;
+      if (defaultDays === 0) {
+        // Today only
+        updateQuery({
+          created_date_after: dateQueryString(today),
+          created_date_before: dateQueryString(today),
+        });
+      } else {
+        updateQuery({
+          created_date_after: dateQueryString(subDays(today, defaultDays)),
+          created_date_before: dateQueryString(today),
+        });
+      }
     }
   }, [created_date_after, created_date_before, updateQuery]);
 


### PR DESCRIPTION
## Proposed Changes

- Make encounter's default date filter configurable

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Encounters list now uses a configurable default date range. If no dates are selected, it can default to “today” or the past N days based on app configuration.
  - Improves first-load experience on the Encounters page by automatically applying the configured date filter, reducing manual input.
  - Admins can adjust the default range without code changes, enabling flexible deployment-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->