### PR TITLE
Null check for Patient instance identifier

### DIFF
--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -238,7 +238,7 @@ export const Demography = (props: PatientProps) => {
       id: "identifiers",
       allowEdit: false,
       details: patientData.instance_identifiers
-        .filter(({ config }) => !config.config.auto_maintained)
+        ?.filter(({ config }) => !config.config.auto_maintained)
         .map((i) => ({
           label: i.config.config.display,
           value: i.value,

--- a/src/components/Patient/PatientHeader.tsx
+++ b/src/components/Patient/PatientHeader.tsx
@@ -39,7 +39,7 @@ export function PatientHeader({
         />
         <div className="flex flex-wrap xl:gap-5 gap-2">
           {patient.instance_identifiers
-            .filter(({ config }) => !config.config.auto_maintained)
+            ?.filter(({ config }) => !config.config.auto_maintained)
             .map((identifier) => (
               <div
                 key={identifier.config.id}

--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -66,7 +66,7 @@ export const PatientInfoHoverCard = ({
       <div className="flex flex-col gap-3">
         <div className="grid grid-cols-2 gap-3 border-t border-gray-200 pt-4">
           {patient.instance_identifiers
-            .filter(({ config }) => !config.config.auto_maintained)
+            ?.filter(({ config }) => !config.config.auto_maintained)
             .map((identifier) => (
               <div
                 key={identifier.config.id}

--- a/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
@@ -226,7 +226,7 @@ export const SummaryPanelEncounterDetails = () => {
           <div className="flex flex-row gap-2">
             <div className="text-sm text-gray-950 font-semibold flex flex-wrap gap-6">
               {patient?.instance_identifiers
-                .filter(({ config }) => !config.config.auto_maintained)
+                ?.filter(({ config }) => !config.config.auto_maintained)
                 .map((identifier) => (
                   <div
                     key={identifier.config.id}


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved stability when viewing patients with missing identifiers, preventing occasional crashes.
  - Patient Details tab now handles absent identifiers gracefully.
  - Patient Header renders reliably even if identifier data is unavailable.
  - Patient Info Hover Card no longer errors when identifiers are missing.
  - Encounter Details summary panel avoids crashes related to absent identifier lists.
- Refactor
  - Minor runtime safety improvements for identifier handling across patient-related views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->