### PR TITLE
show only active instances/bed in location sheet

### DIFF
--- a/src/components/Location/LocationSheet.tsx
+++ b/src/components/Location/LocationSheet.tsx
@@ -184,6 +184,7 @@ export function LocationSheet({
           name: searchTerm,
           parent: selectedLocation?.id,
           available: showAvailableOnly ? "true" : undefined,
+          status: "active",
           ...(!selectedLocation ? { mine: true } : {}),
         },
         signal,


### PR DESCRIPTION
## Proposed Changes

before

<img width="879" height="910" alt="image" src="https://github.com/user-attachments/assets/6485b505-3617-4f3f-a11a-722d884858b3" />


after

<img width="1754" height="825" alt="image" src="https://github.com/user-attachments/assets/7c7ba6ec-7f0e-49dd-9ece-9e8569e29684" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Beds shown after selecting a location now only include active entries, preventing inactive beds from appearing in lists and selections.

* **Improvements**
  * Streamlined bed results to reflect current availability more accurately when filtering by location, reducing confusion and selection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->