### PR TITLE
fix: update clear button visibility logic in ResourceDefinitionCategoryPicker

### DIFF
--- a/src/components/Common/ResourceDefinitionCategoryPicker.tsx
+++ b/src/components/Common/ResourceDefinitionCategoryPicker.tsx
@@ -141,6 +141,7 @@ export function ResourceDefinitionCategoryPicker<T>({
   ref,
   hideClearButton = false,
 }: ResourceDefinitionCategoryPickerProps<T>) {
+  const shouldHideClearButton = allowMultiple || hideClearButton;
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const isMobile = useBreakpoints({ default: true, sm: false });
@@ -325,7 +326,6 @@ export function ResourceDefinitionCategoryPicker<T>({
 
     if (allowMultiple) {
       const currentValues = Array.isArray(value) ? value : value ? [value] : [];
-
       const isSelected = currentValues.some(
         (v: T) => mapper!(v).slug === definition.slug,
       );
@@ -821,7 +821,7 @@ export function ResourceDefinitionCategoryPicker<T>({
                 />
               </Button>
             </DrawerTrigger>
-            {value && !hideClearButton && (
+            {value && !shouldHideClearButton && (
               <Button
                 variant="outline"
                 onClick={handleClearSelection}
@@ -938,7 +938,7 @@ export function ResourceDefinitionCategoryPicker<T>({
                 />
               </Button>
             </PopoverTrigger>
-            {value && !hideClearButton && (
+            {value && !shouldHideClearButton && (
               <Button
                 variant="outline"
                 onClick={handleClearSelection}


### PR DESCRIPTION


## Proposed Changes
<img width="891" height="232" alt="image" src="https://github.com/user-attachments/assets/54026694-4502-422d-9d31-bbf113b72615" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Clear button behavior updated in the category picker: it now hides when multiple selections are enabled, preventing accidental clearing of multi-select choices.
  - Consistent visibility across mobile (drawer) and desktop (popover) views, ensuring a uniform experience.
  - Improved clarity for users by only showing the clear option when it’s appropriate for the current selection mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->