### PR TITLE
fixes questionnaire print route not found in clinical history

### DIFF
--- a/src/Routers/routes/ConsultationRoutes.tsx
+++ b/src/Routers/routes/ConsultationRoutes.tsx
@@ -55,6 +55,7 @@ const consultationRoutes: AppRoutes = {
   }, {}),
   ...[
     "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire_response/:questionnaireResponseId/print",
+    "/facility/:facilityId/patient/:patientId/history/questionnaire_response/:questionnaireResponseId/print",
     "/organization/:organizationId/patient/:patientId/encounter/:encounterId/questionnaire_response/:questionnaireResponseId/print",
     "/facility/:facilityId/patient/:patientId/questionnaire_response/:questionnaireResponseId/print",
     "/organization/:organizationId/patient/:patientId/questionnaire_response/:questionnaireResponseId/print",


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a dedicated route to print a patient’s History Questionnaire Response, aligned with existing questionnaire print views.
  - Enables opening a print-friendly page for a specific patient and facility, allowing quick export/printing of completed history questionnaires.
  - Accessible via existing navigation where print options are available; maintains consistent behavior and layout with other print views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->