### PR TITLE
Enforce client-side input validation on Patient search fields #13953

### DIFF
--- a/src/components/Patient/PatientIdentifierFilter.tsx
+++ b/src/components/Patient/PatientIdentifierFilter.tsx
@@ -155,6 +155,23 @@ export default function PatientIdentifierFilter({
     verifyPatient();
   };
 
+  const isPhoneNumberSearch = facility?.patient_instance_identifier_configs
+    ?.find((c) => c.id === searchType)
+    ?.config.display?.toLowerCase()
+    .includes("phone");
+
+  const handleSearchTermChange = (value: string) => {
+    let filteredValue = value;
+
+    if (isPhoneNumberSearch) {
+      filteredValue = value.replace(/[^0-9+\-() ]/g, "");
+    } else {
+      filteredValue = value.replace(/[^a-zA-Z\s\-']/g, "");
+    }
+
+    setSearchTerm(filteredValue);
+  };
+
   return (
     <>
       <div
@@ -195,8 +212,9 @@ export default function PatientIdentifierFilter({
                       : t("select_search_type")
                   }
                   value={searchTerm}
-                  onValueChange={setSearchTerm}
+                  onValueChange={handleSearchTermChange}
                   className="pl-8 pr-8 border-none focus:ring-0 focus:outline-none"
+                  inputMode={isPhoneNumberSearch ? "tel" : "text"}
                 />
                 {searchTerm && (
                   <Button


### PR DESCRIPTION
## Proposed Changes

Fixes #13953
- Implements client-side input filtering in `PatientIdentifierFilter.tsx` to prevent invalid characters based on the selected search type.
- For **Search by Phone Number** (identified via the "phone" display name): Restricts input to digits (`0-9`), plus signs (`+`), hyphens (`-`), and parentheses (`()`).
- For **Search by Patient Name** (and other non-phone searches): Filters out purely numeric input, allowing only letters, spaces, hyphens, and apostrophes.
- Adds the `inputMode` attribute (`tel` or `text`) for optimized mobile keyboard user experience.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Improved patient search input behavior with automatic sanitization based on search type.
  * Phone-number searches now accept only digits and common phone symbols for cleaner input.
  * Non-phone searches restrict input to letters, spaces, hyphens, and apostrophes for more relevant queries.
  * Dynamic keyboard: displays a phone keypad for phone-number searches and a standard keyboard otherwise, enhancing mobile usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->