### PR TITLE
Fix: Navigation from Appointment details to Queue board and to Appointment details page

### DIFF
--- a/src/pages/Appointments/components/AppointmentTokenCard.tsx
+++ b/src/pages/Appointments/components/AppointmentTokenCard.tsx
@@ -161,6 +161,7 @@ const TokenCard = ({
                 className="underline font-semibold text-base capitalize text-gray-950"
               >
                 <Link
+                  basePath="/"
                   href={`/facility/${facility.id}/${resourceTypeToResourcePathSlug[appointment.resource_type]}/${appointment.resource.id}/queues/${appointment.token?.queue.id}`}
                 >
                   {t("queue_board")}

--- a/src/pages/Facility/services/HealthcareServiceShow.tsx
+++ b/src/pages/Facility/services/HealthcareServiceShow.tsx
@@ -33,17 +33,17 @@ function LocationCard({
       case InternalType.pharmacy:
         return {
           text: t("view_prescriptions"),
-          link: `/facility/${facilityId}/locations/${locationId}/medication_requests/`,
+          link: `/facility/${facilityId}/locations/${locationId}/medication_requests`,
         };
       case InternalType.lab:
         return {
           text: t("view_requests"),
-          link: `/facility/${facilityId}/locations/${locationId}/service_requests/`,
+          link: `/facility/${facilityId}/locations/${locationId}/service_requests`,
         };
       default:
         return {
           text: t("view_appointments"),
-          link: `/facility/${facilityId}/locations/${locationId}/appointments/`,
+          link: `/facility/${facilityId}/locations/${locationId}/appointments`,
         };
     }
   };

--- a/src/pages/PublicAppointments/PatientSelect.tsx
+++ b/src/pages/PublicAppointments/PatientSelect.tsx
@@ -117,7 +117,7 @@ export default function PatientSelect({
 
   if (!staffId) {
     toast.error(t("staff_not_found"));
-    navigate(`/facility/${facilityId}/`);
+    navigate(`/facility/${facilityId}`);
   } else if (!tokenData) {
     toast.error(t("phone_number_not_found"));
     navigate(`/facility/${facilityId}/appointments/${staffId}/otp/send`);

--- a/src/pages/PublicAppointments/Schedule.tsx
+++ b/src/pages/PublicAppointments/Schedule.tsx
@@ -57,7 +57,7 @@ export function ScheduleAppointment(props: AppointmentsProps) {
 
   if (!staffId) {
     toast.error(t("staff_username_not_found"));
-    navigate(`/facility/${facilityId}/`);
+    navigate(`/facility/${facilityId}`);
   } else if (!tokenData) {
     toast.error(t("phone_number_not_found"));
     navigate(`/facility/${facilityId}/appointments/${staffId}/otp/send`);


### PR DESCRIPTION
## Proposed Changes
Fix: Navigation from Appointment details to Queue board and to Appointment details page

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized internal links by removing trailing slashes across facility and public appointments pages for consistent navigation.
  * Improved redirects when staff information is missing, ensuring users land on the correct facility page.
  * Adjusted the queue board link resolution for more reliable routing without changing the visible URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->