### PR TITLE
Fixes #13911 : After editing location in healthcare service the page …

### DIFF
--- a/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
+++ b/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
@@ -183,7 +183,9 @@ function HealthcareServiceFormContent({
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ["healthcareServices"] });
         toast.success(t("healthcare_service_updated_successfully"));
-        navigate(`/facility/${facilityId}/settings/healthcare_services`);
+        navigate(
+          `/facility/${facilityId}/settings/healthcare_services/${healthcareServiceId}`,
+        );
       },
     });
 


### PR DESCRIPTION
…is redirected to the service list page instead of service details page

## Proposed Changes

Fixes #13911 
Change the navigation to the proposed state as the problem statement mentioned

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [X] Add specs that demonstrate the bug or test the new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [X] Request peer reviews.
- [X] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * After successfully updating a healthcare service, you’ll be redirected to that service’s detail page instead of the list. This streamlines review of your changes, provides immediate visibility into updated information, and offers quicker access to follow-up actions (e.g., editing or managing related settings). All other form behavior remains unchanged, ensuring a smoother, more consistent post-update experience without altering existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->