### PR TITLE
hide auto-maintained identifiers

### DIFF
--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -237,10 +237,12 @@ export const Demography = (props: PatientProps) => {
     {
       id: "identifiers",
       allowEdit: false,
-      details: patientData.instance_identifiers?.map((i) => ({
-        label: i.config.config.display,
-        value: i.value,
-      })),
+      details: patientData.instance_identifiers
+        .filter(({ config }) => !config.config.auto_maintained)
+        .map((i) => ({
+          label: i.config.config.display,
+          value: i.value,
+        })),
     },
     {
       id: "tags",

--- a/src/components/Patient/PatientHeader.tsx
+++ b/src/components/Patient/PatientHeader.tsx
@@ -38,17 +38,21 @@ export function PatientHeader({
           disabled={isPatientPage}
         />
         <div className="flex flex-wrap xl:gap-5 gap-2">
-          {patient.instance_identifiers?.map((identifier) => (
-            <div
-              key={identifier.config.id}
-              className="flex flex-col gap-1 items-start md:hidden xl:flex"
-            >
-              <span className="text-xs text-gray-700 md:w-auto">
-                {identifier.config.config.display}:{" "}
-              </span>
-              <span className="text-sm font-semibold">{identifier.value}</span>
-            </div>
-          ))}
+          {patient.instance_identifiers
+            .filter(({ config }) => !config.config.auto_maintained)
+            .map((identifier) => (
+              <div
+                key={identifier.config.id}
+                className="flex flex-col gap-1 items-start md:hidden xl:flex"
+              >
+                <span className="text-xs text-gray-700 md:w-auto">
+                  {identifier.config.config.display}:{" "}
+                </span>
+                <span className="text-sm font-semibold">
+                  {identifier.value}
+                </span>
+              </div>
+            ))}
           {patient.instance_tags?.length > 0 && (
             <div className="flex flex-col gap-1 items-start">
               <span className="text-xs text-gray-700">

--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -65,17 +65,19 @@ export const PatientInfoHoverCard = ({
       </div>
       <div className="flex flex-col gap-3">
         <div className="grid grid-cols-2 gap-3 border-t border-gray-200 pt-4">
-          {patient.instance_identifiers?.map((identifier) => (
-            <div
-              key={identifier.config.id}
-              className="flex flex-col gap-0.5 text-sm"
-            >
-              <span className="font-medium text-gray-700">
-                {identifier.config.config.display}:{" "}
-              </span>
-              <span className="font-semibold">{identifier.value}</span>
-            </div>
-          ))}
+          {patient.instance_identifiers
+            .filter(({ config }) => !config.config.auto_maintained)
+            .map((identifier) => (
+              <div
+                key={identifier.config.id}
+                className="flex flex-col gap-0.5 text-sm"
+              >
+                <span className="font-medium text-gray-700">
+                  {identifier.config.config.display}:{" "}
+                </span>
+                <span className="font-semibold">{identifier.value}</span>
+              </div>
+            ))}
           {patient.phone_number && (
             <div className="flex flex-col gap-1 text-sm font-medium">
               <span className="text-gray-700">{t("contact")}</span>

--- a/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
@@ -225,17 +225,19 @@ export const SummaryPanelEncounterDetails = () => {
 
           <div className="flex flex-row gap-2">
             <div className="text-sm text-gray-950 font-semibold flex flex-wrap gap-6">
-              {patient?.instance_identifiers?.map((identifier) => (
-                <div
-                  key={identifier.config.id}
-                  className="flex flex-col items-start"
-                >
-                  <span className="text-gray-600 md:w-auto">
-                    {identifier.config.config.display}:{" "}
-                  </span>
-                  <span className="font-semibold">{identifier.value}</span>
-                </div>
-              ))}
+              {patient?.instance_identifiers
+                .filter(({ config }) => !config.config.auto_maintained)
+                .map((identifier) => (
+                  <div
+                    key={identifier.config.id}
+                    className="flex flex-col items-start"
+                  >
+                    <span className="text-gray-600 md:w-auto">
+                      {identifier.config.config.display}:{" "}
+                    </span>
+                    <span className="font-semibold">{identifier.value}</span>
+                  </div>
+                ))}
             </div>
           </div>
 


### PR DESCRIPTION
## Proposed Changes

- hide auto-maintained identifiers on all usages of patient's instance identifiers

# before

<img width="1493" height="381" alt="image" src="https://github.com/user-attachments/assets/4fa2291f-4470-4c6f-834f-e494f1256f88" />

# after

<img width="1410" height="359" alt="image" src="https://github.com/user-attachments/assets/f60b60a7-45ee-40d3-a705-9b2c9a408c1c" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patient identifiers now exclude auto-maintained entries across the app (Patient Details, Patient Header, Info Hover Card, and Encounter Summary). Only user-relevant identifiers are shown, reducing clutter and confusion.
  * Display labels and values remain unchanged; only the visible set of identifiers is filtered.
  * No changes to layout or navigation; presentation is consistent across affected views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->