### PR TITLE
Modified filter-tabs in various components

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -5330,6 +5330,7 @@
   "validation_errors": "Validation Errors",
   "validation_failed": "Validation failed",
   "value": "Value",
+  "values": "Values",
   "value_already_selected": "Value already selected",
   "value_set": "Value Set",
   "value_set_search_placeholder": "Type to search and select from the list",

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -12,6 +12,8 @@ import { cn } from "@/lib/utils";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
+import CircularProgress from "@/components/Common/CircularProgress";
+import LanguageSelectorLogin from "@/components/Common/LanguageSelectorLogin";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -20,6 +22,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import { Input } from "@/components/ui/input";
 import {
   InputOTP,
@@ -29,10 +32,6 @@ import {
 import { PasswordInput } from "@/components/ui/input-password";
 import { Label } from "@/components/ui/label";
 import { PhoneInput } from "@/components/ui/phone-input";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-import CircularProgress from "@/components/Common/CircularProgress";
-import LanguageSelectorLogin from "@/components/Common/LanguageSelectorLogin";
 
 import { useAuthContext } from "@/hooks/useAuthUser";
 
@@ -40,11 +39,11 @@ import { LocalStorageKeys } from "@/common/constants";
 
 import FiltersCache from "@/Utils/FiltersCache";
 import ViewCache from "@/Utils/ViewCache";
+import routes from "@/Utils/request/api";
 import mutate from "@/Utils/request/mutate";
 import { HTTPError } from "@/Utils/request/types";
 import authApi from "@/types/auth/authApi";
-import { TokenData } from "@/types/otp/otp";
-import otpApi from "@/types/otp/otpApi";
+import { TokenData } from "@/types/auth/otp";
 
 import { AuthHero } from "./AuthHero";
 
@@ -93,6 +92,14 @@ const Login = (props: LoginProps) => {
   const { forgot } = props;
   const [params, setQueryParams] = useQueryParams();
   const { mode } = params;
+  const loginMode = (mode as LoginMode | undefined) ?? "staff";
+  useEffect(() => {
+    const desired =
+      disablePatientLogin && loginMode === "patient" ? "staff" : loginMode;
+    if (!mode || mode !== desired) {
+      setQueryParams({ mode: desired as LoginMode }, { replace: false });
+    }
+  }, [mode, loginMode, setQueryParams, disablePatientLogin]);
   const initErr: any = {};
   const [form, setForm] = useState(initForm);
   const [errors, setErrors] = useState(initErr);
@@ -104,30 +111,25 @@ const Login = (props: LoginProps) => {
   const [otp, setOtp] = useState("");
   const [otpError, setOtpError] = useState<string>("");
   const [otpValidationError, setOtpValidationError] = useState<string>("");
-  const [resendOtpCountdown, setResendOtpCountdown] =
-    useState(resendOtpTimeout);
+  const [resendOtpCountdown, setResendOtpCountdown] = useState<number>(
+    resendOtpTimeout ?? 60,
+  );
 
   // Timer Function for resend OTP
   useEffect(() => {
-    if (resendOtpCountdown <= 0) {
-      return;
-    }
-
-    const timer = setInterval(() => {
-      setResendOtpCountdown((prevTime) => prevTime - 1);
-    }, 1000);
-
+    if (!Number.isFinite(resendOtpCountdown) || resendOtpCountdown <= 0) return;
+    const timer = setInterval(() => setResendOtpCountdown((t) => t - 1), 1000);
     return () => clearInterval(timer);
-  }, []);
+  }, [resendOtpCountdown]);
 
   // Remember the last login mode
   useEffect(() => {
-    localStorage.setItem(LocalStorageKeys.loginPreference, mode);
-  }, [mode]);
+    localStorage.setItem(LocalStorageKeys.loginPreference, loginMode);
+  }, [loginMode]);
 
   // Send OTP Mutation
   const { mutate: sendOtp, isPending: sendOtpPending } = useMutation({
-    mutationFn: mutate(otpApi.send),
+    mutationFn: mutate(routes.otp.sendOtp),
     onSuccess: () => {
       setIsOtpSent(true);
       setOtpError("");
@@ -147,7 +149,9 @@ const Login = (props: LoginProps) => {
   // Verify OTP Mutation
   const { mutate: verifyOtp, isPending: verifyOtpPending } = useMutation({
     mutationFn: async (data: OtpLoginData) => {
-      const response = await mutate(otpApi.login, { silent: true })(data);
+      const response = await mutate(routes.otp.loginByOtp, { silent: true })(
+        data,
+      );
       if ("errors" in response) {
         throw response;
       }
@@ -183,7 +187,7 @@ const Login = (props: LoginProps) => {
         errorMessage = error.message;
       }
       setOtpValidationError(errorMessage);
-      toast.error(errorMessage);
+      toast.error(t(errorMessage));
     },
   });
 
@@ -296,7 +300,7 @@ const Login = (props: LoginProps) => {
 
     if (!isOtpSent) {
       sendOtp({ phone_number: phone });
-      setResendOtpCountdown(resendOtpTimeout);
+      setResendOtpCountdown(resendOtpTimeout ?? 60);
     } else {
       verifyOtp({ phone_number: phone, otp });
     }
@@ -365,21 +369,144 @@ const Login = (props: LoginProps) => {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                {disablePatientLogin ? (
-                  <>
-                    {/* Staff Login */}
-                    {!forgotPassword ? (
-                      <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="flex w-full">
+                  <FilterTabs
+                    value={loginMode}
+                    onValueChange={(value) => {
+                      if (disablePatientLogin && value === "patient") return;
+                      setQueryParams(
+                        { mode: value as LoginMode },
+                        { replace: false },
+                      );
+                      if (value === "staff") {
+                        resetPatientLogin();
+                      } else {
+                        setForgotPassword(false);
+                      }
+                    }}
+                    options={
+                      disablePatientLogin
+                        ? [{ value: "staff", label: "staff_login" }]
+                        : [
+                            { value: "staff", label: "staff_login" },
+                            { value: "patient", label: "patient_login" },
+                          ]
+                    }
+                    variant="background"
+                    className="flex-1 mb-2"
+                    showAllOption={false}
+                  />
+                </div>
+
+                {/* Staff Login */}
+                {loginMode === "staff" &&
+                  (!forgotPassword ? (
+                    <form onSubmit={handleSubmit} className="space-y-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="username">{t("username")}</Label>
+                        <Input
+                          id="username"
+                          name="username"
+                          type="text"
+                          data-cy="username"
+                          autoComplete="username"
+                          value={form.username}
+                          onChange={handleChange}
+                          className={cn(
+                            errors.username &&
+                              "border-red-500 focus-visible:ring-red-500",
+                          )}
+                        />
+                        {errors.username && (
+                          <p className="text-sm text-red-500">
+                            {t(errors.username)}
+                          </p>
+                        )}
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="password">{t("password")}</Label>
+                        <PasswordInput
+                          id="password"
+                          name="password"
+                          data-cy="password"
+                          autoComplete="current-password"
+                          value={form.password}
+                          onChange={handleChange}
+                          className={cn(
+                            errors.password &&
+                              "border-red-500 focus-visible:ring-red-500",
+                          )}
+                        />
+                        {errors.password && (
+                          <p className="text-sm text-red-500">
+                            {t(errors.password)}
+                          </p>
+                        )}
+                      </div>
+
+                      {isCaptchaEnabled && reCaptchaSiteKey && (
+                        <div className="py-4">
+                          <ReCaptcha
+                            sitekey={reCaptchaSiteKey}
+                            onChange={onCaptchaChange}
+                          />
+                        </div>
+                      )}
+
+                      <Button
+                        variant="link"
+                        type="button"
+                        onClick={() => setForgotPassword(true)}
+                        className="px-0"
+                      >
+                        {t("forget_password")}
+                      </Button>
+
+                      <Button
+                        type="submit"
+                        className="w-full"
+                        variant="primary"
+                        data-cy="submit"
+                        disabled={isLoading}
+                      >
+                        {isLoading ? (
+                          <CircularProgress className="text-white" />
+                        ) : (
+                          t("login")
+                        )}
+                      </Button>
+                    </form>
+                  ) : (
+                    <form onSubmit={handleForgetSubmit} className="space-y-4">
+                      <Button
+                        variant="link"
+                        type="button"
+                        onClick={() => setForgotPassword(false)}
+                        className="px-0 mb-4 flex items-center gap-2"
+                      >
+                        <CareIcon icon="l-arrow-left" className="text-lg" />
+                        <span>{t("back_to_login")}</span>
+                      </Button>
+
+                      <div className="space-y-4">
+                        <div>
+                          <h2 className="text-2xl font-bold text-gray-900">
+                            {t("forget_password")}
+                          </h2>
+                          <p className="text-sm text-gray-500 mt-2">
+                            {t("forget_password_instruction")}
+                          </p>
+                        </div>
+
                         <div className="space-y-2">
                           <Label htmlFor="username">{t("username")}</Label>
                           <Input
-                            id="username"
+                            id="forgot_username"
                             name="username"
                             type="text"
-                            data-cy="username"
-                            autoComplete="username"
                             value={form.username}
                             onChange={handleChange}
+                            placeholder={t("enter_your_username")}
                             className={cn(
                               errors.username &&
                                 "border-red-500 focus-visible:ring-red-500",
@@ -434,366 +561,137 @@ const Login = (props: LoginProps) => {
                           type="submit"
                           className="w-full"
                           variant="primary"
-                          data-cy="submit"
                           disabled={isLoading}
                         >
                           {isLoading ? (
                             <CircularProgress className="text-white" />
                           ) : (
-                            t("login")
+                            t("send_reset_link")
                           )}
                         </Button>
-                      </form>
-                    ) : (
-                      <form onSubmit={handleForgetSubmit} className="space-y-4">
-                        <Button
-                          variant="link"
-                          type="button"
-                          onClick={() => setForgotPassword(false)}
-                          className="px-0 mb-4 flex items-center gap-2"
-                        >
-                          <CareIcon icon="l-arrow-left" className="text-lg" />
-                          <span>{t("back_to_login")}</span>
-                        </Button>
+                      </div>
+                    </form>
+                  ))}
 
-                        <div className="space-y-4">
-                          <div>
-                            <h2 className="text-2xl font-bold text-gray-900">
-                              {t("forget_password")}
-                            </h2>
-                            <p className="text-sm text-gray-500 mt-2">
-                              {t("forget_password_instruction")}
-                            </p>
-                          </div>
-
-                          <div className="space-y-2">
-                            <Label htmlFor="forgot_username">
-                              {t("username")}
-                            </Label>
-                            <Input
-                              id="forgot_username"
-                              name="username"
-                              type="text"
-                              value={form.username}
-                              onChange={handleChange}
-                              placeholder={t("enter_your_username")}
-                              className={cn(
-                                errors.username &&
-                                  "border-red-500 focus-visible:ring-red-500",
-                              )}
-                            />
-                            {errors.username && (
-                              <p className="text-sm text-red-500">
-                                {t(errors.username)}
-                              </p>
-                            )}
-                          </div>
-
-                          <Button
-                            type="submit"
-                            className="w-full"
-                            variant="primary"
-                            disabled={isLoading}
-                          >
-                            {isLoading ? (
-                              <CircularProgress className="text-white" />
-                            ) : (
-                              t("send_reset_link")
-                            )}
-                          </Button>
-                        </div>
-                      </form>
-                    )}
-                  </>
-                ) : (
-                  <Tabs
-                    value={mode === "patient" ? "patient" : "staff"}
-                    onValueChange={(value) => {
-                      setQueryParams({ mode: value as LoginMode });
-                      if (value === "staff") {
-                        resetPatientLogin();
-                      } else {
-                        setForgotPassword(false);
-                      }
-                    }}
-                  >
-                    <TabsList className="flex w-full">
-                      <TabsTrigger className="flex-1" value="staff">
-                        {t("staff_login")}
-                      </TabsTrigger>
-                      {!disablePatientLogin && (
-                        <TabsTrigger className="flex-1" value="patient">
-                          {t("patient_login")}
-                        </TabsTrigger>
+                {/* Patient Login */}
+                {loginMode === "patient" && !disablePatientLogin && (
+                  <form onSubmit={handlePatientLogin} className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="phone">{t("phone_number")}</Label>
+                      <PhoneInput
+                        id="phone"
+                        name="phone"
+                        value={phone}
+                        onChange={(value) => {
+                          setPhone(value ?? "");
+                          setOtpError("");
+                          setOtpValidationError("");
+                        }}
+                        disabled={isOtpSent}
+                        placeholder={t("enter_phone_number")}
+                      />
+                      {otpError && (
+                        <p className="text-sm text-red-500">{t(otpError)}</p>
                       )}
-                    </TabsList>
+                    </div>
 
-                    {/* Staff Login */}
-                    <TabsContent value="staff">
-                      {!forgotPassword ? (
-                        <form onSubmit={handleSubmit} className="space-y-4">
-                          <div className="space-y-2">
-                            <Label htmlFor="username">{t("username")}</Label>
-                            <Input
-                              id="username"
-                              name="username"
-                              type="text"
-                              data-cy="username"
-                              autoComplete="username"
-                              value={form.username}
-                              onChange={handleChange}
-                              className={cn(
-                                errors.username &&
-                                  "border-red-500 focus-visible:ring-red-500",
-                              )}
-                            />
-                            {errors.username && (
-                              <p className="text-sm text-red-500">
-                                {t(errors.username)}
-                              </p>
-                            )}
-                          </div>
-                          <div className="space-y-2">
-                            <Label htmlFor="password">{t("password")}</Label>
-                            <PasswordInput
-                              id="password"
-                              name="password"
-                              data-cy="password"
-                              autoComplete="current-password"
-                              value={form.password}
-                              onChange={handleChange}
-                              className={cn(
-                                errors.password &&
-                                  "border-red-500 focus-visible:ring-red-500",
-                              )}
-                            />
-                            {errors.password && (
-                              <p className="text-sm text-red-500">
-                                {t(errors.password)}
-                              </p>
-                            )}
-                          </div>
-
-                          {isCaptchaEnabled && reCaptchaSiteKey && (
-                            <div className="py-4">
-                              <ReCaptcha
-                                sitekey={reCaptchaSiteKey}
-                                onChange={onCaptchaChange}
-                              />
-                            </div>
-                          )}
-
-                          <Button
-                            variant="link"
-                            type="button"
-                            onClick={() => setForgotPassword(true)}
-                            className="px-0"
-                          >
-                            {t("forget_password")}
-                          </Button>
-
-                          <Button
-                            type="submit"
-                            className="w-full"
-                            variant="primary"
-                            data-cy="submit"
-                            disabled={isLoading}
-                          >
-                            {isLoading ? (
-                              <CircularProgress className="text-white" />
-                            ) : (
-                              t("login")
-                            )}
-                          </Button>
-                        </form>
-                      ) : (
-                        <form
-                          onSubmit={handleForgetSubmit}
-                          className="space-y-4"
-                        >
-                          <Button
-                            variant="link"
-                            type="button"
-                            onClick={() => setForgotPassword(false)}
-                            className="px-0 mb-4 flex items-center gap-2"
-                          >
-                            <CareIcon icon="l-arrow-left" className="text-lg" />
-                            <span>{t("back_to_login")}</span>
-                          </Button>
-
-                          <div className="space-y-4">
-                            <div>
-                              <h2 className="text-2xl font-bold text-gray-900">
-                                {t("forget_password")}
-                              </h2>
-                              <p className="text-sm text-gray-500 mt-2">
-                                {t("forget_password_instruction")}
-                              </p>
-                            </div>
-
-                            <div className="space-y-2">
-                              <Label htmlFor="forgot_username">
-                                {t("username")}
-                              </Label>
-                              <Input
-                                id="forgot_username"
-                                name="username"
-                                type="text"
-                                value={form.username}
-                                onChange={handleChange}
-                                placeholder={t("enter_your_username")}
-                                className={cn(
-                                  errors.username &&
-                                    "border-red-500 focus-visible:ring-red-500",
-                                )}
-                              />
-                              {errors.username && (
-                                <p className="text-sm text-red-500">
-                                  {t(errors.username)}
-                                </p>
-                              )}
-                            </div>
-
-                            <Button
-                              type="submit"
-                              className="w-full"
-                              variant="primary"
-                              disabled={isLoading}
-                            >
-                              {isLoading ? (
-                                <CircularProgress className="text-white" />
-                              ) : (
-                                t("send_reset_link")
-                              )}
-                            </Button>
-                          </div>
-                        </form>
-                      )}
-                    </TabsContent>
-
-                    {/* Patient Login */}
-                    <TabsContent value="patient">
-                      <form onSubmit={handlePatientLogin} className="space-y-4">
-                        <div className="space-y-2">
-                          <Label htmlFor="phone">{t("phone_number")}</Label>
-                          <PhoneInput
-                            id="phone"
-                            name="phone"
-                            value={phone}
+                    {isOtpSent && (
+                      <div className="space-y-2">
+                        <Label htmlFor="otp" className="mb-4">
+                          {t("enter_otp")}
+                        </Label>
+                        <div className="flex justify-center">
+                          <InputOTP
+                            value={otp}
+                            maxLength={5}
+                            pattern={REGEXP_ONLY_DIGITS}
+                            autoComplete="one-time-code"
+                            autoFocus
                             onChange={(value) => {
-                              setPhone(value ?? "");
+                              setOtp(value);
+                              setOtpValidationError("");
+                            }}
+                          >
+                            <InputOTPGroup>
+                              {[...Array(5)].map((_, index) => (
+                                <InputOTPSlot
+                                  key={index}
+                                  index={index}
+                                  className={cn(
+                                    "size-10",
+                                    otpValidationError &&
+                                      "border-red-500 focus-visible:ring-red-500",
+                                  )}
+                                />
+                              ))}
+                            </InputOTPGroup>
+                          </InputOTP>
+                        </div>
+                        {otpValidationError && (
+                          <p className="text-sm text-red-500 text-center">
+                            {t(otpValidationError)}
+                          </p>
+                        )}
+                      </div>
+                    )}
+
+                    <Button
+                      type="submit"
+                      className="w-full"
+                      variant="primary"
+                      disabled={
+                        isLoading ||
+                        !isValidPhoneNumber(phone) ||
+                        (isOtpSent && otp.length !== 5)
+                      }
+                    >
+                      {isLoading ? (
+                        <CircularProgress className="text-white" />
+                      ) : isOtpSent ? (
+                        t("verify_otp")
+                      ) : (
+                        t("send_otp")
+                      )}
+                    </Button>
+                    {isOtpSent && (
+                      <div className="flex flex-col items-center gap-2 text-center">
+                        {resendOtpCountdown <= 0 ? (
+                          <Button
+                            variant="link"
+                            type="button"
+                            className="h-auto p-0"
+                            onClick={() => {
+                              sendOtp({ phone_number: phone });
+                              setResendOtpCountdown(resendOtpTimeout ?? 60);
+                            }}
+                          >
+                            {t("resend_otp")}
+                          </Button>
+                        ) : (
+                          <p className="text-sm text-gray-500">
+                            {t("resend_otp_timer", {
+                              time: resendOtpCountdown,
+                            })}
+                          </p>
+                        )}
+                        <div className="flex items-center text-sm">
+                          <Button
+                            variant="link"
+                            type="button"
+                            className="h-auto p-0 text-primary-600"
+                            onClick={() => {
+                              setIsOtpSent(false);
+                              setOtp("");
                               setOtpError("");
                               setOtpValidationError("");
                             }}
-                            disabled={isOtpSent}
-                            placeholder={t("enter_phone_number")}
-                          />
-                          {otpError && (
-                            <p className="text-sm text-red-500">
-                              {t(otpError)}
-                            </p>
-                          )}
+                          >
+                            {t("change_phone_number")}
+                          </Button>
                         </div>
-
-                        {isOtpSent && (
-                          <div className="space-y-2">
-                            <Label htmlFor="otp" className="mb-4">
-                              {t("enter_otp")}
-                            </Label>
-                            <div className="flex justify-center">
-                              <InputOTP
-                                value={otp}
-                                maxLength={5}
-                                pattern={REGEXP_ONLY_DIGITS}
-                                autoComplete="one-time-code"
-                                autoFocus
-                                onChange={(value) => {
-                                  setOtp(value);
-                                  setOtpValidationError("");
-                                }}
-                              >
-                                <InputOTPGroup>
-                                  {[...Array(5)].map((_, index) => (
-                                    <InputOTPSlot
-                                      key={index}
-                                      index={index}
-                                      className={cn(
-                                        "size-10",
-                                        otpValidationError &&
-                                          "border-red-500 focus-visible:ring-red-500",
-                                      )}
-                                    />
-                                  ))}
-                                </InputOTPGroup>
-                              </InputOTP>
-                            </div>
-                            {otpValidationError && (
-                              <p className="text-sm text-red-500 text-center">
-                                {t(otpValidationError)}
-                              </p>
-                            )}
-                          </div>
-                        )}
-
-                        <Button
-                          type="submit"
-                          className="w-full"
-                          variant="primary"
-                          disabled={
-                            isLoading ||
-                            !isValidPhoneNumber(phone) ||
-                            (isOtpSent && otp.length !== 5)
-                          }
-                        >
-                          {isLoading ? (
-                            <CircularProgress className="text-white" />
-                          ) : isOtpSent ? (
-                            t("verify_otp")
-                          ) : (
-                            t("send_otp")
-                          )}
-                        </Button>
-                        {isOtpSent && (
-                          <div className="flex flex-col items-center gap-2 text-center">
-                            {resendOtpCountdown <= 0 ? (
-                              <Button
-                                variant="link"
-                                type="button"
-                                className="h-auto p-0"
-                                onClick={() => {
-                                  sendOtp({ phone_number: phone });
-                                  setResendOtpCountdown(resendOtpTimeout);
-                                }}
-                              >
-                                {t("resend_otp")}
-                              </Button>
-                            ) : (
-                              <p className="text-sm text-gray-500">
-                                {t("resend_otp_timer", {
-                                  time: resendOtpCountdown,
-                                })}
-                              </p>
-                            )}
-                            <div className="flex items-center text-sm">
-                              <Button
-                                variant="link"
-                                type="button"
-                                className="h-auto p-0 text-primary-600"
-                                onClick={() => {
-                                  setIsOtpSent(false);
-                                  setOtp("");
-                                  setOtpError("");
-                                  setOtpValidationError("");
-                                }}
-                              >
-                                {t("change_phone_number")}
-                              </Button>
-                            </div>
-                          </div>
-                        )}
-                      </form>
-                    </TabsContent>
-                  </Tabs>
+                      </div>
+                    )}
+                  </form>
                 )}
               </CardContent>
             </Card>

--- a/src/components/Common/Charts/ObservationChart.tsx
+++ b/src/components/Common/Charts/ObservationChart.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   CartesianGrid,
@@ -14,6 +15,7 @@ import {
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Card } from "@/components/ui/card";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import {
   Popover,
   PopoverContent,
@@ -28,7 +30,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { Avatar } from "@/components/Common/Avatar";
 
@@ -105,6 +106,8 @@ const formatChartDate = (
   };
 };
 
+type ObservationTab = "graph" | "data" | "history";
+
 export const ObservationVisualizer = ({
   patientId,
   codeGroups,
@@ -114,6 +117,13 @@ export const ObservationVisualizer = ({
   canAccess,
 }: ObservationVisualizerProps) => {
   const { t } = useTranslation();
+  const [activeTabs, setActiveTabs] = useState<Record<number, ObservationTab>>(
+    {},
+  );
+  const getActiveTab = (index: number) => activeTabs[index] ?? "graph";
+  const handleActiveTabChange = (index: number, value: ObservationTab) => {
+    setActiveTabs((prev) => ({ ...prev, [index]: value }));
+  };
 
   // Flatten all codes for a single API request
   const allCodes = codeGroups.flatMap((group) => group.codes);
@@ -239,56 +249,66 @@ export const ObservationVisualizer = ({
     };
   });
 
+  const tabOptions = [
+    { value: "graph", label: "graph" },
+    { value: "data", label: "recent_data" },
+    { value: "history", label: "full_history" },
+  ];
   return (
     <div
       className="grid gap-4"
       style={{ gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))` }}
     >
-      {processedDataByGroup.map((group, groupIndex) => (
-        <Card key={groupIndex} className="p-4">
-          <div className="mb-4 flex items-center justify-between">
-            <div className="flex items-center gap-1">
-              <h3 className="text-sm font-medium">{group.title}</h3>
-              <Popover>
-                <PopoverTrigger className="!px-0">
-                  <CareIcon
-                    icon="l-info-circle"
-                    className="size-4 text-gray-500 hover:text-gray-700 cursor-pointer"
-                  />
-                </PopoverTrigger>
-                <PopoverContent
-                  className="max-w-fit w-[calc(100vw-2rem)] sm:max-w-fit sm:w-auto break-words"
-                  side="bottom"
-                  align="start"
-                  sideOffset={4}
-                  collisionPadding={16}
-                >
-                  <div className="space-y-2">
-                    <div className="font-medium">Observations:</div>
-                    {group.codes.map((code) => (
-                      <div key={code.code} className="text-xs">
-                        {code.display} ({code.code})
-                      </div>
-                    ))}
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
-          </div>
-          <Tabs defaultValue="graph" className="w-full">
-            <TabsList className="flex w-full">
-              <TabsTrigger className="flex-1" value="graph">
-                {t("graph")}
-              </TabsTrigger>
-              <TabsTrigger className="flex-1" value="data">
-                {t("recent_data")}
-              </TabsTrigger>
-              <TabsTrigger className="flex-1" value="history">
-                {t("full_history")}
-              </TabsTrigger>
-            </TabsList>
+      {processedDataByGroup.map((group, groupIndex) => {
+        const currentTab = getActiveTab(groupIndex);
 
-            <TabsContent value="graph">
+        return (
+          <Card key={groupIndex} className="p-4">
+            <div className="mb-4 flex items-center justify-between">
+              <div className="flex items-center gap-1">
+                <h3 className="text-sm font-medium">{group.title}</h3>
+                <Popover>
+                  <PopoverTrigger className="!px-0">
+                    <CareIcon
+                      icon="l-info-circle"
+                      className="size-4 text-gray-500 hover:text-gray-700 cursor-pointer"
+                    />
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="max-w-fit w-[calc(100vw-2rem)] sm:max-w-fit sm:w-auto break-words"
+                    side="bottom"
+                    align="start"
+                    sideOffset={4}
+                    collisionPadding={16}
+                  >
+                    <div className="space-y-2">
+                      <div className="font-medium">Observations:</div>
+                      {group.codes.map((code) => (
+                        <div key={code.code} className="text-xs">
+                          {code.display} ({code.code})
+                        </div>
+                      ))}
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              </div>
+            </div>
+
+            <div className="mb-4">
+              <FilterTabs
+                value={currentTab}
+                onValueChange={(value) =>
+                  handleActiveTabChange(groupIndex, value as ObservationTab)
+                }
+                options={tabOptions}
+                variant="underline"
+                showAllOption={false}
+                maxVisibleTabs={3}
+                showMoreDropdown={false}
+              />
+            </div>
+
+            {currentTab === "graph" && (
               <div style={{ height: `${height}px` }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart
@@ -343,17 +363,16 @@ export const ObservationVisualizer = ({
                   </LineChart>
                 </ResponsiveContainer>
               </div>
-            </TabsContent>
-
-            <TabsContent value="data">
+            )}
+            {currentTab === "data" && (
               <div className="max-h-[400px] overflow-auto">
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>Time</TableHead>
-                      <TableHead>Values</TableHead>
-                      <TableHead>Entered By</TableHead>
-                      <TableHead>Notes</TableHead>
+                      <TableHead>{t("time")}</TableHead>
+                      <TableHead>{t("values")}</TableHead>
+                      <TableHead>{t("entered_by")}</TableHead>
+                      <TableHead>{t("notes")}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -426,18 +445,17 @@ export const ObservationVisualizer = ({
                   </TableBody>
                 </Table>
               </div>
-            </TabsContent>
-
-            <TabsContent value="history">
+            )}
+            {currentTab === "history" && (
               <ObservationHistoryTable
                 patientId={patientId}
                 encounterId={encounterId}
                 codes={group.codes}
               />
-            </TabsContent>
-          </Tabs>
-        </Card>
-      ))}
+            )}
+          </Card>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/Common/ResourceDefinitionCategoryPicker.tsx
+++ b/src/components/Common/ResourceDefinitionCategoryPicker.tsx
@@ -31,13 +31,13 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
 import useBreakpoints from "@/hooks/useBreakpoints";
@@ -245,12 +245,17 @@ export function ResourceDefinitionCategoryPicker<T>({
     [categoriesResponse?.results],
   );
 
+  // Keep raw API results and mapped display definitions separate
+  const rawDefinitions = useMemo(
+    () => (definitionsResponse?.results || []) as T[],
+    [definitionsResponse?.results],
+  );
+
   const definitions = useMemo(() => {
-    const results = definitionsResponse?.results || [];
     return mapper
-      ? results.map(mapper)
-      : (results as BaseCategoryPickerDefinition[]);
-  }, [definitionsResponse?.results, mapper]);
+      ? rawDefinitions.map(mapper)
+      : (rawDefinitions as unknown as BaseCategoryPickerDefinition[]);
+  }, [rawDefinitions, mapper]);
 
   const favorites = useMemo(() => {
     if (!enableFavorites || !favoritesResponse) return [];
@@ -263,6 +268,28 @@ export function ResourceDefinitionCategoryPicker<T>({
       ? favoritesArray.map(mapper)
       : (favoritesArray as BaseCategoryPickerDefinition[]);
   }, [favoritesResponse, mapper, enableFavorites]);
+
+  // Map slug -> original T across defs/favorites/recent so selection can return T
+  const rawBySlug = useMemo(() => {
+    // Prefer full definitions over (potentially sparse) favorites/recent
+    const allRaw = [
+      ...(Array.isArray(favoritesResponse)
+        ? (favoritesResponse as T[])
+        : (favoritesResponse as unknown as { results?: T[] })?.results || []),
+      ...(Array.isArray(recentResponse)
+        ? (recentResponse as T[])
+        : (recentResponse as unknown as { results?: T[] })?.results || []),
+      ...((definitionsResponse?.results || []) as T[]),
+    ] as T[];
+
+    const entries = allRaw.map((item) => {
+      const def = mapper
+        ? mapper(item)
+        : (item as unknown as BaseCategoryPickerDefinition);
+      return [def.slug, item] as const;
+    });
+    return new Map<string, T>(entries);
+  }, [definitionsResponse?.results, favoritesResponse, recentResponse, mapper]);
 
   const recentlyUsed = useMemo(() => {
     if (!enableFavorites || !recentResponse) return [];
@@ -315,6 +342,8 @@ export function ResourceDefinitionCategoryPicker<T>({
   });
 
   const handleDefinitionSelect = (definition: BaseCategoryPickerDefinition) => {
+    const original = (rawBySlug.get(definition.slug) ??
+      (definition as unknown)) as T;
     if (enableFavorites && favoritesConfig) {
       addToRecentMutation.mutate(definition.slug);
     }
@@ -333,10 +362,10 @@ export function ResourceDefinitionCategoryPicker<T>({
           ) as T[],
         );
       } else {
-        onValueChange([...currentValues, definition] as T[]);
+        onValueChange([...currentValues, original] as T[]);
       }
     } else {
-      onValueChange(definition as T);
+      onValueChange(original as T);
       setOpen(false);
       resetSearch();
     }
@@ -779,6 +808,48 @@ export function ResourceDefinitionCategoryPicker<T>({
     </Command>
   );
 
+  const tabOptions = [
+    { value: "search", label: "search" },
+    { value: "favorites", label: "favorites" },
+  ];
+
+  const renderFavoritesContent = () => (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-2 border-b flex-shrink-0">
+        <FilterTabs
+          value={favSubTab}
+          onValueChange={setFavSubTab}
+          options={[
+            {
+              value: "recent",
+              label: "recent",
+              icon: <Clock className="h-4 w-4" />,
+            },
+            {
+              value: "favorites",
+              label: "favorites",
+              icon:
+                favorites.length > 0 ? (
+                  <Badge variant="secondary">{favorites.length}</Badge>
+                ) : undefined,
+            },
+          ]}
+          variant="underline"
+          className="w-full"
+          showAllOption={false}
+        />
+      </div>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        {favSubTab === "recent" && (
+          <div className="h-full mt-0">{renderRecentItems()}</div>
+        )}
+        {favSubTab === "favorites" && (
+          <div className="h-full mt-0">{renderFavoriteItems()}</div>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className="space-y-2">
       {isMobile ? (
@@ -865,33 +936,30 @@ export function ResourceDefinitionCategoryPicker<T>({
             </div>
 
             {enableFavorites ? (
-              <Tabs
-                value={activeTab}
-                onValueChange={setActiveTab}
-                className="flex flex-col flex-1 min-h-0"
-              >
-                <div className="px-4 py-2 border-b flex-shrink-0">
-                  <TabsList className="grid w-full grid-cols-3">
-                    <TabsTrigger value="search">{t("search")}</TabsTrigger>
-                    <TabsTrigger value="recent">{t("recent")}</TabsTrigger>
-                    <TabsTrigger value="favorites">
-                      {t("favorites")} ({favorites.length})
-                    </TabsTrigger>
-                  </TabsList>
+              <div className="flex flex-col flex-1 min-h-0">
+                <div className="px-4 py-3 border-b flex-shrink-0">
+                  <FilterTabs
+                    value={activeTab}
+                    onValueChange={setActiveTab}
+                    options={tabOptions}
+                    variant="underline"
+                    className="w-full"
+                    maxVisibleTabs={2}
+                    showAllOption={false}
+                    data-cy="rcp-mobile-main-tabs"
+                  />
                 </div>
-
                 <div className="flex-1 min-h-0 overflow-hidden">
-                  <TabsContent value="search" className="h-full mt-0" autoFocus>
-                    {renderMainContent()}
-                  </TabsContent>
-                  <TabsContent value="recent" className="h-full mt-0">
-                    {renderRecentItems()}
-                  </TabsContent>
-                  <TabsContent value="favorites" className="h-full mt-0">
-                    {renderFavoriteItems()}
-                  </TabsContent>
+                  {activeTab === "search" && (
+                    <div className="h-full mt-0">{renderMainContent()}</div>
+                  )}
+                  {activeTab === "favorites" && (
+                    <div className="h-full mt-0">
+                      {renderFavoritesContent()}
+                    </div>
+                  )}
                 </div>
-              </Tabs>
+              </div>
             ) : (
               <div className="flex-1 min-h-0">{renderMainContent()}</div>
             )}
@@ -938,7 +1006,7 @@ export function ResourceDefinitionCategoryPicker<T>({
 
           <PopoverContent
             className={cn(
-              "p-0 shadow-lg border-0 -w-[var(--radix-popover-trigger-width)] sm:max-w-[80vw]",
+              "p-0 shadow-lg border-0 min-w-[var(--radix-popover-trigger-width)] sm:max-w-[80vw]",
               enableFavorites ? "md:max-w-[70vw]" : "min-w-[420px]",
             )}
             align="start"
@@ -984,14 +1052,31 @@ export function ResourceDefinitionCategoryPicker<T>({
               {enableFavorites && (
                 <div className="max-w-72 w-full border-l border-gray-200">
                   <div className="px-4 py-1 border-b bg-gray-50">
-                    <Tabs value={favSubTab} onValueChange={setFavSubTab}>
-                      <TabsList className="grid w-full grid-cols-2">
-                        <TabsTrigger value="recent">{t("recent")}</TabsTrigger>
-                        <TabsTrigger value="favorites">
-                          {t("favorites")} ({favorites.length})
-                        </TabsTrigger>
-                      </TabsList>
-                    </Tabs>
+                    <FilterTabs
+                      value={favSubTab}
+                      onValueChange={setFavSubTab}
+                      options={[
+                        {
+                          value: "recent",
+                          label: "recent",
+                          icon: <Clock className="h-4 w-4" />,
+                        },
+                        {
+                          value: "favorites",
+                          label: "favorites",
+                          icon:
+                            favorites.length > 0 ? (
+                              <Badge variant="secondary">
+                                {favorites.length}
+                              </Badge>
+                            ) : undefined,
+                        },
+                      ]}
+                      className="flex"
+                      variant="underline"
+                      showAllOption={false}
+                      maxVisibleTabs={2}
+                    />
                   </div>
 
                   <div className="overflow-auto min-h-0 max-h-[40vh]">

--- a/src/components/Facility/FacilityUsers.tsx
+++ b/src/components/Facility/FacilityUsers.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 
 import Page from "@/components/Common/Page";
 import SearchInput from "@/components/Common/SearchInput";
@@ -102,21 +102,26 @@ export default function FacilityUsers(props: { facilityId: string }) {
           }
           className="w-full max-w-sm"
         />
-        <Tabs
+        <FilterTabs
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as "card" | "list")}
-        >
-          <TabsList className="flex">
-            <TabsTrigger value="card" id="user-card-view">
-              <CareIcon icon="l-credit-card" className="text-lg" />
-              <span>{t("card")}</span>
-            </TabsTrigger>
-            <TabsTrigger value="list" id="user-list-view">
-              <CareIcon icon="l-list-ul" className="text-lg" />
-              <span>{t("list")}</span>
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
+          options={[
+            {
+              value: "card",
+              label: "card",
+              icon: <CareIcon icon="l-credit-card" className="text-lg" />,
+            },
+            {
+              value: "list",
+              label: "list",
+              icon: <CareIcon icon="l-list-ul" className="text-lg" />,
+            },
+          ]}
+          className="flex"
+          variant="background"
+          showAllOption={false}
+          maxVisibleTabs={2}
+        />
       </div>
       <div className="overflow-x-auto overflow-y-hidden">{usersList}</div>
     </Page>

--- a/src/components/Files/FilesTab.tsx
+++ b/src/components/Files/FilesTab.tsx
@@ -1,7 +1,4 @@
-import { t } from "i18next";
-import { useQueryParams } from "raviger";
-
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 
 import { DischargeTab } from "@/components/Files/DischargeSummarySubTab";
 import { DrawingPage } from "@/components/Files/DrawingSubTab";
@@ -16,6 +13,7 @@ import {
 } from "@/types/emr/encounter/encounter";
 import { PatientRead } from "@/types/emr/patient/patient";
 import { FileType } from "@/types/files/file";
+import { useState } from "react";
 
 interface FilesTabsProps {
   type: FileType.ENCOUNTER | FileType.PATIENT;
@@ -24,12 +22,7 @@ interface FilesTabsProps {
   readOnly?: boolean;
 }
 
-type QueryParams = {
-  file: "all" | "discharge_summary" | "drawings";
-};
-
-const allowedTabs = ["all", "discharge_summary", "drawings"] as const;
-type TabType = (typeof allowedTabs)[number];
+type TabType = "all" | "discharge_summary" | "drawings";
 
 export const FilesTab = ({
   patient,
@@ -37,8 +30,6 @@ export const FilesTab = ({
   encounter,
   readOnly,
 }: FilesTabsProps) => {
-  const [qParams, setQParams] = useQueryParams<QueryParams>();
-
   const { hasPermission } = usePermissions();
   const { canWritePatient } = getPermissions(
     hasPermission,
@@ -49,9 +40,7 @@ export const FilesTab = ({
     encounter?.permissions ?? [],
   );
 
-  const tabValue: TabType = allowedTabs.includes(qParams.file)
-    ? qParams.file
-    : "all";
+  const [activeTab, setActiveTab] = useState<TabType>("all");
 
   const canWriteCurrentEncounter =
     canWriteEncounter &&
@@ -68,70 +57,64 @@ export const FilesTab = ({
       encounter: encounter?.id,
     }[type] || "";
 
+  const tabOptions: { value: TabType; label: string }[] = [
+    { value: "all", label: "files" },
+    ...(type === FileType.ENCOUNTER && encounter
+      ? [
+          {
+            value: "discharge_summary" as TabType,
+            label: "discharge_summary",
+          },
+        ]
+      : []),
+    { value: "drawings", label: "drawings" },
+  ];
+
+  const availableTabs = tabOptions.map((option) => option.value);
+  const resolvedTab = availableTabs.includes(activeTab) ? activeTab : "all";
+
   return (
     <div className="space-y-4">
-      <Tabs
-        value={tabValue}
-        onValueChange={(value) => {
-          setQParams({ file: value as TabType }, { overwrite: false });
-        }}
-      >
-        <TabsList className={type != "encounter" ? "mt-2" : ""}>
-          <TabsTrigger
-            value="all"
-            className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
-          >
-            {t("files")}
-          </TabsTrigger>
-          {type === "encounter" && encounter && (
-            <TabsTrigger
-              value="discharge_summary"
-              className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
-            >
-              {t("discharge_summary")}
-            </TabsTrigger>
-          )}
-          <TabsTrigger
-            value="drawings"
-            className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
-          >
-            {t("drawings")}
-          </TabsTrigger>
-        </TabsList>
+      <FilterTabs
+        value={resolvedTab}
+        onValueChange={(value) => setActiveTab((value || "all") as TabType)}
+        options={tabOptions}
+        variant="background"
+        showAllOption={false}
+        maxVisibleTabs={3}
+        className="data-[state=active]:bg-white rounded-md px-4 font-semibold"
+      />
 
-        <TabsContent value="all">
-          <FilesPage
+      {resolvedTab === "all" && (
+        <FilesPage
+          type={type}
+          encounter={encounter}
+          patient={patient}
+          associatingId={associatingId}
+          canEdit={canEdit}
+        />
+      )}
+
+      {resolvedTab === "discharge_summary" && encounter && (
+        <DischargeTab
+          type={type}
+          encounter={encounter}
+          canEdit={canEdit}
+          // facilityId={facilityId || ""}
+        />
+      )}
+
+      {resolvedTab === "drawings" && (
+        <div>
+          <DrawingPage
             type={type}
-            encounter={encounter}
-            patient={patient}
-            associatingId={associatingId}
-            canEdit={canEdit}
+            {...(type === FileType.PATIENT
+              ? { patientId: patient?.id }
+              : { encounter: encounter })}
+            readOnly={readOnly}
           />
-        </TabsContent>
-
-        {type === "encounter" && encounter && (
-          <TabsContent value="discharge_summary">
-            <DischargeTab
-              type={type}
-              encounter={encounter}
-              canEdit={canEdit}
-              // facilityId={facilityId || ""}
-            />
-          </TabsContent>
-        )}
-
-        <TabsContent value="drawings">
-          <div>
-            <DrawingPage
-              type={type}
-              {...(type === FileType.PATIENT
-                ? { patientId: patient?.id }
-                : { encounter: encounter })}
-              readOnly={readOnly}
-            />
-          </div>
-        </TabsContent>
-      </Tabs>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -11,6 +11,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { FilterTabs } from "@/components/ui/filter-tabs";
 import {
   Sheet,
   SheetContent,
@@ -26,7 +27,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { PaginatedResponse } from "@/Utils/request/types";
 
@@ -355,19 +355,18 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
             </SheetTitle>
           </SheetHeader>
           {structuredTypes.length > 1 && (
-            <Tabs
+            <FilterTabs
               value={activeType}
               onValueChange={handleTabChange}
-              className="w-full"
-            >
-              <TabsList className="w-full">
-                {structuredTypes.map(({ type }) => (
-                  <TabsTrigger key={type} value={type} className="flex-1">
-                    {type}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </Tabs>
+              options={structuredTypes.map((st) => ({
+                value: st.type,
+                label: st.type,
+              }))}
+              variant="background"
+              className="w-full mb-2"
+              showAllOption={false}
+              maxVisibleTabs={structuredTypes.length}
+            />
           )}
         </div>
 


### PR DESCRIPTION
## Proposed Changes

Fixes #13733 
- Replaced `Tabs` with `FilterTabs`
- Needs modified `filter-tabs` from https://github.com/ohcnetwork/care_fe/pull/13920

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added patient OTP login with code entry, resend timer, and change-phone-number option.
  - Enhanced forgot-password flow with clearer messaging.
- Refactor
  - Unified multiple screens to a new FilterTabs UI for smoother navigation (login, observation charts, resource picker, facility users, files, historical records).
  - Observation charts now offer per-group tabs for graph, recent data, and full history.
  - Resource picker gains a favorites/recent panel with counts.
  - Files view streamlines tab handling independent of URL.
- Chores
  - Updated localization catalog with a new “Values” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->