### PR TITLE
Filter out system identifiers

### DIFF
--- a/src/components/Patient/PatientHeader.tsx
+++ b/src/components/Patient/PatientHeader.tsx
@@ -5,7 +5,10 @@ import { Card } from "@/components/ui/card";
 
 import { cn } from "@/lib/utils";
 import { PatientHoverCard } from "@/pages/Facility/services/serviceRequests/PatientHoverCard";
-import { PatientRead } from "@/types/emr/patient/patient";
+import {
+  filterOutSystemIdentifiers,
+  PatientRead,
+} from "@/types/emr/patient/patient";
 import { getTagHierarchyDisplay } from "@/types/emr/tagConfig/tagConfig";
 import dayjs from "dayjs";
 
@@ -38,17 +41,21 @@ export function PatientHeader({
           disabled={isPatientPage}
         />
         <div className="flex flex-wrap xl:gap-5 gap-2">
-          {patient.instance_identifiers?.map((identifier) => (
-            <div
-              key={identifier.config.id}
-              className="flex flex-col gap-1 items-start md:hidden xl:flex"
-            >
-              <span className="text-xs text-gray-700 md:w-auto">
-                {identifier.config.config.display}:{" "}
-              </span>
-              <span className="text-sm font-semibold">{identifier.value}</span>
-            </div>
-          ))}
+          {filterOutSystemIdentifiers(patient.instance_identifiers || []).map(
+            (identifier) => (
+              <div
+                key={identifier.config.id}
+                className="flex flex-col gap-1 items-start md:hidden xl:flex"
+              >
+                <span className="text-xs text-gray-700 md:w-auto">
+                  {identifier.config.config.display}:{" "}
+                </span>
+                <span className="text-sm font-semibold">
+                  {identifier.value}
+                </span>
+              </div>
+            ),
+          )}
           {patient.instance_tags?.length > 0 && (
             <div className="flex flex-col gap-1 items-start">
               <span className="text-xs text-gray-700">

--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -3,7 +3,10 @@ import { PatientAddressLink } from "@/components/Patient/PatientAddressLink";
 import { formatPatientAddress } from "@/components/Patient/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { PatientRead } from "@/types/emr/patient/patient";
+import {
+  filterOutSystemIdentifiers,
+  PatientRead,
+} from "@/types/emr/patient/patient";
 import { getTagHierarchyDisplay } from "@/types/emr/tagConfig/tagConfig";
 import { formatPatientAge } from "@/Utils/utils";
 import { Phone } from "lucide-react";
@@ -65,17 +68,19 @@ export const PatientInfoHoverCard = ({
       </div>
       <div className="flex flex-col gap-3">
         <div className="grid grid-cols-2 gap-3 border-t border-gray-200 pt-4">
-          {patient.instance_identifiers?.map((identifier) => (
-            <div
-              key={identifier.config.id}
-              className="flex flex-col gap-0.5 text-sm"
-            >
-              <span className="font-medium text-gray-700">
-                {identifier.config.config.display}:{" "}
-              </span>
-              <span className="font-semibold">{identifier.value}</span>
-            </div>
-          ))}
+          {filterOutSystemIdentifiers(patient.instance_identifiers || []).map(
+            (identifier) => (
+              <div
+                key={identifier.config.id}
+                className="flex flex-col gap-0.5 text-sm"
+              >
+                <span className="font-medium text-gray-700">
+                  {identifier.config.config.display}:{" "}
+                </span>
+                <span className="font-semibold">{identifier.value}</span>
+              </div>
+            ),
+          )}
           {patient.phone_number && (
             <div className="flex flex-col gap-1 text-sm font-medium">
               <span className="text-gray-700">{t("contact")}</span>

--- a/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/types/billing/account/Account";
 import accountApi from "@/types/billing/account/accountApi";
 import { ENCOUNTER_PRIORITY_COLORS } from "@/types/emr/encounter/encounter";
+import { filterOutSystemIdentifiers } from "@/types/emr/patient/patient";
 
 export const SummaryPanelEncounterDetails = () => {
   const { t } = useTranslation();
@@ -225,7 +226,9 @@ export const SummaryPanelEncounterDetails = () => {
 
           <div className="flex flex-row gap-2">
             <div className="text-sm text-gray-950 font-semibold flex flex-wrap gap-6">
-              {patient?.instance_identifiers?.map((identifier) => (
+              {filterOutSystemIdentifiers(
+                patient?.instance_identifiers || [],
+              ).map((identifier) => (
                 <div
                   key={identifier.config.id}
                   className="flex flex-col items-start"

--- a/src/types/emr/patient/patient.ts
+++ b/src/types/emr/patient/patient.ts
@@ -119,3 +119,9 @@ export interface PublicPatientCreate {
   pincode: number;
   geo_organization: string;
 }
+
+export function filterOutSystemIdentifiers(identifiers: PatientIdentifier[]) {
+  return identifiers.filter(
+    (identifier) => identifier.config.config.auto_maintained !== true,
+  );
+}


### PR DESCRIPTION
## Proposed Changes

- Add a function to filter out system identifiers.
- Use that to filter out the system identifiers in respective places.

<img width="2020" height="376" alt="image" src="https://github.com/user-attachments/assets/dfbc0866-1e33-4cea-ac90-7ab3a913262b" />


---

<img width="2215" height="247" alt="image" src="https://github.com/user-attachments/assets/244da6ed-d117-4b71-8ed9-721d77729693" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - System-generated patient identifiers are no longer displayed across patient views (Header, Info Hover Card, Encounter Details), reducing clutter and preventing confusion.
  - Improved handling when patient identifiers are missing, avoiding empty or erroneous displays.

- Chores
  - Introduced a shared utility to consistently filter out system-maintained identifiers across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->