### PR TITLE
Fixes order id being present in url while switching location

### DIFF
--- a/src/components/ui/sidebar/facility/location/location-switcher.tsx
+++ b/src/components/ui/sidebar/facility/location/location-switcher.tsx
@@ -130,6 +130,8 @@ export function LocationSelectorDialog({
   const path = usePath();
   const subPath =
     path?.match(/\/facility\/[^/]+\/locations\/[^/]+\/(.*)/)?.[1] || "";
+  const uuidPattern =
+    /\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
   const currentParentId = locationLevel.length
     ? locationLevel[locationLevel.length - 1].id
@@ -183,8 +185,9 @@ export function LocationSelectorDialog({
       } else if (navigateUrl) {
         navigate(navigateUrl(newLocation));
       } else {
+        const newSubPath = subPath.replace(uuidPattern, "");
         navigate(
-          `/facility/${facilityId}/locations/${newLocation.id}/${subPath}`,
+          `/facility/${facilityId}/locations/${newLocation.id}/${newSubPath}`,
         );
       }
     }


### PR DESCRIPTION
## Proposed Changes

Fixes `orderId` being present when switching locations allowing users of a particular location to see orders they dont have access to
- Identified the uuid in url and replace it with an empty string

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects navigation after selecting a facility location by removing unintended trailing identifiers from the URL when no custom navigation is provided. This prevents misrouting, 404s, and inconsistent breadcrumbs; improves deep-linking, sharing, and bookmarking; and aligns sidebar location links with the main facility path. Users should now land on the expected location overview instead of item-specific pages. Behavior with custom navigation handlers remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->