### PR TITLE
fix responsiveness of address link in appointments detail page

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -682,7 +682,7 @@ const AppointmentDetailsContent = ({
             </div>
             <div className="flex flex-row items-start gap-2 text-sm">
               <DrawingPinIcon className="size-4 text-gray-500 mt-1" />
-              <div className="flex flex-col xl:flex-row xl:justify-between xl:items-end gap-2 w-full">
+              <div className="flex flex-col gap-2 w-full">
                 <div>
                   <p className="text-gray-600 break-words">
                     {formatPatientAddress(appointment.patient.address) || (


### PR DESCRIPTION
## Proposed Changes

<img width="417" height="366" alt="image" src="https://github.com/user-attachments/assets/df8ec560-8928-4ab9-b275-3d95c7ad0f43" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Appointment Details address section to a consistent vertical layout across all screen sizes.
  * Ensures the address block uses full width for improved readability and alignment.
  * Removes large-screen-only horizontal alignment that could cause uneven spacing or misalignment.
  * Visual-only change with no impact on functionality or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->