### PR TITLE
Fixed routes for edit and cancel in Product Knowledge

### DIFF
--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -991,9 +991,13 @@ function ProductKnowledgeFormContent({
                 type="button"
                 variant="outline"
                 onClick={() =>
-                  navigate(
-                    `/facility/${facilityId}/settings/product_knowledge/categories/${categorySlug}`,
-                  )
+                  isEditMode
+                    ? navigate(
+                        `/facility/${facilityId}/settings/product_knowledge/${slug}`,
+                      )
+                    : navigate(
+                        `/facility/${facilityId}/settings/product_knowledge/categories/${categorySlug}`,
+                      )
                 }
               >
                 {t("cancel")}

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { PlusCircle, X } from "lucide-react";
-import { navigate } from "raviger";
+import { Link, navigate } from "raviger";
 import React from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -987,20 +987,16 @@ function ProductKnowledgeFormContent({
             </div>
 
             <div className="mt-6 flex justify-end space-x-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() =>
-                  isEditMode
-                    ? navigate(
-                        `/facility/${facilityId}/settings/product_knowledge/${slug}`,
-                      )
-                    : navigate(
-                        `/facility/${facilityId}/settings/product_knowledge/categories/${categorySlug}`,
-                      )
-                }
-              >
-                {t("cancel")}
+              <Button type="button" variant="outline" asChild>
+                <Link
+                  href={
+                    isEditMode
+                      ? `/product_knowledge/${slug}`
+                      : `/product_knowledge/categories/${categorySlug}`
+                  }
+                >
+                  {t("cancel")}
+                </Link>
               </Button>
               <Button type="submit" disabled={isPending}>
                 {isPending ? t("saving") : t("save")}

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
@@ -172,7 +172,7 @@ function ProductKnowledgeTableRow({
                   size="sm"
                   onClick={() =>
                     navigate(
-                      `/facility/${facilityId}/settings/product_knowledge/${product.slug}`,
+                      `/facility/${facilityId}/settings/product_knowledge/${product.slug}/edit`,
                     )
                   }
                 >

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { navigate } from "raviger";
+import { Link, navigate } from "raviger";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -167,16 +167,10 @@ function ProductKnowledgeTableRow({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() =>
-                    navigate(
-                      `/facility/${facilityId}/settings/product_knowledge/${product.slug}/edit`,
-                    )
-                  }
-                >
-                  <CareIcon icon="l-edit" className="h-4 w-4" />
+                <Button asChild variant="ghost" size="sm">
+                  <Link href={`/product_knowledge/${product.slug}/edit`}>
+                    <CareIcon icon="l-edit" className="h-4 w-4" />
+                  </Link>
                 </Button>
               </TooltipTrigger>
               <TooltipContent>


### PR DESCRIPTION
## Proposed Changes

Fixes #13932
- Changed route in PKListComps for edit to take to edit page
- Changed route in PKForm for cancel to take back to PKDetails when editing else back to categories while creating

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product Knowledge form cancel is now context-aware: when editing it returns to the item details; when creating it returns to the relevant category list.
  * From the Product Knowledge list, the Edit action now opens a dedicated edit page so viewing and editing are separate.
* **Behavior Change**
  * Edit action on mobile cards uses a compact icon-only interaction; “See details” remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->