### PR TITLE
Fix: Correct back navigation after editing Product Knowledge #13988

### DIFF
--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeView.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeView.tsx
@@ -89,7 +89,9 @@ export default function ProductKnowledgeView({ facilityId, slug }: Props) {
   return (
     <Page title={product.name} hideTitleOnPage={true}>
       <div className="container mx-auto max-w-3xl space-y-6">
-        <BackButton>
+        <BackButton
+          to={`/facility/${facilityId}/settings/product_knowledge/categories/${product.category.slug}`}
+        >
           <ArrowLeft />
           {t("back")}
         </BackButton>


### PR DESCRIPTION
## Proposed Changes

Fixes #13988 
- Updated the Back button on the ProductKnowledgeView.tsx page to always navigate back to the Product Knowledge Category page instead of the edit page.
- Used product.category.slug to construct the correct path: /facility/{facilityId}/settings/product_knowledge/categories/{categorySlug}

https://github.com/user-attachments/assets/392759b2-a830-4f3c-a20e-b31b0c2a9bc9

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Back button in Product Knowledge now takes you directly to the product’s category editor after a successful action, providing a clear, predictable return path instead of relying on browser history.
  * Navigation respects the current facility and product category context for accurate routing.
  * On error, the Back button behavior remains unchanged, ensuring no disruption to existing error handling flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->