### PR TITLE
Added Clear All button in Practitioner Selector

### DIFF
--- a/src/pages/Appointments/components/PractitionerSelector.tsx
+++ b/src/pages/Appointments/components/PractitionerSelector.tsx
@@ -491,101 +491,96 @@ export const PractitionerSelector = ({
             </div>
           </div>
 
-                {/* Sidebar Content */}
-                <div className="flex-1 overflow-y-auto max-h-[400px]">
-                  {/* Show child organizations if current org has children */}
-                  {childOrganizations?.results?.length ? (
-                    <div className="p-2">
-                      <h3 className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
-                        {t("departments")}
+          {/* Sidebar Content */}
+          <div className="flex-1 overflow-y-auto max-h-[400px]">
+            {/* Show child organizations if current org has children */}
+            {childOrganizations?.results?.length ? (
+              <div className="p-2">
+                <h3 className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  {t("departments")}
+                </h3>
+                {childOrganizations.results.map((organization) => (
+                  <div
+                    key={organization.id}
+                    className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 cursor-pointer"
+                    onClick={() => handleChildOrganizationClick(organization)}
+                  >
+                    <div className="flex-shrink-0">
+                      <div
+                        className={cn(
+                          "h-3 w-3 rounded-full flex-shrink-0 border",
+                          getColorForTag(organization.id),
+                        )}
+                      />
+                    </div>
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="font-medium text-sm truncate">
+                        {organization.name}
+                      </span>
+                      {organization.description && (
+                        <span className="text-xs text-gray-500 truncate mt-0.5">
+                          {organization.description}
+                        </span>
+                      )}
+                    </div>
+                    {organization.has_children && (
+                      <ChevronRight className="h-4 w-4 text-gray-500" />
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              /* Show users if current org has no children or is a leaf organization */
+              <div className="p-2">
+                {isLoadingOrganizationUsers ? (
+                  <div className="p-6 space-y-3">
+                    <div className="flex items-center gap-3">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <div className="space-y-1 flex-1">
+                        <div className="h-4 w-3/4 bg-gray-200 rounded animate-pulse" />
+                        <div className="h-3 w-1/2 bg-gray-200 rounded animate-pulse" />
+                      </div>
+                    </div>
+                  </div>
+                ) : organizationUsers?.users?.length ? (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <h3 className="px-2 py-1 text-sm font-medium text-gray-500 uppercase tracking-wide">
+                        {t("practitioners")}
                       </h3>
-                      {childOrganizations.results.map((organization) => (
-                        <div
-                          key={organization.id}
-                          className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 cursor-pointer"
-                          onClick={() =>
-                            handleChildOrganizationClick(organization)
-                          }
-                        >
-                          <div className="flex-shrink-0">
-                            <div
-                              className={cn(
-                                "h-3 w-3 rounded-full flex-shrink-0 border",
-                                getColorForTag(organization.id),
-                              )}
-                            />
-                          </div>
-                          <div className="flex flex-col min-w-0 flex-1">
-                            <span className="font-medium text-sm truncate">
-                              {organization.name}
-                            </span>
-                            {organization.description && (
-                              <span className="text-xs text-gray-500 truncate mt-0.5">
-                                {organization.description}
-                              </span>
-                            )}
-                          </div>
-                          {organization.has_children && (
-                            <ChevronRight className="h-4 w-4 text-gray-500" />
+                      {multiple && (
+                        <div className="max-h-[400px] overflow-y-auto space-x-1">
+                          <Button
+                            variant="outline"
+                            size="xs"
+                            onClick={() => {
+                              handleSelectAll(
+                                organizationUsers.users as NonEmptyArray<UserReadMinimal>,
+                              );
+                            }}
+                          >
+                            {t("select_all")}
+                          </Button>
+                          {selected.filter((s) =>
+                            organizationUsers.users.some((u) => u.id === s.id),
+                          ).length > 1 && (
+                            <Button
+                              variant="outline"
+                              size="xs"
+                              onClick={() =>
+                                clearOrganizationUsers(organizationUsers)
+                              }
+                            >
+                              {t("clear_all")}
+                            </Button>
                           )}
                         </div>
-                      ))}
+                      )}
                     </div>
-                  ) : (
-                    /* Show users if current org has no children or is a leaf organization */
-                    <div className="p-2">
-                      {isLoadingOrganizationUsers ? (
-                        <div className="p-6 space-y-3">
-                          <div className="flex items-center gap-3">
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            <div className="space-y-1 flex-1">
-                              <div className="h-4 w-3/4 bg-gray-200 rounded animate-pulse" />
-                              <div className="h-3 w-1/2 bg-gray-200 rounded animate-pulse" />
-                            </div>
-                          </div>
-                        </div>
-                      ) : organizationUsers?.users?.length ? (
-                        <>
-                          <div className="flex items-center justify-between">
-                            <h3 className="px-2 py-1 text-sm font-medium text-gray-500 uppercase tracking-wide">
-                              {t("practitioners")}
-                            </h3>
-                            {multiple && (
-                              <div className="max-h-[400px] overflow-y-auto space-x-1">
-                                <Button
-                                  variant="outline"
-                                  size="xs"
-                                  onClick={() => {
-                                    handleSelectAll(
-                                      organizationUsers.users as NonEmptyArray<UserReadMinimal>,
-                                    );
-                                  }}
-                                >
-                                  {t("select_all")}
-                                </Button>
-                                {selected.filter((s) =>
-                                  organizationUsers.users.some(
-                                    (u) => u.id === s.id,
-                                  ),
-                                ).length > 1 && (
-                                  <Button
-                                    variant="outline"
-                                    size="xs"
-                                    onClick={() =>
-                                      clearOrganizationUsers(organizationUsers)
-                                    }
-                                  >
-                                    {t("clear_all")}
-                                  </Button>
-                                )}
-                              </div>
-                            )}
-                          </div>
-                          {organizationUsers.users.map((user) => {
-                            const isSelected = selected?.some(
-                              (s) => s.id === user.id,
-                            );
-
+                    {organizationUsers.users.map((user) => {
+                      const isSelected = selected?.some(
+                        (s) => s.id === user.id,
+                      );
                       return (
                         <div
                           key={user.id}

--- a/src/pages/Appointments/components/PractitionerSelector.tsx
+++ b/src/pages/Appointments/components/PractitionerSelector.tsx
@@ -581,6 +581,7 @@ export const PractitionerSelector = ({
                       const isSelected = selected?.some(
                         (s) => s.id === user.id,
                       );
+
                       return (
                         <div
                           key={user.id}

--- a/src/pages/Appointments/components/PractitionerSelector.tsx
+++ b/src/pages/Appointments/components/PractitionerSelector.tsx
@@ -185,6 +185,15 @@ export const PractitionerSelector = ({
     onSelect([]);
   };
 
+  const clearOrganizationUsers = (organizationUsers: {
+    users: UserReadMinimal[];
+  }) => {
+    const remainingSelected = selected.filter(
+      (s) => !organizationUsers.users.some((u) => u.id === s.id),
+    );
+    onSelect(remainingSelected);
+  };
+
   const handleUserSelect = (user: UserReadMinimal) => {
     if (selected && multiple) {
       onSelect([...selected, user]);
@@ -554,11 +563,17 @@ export const PractitionerSelector = ({
                                 >
                                   {t("select_all")}
                                 </Button>
-                                {selected.length > 1 && (
+                                {selected.filter((s) =>
+                                  organizationUsers.users.some(
+                                    (u) => u.id === s.id,
+                                  ),
+                                ).length > 1 && (
                                   <Button
                                     variant="outline"
                                     size="xs"
-                                    onClick={handleClearAll}
+                                    onClick={() =>
+                                      clearOrganizationUsers(organizationUsers)
+                                    }
                                   >
                                     {t("clear_all")}
                                   </Button>

--- a/src/pages/Appointments/components/PractitionerSelector.tsx
+++ b/src/pages/Appointments/components/PractitionerSelector.tsx
@@ -482,83 +482,94 @@ export const PractitionerSelector = ({
             </div>
           </div>
 
-          {/* Sidebar Content */}
-          <div className="flex-1 overflow-y-auto max-h-[400px]">
-            {/* Show child organizations if current org has children */}
-            {childOrganizations?.results?.length ? (
-              <div className="p-2">
-                <h3 className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
-                  {t("departments")}
-                </h3>
-                {childOrganizations.results.map((organization) => (
-                  <div
-                    key={organization.id}
-                    className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 cursor-pointer"
-                    onClick={() => handleChildOrganizationClick(organization)}
-                  >
-                    <div className="flex-shrink-0">
-                      <div
-                        className={cn(
-                          "h-3 w-3 rounded-full flex-shrink-0 border",
-                          getColorForTag(organization.id),
-                        )}
-                      />
-                    </div>
-                    <div className="flex flex-col min-w-0 flex-1">
-                      <span className="font-medium text-sm truncate">
-                        {organization.name}
-                      </span>
-                      {organization.description && (
-                        <span className="text-xs text-gray-500 truncate mt-0.5">
-                          {organization.description}
-                        </span>
-                      )}
-                    </div>
-                    {organization.has_children && (
-                      <ChevronRight className="h-4 w-4 text-gray-500" />
-                    )}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              /* Show users if current org has no children or is a leaf organization */
-              <div className="p-2">
-                {isLoadingOrganizationUsers ? (
-                  <div className="p-6 space-y-3">
-                    <div className="flex items-center gap-3">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      <div className="space-y-1 flex-1">
-                        <div className="h-4 w-3/4 bg-gray-200 rounded animate-pulse" />
-                        <div className="h-3 w-1/2 bg-gray-200 rounded animate-pulse" />
-                      </div>
-                    </div>
-                  </div>
-                ) : organizationUsers?.users?.length ? (
-                  <>
-                    <div className="flex items-center justify-between">
-                      <h3 className="px-2 py-1 text-sm font-medium text-gray-500 uppercase tracking-wide">
-                        {t("practitioners")}
+                {/* Sidebar Content */}
+                <div className="flex-1 overflow-y-auto max-h-[400px]">
+                  {/* Show child organizations if current org has children */}
+                  {childOrganizations?.results?.length ? (
+                    <div className="p-2">
+                      <h3 className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+                        {t("departments")}
                       </h3>
-                      {multiple && (
-                        <div className="max-h-[400px] overflow-y-auto">
-                          <Button
-                            variant="outline"
-                            size="xs"
-                            onClick={() => {
-                              handleSelectAll(
-                                organizationUsers.users as NonEmptyArray<UserReadMinimal>,
-                              );
-                            }}
-                          >
-                            {t("select_all")}
-                          </Button>
+                      {childOrganizations.results.map((organization) => (
+                        <div
+                          key={organization.id}
+                          className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 cursor-pointer"
+                          onClick={() =>
+                            handleChildOrganizationClick(organization)
+                          }
+                        >
+                          <div className="flex-shrink-0">
+                            <div
+                              className={cn(
+                                "h-3 w-3 rounded-full flex-shrink-0 border",
+                                getColorForTag(organization.id),
+                              )}
+                            />
+                          </div>
+                          <div className="flex flex-col min-w-0 flex-1">
+                            <span className="font-medium text-sm truncate">
+                              {organization.name}
+                            </span>
+                            {organization.description && (
+                              <span className="text-xs text-gray-500 truncate mt-0.5">
+                                {organization.description}
+                              </span>
+                            )}
+                          </div>
+                          {organization.has_children && (
+                            <ChevronRight className="h-4 w-4 text-gray-500" />
+                          )}
                         </div>
-                      )}
+                      ))}
                     </div>
-                    {organizationUsers.users.map((user) => {
-                      const isSelected = selected?.some(
-                        (s) => s.id === user.id,
-                      );
+                  ) : (
+                    /* Show users if current org has no children or is a leaf organization */
+                    <div className="p-2">
+                      {isLoadingOrganizationUsers ? (
+                        <div className="p-6 space-y-3">
+                          <div className="flex items-center gap-3">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            <div className="space-y-1 flex-1">
+                              <div className="h-4 w-3/4 bg-gray-200 rounded animate-pulse" />
+                              <div className="h-3 w-1/2 bg-gray-200 rounded animate-pulse" />
+                            </div>
+                          </div>
+                        </div>
+                      ) : organizationUsers?.users?.length ? (
+                        <>
+                          <div className="flex items-center justify-between">
+                            <h3 className="px-2 py-1 text-sm font-medium text-gray-500 uppercase tracking-wide">
+                              {t("practitioners")}
+                            </h3>
+                            {multiple && (
+                              <div className="max-h-[400px] overflow-y-auto space-x-1">
+                                <Button
+                                  variant="outline"
+                                  size="xs"
+                                  onClick={() => {
+                                    handleSelectAll(
+                                      organizationUsers.users as NonEmptyArray<UserReadMinimal>,
+                                    );
+                                  }}
+                                >
+                                  {t("select_all")}
+                                </Button>
+                                {selected.length > 1 && (
+                                  <Button
+                                    variant="outline"
+                                    size="xs"
+                                    onClick={handleClearAll}
+                                  >
+                                    {t("clear_all")}
+                                  </Button>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          {organizationUsers.users.map((user) => {
+                            const isSelected = selected?.some(
+                              (s) => s.id === user.id,
+                            );
 
                       return (
                         <div


### PR DESCRIPTION
## Proposed Changes

In Practitioner Selector, `Clear All` button is added for department filtered users.

<img width="517" height="332" alt="image" src="https://github.com/user-attachments/assets/d077cc74-3faa-4295-ac31-1778af3d3c58" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [X] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Clear all” action to the practitioner multi-select and sidebar organization view that appears when multiple items are selected and removes practitioners scoped to the current organization.

- **Style**
  - Adjusted multi-select header and sidebar action spacing to improve layout and accommodate both “Select all” and the new “Clear all” control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->