### PR TITLE
Remove unsupported ordering param from tokenQueueApi list API

### DIFF
--- a/src/pages/Facility/queues/QueuesIndex.tsx
+++ b/src/pages/Facility/queues/QueuesIndex.tsx
@@ -284,7 +284,6 @@ export default function QueuesIndex({
         date: qParams.date,
         limit: resultsPerPage,
         offset: ((qParams.page ?? 1) - 1) * resultsPerPage,
-        ordering: "-created_date",
       },
     }),
   });


### PR DESCRIPTION
## Proposed Changes
- Remove unsupported ordering param from tokenQueueApi list API

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue list now follows the server’s default ordering instead of a forced created-date sort, providing a more consistent and predictable display across the app.
  * No changes to filters, pagination, or error handling.

* **Refactor**
  * Simplified the queue retrieval configuration to rely on backend defaults, reducing client-side assumptions while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->