### PR TITLE
feat: Add keyboard shortcuts for tab navigation and update NavTabs component

### DIFF
--- a/src/components/ui/nav-tabs.tsx
+++ b/src/components/ui/nav-tabs.tsx
@@ -31,6 +31,7 @@ interface Props<TabKey extends string> {
   tabTriggerClassName?: string;
   showMoreAfterIndex?: number;
   tabContentClassName?: string;
+  enableIndexShortcut?: boolean;
 }
 
 const getTabsToShowAndShowMore = <TabKey extends string>(
@@ -68,6 +69,7 @@ export const NavTabs = <TabKey extends string>({
   setPageTitle = true,
   tabTriggerClassName,
   showMoreAfterIndex,
+  enableIndexShortcut = false,
   ...props
 }: Props<TabKey> & React.ComponentProps<typeof Tabs>) => {
   const { t } = useTranslation();
@@ -86,7 +88,7 @@ export const NavTabs = <TabKey extends string>({
       onValueChange={(tab) => onTabChange(tab as TabKey)}
     >
       <TabsList className="w-full justify-evenly sm:justify-start border-b rounded-none bg-transparent p-0 h-auto overflow-x-auto">
-        {visibleTabs.map((option) => (
+        {visibleTabs.map((option, index) => (
           <TabsTrigger
             key={option}
             value={option}
@@ -99,6 +101,9 @@ export const NavTabs = <TabKey extends string>({
             {tabs[option].label}
             {tabs[option].shortcutId && (
               <ShortcutBadge actionId={tabs[option].shortcutId}></ShortcutBadge>
+            )}
+            {enableIndexShortcut && (
+              <ShortcutBadge actionId={`tab-index-${index}`}></ShortcutBadge>
             )}
           </TabsTrigger>
         ))}

--- a/src/components/ui/nav-tabs.tsx
+++ b/src/components/ui/nav-tabs.tsx
@@ -103,7 +103,9 @@ export const NavTabs = <TabKey extends string>({
               <ShortcutBadge actionId={tabs[option].shortcutId}></ShortcutBadge>
             )}
             {enableIndexShortcut && (
-              <ShortcutBadge actionId={`tab-index-${index}`}></ShortcutBadge>
+              <ShortcutBadge
+                actionId={`tab-index-${index + 1}`}
+              ></ShortcutBadge>
             )}
           </TabsTrigger>
         ))}

--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -7,8 +7,17 @@
     { "key": "shift+arrowLeft", "action": "go-back", "description": "Go Back", "when": "always" },
     { "key": "enter", "action": "enter-action", "description": "Enter Current Action", "when": "always" },
     { "key": "cmd+k", "action": "search-input-shortcut", "description": "Search Input", "when": "always" },
-    { "key": "e", "action": "edit-button", "description": "Edit", "when": "always" }
-    
+    { "key": "e", "action": "edit-button", "description": "Edit", "when": "always" },
+    { "key": "shift+1", "action": "tab-index-1", "description": "Switch to Tab 1", "when": "always" },
+    { "key": "shift+2", "action": "tab-index-2", "description": "Switch to Tab 2", "when": "always" },
+    { "key": "shift+3", "action": "tab-index-3", "description": "Switch to Tab 3", "when": "always" },
+    { "key": "shift+4", "action": "tab-index-4", "description": "Switch to Tab 4", "when": "always" },
+    { "key": "shift+5", "action": "tab-index-5", "description": "Switch to Tab 5", "when": "always" },
+    { "key": "shift+6", "action": "tab-index-6", "description": "Switch to Tab 6", "when": "always" },
+    { "key": "shift+7", "action": "tab-index-7", "description": "Switch to Tab 7", "when": "always" },
+    { "key": "shift+8", "action": "tab-index-8", "description": "Switch to Tab 8", "when": "always" },
+    { "key": "shift+9", "action": "tab-index-9", "description": "Switch to Tab 9", "when": "always" }
+
   ],
 
   "facility": [


### PR DESCRIPTION
## Proposed Changes

<img width="1453" height="60" alt="image" src="https://github.com/user-attachments/assets/cdd97bf0-90c8-45cf-ac6b-5f261b12691d" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional tab index badges that display numeric shortcuts next to tab labels (disabled by default).
  * Global keyboard shortcuts added: Shift+1 through Shift+9 to jump to tabs 1–9.
  * Existing shortcut behavior and tab functionality remain unchanged unless the index badges are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->