### PR TITLE
Added patient tags in patient info hover card

### DIFF
--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -1,8 +1,10 @@
 import { Avatar } from "@/components/Common/Avatar";
 import { PatientAddressLink } from "@/components/Patient/PatientAddressLink";
 import { formatPatientAddress } from "@/components/Patient/utils";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PatientRead } from "@/types/emr/patient/patient";
+import { getTagHierarchyDisplay } from "@/types/emr/tagConfig/tagConfig";
 import { formatPatientAge } from "@/Utils/utils";
 import { Phone } from "lucide-react";
 import { Link } from "raviger";
@@ -61,7 +63,7 @@ export const PatientInfoHoverCard = ({
           </Link>
         </Button>
       </div>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
         <div className="grid grid-cols-2 gap-3 border-t border-gray-200 pt-4">
           {patient.instance_identifiers?.map((identifier) => (
             <div
@@ -118,6 +120,27 @@ export const PatientInfoHoverCard = ({
             </div>
           </div>
         </div>
+        {patient.instance_tags.length > 0 && (
+          <div className="flex items-start border-t border-gray-200 pt-2">
+            <div className="flex flex-col gap-1 text-sm font-medium w-full">
+              <span className="text-gray-700">{t("patient_tags")}:</span>
+              <div className="flex flex-wrap gap-2 text-sm whitespace-nowrap">
+                <>
+                  {patient.instance_tags.map((tag) => (
+                    <Badge
+                      key={tag.id}
+                      variant="secondary"
+                      className="capitalize"
+                      title={tag.description}
+                    >
+                      {getTagHierarchyDisplay(tag)}
+                    </Badge>
+                  ))}
+                </>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Proposed Changes
Added patient tags in patient info hover card

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Patient hover card now displays patient tags when available.
  - Tags appear as compact badges with readable labels and descriptive titles for quick context.
  - Supports hierarchical tag display for clearer categorization.

- Style
  - Reduced spacing in the main info block for a tighter, more streamlined layout.

- Chores
  - No changes to public APIs; existing behavior remains intact aside from the new tags section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->