### PR TITLE
fix responsivnes of "authenticate your account" and facility description markdown

### DIFF
--- a/src/components/Auth/Authenticate.tsx
+++ b/src/components/Auth/Authenticate.tsx
@@ -116,7 +116,7 @@ export const Authenticate = () => {
           <div className="w-full max-w-[400px] space-y-6">
             <Card className="mx-4">
               <CardHeader className="space-y-1 px-4">
-                <CardTitle className="text-3xl font-bold w-15 text-black text-center">
+                <CardTitle className="text-3xl font-bold md:w-15 text-black text-center">
                   {t("authenticate_your_account")}
                 </CardTitle>
               </CardHeader>

--- a/src/components/Auth/Authenticate.tsx
+++ b/src/components/Auth/Authenticate.tsx
@@ -116,7 +116,7 @@ export const Authenticate = () => {
           <div className="w-full max-w-[400px] space-y-6">
             <Card className="mx-4">
               <CardHeader className="space-y-1 px-4">
-                <CardTitle className="text-3xl font-bold md:w-15 text-black text-center">
+                <CardTitle className="text-3xl font-bold text-black text-center">
                   {t("authenticate_your_account")}
                 </CardTitle>
               </CardHeader>

--- a/src/components/Facility/FacilityHome.tsx
+++ b/src/components/Facility/FacilityHome.tsx
@@ -333,7 +333,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
 
               {facilityData?.description && (
                 <Card>
-                  <CardContent className="mt-4 break-all">
+                  <CardContent className="mt-4 break-words">
                     <Markdown
                       content={facilityData.description}
                       className="text-sm"

--- a/src/components/Facility/FacilityHome.tsx
+++ b/src/components/Facility/FacilityHome.tsx
@@ -333,7 +333,7 @@ export const FacilityHome = ({ facilityId }: Props) => {
 
               {facilityData?.description && (
                 <Card>
-                  <CardContent className="mt-4">
+                  <CardContent className="mt-4 break-all">
                     <Markdown
                       content={facilityData.description}
                       className="text-sm"

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "rounded-xl border border-gray-200 bg-white text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 break-words break-all md:break-normal",
+        "rounded-xl border border-gray-200 bg-white text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Proposed Changes

- fix responsivnes of "authenticate your account" and facility description markdown

<img width="437" height="716" alt="image" src="https://github.com/user-attachments/assets/5552c042-424c-4c3d-914d-c705a720f6d9" />

<img width="438" height="711" alt="image" src="https://github.com/user-attachments/assets/9f6fe755-c45c-454c-b071-cf121da417a8" />

<img width="1511" height="742" alt="image" src="https://github.com/user-attachments/assets/d304c403-2e2c-4eb4-9576-b73d0d347555" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved text wrapping for facility descriptions to prevent overflow and enhance readability, especially for long words and URLs.
  - Standardized Card component wrapping behavior for more natural, consistent text flow across screen sizes.
  - Polished authentication screen layout by adjusting title sizing/spacing for a cleaner presentation.
  - Ensures a more consistent look and feel across cards without altering functionality or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->