### PR TITLE
Fix: Patient questionnaire updates are not showing up in updates tab

### DIFF
--- a/src/components/Patient/PatientDetailsTab/patientUpdates.tsx
+++ b/src/components/Patient/PatientDetailsTab/patientUpdates.tsx
@@ -62,6 +62,7 @@ export const Updates = (props: PatientProps) => {
       <QuestionnaireResponsesList
         patientId={patientId}
         canAccess={canViewPatientQuestionnaireResponses}
+        subjectType="patient"
       />
     </div>
   );


### PR DESCRIPTION
## Proposed Changes
 - passed subjectType = "patient" to fetch patient type questionnaire responses 
 
 
Originally reported by @Vikaspal8923  

https://rebuildearth.slack.com/archives/C010GQBMFJ9/p1759400285003399

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Patient Updates now correctly recognizes patient-specific questionnaire responses, improving the accuracy and clarity of the list in the Patient Details view.
  - Users should see more consistent labeling and behavior when viewing questionnaire items within the Updates tab for patients, reducing confusion and mismatches in displayed context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->