### PR TITLE
Modified filter-tabs in account, invoice & paymentReconciliation pages

### DIFF
--- a/src/pages/Facility/billing/account/AccountList.tsx
+++ b/src/pages/Facility/billing/account/AccountList.tsx
@@ -11,6 +11,7 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { Input } from "@/components/ui/input";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
@@ -20,7 +21,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { Avatar } from "@/components/Common/Avatar";
 import Page from "@/components/Common/Page";
@@ -116,24 +116,18 @@ export function AccountList({
           />
           <div className="mb-4 flex flex-col sm:flex-row sm:flex-wrap sm:items-center justify-between gap-4">
             <div className="flex flex-wrap gap-4">
-              <Tabs
-                value={qParams.status ?? "all"}
-                onValueChange={(value) =>
-                  updateQuery({ status: value === "all" ? undefined : value })
+              <FilterTabs
+                value={qParams.status ?? ""}
+                onValueChange={(nextValue) =>
+                  updateQuery({ status: nextValue ? nextValue : undefined })
                 }
                 className="overflow-y-auto max-w-[calc(100%)] max-sm:hidden text-gray-950"
-              >
-                <TabsList>
-                  <TabsTrigger value="all">{t("all_accounts")}</TabsTrigger>
-                  {Object.keys(ACCOUNT_STATUS_COLORS).map((key) => (
-                    <TabsTrigger key={key} value={key}>
-                      <span className="text-gray-950 font-medium text-sm">
-                        {t(key)}
-                      </span>
-                    </TabsTrigger>
-                  ))}
-                </TabsList>
-              </Tabs>
+                allOptionLabel="all_accounts"
+                options={Object.keys(ACCOUNT_STATUS_COLORS).map((key) => ({
+                  value: key,
+                  label: key,
+                }))}
+              />
 
               <Select
                 defaultValue={qParams.status ?? "all"}

--- a/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
   Select,
@@ -36,7 +37,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
@@ -277,6 +277,11 @@ export function BedChargeItemsTable({
     );
   };
 
+  const tabOptions = Object.values(ChargeItemStatus).map((s) => ({
+    value: s,
+    label: s,
+  }));
+
   return (
     <div>
       <AddMultipleChargeItemsSheet
@@ -305,7 +310,7 @@ export function BedChargeItemsTable({
       />
       <div className="mb-4">
         {/* Desktop Tabs */}
-        <Tabs
+        <FilterTabs
           value={qParams.charge_item_status ?? "all"}
           onValueChange={(value) =>
             updateQuery({
@@ -313,16 +318,8 @@ export function BedChargeItemsTable({
             })
           }
           className="max-sm:hidden"
-        >
-          <TabsList>
-            <TabsTrigger value="all">{t("all")}</TabsTrigger>
-            {Object.values(ChargeItemStatus).map((status) => (
-              <TabsTrigger key={status} value={status}>
-                {t(status)}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+          options={tabOptions}
+        />
         {/* Mobile Select */}
         <Select
           value={qParams.charge_item_status ?? "all"}

--- a/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
@@ -25,6 +25,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { EmptyState } from "@/components/ui/empty-state";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
   Select,
@@ -41,7 +42,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
@@ -61,7 +61,6 @@ import {
 import chargeItemApi from "@/types/billing/chargeItem/chargeItemApi";
 import query from "@/Utils/request/query";
 
-import CareIcon from "@/CAREUI/icons/CareIcon";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import AddChargeItemsBillingSheet from "./AddChargeItemsBillingSheet";
 import EditChargeItemSheet from "./EditChargeItemSheet";
@@ -180,28 +179,26 @@ export function ChargeItemsTable({
     }
   };
 
+  const tabOptions = Object.values(ChargeItemStatus).map((s) => ({
+    value: s,
+    label: s,
+  }));
+
   return (
     <div>
       <div className="mb-4 flex flex-col sm:flex-row justify-between items-center gap-2">
         {/* Desktop Tabs */}
-        <Tabs
+        <FilterTabs
           value={qParams.charge_item_status ?? "all"}
           onValueChange={(value) =>
             updateQuery({
-              charge_item_status: value === "all" ? undefined : value,
+              charge_item_status: value || undefined,
             })
           }
+          label={t("status")}
           className="max-sm:hidden w-2/3 md:w-full overflow-x-auto"
-        >
-          <TabsList className="overflow-x-auto">
-            <TabsTrigger value="all">{t("all")}</TabsTrigger>
-            {Object.values(ChargeItemStatus).map((status) => (
-              <TabsTrigger key={status} value={status}>
-                {t(status)}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+          options={tabOptions}
+        />
         {/* Mobile Select */}
         <Select
           value={qParams.charge_item_status ?? "all"}
@@ -249,8 +246,9 @@ export function ChargeItemsTable({
         <TableSkeleton count={3} />
       ) : !chargeItems?.results?.length ? (
         <EmptyState
-          icon={<CareIcon icon="l-receipt" className="text-primary size-6" />}
+          icon="l-receipt"
           title={t("no_charge_items")}
+          description={t("no_charge_items")}
         />
       ) : (
         <div className="rounded-md overflow-x-auto border-2 border-white shadow-md">
@@ -313,7 +311,7 @@ export function ChargeItemsTable({
                         )}
                       </Button>
                     </TableCell>
-                    <TableCell className="bor-medium">
+                    <TableCell className="border-x p-3 text-gray-950">
                       {item.title}
                       {item.description && (
                         <p className="text-xs text-gray-500 whitespace-pre-wrap">

--- a/src/pages/Facility/billing/invoice/InvoicesData.tsx
+++ b/src/pages/Facility/billing/invoice/InvoicesData.tsx
@@ -8,6 +8,7 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { Input } from "@/components/ui/input";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
@@ -18,7 +19,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 import {
@@ -100,25 +100,23 @@ export default function InvoicesData({
 
   const invoices = (response?.results as InvoiceRead[]) || [];
 
+  const tabOptions = Object.values(InvoiceStatus).map((status) => ({
+    value: status,
+    label: statusMap[status].label,
+  }));
+
   return (
     <>
       <div className="flex flex-row justify-between items-center gap-2 max-sm:flex-col pb-4">
-        <Tabs
-          defaultValue={qParams.status ?? "all"}
-          onValueChange={(value) =>
-            updateQuery({ status: value === "all" ? undefined : value })
-          }
-          className="max-sm:hidden"
-        >
-          <TabsList>
-            <TabsTrigger value="all">{t("all")}</TabsTrigger>
-            {Object.values(InvoiceStatus).map((status) => (
-              <TabsTrigger key={status} value={status}>
-                {t(statusMap[status].label)}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+        <FilterTabs
+          value={qParams.status ?? "all"}
+          onValueChange={(value) => updateQuery({ status: value || undefined })}
+          className="hidden sm:flex"
+          options={tabOptions}
+          // Optional UX: label and underline variant for consistency
+          // label="filter_by_status"
+          // variant="underline"
+        />
         <div className="relative w-full sm:max-w-xs border border-gray-400 rounded-md">
           <CareIcon
             icon="l-search"
@@ -159,9 +157,9 @@ export default function InvoicesData({
         <TableSkeleton count={3} />
       ) : !invoices?.length ? (
         <EmptyState
-          icon={<CareIcon icon="l-file-alt" className="text-primary size-6" />}
+          icon="l-file-alt"
           title={t("no_invoices")}
-          description={t("try_adjusting_your_filters_or_search")}
+          description={t("no_invoices_description")}
         />
       ) : (
         <div>

--- a/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { EyeIcon } from "lucide-react";
 import { Link } from "raviger";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -19,7 +19,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import { FilterTabs } from "@/components/ui/filter-tabs";
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 import {
@@ -82,11 +83,13 @@ export default function PaymentsData({
   });
 
   useEffect(() => {
-    updateQuery({ ordering: "-payment_datetime" });
-  }, []);
+    if (!qParams.ordering) {
+      updateQuery({ ordering: "-payment_datetime" });
+    }
+  }, [qParams.ordering, updateQuery]);
 
   const { data: response, isLoading } = useQuery({
-    queryKey: ["payments", accountId, qParams],
+    queryKey: ["payments", facilityId, accountId, qParams],
     queryFn: query(paymentReconciliationApi.listPaymentReconciliation, {
       pathParams: { facilityId },
       queryParams: {
@@ -102,28 +105,41 @@ export default function PaymentsData({
 
   const payments = (response?.results as PaymentReconciliationRead[]) || [];
 
+  const statusTabOptions = useMemo(
+    () =>
+      Object.values(PaymentReconciliationStatus).map((status) => ({
+        value: status,
+        // pass translation keys; FilterTabs will call t()
+        label: status,
+      })),
+    [],
+  );
+
+  const typeTabOptions = useMemo(
+    () =>
+      Object.values(PaymentReconciliationType).map((type) => ({
+        value: type,
+        // pass translation keys from typeMap; FilterTabs will call t()
+        label: typeMap[type],
+      })),
+    [],
+  );
+
   return (
     <>
       <div className="flex w-full flex-col items-center my-4 gap-2 md:flex-row md:flex-wrap md:gap-y-4 md:justify-start lg:flex-nowrap lg:justify-between">
         <div className="flex w-full flex-col items-center gap-3 md:flex-row md:flex-wrap md:gap-y-4">
-          <Tabs
-            defaultValue={qParams.status ?? "all"}
+          <FilterTabs
+            value={qParams.status ?? ""}
             onValueChange={(value) =>
               updateQuery({ status: value === "all" ? undefined : value })
             }
             className="hidden sm:flex"
-          >
-            <TabsList>
-              <TabsTrigger value="all">{t("all_status")}</TabsTrigger>
-              {Object.values(PaymentReconciliationStatus).map((status) => (
-                <TabsTrigger key={status} value={status}>
-                  {t(status)}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
+            options={statusTabOptions}
+            allOptionLabel="all_status"
+          />
           <Select
-            defaultValue={qParams.status ?? "all"}
+            value={qParams.status ?? "all"}
             onValueChange={(value) =>
               updateQuery({ status: value === "all" ? undefined : value })
             }
@@ -143,28 +159,23 @@ export default function PaymentsData({
             </SelectContent>
           </Select>
 
-          <Tabs
-            defaultValue={qParams.reconciliation_type ?? "all"}
+          <FilterTabs
+            value={qParams.reconciliation_type ?? ""}
             onValueChange={(value) =>
               updateQuery({
                 reconciliation_type: value === "all" ? undefined : value,
               })
             }
             className="hidden sm:flex"
-          >
-            <TabsList>
-              <TabsTrigger value="all">{t("all_type")}</TabsTrigger>
-              {Object.values(PaymentReconciliationType).map((type) => (
-                <TabsTrigger key={type} value={type}>
-                  {t(typeMap[type])}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
+            options={typeTabOptions}
+            allOptionLabel="all_type"
+          />
           <Select
-            defaultValue={qParams.status ?? "all"}
+            value={qParams.reconciliation_type ?? "all"}
             onValueChange={(value) =>
-              updateQuery({ status: value === "all" ? undefined : value })
+              updateQuery({
+                reconciliation_type: value === "all" ? undefined : value,
+              })
             }
           >
             <SelectTrigger className="sm:hidden border-gray-400 text-gray-950 rounded-sm">
@@ -206,9 +217,7 @@ export default function PaymentsData({
         <TableSkeleton count={3} />
       ) : !payments?.length ? (
         <EmptyState
-          icon={
-            <CareIcon icon="l-credit-card" className="text-primary size-6" />
-          }
+          icon="l-credit-card"
           title={t("no_payments")}
           description={t("no_payments_description")}
         />
@@ -274,8 +283,10 @@ export default function PaymentsData({
                       </Button>
                     )}
                   </TableCell>
-                  <TableCell>{typeMap[payment.reconciliation_type]}</TableCell>
-                  <TableCell>{methodMap[payment.method]}</TableCell>
+                  <TableCell>
+                    {t(typeMap[payment.reconciliation_type])}
+                  </TableCell>
+                  <TableCell>{t(methodMap[payment.method])}</TableCell>
                   <TableCell>
                     <MonetaryDisplay
                       amount={String(


### PR DESCRIPTION
## Proposed Changes

Fixes #13733 
- Replaced `Tabs` with `FilterTabs`
- Needs modified `filter-tabs` from https://github.com/ohcnetwork/care_fe/pull/13920

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified FilterTabs for status/type filtering across Accounts, Charge Items, Bed Charge Items, Invoices, and Payments.
  - Responsive filtering: desktop tabs with mobile-select retained.
- Style
  - Updated empty states with clearer descriptions and new icons.
  - Minor table styling tweaks for improved readability.
- Improvements
  - More consistent “All” behavior in filters and cleaner labels with translations.
- Bug Fixes
  - Default sorting now applied only when not previously set, preventing unintended overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->