### PR TITLE
adds support for 'clear all' in multi practitioner selector

### DIFF
--- a/src/pages/Appointments/components/PractitionerSelector.tsx
+++ b/src/pages/Appointments/components/PractitionerSelector.tsx
@@ -376,7 +376,6 @@ export const PractitionerSelector = ({
                               variant="outline"
                               size="xs"
                               onClick={handleClearAll}
-                              className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700"
                             >
                               {t("clear_all")}
                             </Button>

--- a/src/pages/Appointments/components/PractitionerSelector.tsx
+++ b/src/pages/Appointments/components/PractitionerSelector.tsx
@@ -180,6 +180,10 @@ export const PractitionerSelector = ({
     onSelect([...selected, ...users]);
   };
 
+  const handleClearAll = () => {
+    onSelect([]);
+  };
+
   const handleUserSelect = (user: UserReadMinimal) => {
     if (selected && multiple) {
       onSelect([...selected, user]);
@@ -362,7 +366,22 @@ export const PractitionerSelector = ({
 
                     {/* Selected Practitioners - Show at the top */}
                     {selected && selected.length > 0 && (
-                      <CommandGroup heading={t("selected")}>
+                      <CommandGroup>
+                        <div className="flex items-center justify-between px-2 py-1.5">
+                          <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                            {t("selected")}
+                          </span>
+                          {multiple && selected.length > 1 && (
+                            <Button
+                              variant="outline"
+                              size="xs"
+                              onClick={handleClearAll}
+                              className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700"
+                            >
+                              {t("clear_all")}
+                            </Button>
+                          )}
+                        </div>
                         {selected.map((user) => (
                           <CommandItem
                             key={user.id}


### PR DESCRIPTION
## Proposed Changes

- adds support for 'clear all' in multi practitioner selector
<img width="899" height="550" alt="image" src="https://github.com/user-attachments/assets/1f597b7c-73c2-40d3-9cd4-15f95c4ed8b5" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Clear All” button to the Selected Practitioners section when multi-select is enabled and multiple practitioners are chosen, allowing one-click clearing of all selections.

- Style
  - Updated the Selected Practitioners header to display a clearer label and accommodate the new Clear All action, improving usability without changing existing selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->