### PR TITLE
Added support for "Set Primary" option for queues

### DIFF
--- a/src/pages/Facility/queues/QueueFormSheet.tsx
+++ b/src/pages/Facility/queues/QueueFormSheet.tsx
@@ -8,7 +8,6 @@ import { toast } from "sonner";
 import * as z from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { DatePicker } from "@/components/ui/date-picker";
 import {
   Form,
@@ -40,13 +39,10 @@ const createQueueFormSchema = z.object({
   date: z.date({
     required_error: "Date is required",
   }),
-  set_is_primary: z.boolean(),
 });
 
 const editQueueFormSchema = z.object({
   name: z.string().min(1, "Queue name is required"),
-  date: z.date().optional(),
-  set_is_primary: z.boolean().optional(),
 });
 
 type CreateQueueFormData = z.infer<typeof createQueueFormSchema>;
@@ -85,7 +81,6 @@ export default function QueueFormSheet({
     defaultValues: {
       name: "",
       date: initialDate,
-      set_is_primary: false,
     },
   });
 
@@ -104,7 +99,6 @@ export default function QueueFormSheet({
       form.reset({
         name: queue.name,
         date: new Date(queue.date),
-        set_is_primary: queue.is_primary,
       });
     }
   }, [queue, isEditMode, form, isOpen]);
@@ -115,7 +109,6 @@ export default function QueueFormSheet({
       form.reset({
         name: "",
         date: initialDate,
-        set_is_primary: false,
       });
     }
   }, [isOpen, form, initialDate]);
@@ -152,16 +145,16 @@ export default function QueueFormSheet({
   });
 
   const onSubmit = (data: QueueFormData) => {
-    if (isEditMode) {
-      updateQueue({ name: data.name });
-    } else {
+    if (!isEditMode && "date" in data) {
       createQueue({
         name: data.name,
         date: dateQueryString(data.date),
         resource_type: resourceType,
         resource_id: resourceId,
-        set_is_primary: data.set_is_primary ?? false,
       });
+    }
+    if (isEditMode) {
+      updateQueue({ name: data.name });
     }
   };
 
@@ -240,30 +233,6 @@ export default function QueueFormSheet({
                         />
                       </FormControl>
                       <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              )}
-
-              {/* Set as Primary - Only show in create mode */}
-              {!isEditMode && (
-                <FormField
-                  control={form.control}
-                  name="set_is_primary"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                      <FormControl>
-                        <Checkbox
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                      <div className="space-y-1 leading-none">
-                        <FormLabel>{t("set_as_primary")}</FormLabel>
-                        <p className="text-sm text-gray-600">
-                          {t("set_as_primary_description")}
-                        </p>
-                      </div>
                     </FormItem>
                   )}
                 />

--- a/src/pages/Facility/queues/QueuesIndex.tsx
+++ b/src/pages/Facility/queues/QueuesIndex.tsx
@@ -1,5 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
-import { MoreVertical, Pencil, Plus, Settings, Square } from "lucide-react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  CheckIcon,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Settings,
+  Square,
+} from "lucide-react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -49,6 +56,8 @@ import tokenSubQueueApi from "@/types/tokens/tokenSubQueue/tokenSubQueueApi";
 import { UserReadMinimal } from "@/types/user/user";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
+import mutate from "@/Utils/request/mutate";
+import queryClient from "@/Utils/request/queryClient";
 import { dateQueryString } from "@/Utils/utils";
 import { startOfDay } from "date-fns";
 import dayjs from "dayjs";
