### PR TITLE
Added Pagination for encounter list in PatientHome

### DIFF
--- a/src/pages/Encounters/tabs/devices.tsx
+++ b/src/pages/Encounters/tabs/devices.tsx
@@ -163,7 +163,7 @@ export const EncounterDevicesTab = () => {
             {!!(data && data.count > limit) && (
               <Pagination
                 data={{ totalCount: data.count }}
-                onChange={(page, _) => setPage(page)}
+                onChange={(page) => setPage(page)}
                 defaultPerPage={limit}
                 cPage={page}
               />

--- a/src/pages/Encounters/tabs/diagnostic-reports.tsx
+++ b/src/pages/Encounters/tabs/diagnostic-reports.tsx
@@ -172,7 +172,7 @@ export const EncounterDiagnosticReportsTab = () => {
             {!!(data && data.count > limit) && (
               <Pagination
                 data={{ totalCount: data.count }}
-                onChange={(page, _) => setPage(page)}
+                onChange={(page) => setPage(page)}
                 defaultPerPage={limit}
                 cPage={page}
               />

--- a/src/pages/Patient/home/PatientHomeEncounters.tsx
+++ b/src/pages/Patient/home/PatientHomeEncounters.tsx
@@ -3,6 +3,7 @@ import { CaptionsOff } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import Pagination from "@/components/Common/Pagination";
 import { CardGridSkeleton } from "@/components/Common/SkeletonLoading";
 import { TimelineWrapper } from "@/components/Common/TimelineWrapper";
 import { TimelineEncounterCard } from "@/components/Facility/EncounterCard";
@@ -26,12 +27,15 @@ export default function PatientHomeEncounters({
 }: PatientHomeEncountersProps) {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState("active");
-
+  const [page, setPage] = useState(1);
+  const limit = 15;
   const { data: encounters, isLoading: encounterLoading } = useQuery({
-    queryKey: ["encounters", patientId, activeTab],
+    queryKey: ["encounters", patientId, activeTab, page, limit],
     queryFn: query(encounterApi.list, {
       queryParams: {
         patient: patientId,
+        limit: limit,
+        offset: (page - 1) * limit,
         status:
           activeTab === "active"
             ? "planned,in_progress,on_hold"
@@ -66,6 +70,14 @@ export default function PatientHomeEncounters({
               isFirst={index === 0}
             />
           ))}
+          <div className="flex items-center justify-center">
+            <Pagination
+              data={{ totalCount: encounters.count }}
+              onChange={(page) => setPage(page)}
+              defaultPerPage={limit}
+              cPage={page}
+            />
+          </div>
         </TimelineWrapper>
       );
     }


### PR DESCRIPTION
## Proposed Changes
- Added Pagination for encounter list in PatientHome
<img width="802" height="679" alt="image" src="https://github.com/user-attachments/assets/6da4c07b-8453-4c77-af8b-fac53810b880" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added client-side pagination to Patient Home Encounters, showing 15 items per page with total count and page navigation controls.
  - Pagination state is preserved while browsing, enabling smooth navigation across pages.

- Refactor
  - Standardized pagination event handling across Devices and Diagnostic Reports tabs for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->