### PR TITLE
feat: Add hidden attribute to clear button in Autocomplete component 

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -300,6 +300,7 @@ export default function Autocomplete({
           className="absolute right-1 top-1/2 -translate-y-1/2 p-0 hover:bg-transparent opacity-50 z-10"
           onClick={handleClear}
           title={t("clear")}
+          hidden={disabled}
         >
           <Cross2Icon className="size-3" />
           <span className="sr-only">{t("clear")}</span>


### PR DESCRIPTION
feat: Add hidden attribute to clear button in Autocomplete component when disabled

## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autocomplete: The clear button is now hidden when the field is disabled on both mobile and desktop. This prevents confusing or unintended interactions and aligns the control’s visibility with its disabled state. When enabled, the clear behavior remains unchanged. This improves consistency and accessibility by ensuring disabled inputs do not present actionable controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->