### PR TITLE
Enable customized patient searches from plugs

### DIFF
--- a/src/components/Common/SearchInput.tsx
+++ b/src/components/Common/SearchInput.tsx
@@ -36,6 +36,7 @@ interface SearchOption {
   value: string;
   component?: React.ComponentType<HTMLDivElement>;
   display: string;
+  onSearch?: (value: string) => void;
 }
 
 interface SearchInputProps
@@ -100,22 +101,34 @@ const SearchInputFieldRenderer = ({
 
         // Only call onSearch if the phone number is valid
         if (isValid) {
-          onSearch(selectedOption.key, phoneValue);
+          if (selectedOption.onSearch) {
+            selectedOption.onSearch(phoneValue);
+          } else {
+            onSearch(selectedOption.key, phoneValue);
+          }
         }
       } else {
-        onSearch(selectedOption.key, phoneValue);
+        if (selectedOption.onSearch) {
+          selectedOption.onSearch(phoneValue);
+        } else {
+          onSearch(selectedOption.key, phoneValue);
+        }
       }
     },
-    [selectedOption.key, onSearch, setSearchValue],
+    [selectedOption.key, selectedOption.onSearch, onSearch, setSearchValue],
   );
 
   const handleTextChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const value = event.target.value;
       setSearchValue(value);
-      onSearch(selectedOption.key, value);
+      if (selectedOption.onSearch) {
+        selectedOption.onSearch(value);
+      } else {
+        onSearch(selectedOption.key, value);
+      }
     },
-    [selectedOption.key, onSearch, setSearchValue],
+    [selectedOption.key, selectedOption.onSearch, onSearch, setSearchValue],
   );
 
   switch (selectedOption.type) {
@@ -201,7 +214,11 @@ export default function SearchInput({
 
       // Only call onSearch if there's a value to search
       if (option.value) {
-        onSearch(option.key, option.value);
+        if (option.onSearch) {
+          option.onSearch(option.value);
+        } else {
+          onSearch(option.key, option.value);
+        }
       }
       onFieldChange?.(safeOptions[index]);
     },

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -28,9 +28,10 @@ import Loading from "@/components/Common/Loading";
 import SearchInput from "@/components/Common/SearchInput";
 
 import { getPermissions } from "@/common/Permissions";
-import { GENDER_TYPES } from "@/common/constants";
+import { GENDER_TYPES, GENDERS } from "@/common/constants";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
+import { PLUGIN_Component } from "@/PluginEngine";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import query from "@/Utils/request/query";
 import { usePermissions } from "@/context/PermissionContext";
@@ -44,10 +45,40 @@ import {
 import patientApi from "@/types/emr/patient/patientApi";
 import { FacilityRead } from "@/types/facility/facility";
 import { PatientIdentifierConfig } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { TFunction } from "i18next";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 const PHONE_NUMBER_CONFIG_SYSTEM =
   "system.care.ohc.network/patient-phone-number";
+
+const sharedStateSchema = z.object({
+  searchOptions: z.array(
+    z.object({
+      key: z.string(),
+      type: z.enum(["text", "phone"]),
+      placeholder: z.string(),
+      value: z.string(),
+      display: z.string(),
+      onSearch: z.function().args(z.string()).optional(),
+    }),
+  ),
+  patientList: z.object({
+    partial: z.boolean(),
+    results: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        phone_number: z.string(),
+        gender: z.enum(GENDERS),
+        year_of_birth: z.number().optional(),
+        partial_id: z.string(),
+      }),
+    ),
+  }),
+  isFetching: z.boolean().nullable(),
+});
 
 export default function PatientIndex({ facilityId }: { facilityId: string }) {
   useShortcutSubContext("patient:search:-global");
@@ -78,6 +109,17 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
     config?: string;
     value?: string;
   }>({});
+  const sharedState = useForm<z.infer<typeof sharedStateSchema>>({
+    resolver: zodResolver(sharedStateSchema),
+    defaultValues: {
+      searchOptions: [],
+      patientList: {
+        partial: false,
+        results: [],
+      },
+      isFetching: null,
+    },
+  });
 
   const handleSearch = useCallback((key: string, value: string) => {
     setIdentifierSearch({ config: key, value });
@@ -95,12 +137,29 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
     enabled: !!(identifierSearch.config && identifierSearch.value),
   });
 
+  useEffect(() => {
+    if (identifierSearch.config && identifierSearch.value) {
+      sharedState.setValue("patientList", {
+        partial: patientList?.partial ?? false,
+        results: (patientList?.results ?? []).map((p) => ({
+          id: p.id,
+          name: p.name,
+          phone_number: p.phone_number,
+          gender: p.gender,
+          year_of_birth: "year_of_birth" in p ? p.year_of_birth : undefined,
+          partial_id: p.id.slice(0, 5),
+        })),
+      });
+      sharedState.setValue("isFetching", isFetching);
+    }
+  }, [patientList, isFetching]);
+
   const handlePatientSelect = (index: number) => {
-    const patient = patientList?.results[index];
+    const patient = sharedState.getValues("patientList.results")[index];
     if (!patient) {
       return;
     }
-    if (patientList && patientList.partial) {
+    if (sharedState.getValues("patientList.partial")) {
       setSelectedPatient(patient);
       setVerificationOpen(true);
       setYearOfBirth("");
@@ -110,7 +169,7 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
           config: identifierSearch.config,
           value: identifierSearch.value,
           phone_number: patient.phone_number,
-          year_of_birth: patient.year_of_birth.toString(),
+          year_of_birth: patient.year_of_birth?.toString(),
           partial_id: patient.id.slice(0, 5),
         },
       });
