### PR TITLE
Modified filter-tabs in licences, pateints & adminOrgs pages

### DIFF
--- a/src/pages/Admin/organizations/components/AdminOrganizationSelector.tsx
+++ b/src/pages/Admin/organizations/components/AdminOrganizationSelector.tsx
@@ -16,6 +16,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { Label } from "@/components/ui/label";
 import {
   Popover,
@@ -23,7 +24,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import useBreakpoints from "@/hooks/useBreakpoints";
 
@@ -120,8 +120,9 @@ export default function FacilityOrganizationSelector(
     );
   };
 
-  const handleOrganizationViewChange = (value: string) => {
-    setShowAllOrgs(value === "all");
+  const handleOrganizationViewChange = (incomingValue: string) => {
+    const nextValue = incomingValue === "" ? "all" : incomingValue;
+    setShowAllOrgs(nextValue === "all");
     setSelectedOrganizations([]);
     setCurrentSelection(null);
     setNavigationLevels([]);
@@ -310,16 +311,16 @@ export default function FacilityOrganizationSelector(
         </div>
       </div>
 
-      <Tabs
+      <FilterTabs
         value={showAllOrgs ? "all" : "mine"}
         onValueChange={handleOrganizationViewChange}
-        className="w-full sm:w-auto"
-      >
-        <TabsList className="grid w-full grid-cols-2 sm:w-[300px]">
-          <TabsTrigger value="mine">{t("my_organizations")}</TabsTrigger>
-          <TabsTrigger value="all">{t("all_organizations")}</TabsTrigger>
-        </TabsList>
-      </Tabs>
+        options={[
+          { value: "mine", label: "my_organizations" },
+          { value: "all", label: "all_organizations" },
+        ]}
+        showAllOption={false}
+        className="grid w-full grid-cols-2 sm:w-[300px]"
+      />
 
       <div className="space-y-3">
         <div className="space-y-3">

--- a/src/pages/Licenses/Licenses.tsx
+++ b/src/pages/Licenses/Licenses.tsx
@@ -6,11 +6,10 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
+import Loading from "@/components/Common/Loading";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-import Loading from "@/components/Common/Loading";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 
 import licenseUrls from "@/pages/Licenses/components/license-urls.json";
 import { getPackageUrl } from "@/pages/Licenses/utils";
@@ -27,7 +26,11 @@ export const LicensesPage = () => {
 
   const { data, isLoading } = useQuery<LicensesSbom>({
     queryKey: ["sbom", tab],
-    queryFn: () => fetch(sbomUrlMap[tab]).then((res) => res.json()),
+    queryFn: async ({ signal }) => {
+      const res = await fetch(sbomUrlMap[tab], { signal });
+      if (!res.ok) throw new Error(`Failed to fetch SBOM (${res.status})`);
+      return res.json();
+    },
   });
 
   return (
@@ -41,15 +44,15 @@ export const LicensesPage = () => {
 
       <div className="p-4">
         <div className="mb-4 flex flex-col space-y-4 md:flex-row md:space-x-4 md:space-y-0">
-          <Tabs
+          <FilterTabs
             value={tab}
             onValueChange={(value) => setTab(value as "frontend" | "backend")}
-          >
-            <TabsList>
-              <TabsTrigger value="frontend">{t("care_frontend")}</TabsTrigger>
-              <TabsTrigger value="backend">{t("care_backend")}</TabsTrigger>
-            </TabsList>
-          </Tabs>
+            options={[
+              { value: "frontend", label: "care_frontend" },
+              { value: "backend", label: "care_backend" },
+            ]}
+            showAllOption={false}
+          />
         </div>
 
         {isLoading || !data ? <Loading /> : <SbomViewer data={data} />}
@@ -109,7 +112,11 @@ const SbomPackage = ({
         target="_blank"
         rel="noopener noreferrer"
         className="hover:text-primary-dark block text-primary"
-        href={`${getPackageUrl(pkg.name, pkg.versionInfo, pkg.externalRefs[0].referenceLocator)}`}
+        href={`${getPackageUrl(
+          pkg.name,
+          pkg.versionInfo,
+          pkg.externalRefs?.[0]?.referenceLocator,
+        )}`}
       >
         <strong className="text-lg">{`${pkg.name} v${pkg.versionInfo}`}</strong>
       </a>

--- a/src/pages/Patient/History/MedicationHistory.tsx
+++ b/src/pages/Patient/History/MedicationHistory.tsx
@@ -1,9 +1,10 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 import { AdministrationTab } from "@/components/Medicine/MedicationAdministration/AdministrationTab";
@@ -18,6 +19,25 @@ import medicationRequestApi from "@/types/emr/medicationRequest/medicationReques
 
 export const MedicationHistory = ({ patientId }: { patientId: string }) => {
   const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<
+    "prescriptions" | "statements" | "administration"
+  >("prescriptions");
+
+  // Tab options for FilterTabs
+  const tabOptions = [
+    {
+      value: "prescriptions",
+      label: "prescriptions",
+    },
+    {
+      value: "statements",
+      label: "medication_statements",
+    },
+    {
+      value: "administration",
+      label: "medicine_administration",
+    },
+  ];
 
   return (
     <div className="max-w-5xl mx-auto">
@@ -29,39 +49,46 @@ export const MedicationHistory = ({ patientId }: { patientId: string }) => {
         />
         <h4 className="text-xl">{t("past_medications")}</h4>
       </div>
-      <Tabs defaultValue="prescriptions" className="w-full">
+
+      <div className="w-full">
         <div className="overflow-x-auto">
-          <TabsList className="mb-4">
-            <TabsTrigger value="prescriptions">
-              {t("prescriptions")}
-            </TabsTrigger>
-            <TabsTrigger value="statements">
-              {t("medication_statements")}
-            </TabsTrigger>
-            <TabsTrigger value="administration">
-              {t("medicine_administration")}
-            </TabsTrigger>
-          </TabsList>
+          <FilterTabs
+            value={activeTab}
+            onValueChange={(value) =>
+              setActiveTab(
+                value as "prescriptions" | "statements" | "administration",
+              )
+            }
+            options={tabOptions}
+            variant="background"
+            className="mb-4"
+            showAllOption={false}
+            maxVisibleTabs={3}
+          />
         </div>
-        <TabsContent value="prescriptions">
+
+        {/* Conditional rendering based on activeTab */}
+        {activeTab === "prescriptions" && (
           <Prescriptions patientId={patientId} />
-        </TabsContent>
-        <TabsContent value="statements">
+        )}
+
+        {activeTab === "statements" && (
           <MedicationStatementList
             patientId={patientId}
             canAccess
             showTimeLine={true}
           />
-        </TabsContent>
-        <TabsContent value="administration">
+        )}
+
+        {activeTab === "administration" && (
           <AdministrationTab
             patientId={patientId}
             canWrite={false}
             canAccess
             showTimeLine={true}
           />
-        </TabsContent>
-      </Tabs>
+        )}
+      </div>
     </div>
   );
 };
@@ -135,7 +162,7 @@ const Prescriptions = ({ patientId }: { patientId: string }) => {
 
                       <div className="space-y-3 overflow-auto w-full">
                         <h3 className="text-sm font-medium text-indigo-700">
-                          {format(date, "dd MMMM, yyyy")}
+                          {format(parseISO(date), "dd MMMM, yyyy")}
                         </h3>
                         <MedicationsTable medications={items} />
                       </div>

--- a/src/pages/Patient/History/index.tsx
+++ b/src/pages/Patient/History/index.tsx
@@ -1,123 +1,232 @@
 import { useQuery } from "@tanstack/react-query";
-import { X } from "lucide-react";
-import { navigate, useQueryParams } from "raviger";
+import dayjs from "dayjs";
+import { Link, navigate } from "raviger";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { NavTabs } from "@/components/ui/nav-tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 
-import Page from "@/components/Common/Page";
+import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
 
-import useBreakpoints from "@/hooks/useBreakpoints";
+import { usePatientContext } from "@/hooks/usePatientUser";
 
 import query from "@/Utils/request/query";
-import { MedicationHistory } from "@/pages/Patient/History/MedicationHistory";
-import patientApi from "@/types/emr/patient/patientApi";
+import PublicAppointmentApi from "@/types/scheduling/PublicAppointmentApi";
+import {
+  APPOINTMENT_STATUS_COLORS,
+  Appointment,
+  formatScheduleResourceName,
+} from "@/types/scheduling/schedule";
 
-import { AllergyHistory } from "./AllergyHistory";
-import { DiagnosesHistory } from "./DiagnosesHistory";
-import { ResponsesHistory } from "./ResponsesHistory";
-import { SymptomsHistory } from "./SymptomsHistory";
+import AppointmentDialog from "./components/AppointmentDialog";
 
-export function ClinicalHistoryPage({
-  patientId,
-  tab = "symptoms",
-  fallBackUrl,
-}: {
-  fallBackUrl?: string;
-  patientId: string;
-  tab: string;
-}) {
+function PatientIndex() {
   const { t } = useTranslation();
-  const [{ sourceUrl }] = useQueryParams();
 
-  const { data: patient } = useQuery({
-    queryKey: ["patient", patientId],
-    queryFn: query(patientApi.getPatient, {
-      pathParams: { id: patientId },
+  const [selectedAppointment, setSelectedAppointment] = useState<
+    Appointment | undefined
+  >();
+  const [appointmentDialogOpen, setAppointmentDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<"scheduled" | "history">(
+    "scheduled",
+  );
+
+  const patient = usePatientContext();
+  const selectedPatient = patient?.selectedPatient;
+  const tokenData = patient?.tokenData;
+
+  if (!tokenData) {
+    navigate("/login");
+  }
+
+  const { data: appointmentsData, isLoading } = useQuery({
+    queryKey: ["appointment", tokenData?.phoneNumber],
+    queryFn: query(PublicAppointmentApi.getAppointments, {
+      headers: {
+        Authorization: `Bearer ${tokenData?.token}`,
+      },
     }),
+    enabled: !!tokenData?.token,
   });
 
-  const handleClose = () => {
-    navigate(sourceUrl || fallBackUrl);
-  };
-
-  const handleTabChange = (value: string) => {
-    navigate(value, {
-      ...(sourceUrl ? { query: { sourceUrl } } : {}),
-    });
-  };
-
-  const showMoreAfterIndex = useBreakpoints({
-    default: 1,
-    xs: 2,
-    sm: 6,
-    xl: 9,
-    "2xl": 12,
-  });
-
-  const tabs = {
-    symptoms: {
-      label: t("past_symptoms"),
-      component: <SymptomsHistory patientId={patientId} />,
-    },
-    diagnoses: {
-      label: t("past_diagnoses"),
-      component: <DiagnosesHistory patientId={patientId} />,
-    },
-    allergies: {
-      label: t("allergies"),
-      component: <AllergyHistory patientId={patientId} />,
-    },
-    medications: {
-      label: t("past_medications"),
-      component: <MedicationHistory patientId={patientId} />,
-    },
-    responses: {
-      label: t("questionnaire_responses"),
-      component: <ResponsesHistory patientId={patientId} />,
-    },
-  } as const;
-
-  return (
-    <Page
-      title={
-        patient
-          ? t("patient_clinical_history_page_title", { name: patient?.name })
-          : t("loading")
-      }
-      hideTitleOnPage
-    >
-      <div className="flex justify-between items-center bg-gray-100 -mx-3 -mt-8 md:-mt-8 md:-mx-9 px-3 md:px-6 pb-3 pt-2 md:rounded-t-lg">
-        <div>
-          {patient ? (
-            <h5 className="text-lg font-semibold">
-              {t("patient_clinical_history_page_title", { name: patient.name })}
-            </h5>
-          ) : (
-            <Skeleton className="w-20 h-4" />
-          )}
+  if (isLoading) {
+    return (
+      <div>
+        <div className="flex justify-between w-full mb-8">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-8 w-48" />
         </div>
-        <div>
-          <Button variant="outline" onClick={handleClose} size="icon">
-            <X className="size-4" />
-          </Button>
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-4 mt-4">
+          <CardListSkeleton count={6} />
         </div>
       </div>
-      <section>
-        <NavTabs
-          className="w-full mt-4"
-          tabContentClassName="mt-8"
-          tabs={tabs}
-          currentTab={tab}
-          onTabChange={handleTabChange}
-          setPageTitle={false}
-          showMoreAfterIndex={showMoreAfterIndex}
-        />
-      </section>
-    </Page>
+    );
+  }
+
+  const appointments = appointmentsData?.results
+    .filter((appointment) => appointment?.patient.id == selectedPatient?.id)
+    .sort(
+      (a, b) =>
+        new Date(a.token_slot.start_datetime).getTime() -
+        new Date(b.token_slot.start_datetime).getTime(),
+    );
+
+  const pastAppointments = appointments?.filter((appointment) =>
+    dayjs().isAfter(dayjs(appointment.token_slot.start_datetime)),
+  );
+
+  const scheduledAppointments = appointments?.filter((appointment) =>
+    dayjs().isBefore(dayjs(appointment.token_slot.start_datetime)),
+  );
+
+  // Tab options for FilterTabs
+  const tabOptions = [
+    {
+      value: "scheduled",
+      label: "scheduled",
+    },
+    {
+      value: "history",
+      label: "history",
+    },
+  ];
+
+  const getAppointmentCard = (appointment: Appointment) => {
+    const appointmentTime = dayjs(appointment.token_slot.start_datetime);
+    const appointmentDate = appointmentTime.format("DD MMMM YYYY");
+    const appointmentTimeSlot = appointmentTime.format("hh:mm a");
+    return (
+      <Card key={appointment.id} className="shadow-sm overflow-hidden">
+        <CardHeader className="px-6 pb-3 bg-secondary-200 flex flex-col md:flex-row justify-between">
+          <CardTitle>
+            <div className="flex flex-col">
+              <span className="text-xs font-medium">
+                {t(appointment.resource_type, { count: 1 })}:{" "}
+              </span>
+              <span className="text-sm">
+                {formatScheduleResourceName(appointment)}
+              </span>
+            </div>
+          </CardTitle>
+          <Button
+            variant="secondary"
+            className="border border-secondary-400"
+            onClick={() => {
+              setSelectedAppointment(appointment);
+              setAppointmentDialogOpen(true);
+            }}
+          >
+            <span>{t("view_details")}</span>
+          </Button>
+        </CardHeader>
+
+        <CardContent className="mt-2 pt-2 px-6 pb-3">
+          <div className="flex flex-col md:flex-row gap-4 justify-between">
+            <div className="flex flex-row gap-3 justify-between md:flex-row md:flex-grow md:mr-6">
+              <div className="flex flex-col gap-0 items-start md:flex-grow md:mr-4">
+                <span className="text-xs font-medium">{t("location")}: </span>
+                <span className="text-sm">
+                  <Link href={`/facility/${appointment.facility.id}`}>
+                    <span className="text-sm underline underline-offset-2 hover:cursor-pointer">
+                      {appointment.facility?.name}
+                    </span>
+                  </Link>
+                </span>
+              </div>
+              <div className="flex flex-col gap-0 items-start md:flex-none">
+                <span className="text-xs font-medium">{t("status")}: </span>
+                <span>
+                  <Badge
+                    variant={APPOINTMENT_STATUS_COLORS[appointment.status]}
+                  >
+                    {t(appointment.status)}
+                  </Badge>
+                </span>
+              </div>
+            </div>
+            <div className="flex flex-row gap-3 justify-between md:flex-none">
+              <div className="flex flex-col gap-0 items-start">
+                <span className="text-xs font-medium">{t("date")}: </span>
+                <span className="text-sm">{appointmentDate}</span>
+              </div>
+              <div className="flex flex-col gap-0 items-start">
+                <span className="text-xs font-medium">{t("time_slot")}: </span>
+                <span className="text-sm">{appointmentTimeSlot}</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  const getAppointmentCardContent = (
+    appointments: Appointment[] | undefined,
+  ) => {
+    return (
+      <div className="grid gap-4 mb-2">
+        {appointments && appointments.length > 0 ? (
+          appointments.map((appointment) => getAppointmentCard(appointment))
+        ) : (
+          <div className="col-span-full text-center bg-white shadow-sm rounded p-4 font-medium">
+            {t("no_appointments")}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <AppointmentDialog
+        setAppointmentDialogOpen={setAppointmentDialogOpen}
+        appointment={selectedAppointment}
+        open={appointmentDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedAppointment(undefined);
+          }
+          setAppointmentDialogOpen(open);
+        }}
+      />
+      <div className="container mx-auto mt-2">
+        <div className="flex justify-between w-full">
+          <span className="text-xl font-bold">{t("appointments")}</span>
+          <Button variant="primary_gradient" className="sticky right-0" asChild>
+            <Link href="/facilities">
+              <span>{t("book_appointment")}</span>
+            </Link>
+          </Button>
+        </div>
+
+        <div className="mt-4">
+          <FilterTabs
+            value={activeTab}
+            onValueChange={(value) =>
+              setActiveTab(value as "scheduled" | "history")
+            }
+            options={tabOptions}
+            variant="background"
+            className="w-full mb-4"
+            showAllOption={false}
+            maxVisibleTabs={2}
+          />
+
+          {/* Conditional rendering based on activeTab */}
+          {activeTab === "scheduled" &&
+            getAppointmentCardContent(scheduledAppointments)}
+
+          {activeTab === "history" &&
+            getAppointmentCardContent(pastAppointments)}
+        </div>
+      </div>
+    </>
   );
 }
 
-export default ClinicalHistoryPage;
+export default PatientIndex;


### PR DESCRIPTION
## Proposed Changes

Fixes #13733 
- Replaced `Tabs` with `FilterTabs`
- Needs modified `filter-tabs` from https://github.com/ohcnetwork/care_fe/pull/13920

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Revamped Patient History into a unified appointments view with “Scheduled” and “History” tabs.
  * Added appointment details dialog and “Book appointment” entry point.
  * Loading skeletons for smoother data-fetching states.

* Improvements
  * Consistent tabbed filtering across pages using a simplified filter UI (Admin Organizations, Licenses, Medication History).
  * Clearer date formatting in medication history.

* Bug Fixes
  * More reliable SBOM data loading with request cancellation and error handling.
  * Resilient package links when external references are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->