### PR TITLE
Fixes #13641 :Text-not-properly-aligned-in-profile-page

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "rounded-xl border border-gray-200 bg-white text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 break-words break-all md:break-normal",
+        "rounded-xl border border-gray-200 bg-white text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 break-words md:break-normal",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Proposed Changes

Fixes #13641
Changed in the card.tsx to remove the normal break it is also effect all the things like delete account as well

<img width="383" height="828" alt="image" src="https://github.com/user-attachments/assets/5210778b-d52e-4e62-9a1e-55204284051e" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [X] Add specs that demonstrate the bug or test the new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [X] Request peer reviews.
- [X] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated card text wrapping to remove forced mid-word breaks, improving readability.
  * Preserves overall visual styling and dark mode appearance.
  * No functional or API changes; behavior is purely visual.
  * Expect more natural line wrapping and fewer split words; very long strings (e.g., URLs) may wrap differently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->