@@ -185,20 +244,28 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
           <div>
             <div className="space-y-6">
               <SearchInput
-                options={getSearchOptions(t, identifierSearch, facility)}
+                options={[
+                  ...getSearchOptions(t, identifierSearch, facility),
+                  ...sharedState.watch("searchOptions"),
+                ]}
                 onSearch={handleSearch}
                 className="w-full"
                 autoFocus
               />
+              <PLUGIN_Component
+                __name="PatientSearch"
+                facilityId={facilityId}
+                state={sharedState}
+              />
 
               <div className="min-h-[200px]" id="patient-search-results">
-                {!!identifierSearch.config && !!identifierSearch.value && (
+                {sharedState.watch("isFetching") !== null && (
                   <>
-                    {isFetching || !patientList ? (
+                    {sharedState.watch("isFetching") ? (
                       <div className="flex items-center justify-center h-[200px]">
                         <Loading />
                       </div>
-                    ) : !patientList.results.length ? (
+                    ) : !sharedState.watch("patientList.results").length ? (
                       <div>
                         <div className="flex flex-col items-center justify-center py-10 text-center">
                           <h3 className="text-lg font-semibold">
@@ -231,27 +298,31 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
                             </TableRow>
                           </TableHeader>
                           <TableBody>
-                            {patientList.results.map((patient, index) => (
-                              <TableRow
-                                key={patient.id}
-                                className="cursor-pointer"
-                                onClick={() => handlePatientSelect(index)}
-                              >
-                                <TableCell className="font-medium">
-                                  {patient.name}
-                                </TableCell>
-                                <TableCell>
-                                  {formatPhoneNumberIntl(patient.phone_number)}
-                                </TableCell>
-                                <TableCell>
-                                  {
-                                    GENDER_TYPES.find(
-                                      (g) => g.id === patient.gender,
-                                    )?.text
-                                  }
-                                </TableCell>
-                              </TableRow>
-                            ))}
+                            {sharedState
+                              .watch("patientList.results")
+                              .map((patient, index) => (
+                                <TableRow
+                                  key={patient.id}
+                                  className="cursor-pointer"
+                                  onClick={() => handlePatientSelect(index)}
+                                >
+                                  <TableCell className="font-medium">
+                                    {patient.name}
+                                  </TableCell>
+                                  <TableCell>
+                                    {formatPhoneNumberIntl(
+                                      patient.phone_number,
+                                    )}
+                                  </TableCell>
+                                  <TableCell>
+                                    {
+                                      GENDER_TYPES.find(
+                                        (g) => g.id === patient.gender,
+                                      )?.text
+                                    }
+                                  </TableCell>
+                                </TableRow>
+                              ))}
                           </TableBody>
                         </Table>
                       </div>

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -55,6 +55,11 @@ export type PatientDetailsTabDemographyGeneralInfoComponentType = React.FC<{
   patientData: PatientRead;
 }>;
 
+export type PatientSearchComponentType = React.FC<{
+  facilityId: string;
+  state: UseFormReturn<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+}>;
+
 // Define supported plugin components
 export type SupportedPluginComponents = {
   DoctorConnectButtons: DoctorConnectButtonComponentType;
@@ -65,6 +70,7 @@ export type SupportedPluginComponents = {
   FacilityHomeActions: FacilityHomeActionsComponentType;
   PatientRegistrationForm: PatientRegistrationFormComponentType;
   PatientDetailsTabDemographyGeneralInfo: PatientDetailsTabDemographyGeneralInfoComponentType;
+  PatientSearch: PatientSearchComponentType;
 };
 
 // Create a type for lazy-loaded components


### PR DESCRIPTION
## Proposed Changes

Added PatientSearch plugin component hook, this hook is meant for extending patient search functionality for the plug. 

Currently the core app uses patient identifiers for searching patient, but there are some use cases where we cannot use patient identifiers, eg: incase of recurring temporary tokens. In this case, alternate option is to extend the search where plugins can search based on custom fields.

This feature is currently required by the ABDM plug to search patients by token generated by scan and share QR code.

To enable above requirements, I have added a plugin component hook which takes shared state as a param which is a react hook form state. This enables plugins to update the shared state at runtime to enable more search options.

Here is how ABDM plug extends it for supporting patient search by scan and share token. https://github.com/10bedicu/care_abdm_fe/pull/55

<img width="1191" height="302" alt="image" src="https://github.com/user-attachments/assets/28589ca5-5e0b-4d47-9ce6-ea6015d92409" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-option search actions: each search option can now handle its own search behavior.
  - Patient Search now supports a plugin component for extensible workflows.

- Bug Fixes
  - More robust patient selection and navigation, preventing errors when year of birth is missing.
  - Clearer loading and empty states during patient search for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->