### PR TITLE
show deceased patient info in appointment show page

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -112,6 +112,7 @@ import {
 
 import { Avatar } from "@/components/Common/Avatar";
 import BackButton from "@/components/Common/BackButton";
+import { PatientDeceasedInfo } from "@/components/Patient/PatientHeader";
 import { PatientInfoCard } from "@/components/Patient/PatientInfoCard";
 import { formatPatientAddress } from "@/components/Patient/utils";
 import {
@@ -288,6 +289,9 @@ export default function AppointmentDetail(props: Props) {
               )
             }
           />
+          <div className="mt-4">
+            <PatientDeceasedInfo patient={appointment.patient} />
+          </div>
         </div>
         <div
           className={cn(


### PR DESCRIPTION
## Proposed Changes

- Requires: https://github.com/ohcnetwork/care/pull/3302

<img width="2054" height="776" alt="image" src="https://github.com/user-attachments/assets/22dd7ce5-a283-4d23-9e12-d6702474366b" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appointment Details now displays deceased patient information, when applicable, directly below the patient info section.
  * Provides clear visual indication of a patient’s deceased status to support accurate context during appointment review.
  * Non-intrusive addition: appears only when relevant and does not alter existing workflows or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->