### PR TITLE
Fixed #13405: Added a back button to Charge Item Definition Details page

### DIFF
--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionDetail.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionDetail.tsx
@@ -18,6 +18,7 @@ import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import BackButton from "@/components/Common/BackButton";
 import { getCurrencySymbol } from "@/components/ui/monetary-display";
 import { getConditionValue } from "@/types/base/condition/condition";
 import {
@@ -29,6 +30,7 @@ import {
   ChargeItemDefinitionStatus,
 } from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
 import chargeItemDefinitionApi from "@/types/billing/chargeItemDefinition/chargeItemDefinitionApi";
+import { ArrowLeft } from "lucide-react";
 
 interface ChargeItemDefinitionDetailProps {
   facilityId: string;
@@ -143,12 +145,19 @@ export function ChargeItemDefinitionDetail({
   }
 
   return (
-    <Page title={chargeItemDefinition.title}>
-      <div className="container mx-auto">
+    <Page title={chargeItemDefinition.title} hideTitleOnPage={true}>
+      <div className="container mx-auto max-w-3xl space-y-6">
+        <BackButton>
+          <ArrowLeft />
+          {t("back")}
+        </BackButton>
         <div className="mb-4">
           <div className="mb-6 flex flex-col sm:flex-row items-start sm:items-center gap-2 justify-between">
             <div>
               <div className="mt-2 flex items-center gap-2">
+                <h1 className="text-2xl font-bold">
+                  {chargeItemDefinition.title}
+                </h1>
                 <Badge
                   variant={
                     CHARGE_ITEM_DEFINITION_STATUS_COLORS[


### PR DESCRIPTION
## Proposed Changes

Fixes #13405 
- Added a back button component to ChargeItemDefinitionDetail.tsx
- The default page title is hidden and an explicit page heading now shows the charge item definition title.

Tagging: @ohcnetwork/care-fe-code-reviewers


https://github.com/user-attachments/assets/0fa78dfd-1255-4105-b3b5-6a6ead4be56e



## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Back button with an arrow icon and localized label on the Charge Item Definition detail page for easier navigation.
- Style
  - Expanded content width for better readability (max-w-3xl).
  - Moved the main title into the content header and displayed it alongside status badges.
  - Hid the previous page-level title and refined spacing and layout to create a cleaner header and content area.
  - Improved overall visual hierarchy without altering existing details, pricing components, or actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->