### PR TITLE
disable patient details edit in org route

### DIFF
--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -144,7 +144,7 @@ export const Demography = (props: PatientProps) => {
   const data: Data[] = [
     {
       id: "general-info",
-      allowEdit: canWritePatient,
+      allowEdit: canWritePatient && !!props.facilityId,
       details: [
         <PLUGIN_Component
           key="patient_details_tab__demography__general_info"


### PR DESCRIPTION
## Proposed Changes

- disable patient details edit in org route

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demography tab: Editing is now available only when the user has write access and a facility is set. The Edit option will no longer appear if no facility is selected, preventing unintended edits to patient demographic information.
  * This change ensures the Edit control accurately reflects user permissions and context, improving consistency and reducing confusion when a facility context is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->