### PR TITLE
fix create encounter crashing

### DIFF
--- a/src/components/Common/RoleOrgSelector.tsx
+++ b/src/components/Common/RoleOrgSelector.tsx
@@ -40,12 +40,7 @@ interface RoleOrgSelectorProps {
 
 export default function RoleOrgSelector(props: RoleOrgSelectorProps) {
   const { t } = useTranslation();
-  const {
-    value,
-    onChange,
-    currentOrganizations,
-    singleSelection = false,
-  } = props;
+  const { onChange, currentOrganizations, singleSelection = false } = props;
 
   const [selectedOrganizations, setSelectedOrganizations] = useState<
     Organization[]
@@ -70,21 +65,6 @@ export default function RoleOrgSelector(props: RoleOrgSelectorProps) {
       },
     }),
   });
-
-  // Sync selectedOrganizations with value prop
-  useEffect(() => {
-    if (value?.length && currentOrganizations?.length) {
-      const matchingOrganizations = currentOrganizations.filter((org) =>
-        value.includes(org.id),
-      );
-
-      if (matchingOrganizations.length === value.length) {
-        setSelectedOrganizations(matchingOrganizations);
-      }
-    } else {
-      setSelectedOrganizations([]);
-    }
-  }, [value, currentOrganizations]);
 
   const handleSelect = (org: Organization) => {
     const isAlreadySelected = !!currentOrganizations?.find(

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
@@ -45,7 +45,6 @@ export default function FacilityOrganizationSelector(
 ) {
   const { t } = useTranslation();
   const {
-    value,
     onChange,
     facilityId,
     currentOrganizations,
@@ -94,21 +93,6 @@ export default function FacilityOrganizationSelector(
       enabled: !!level.id,
     })),
   });
-
-  // Sync selectedOrganizations with value prop
-  useEffect(() => {
-    if (value?.length && currentOrganizations?.length) {
-      const matchingOrganizations = currentOrganizations.filter((org) =>
-        value.includes(org.id),
-      );
-
-      if (matchingOrganizations.length === value.length) {
-        setSelectedOrganizations(matchingOrganizations);
-      }
-    } else {
-      setSelectedOrganizations([]);
-    }
-  }, [value, currentOrganizations]);
 
   const handleSelect = (org: FacilityOrganizationRead) => {
     const isAlreadySelected = !!currentOrganizations?.find(


### PR DESCRIPTION
## Proposed Changes

- fixes create encounter crashing by reverting bad state management in dept. selector caused from #13892

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Organization selectors no longer auto-populate or auto-sync with existing values; selections are controlled solely by user input.
  - Selections are updated only upon explicit confirmation, preventing automatic changes during editing.
  - Initial state is no longer pre-filled from prior selections; users choose organizations each time as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->