### PR TITLE
Icons and labels for filter-tabs, implemented filter-tabs in pharmacy pages

### DIFF
--- a/src/components/ui/filter-tabs.tsx
+++ b/src/components/ui/filter-tabs.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from "lucide-react";
-import { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
@@ -13,10 +13,15 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
+// Support both string and { value, label } option
+type FilterTabOption =
+  | string
+  | { value: string; label: string; icon?: React.ReactNode };
+
 interface FilterTabsProps {
   value: string;
   onValueChange: (value: string) => void;
-  options: string[];
+  options: FilterTabOption[];
   label?: string;
   showAllOption?: boolean;
   allOptionLabel?: string;
@@ -42,19 +47,27 @@ export function FilterTabs({
 }: FilterTabsProps) {
   const { t } = useTranslation();
 
+  // Helpers to extract value and label
+  const getOptionValue = (option: FilterTabOption) =>
+    typeof option === "string" ? option : option.value;
+  const getOptionLabel = (option: FilterTabOption) =>
+    typeof option === "string" ? t(option) : t(option.label);
+
+  // Prepare arrays of values for visible/dropdown logic
+  const optionValues = useMemo(() => options.map(getOptionValue), [options]);
+
   // State for managing visible tabs when using dropdown
   const [visibleOptions, setVisibleOptions] = useState<string[]>(() => {
-    if (!showMoreDropdown) return options;
+    if (!showMoreDropdown) return optionValues;
 
     if (defaultVisibleOptions) {
-      // Validate and respect maxVisibleTabs even with defaultVisibleOptions
       const validDefaultOptions = defaultVisibleOptions.filter((option) =>
-        options.includes(option),
+        optionValues.includes(option),
       );
       return validDefaultOptions.slice(0, maxVisibleTabs);
     }
 
-    return options.slice(0, maxVisibleTabs);
+    return optionValues.slice(0, maxVisibleTabs);
   });
 
   const [dropdownOptions, setDropdownOptions] = useState<string[]>(() => {
@@ -62,29 +75,48 @@ export function FilterTabs({
 
     if (defaultVisibleOptions) {
       const validDefaultOptions = defaultVisibleOptions
-        .filter((option) => options.includes(option))
+        .filter((option) => optionValues.includes(option))
         .slice(0, maxVisibleTabs);
 
-      return options.filter((option) => !validDefaultOptions.includes(option));
+      return optionValues.filter(
+        (option) => !validDefaultOptions.includes(option),
+      );
     }
 
-    return options.slice(maxVisibleTabs);
+    return optionValues.slice(maxVisibleTabs);
   });
 
-  const handleValueChange = (newValue: string) => {
-    if (newValue === "all") {
-      onValueChange("");
-    } else {
-      onValueChange(newValue);
+  // Keep derived state in sync when inputs change
+  useEffect(() => {
+    if (!showMoreDropdown) {
+      setVisibleOptions(optionValues);
+      setDropdownOptions([]);
+      return;
     }
+    const baseVisible =
+      (defaultVisibleOptions &&
+        defaultVisibleOptions
+          .filter((opt) => optionValues.includes(opt))
+          .slice(0, maxVisibleTabs)) ||
+      optionValues.slice(0, maxVisibleTabs);
+    setVisibleOptions(baseVisible);
+    setDropdownOptions(
+      optionValues.filter((opt) => !baseVisible.includes(opt)),
+    );
+  }, [optionValues, showMoreDropdown, defaultVisibleOptions, maxVisibleTabs]);
+
+  const handleValueChange = (newValue: string) => {
+    if (showAllOption && newValue === "all") {
+      onValueChange("");
+      return;
+    }
+    onValueChange(newValue);
   };
 
   const handleDropdownSelect = (selectedOption: string) => {
     if (!showMoreDropdown) return;
 
-    // Safety check: ensure we have visible options to swap
     if (visibleOptions.length === 0) {
-      // If no visible options, just add the selected option to visible
       setVisibleOptions([selectedOption]);
       setDropdownOptions(
         dropdownOptions.filter((option) => option !== selectedOption),
@@ -93,7 +125,6 @@ export function FilterTabs({
       return;
     }
 
-    // Swap the last visible tab with the selected dropdown option
     const lastVisibleOption = visibleOptions[visibleOptions.length - 1];
     const newVisibleOptions = [...visibleOptions.slice(0, -1), selectedOption];
     const newDropdownOptions = [
@@ -127,7 +158,11 @@ export function FilterTabs({
     return "text-gray-500 font-medium text-sm px-3 flex items-center";
   };
 
-  const tabsToShow = showMoreDropdown ? visibleOptions : options;
+  // Find the option object by value
+  const findOption = (val: string) =>
+    options.find((opt) => getOptionValue(opt) === val);
+
+  const tabsToShow = showMoreDropdown ? visibleOptions : optionValues;
 
   return (
     <div className={cn("flex items-center gap-4", className)}>
@@ -141,15 +176,19 @@ export function FilterTabs({
               {t(allOptionLabel)}
             </TabsTrigger>
           )}
-          {tabsToShow.map((option) => (
-            <TabsTrigger
-              key={option}
-              value={option}
-              className={getTriggerClassName()}
-            >
-              {t(option)}
-            </TabsTrigger>
-          ))}
+          {tabsToShow.map((val) => {
+            const option = findOption(val);
+            return (
+              <TabsTrigger
+                key={val}
+                value={val}
+                className={getTriggerClassName()}
+              >
+                {option && typeof option === "object" && option.icon}
+                {option ? getOptionLabel(option) : t(val)}
+              </TabsTrigger>
+            );
+          })}
           {showMoreDropdown && dropdownOptions.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -159,15 +198,21 @@ export function FilterTabs({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {dropdownOptions.map((option) => (
-                  <DropdownMenuItem
-                    key={option}
-                    onClick={() => handleDropdownSelect(option)}
-                    className="text-gray-950 font-medium text-sm"
-                  >
-                    {t(option)}
-                  </DropdownMenuItem>
-                ))}
+                {dropdownOptions.map((val) => {
+                  const option = findOption(val);
+                  return (
+                    <DropdownMenuItem
+                      key={val}
+                      onClick={() => handleDropdownSelect(val)}
+                      className="text-gray-950 font-medium text-sm"
+                    >
+                      <span className="flex items-center gap-1">
+                        {option && typeof option === "object" && option.icon}
+                        {option ? getOptionLabel(option) : t(val)}
+                      </span>
+                    </DropdownMenuItem>
+                  );
+                })}
               </DropdownMenuContent>
             </DropdownMenu>
           )}

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { EmptyState } from "@/components/ui/empty-state";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import {
   Select,
   SelectContent,
@@ -27,7 +28,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
@@ -452,17 +452,15 @@ export default function DispensedMedicationList({
       </div>
 
       <div className="mb-4">
-        <Tabs
+        <FilterTabs
           value={paymentFilter}
           onValueChange={(value) => updateQuery({ payment_status: value })}
           className="w-full"
-        >
-          <TabsList>
-            <TabsTrigger value="all">{t("all")}</TabsTrigger>
-            <TabsTrigger value="paid">{t("paid")}</TabsTrigger>
-            <TabsTrigger value="unpaid">{t("unpaid")}</TabsTrigger>
-          </TabsList>
-        </Tabs>
+          options={[
+            { value: "paid", label: "paid" },
+            { value: "unpaid", label: "unpaid" },
+          ]}
+        />
       </div>
 
       {isLoading ? (

--- a/src/pages/Facility/services/pharmacy/DispensesView.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensesView.tsx
@@ -1,18 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeftIcon, ChevronDown } from "lucide-react";
+import { ArrowLeftIcon } from "lucide-react";
 import { navigate } from "raviger";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 
 import Page from "@/components/Common/Page";
 
@@ -46,27 +39,6 @@ export default function DispensesView({
   ];
 
   const allStatuses = Object.values(MedicationDispenseStatus);
-  const [visibleTabs, setVisibleTabs] = useState<MedicationDispenseStatus[]>(
-    defaultVisibleStatuses,
-  );
-  const [dropdownItems, setDropdownItems] = useState<
-    MedicationDispenseStatus[]
-  >(allStatuses.filter((status) => !defaultVisibleStatuses.includes(status)));
-
-  const handleDropdownSelect = (value: MedicationDispenseStatus) => {
-    const lastVisibleTab = visibleTabs[visibleTabs.length - 1];
-    const newVisibleTabs = [...visibleTabs.slice(0, -1), value];
-    const newDropdownItems = [
-      ...dropdownItems.filter((item) => item !== value),
-      lastVisibleTab,
-    ];
-
-    setVisibleTabs(newVisibleTabs);
-    setDropdownItems(newDropdownItems);
-    navigate(
-      `/facility/${facilityId}/locations/${locationId}/medication_dispense/patient/${patientId}/${value}`,
-    );
-  };
 
   const { data: patientData } = useQuery({
     queryKey: ["patient", patientId],
@@ -75,6 +47,11 @@ export default function DispensesView({
     }),
     enabled: !!patientId,
   });
+
+  const tabOptions = allStatuses.map((statusValue) => ({
+    value: statusValue,
+    label: statusValue,
+  }));
 
   return (
     <Page title={t("pharmacy_medications")} hideTitleOnPage>
@@ -99,63 +76,35 @@ export default function DispensesView({
           <PatientHeader patient={patientData} facilityId={facilityId} />
         </Card>
       )}
-      <Tabs
+      <FilterTabs
         value={status}
         onValueChange={(value) =>
           navigate(
             `/facility/${facilityId}/locations/${locationId}/medication_dispense/patient/${patientId}/${value}`,
           )
         }
-      >
-        <TabsList className="w-full justify-evenly sm:justify-start border-b rounded-none bg-transparent p-0 h-auto overflow-x-auto">
-          {visibleTabs.map((statusValue) => (
-            <TabsTrigger
-              key={statusValue}
-              value={statusValue}
-              className="border-b-3 px-1.5 sm:px-2.5 py-2 text-gray-600 font-semibold hover:text-gray-900 data-[state=active]:border-b-primary-700  data-[state=active]:text-primary-800 data-[state=active]:bg-transparent data-[state=active]:shadow-none rounded-none"
-            >
-              {t(statusValue)}
-            </TabsTrigger>
-          ))}
-          {dropdownItems.length > 0 && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="text-gray-500 font-semibold hover:text-gray-900 hover:bg-transparent pb-2.5 px-2.5"
-                >
-                  {t("more")}
-                  <ChevronDown />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {dropdownItems.map((statusValue) => (
-                  <DropdownMenuItem
-                    key={statusValue}
-                    onClick={() => handleDropdownSelect(statusValue)}
-                    className="text-gray-950 font-medium text-sm"
-                  >
-                    {t(statusValue)}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </TabsList>
+        options={tabOptions}
+        variant="underline"
+        showAllOption={false}
+        showMoreDropdown={true}
+        maxVisibleTabs={4}
+        defaultVisibleOptions={defaultVisibleStatuses}
+      />
 
-        <div>
-          {Object.values(MedicationDispenseStatus).map((statusValue) => (
-            <TabsContent key={statusValue} value={statusValue} className="p-2">
+      <div>
+        {Object.values(MedicationDispenseStatus).map((statusValue) =>
+          status === statusValue ? (
+            <div key={statusValue} className="p-2">
               <DispensedMedicationList
                 facilityId={facilityId}
                 patientId={patientId}
                 locationId={locationId}
                 status={statusValue}
               />
-            </TabsContent>
-          ))}
-        </div>
-      </Tabs>
+            </div>
+          ) : null,
+        )}
+      </div>
     </Page>
   );
 }

--- a/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
@@ -6,8 +6,8 @@ import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { Input } from "@/components/ui/input";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import Page from "@/components/Common/Page";
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
@@ -22,7 +22,6 @@ import {
 
 import useFilters from "@/hooks/useFilters";
 
-import CareIcon from "@/CAREUI/icons/CareIcon";
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
 import {
@@ -75,26 +74,23 @@ export default function MedicationDispenseHistory({
     },
   } as const;
 
+  const tabOptions = Object.entries(DISPENSE_STATUS_OPTIONS).map(
+    ([key, { label }]) => ({
+      value: key,
+      label: label,
+    }),
+  );
+
   return (
     <Page title={t("medication_dispense")}>
       <div className="mb-4 pt-6">
-        <Tabs
+        <FilterTabs
           value={qParams.exclude_status || "pending"}
           onValueChange={(value) => updateQuery({ exclude_status: value })}
           className="w-full"
-        >
-          <TabsList className="w-full justify-evenly sm:justify-start border-b rounded-none bg-transparent p-0 h-auto overflow-x-auto">
-            {Object.entries(DISPENSE_STATUS_OPTIONS).map(([key, { label }]) => (
-              <TabsTrigger
-                key={key}
-                value={key}
-                className="border-b-2 px-2 sm:px-4 py-2 text-gray-600 hover:text-gray-900 data-[state=active]:border-b-primary-700  data-[state=active]:text-primary-800 data-[state=active]:bg-transparent data-[state=active]:shadow-none rounded-none"
-              >
-                {t(label)}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+          options={tabOptions}
+          showAllOption={false}
+        />
       </div>
       <div className="flex items-center gap-4 mb-6">
         <div className="flex-1">
@@ -112,12 +108,7 @@ export default function MedicationDispenseHistory({
           <TableSkeleton count={5} />
         ) : prescriptionQueue?.results?.length === 0 ? (
           <EmptyState
-            icon={
-              <CareIcon
-                icon="l-prescription-bottle"
-                className="text-primary size-6"
-              />
-            }
+            icon="l-prescription-bottle"
             title={t("no_prescriptions_found")}
             description={t("no_prescriptions_found_description")}
           />

--- a/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
@@ -1,20 +1,13 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUpRightSquare, ChevronDown, NotepadText } from "lucide-react";
+import { ArrowUpRightSquare } from "lucide-react";
 import { navigate } from "raviger";
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { EmptyState } from "@/components/ui/empty-state";
-import { Separator } from "@/components/ui/separator";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 
 import Page from "@/components/Common/Page";
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
@@ -29,13 +22,13 @@ import {
 
 import useFilters from "@/hooks/useFilters";
 
-import CareIcon from "@/CAREUI/icons/CareIcon";
 import PatientIdentifierFilter from "@/components/Patient/PatientIdentifierFilter";
 import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
 import { tagFilter } from "@/components/ui/multi-filter/filterConfigs";
 import MultiFilter from "@/components/ui/multi-filter/MultiFilter";
 import useMultiFilterState from "@/components/ui/multi-filter/utils/useMultiFilterState";
 import { createFilterConfig } from "@/components/ui/multi-filter/utils/Utils";
+import useBreakpoints from "@/hooks/useBreakpoints";
 import {
   ENCOUNTER_CLASS_ICONS,
   ENCOUNTER_CLASSES_COLORS,
@@ -77,17 +70,8 @@ export default function MedicationRequestList({
     .filter(Boolean) as TagConfig[];
 
   // State for visible tabs and dropdown items
-  const [visibleTabs, setVisibleTabs] = useState<("all" | EncounterClass)[]>([
-    "all",
-    "imp",
-    "amb",
-    "emer",
-  ]);
-  const [dropdownItems, setDropdownItems] = useState<EncounterClass[]>([
-    "obsenc",
-    "vr",
-    "hh",
-  ]);
+  const [visibleTabs] = useState<EncounterClass[]>(["imp", "amb", "emer"]);
+  const [dropdownItems] = useState<EncounterClass[]>(["obsenc", "vr", "hh"]);
 
   // Create filter configurations
   const filters = useMemo(
@@ -133,26 +117,10 @@ export default function MedicationRequestList({
   });
 
   // Handle tab selection
-  const handleTabSelect = (value: string) => {
-    updateQuery({
-      encounter_class: value === "all" ? undefined : value,
-    });
-  };
+  const handleTabSelect = (value: string) =>
+    updateQuery({ encounter_class: value === "" ? undefined : value });
 
   // Handle dropdown item selection
-  const handleDropdownSelect = (value: EncounterClass) => {
-    // Swap the selected dropdown item with the last visible tab
-    const lastVisibleTab = visibleTabs[visibleTabs.length - 1];
-    const newVisibleTabs = [...visibleTabs.slice(0, -1), value];
-    const newDropdownItems = [
-      ...dropdownItems.filter((item) => item !== value),
-      lastVisibleTab as EncounterClass,
-    ];
-
-    setVisibleTabs(newVisibleTabs);
-    setDropdownItems(newDropdownItems);
-    handleTabSelect(value);
-  };
 
   const { data: prescriptionQueue, isLoading } = useQuery<
     PaginatedResponse<PrescriptionSummary>
@@ -173,96 +141,71 @@ export default function MedicationRequestList({
     }),
   });
 
+  // Encounter class tab options with icons
+  const encounterClassTabOptions = [
+    ...visibleTabs.map((key) => ({
+      value: key,
+      label: `encounter_class__${key}`,
+      icon: React.createElement(ENCOUNTER_CLASS_ICONS[key as EncounterClass], {
+        className: "size-4",
+      }),
+    })),
+    ...dropdownItems.map((key) => ({
+      value: key,
+      label: `encounter_class__${key}`,
+      icon: React.createElement(ENCOUNTER_CLASS_ICONS[key as EncounterClass], {
+        className: "size-4",
+      }),
+    })),
+  ];
+
+  const maxVisibleTabs = useBreakpoints({
+    default: 2,
+    xs: 3,
+    sm: 4,
+    md: 5,
+    lg: 7,
+  });
+
   return (
     <Page title={t("prescription_queue")}>
       {/* Priority tabs with original styling */}
       <div className="mb-4 pt-6">
-        <Tabs
-          value={qParams.status || "active"}
+        <FilterTabs
+          value={qParams.status || PrescriptionStatus.active}
           onValueChange={(value) => updateQuery({ status: value })}
-          className="w-full"
-        >
-          <TabsList className="w-full justify-evenly sm:justify-start border-b rounded-none bg-transparent p-0 h-auto overflow-x-auto">
-            {[
-              PrescriptionStatus.active,
-              PrescriptionStatus.completed,
-              PrescriptionStatus.cancelled,
-            ].map((key) => (
-              <TabsTrigger
-                key={key}
-                value={key}
-                className="border-b-2 px-2 sm:px-4 py-2 text-gray-600 hover:text-gray-900 data-[state=active]:border-b-primary-700  data-[state=active]:text-primary-800 data-[state=active]:bg-transparent data-[state=active]:shadow-none rounded-none"
-              >
-                {t(`prescription_status__${key}`)}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+          options={[
+            PrescriptionStatus.active,
+            PrescriptionStatus.completed,
+            PrescriptionStatus.cancelled,
+          ]}
+          variant="underline"
+          defaultVisibleOptions={[
+            PrescriptionStatus.active,
+            PrescriptionStatus.completed,
+            PrescriptionStatus.cancelled,
+          ]}
+          showAllOption={false}
+          allOptionLabel="all_prescriptions"
+          className="w-full justify-evenly sm:justify-start border-b rounded-none bg-transparent h-auto"
+        />
       </div>
       {/* Category tabs and search */}
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center justify-between lg:gap-6 mb-2">
         <div className="flex flex-wrap gap-2">
-          {/* Encounter Class Tabs */}
-          <Tabs
-            value={qParams.encounter_class || "all"}
+          {/* Encounter Class Tabs with icons */}
+          <FilterTabs
+            value={qParams.encounter_class || ""}
+            defaultVisibleOptions={visibleTabs}
+            showAllOption
+            allOptionLabel="all_prescriptions"
             onValueChange={handleTabSelect}
+            options={encounterClassTabOptions}
+            variant="background"
+            showMoreDropdown
+            maxVisibleTabs={maxVisibleTabs}
             className="overflow-y-auto text-gray-950"
-          >
-            <TabsList className="flex items-center">
-              <TabsTrigger value="all">
-                <span className="text-gray-950 font-medium text-sm flex items-center gap-1">
-                  <NotepadText className="size-4 text-gray-500" />
-                  {t("all_prescriptions")}
-                </span>
-              </TabsTrigger>
-              {visibleTabs.slice(1).map((key) => (
-                <TabsTrigger key={key} value={key}>
-                  <span className="text-gray-950 font-medium text-sm flex items-center gap-1">
-                    {React.createElement(
-                      ENCOUNTER_CLASS_ICONS[key as EncounterClass],
-                      {
-                        className: "size-4 text-gray-500",
-                      },
-                    )}
-                    {t(`encounter_class__${key as EncounterClass}`)}
-                  </span>
-                </TabsTrigger>
-              ))}
-              {dropdownItems.length > 0 && (
-                <>
-                  <Separator
-                    orientation="vertical"
-                    className="bg-gray-300 ml-2"
-                  />
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        className="text-gray-950 font-medium text-sm px-3 flex items-center"
-                      >
-                        {t("more")}
-                        <ChevronDown />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-40">
-                      {dropdownItems.map((key) => (
-                        <DropdownMenuItem
-                          key={key}
-                          onClick={() => handleDropdownSelect(key)}
-                          className="text-gray-950 font-medium text-sm flex items-center gap-1"
-                        >
-                          {React.createElement(ENCOUNTER_CLASS_ICONS[key], {
-                            className: "size-4",
-                          })}
-                          {t(`encounter_class__${key}`)}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </>
-              )}
-            </TabsList>
-          </Tabs>
+          />
         </div>
         <div className="flex items-center gap-2">
           <PatientIdentifierFilter
@@ -293,12 +236,7 @@ export default function MedicationRequestList({
           <TableSkeleton count={5} />
         ) : prescriptionQueue?.results?.length === 0 ? (
           <EmptyState
-            icon={
-              <CareIcon
-                icon="l-prescription-bottle"
-                className="text-primary size-6"
-              />
-            }
+            icon="l-prescription-bottle"
             title={t("no_prescriptions_found")}
             description={t("no_prescriptions_found_description")}
           />


### PR DESCRIPTION
## Proposed Changes

Fixes #13733
Fixes #13772
- Modified `filter-tabs` to support labels and icons
- Implemented `filter-tabs` in pharmacy section

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced unified FilterTabs with support for object-based options, icons, localized labels, “All” option, and “Show more” dropdown.
- Refactor
  - Replaced legacy Tabs with FilterTabs across pharmacy pages (Dispenses, Dispensed Medication List, Dispense History, Medication Requests).
  - Streamlined filtering to explicit options (e.g., Paid/Unpaid) with consistent status-driven navigation and responsive max visible tabs.
- Style/UI
  - Cleaner tab layout with simplified dropdown behavior; removed chevron clutter.
  - Updated empty states to use standardized icon identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->