### PR TITLE
Add keyboard shortcut for 'escape' and update JSON key name

### DIFF
--- a/src/Utils/keyboardShortcutUtils.ts
+++ b/src/Utils/keyboardShortcutUtils.ts
@@ -47,6 +47,9 @@ export function formatKeyboardShortcut(key: string): string {
     // Single key (a -> A)
     if (key === "arrowDown") {
       return "↓";
+    }
+    if (key === "escape") {
+      return "ESC";
     } else if (key === "arrowLeft") {
       return "←";
     }

--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -2,7 +2,7 @@
   "global": [
     { "key": "p", "action": "print-button", "description": "Print", "when": "always" },
     { "key": "shift+?", "action": "show-shortcuts", "description": "Show Keyboard Shortcuts", "when": "always" },
-    { "key": "esc", "action": "cancel-action", "description": "Cancel Current Action", "when": "always" },
+    { "key": "escape", "action": "cancel-action", "description": "Cancel Current Action", "when": "always" },
     { "key": "shift+enter", "action": "submit-action", "description": "Submit Current Action", "when": "always" },
     { "key": "shift+arrowLeft", "action": "go-back", "description": "Go Back", "when": "always" },
     { "key": "enter", "action": "enter-action", "description": "Enter Current Action", "when": "always" },


### PR DESCRIPTION
## Proposed Changes

ESC shortcut was not working, now that's fixed.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Style
  - Shortcut hints now display the Escape key as “ESC” instead of “ESCAPE” for clearer readability.

- Bug Fixes
  - Standardized the Escape key naming in shortcut configuration to ensure consistent recognition across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->