### PR TITLE
Fix #13825 : Done with white space not allowance while creating and e…

### DIFF
--- a/src/pages/Facility/queues/QueueFormSheet.tsx
+++ b/src/pages/Facility/queues/QueueFormSheet.tsx
@@ -35,14 +35,22 @@ import { dateQueryString } from "@/Utils/utils";
 import dayjs from "dayjs";
 
 const createQueueFormSchema = z.object({
-  name: z.string().min(1, "Queue name is required"),
+  name: z
+    .string()
+    .min(1, "Queue name is required")
+    .trim()
+    .refine((val) => val.length > 0, "Queue name cannot be empty"),
   date: z.date({
     required_error: "Date is required",
   }),
 });
 
 const editQueueFormSchema = z.object({
-  name: z.string().min(1, "Queue name is required"),
+  name: z
+    .string()
+    .min(1, "Queue name is required")
+    .trim()
+    .refine((val) => val.length > 0, "Queue name cannot be empty"),
 });
 
 type CreateQueueFormData = z.infer<typeof createQueueFormSchema>;

--- a/src/pages/Facility/queues/SubQueueFormSheet.tsx
+++ b/src/pages/Facility/queues/SubQueueFormSheet.tsx
@@ -37,12 +37,20 @@ import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 
 const createSubQueueFormSchema = z.object({
-  name: z.string().min(1, "Service point name is required"),
+  name: z
+    .string()
+    .min(1, "Service point name is required")
+    .trim()
+    .refine((val) => val.length > 0, "Service point name cannot be empty"),
   status: z.nativeEnum(TokenSubQueueStatus),
 });
 
 const editSubQueueFormSchema = z.object({
-  name: z.string().min(1, "Service point name is required"),
+  name: z
+    .string()
+    .min(1, "Service point name is required")
+    .trim()
+    .refine((val) => val.length > 0, "Service point name cannot be empty"),
   status: z.nativeEnum(TokenSubQueueStatus),
 });
 


### PR DESCRIPTION

## Proposed Changes

- Modified Queue form schema validation to prevent whitespace-only names
- Updated Service Point form schema validation to prevent whitespace-only names
- Added proper validation messages for better user feedback

Schema changes: For both Queue and Service Point forms, updated the name validation to:

1. Trim whitespace
2. Enforce minimum length after trimming
3. Add refinement to prevent empty strings after trimming

Fixes  #13825

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/592c77e6-3b90-4432-92dc-7faffc2afe0a" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/be402e83-28e3-4425-89ac-c8beb4ad0a62" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [X] Add specs that demonstrate the bug or test the new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [X] Request peer reviews.
- [X] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue and Sub-Queue forms now trim leading/trailing spaces and reject whitespace-only names on create and edit.
  * Improved validation ensures names are truly non-empty after trimming, preventing accidental submissions with only spaces.
  * Error messages more accurately reflect empty or invalid inputs, providing clearer guidance to users.
  * Consistent validation across create and edit flows reduces invalid entries and improves data quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->