### PR TITLE
Fix: Questionnaire print breaking for clinical history qnr response tab

### DIFF
--- a/src/Routers/routes/ConsultationRoutes.tsx
+++ b/src/Routers/routes/ConsultationRoutes.tsx
@@ -40,6 +40,8 @@ const consultationRoutes: AppRoutes = {
     "/facility/:facilityId/patient/:patientId/questionnaire/:questionnaireId/responses/print",
     "/organization/:organizationId/patient/:patientId/questionnaire/:questionnaireId/responses/print",
     "/patient/:patientId/questionnaire/:questionnaireId/responses/print",
+    "/facility/:facilityId/patient/:patientId/history/questionnaire/:questionnaireId/responses/print",
+    "/patient/:patientId/history/questionnaire/:questionnaireId/responses/print",
   ].reduce((acc: AppRoutes, path) => {
     acc[path] = ({ encounterId, patientId, questionnaireId, facilityId }) => {
       return (
@@ -56,6 +58,7 @@ const consultationRoutes: AppRoutes = {
   ...[
     "/facility/:facilityId/patient/:patientId/encounter/:encounterId/questionnaire_response/:questionnaireResponseId/print",
     "/facility/:facilityId/patient/:patientId/history/questionnaire_response/:questionnaireResponseId/print",
+    "/patient/:patientId/history/questionnaire_response/:questionnaireResponseId/print",
     "/organization/:organizationId/patient/:patientId/encounter/:encounterId/questionnaire_response/:questionnaireResponseId/print",
     "/facility/:facilityId/patient/:patientId/questionnaire_response/:questionnaireResponseId/print",
     "/organization/:organizationId/patient/:patientId/questionnaire_response/:questionnaireResponseId/print",


### PR DESCRIPTION
## Proposed Changes

 - Added the missing routes for print of qnr for clinical history page 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new print pages for questionnaire responses:
    - Print all responses for a questionnaire from a patient’s history (available in patient-only and facility+patient contexts).
    - Print a specific questionnaire response directly.
  * Enhances access to clean, printable views for records, referrals, and offline sharing, with no impact on existing navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->