### PR TITLE
Fix patient tags as nullable in PatientInfoHoverCard

### DIFF
--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -120,7 +120,7 @@ export const PatientInfoHoverCard = ({
             </div>
           </div>
         </div>
-        {patient.instance_tags.length > 0 && (
+        {patient.instance_tags?.length > 0 && (
           <div className="flex items-start border-t border-gray-200 pt-2">
             <div className="flex flex-col gap-1 text-sm font-medium w-full">
               <span className="text-gray-700">{t("patient_tags")}:</span>


### PR DESCRIPTION
## Proposed Changes
Fix: Patient tags as nullable in PatientInfoHoverCard

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the Patient Info hover card by safely handling patients without instance tags.
  * Prevents rare rendering errors or crashes when tag data is missing or not yet loaded.
  * Ensures the tag section appears only when tags are available, avoiding empty or misleading UI.
  * No visual or behavioral changes otherwise; users should experience smoother, more reliable hover card interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->