@@ -77,6 +86,17 @@ function QueueRow({
     resourceType === SchedulableResourceType.Practitioner
       ? `/facility/${facilityId}/practitioner/${resourceId}/queues/${queue.id}/ongoing`
       : `/queues/${queue.id}/ongoing`;
+
+  const { mutate: setPrimary } = useMutation({
+    mutationFn: mutate(tokenQueueApi.setPrimary, {
+      pathParams: { facility_id: facilityId, id: queue.id },
+    }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["tokenQueues", facilityId],
+      });
+    },
+  });
 
   return (
     <TableRow className="hover:bg-gray-200">
@@ -147,6 +167,13 @@ function QueueRow({
                 </DropdownMenuItem>
               }
             />
+            <DropdownMenuItem
+              onClick={() => setPrimary({})}
+              disabled={queue.is_primary}
+            >
+              <CheckIcon className="h-4 w-4 mr-2" />
+              {t("set_as_primary")}
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </TableCell>

--- a/src/pages/Facility/queues/QueuesIndex.tsx
+++ b/src/pages/Facility/queues/QueuesIndex.tsx
@@ -2,10 +2,10 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   CheckIcon,
   MoreVertical,
+  Notebook,
   Pencil,
   Plus,
   Settings,
-  Square,
 } from "lucide-react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -145,13 +145,13 @@ function QueueRow({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-              <MoreVertical className="h-4 w-4" />
+              <MoreVertical className="size-4" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="border border-gray-200">
             <DropdownMenuItem asChild>
               <Link href={queueLink} className="flex items-center gap-2">
-                <Square className="h-4 w-4" />
+                <Notebook className="size-4 mr-2" />
                 {t("open_queue_board")}
               </Link>
             </DropdownMenuItem>
@@ -162,7 +162,7 @@ function QueueRow({
               queueId={queue.id}
               trigger={
                 <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                  <Pencil className="h-4 w-4 mr-2" />
+                  <Pencil className="size-4 mr-2" />
                   {t("edit_queue_name")}
                 </DropdownMenuItem>
               }
@@ -171,7 +171,7 @@ function QueueRow({
               onClick={() => setPrimary({})}
               disabled={queue.is_primary}
             >
-              <CheckIcon className="h-4 w-4 mr-2" />
+              <CheckIcon className="size-4 mr-2" />
               {t("set_as_primary")}
             </DropdownMenuItem>
           </DropdownMenuContent>
@@ -354,7 +354,7 @@ export default function QueuesIndex({
               initialDate={startOfDay(qParams.date)}
               trigger={
                 <Button size="sm" className="font-bold" disabled={isPast}>
-                  <Plus className="h-4 w-4 mr-2" />
+                  <Plus className="size-4 mr-2" />
                   {t("create_queue")}
                 </Button>
               }
@@ -388,7 +388,7 @@ export default function QueuesIndex({
                     initialDate={startOfDay(qParams.date)}
                     trigger={
                       <Button disabled={isPast}>
-                        <Plus className="h-4 w-4 mr-2" />
+                        <Plus className="size-4 mr-2" />
                         {t("create_first_queue")}
                       </Button>
                     }
@@ -461,7 +461,7 @@ export default function QueuesIndex({
                   resourceId={effectiveResourceId}
                   trigger={
                     <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                      <Plus className="h-4 w-4" />
+                      <Plus className="size-4" />
                     </Button>
                   }
                 />
@@ -486,7 +486,7 @@ export default function QueuesIndex({
                     resourceId={effectiveResourceId}
                     trigger={
                       <Button>
-                        <Plus className="h-4 w-4 mr-2" />
+                        <Plus className="size-4 mr-2" />
                         {t("add_first_service_point")}
                       </Button>
                     }

--- a/src/types/tokens/tokenQueue/tokenQueue.ts
+++ b/src/types/tokens/tokenQueue/tokenQueue.ts
@@ -13,7 +13,6 @@ export interface TokenQueueCreate
   extends Omit<TokenQueue, "id" | "is_primary"> {
   resource_type: SchedulableResourceType;
   resource_id: string;
-  set_is_primary: boolean;
 }
 
 export interface TokenQueueRead extends TokenQueue {


### PR DESCRIPTION
## Proposed Changes
- Remove the set primary option from create queue form because there is no support in backend
- Added set primary option in the drop down options using separate set_primary API
<img width="967" height="479" alt="image" src="https://github.com/user-attachments/assets/18ef68ad-64c3-4323-a21b-50383f868ca8" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Mark a queue as Primary directly from the queue list via the row menu; changes reflect immediately.

* Changes
  * Removed the “Set as Primary” option from the queue create/edit form. Primary designation is now managed from the list.

* Style
  * Standardized icon sizing in the queue list actions for a more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->