### PR TITLE
Fix #14023 :Improve product knowledge form validation UI messages

### DIFF
--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -50,7 +50,6 @@ import {
 } from "@/types/inventory/productKnowledge/productKnowledge";
 import productKnowledgeApi from "@/types/inventory/productKnowledge/productKnowledgeApi";
 
-// Define a Code schema to match the API type
 const codeSchema = z.object({
   code: z.string().min(1, { message: "Code is required" }),
   display: z.string().min(1, { message: "Display name is required" }),
@@ -65,9 +64,7 @@ const formSchema = z.object({
   alternate_identifier: z.string().trim().optional(),
   category: z.string(),
   code: codeSchema.nullable(),
-  base_unit: codeSchema.optional().refine((data) => data, {
-    message: "Base unit is required",
-  }),
+  base_unit: codeSchema,
   names: z
     .array(
       z.object({
@@ -172,14 +169,12 @@ function ProductKnowledgeFormContent({
   const queryClient = useQueryClient();
   const isEditMode = Boolean(slug);
 
-  // Create default storage guidelines and units
   const defaultUnitCode: Code = {
     code: "d",
     display: "Day",
     system: "http://unitsofmeasure.org",
   };
 
-  // Handle form initialization with proper mapping of types
   const getDefaultValues = () => {
     if (isEditMode && existingData) {
       return {
@@ -192,7 +187,7 @@ function ProductKnowledgeFormContent({
         code: existingData.code?.code ? existingData.code : null,
         base_unit: existingData.base_unit?.code
           ? existingData.base_unit
-          : undefined,
+          : DOSAGE_UNITS_CODES[0],
         names: existingData.names || [],
         storage_guidelines: existingData.storage_guidelines || [],
         definitional:
@@ -208,7 +203,7 @@ function ProductKnowledgeFormContent({
       names: [],
       storage_guidelines: [],
       code: null,
-      base_unit: undefined,
+      base_unit: DOSAGE_UNITS_CODES[0],
       definitional: null,
       status: ProductKnowledgeStatus.active,
       category: categorySlug,
@@ -285,7 +280,6 @@ function ProductKnowledgeFormContent({
   const isPending = isCreating || isUpdating;
 
   function onSubmit(data: z.infer<typeof formSchema>) {
-    // Convert null to undefined where needed to match API types
     const formattedData = {
       ...data,
       code: data.code || undefined,
@@ -332,7 +326,6 @@ function ProductKnowledgeFormContent({
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            {/* Basic Information Section */}
             <div className="rounded-lg border border-gray-200 bg-white p-4">
               <div className="space-y-4">
                 <div>
@@ -559,7 +552,6 @@ function ProductKnowledgeFormContent({
               </div>
             </div>
 
-            {/* Alternative Names Section */}
             <div className="rounded-lg border border-gray-200 bg-white p-4">
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
@@ -664,7 +656,6 @@ function ProductKnowledgeFormContent({
               </div>
             </div>
 
-            {/* Storage Guidelines Section */}
             <div className="rounded-lg border border-gray-200 bg-white p-4">
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
@@ -739,7 +730,7 @@ function ProductKnowledgeFormContent({
                                         field.onChange(
                                           e.target.value
                                             ? parseInt(e.target.value)
-                                            : "",
+                                            : undefined,
                                         )
                                       }
                                     />
@@ -793,7 +784,7 @@ function ProductKnowledgeFormContent({
                                         >
                                           <span>
                                             {t(`unit_${duration.code}`)}
-                                            <span className="text-sm ml-1 text-gray-500">
+                                            <span className="ml-1 text-sm text-gray-500">
                                               ({duration.code})
                                             </span>
                                           </span>
@@ -826,7 +817,6 @@ function ProductKnowledgeFormContent({
               </div>
             </div>
 
-            {/* Product Definition Section - UPDATED */}
             <div className="rounded-lg border border-gray-200 bg-white p-4">
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
@@ -868,7 +858,6 @@ function ProductKnowledgeFormContent({
 
                 {form.watch("definitional") ? (
                   <div className="space-y-4">
-                    {/* Dosage Form - Optional */}
                     <div>
                       <FormField
                         control={form.control}
@@ -900,7 +889,6 @@ function ProductKnowledgeFormContent({
                       />
                     </div>
 
-                    {/* Intended Routes */}
                     <div className="space-y-4">
                       <div className="flex items-center justify-between">
                         <div>

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -52,52 +52,53 @@ import productKnowledgeApi from "@/types/inventory/productKnowledge/productKnowl
 
 // Define a Code schema to match the API type
 const codeSchema = z.object({
-  code: z.string().min(1, "Code is required"),
-  display: z.string().min(1, "Display name is required"),
-  system: z.string().min(1, "System is required"),
+  code: z.string().min(1, { message: "Code is required" }),
+  display: z.string().min(1, { message: "Display name is required" }),
+  system: z.string().min(1, { message: "System is required" }),
 });
 
 const formSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  slug_value: z.string().min(1, "Slug is required"),
+  name: z.string().min(1, { message: "Name is required" }),
+  slug_value: z.string().min(1, { message: "Slug is required" }),
   product_type: z.nativeEnum(ProductKnowledgeType),
   status: z.nativeEnum(ProductKnowledgeStatus),
   alternate_identifier: z.string().trim().optional(),
   category: z.string(),
   code: codeSchema.nullable(),
-  base_unit: codeSchema.nullable(),
+  base_unit: codeSchema.optional().refine((data) => data, {
+    message: "Base unit is required",
+  }),
   names: z
     .array(
       z.object({
         name_type: z.nativeEnum(ProductNameTypes),
-        name: z.string().min(1, "Name is required"),
+        name: z.string().min(1, { message: "Name is required" }),
       }),
     )
     .default([]),
   storage_guidelines: z
     .array(
       z.object({
-        note: z.string().min(1, "Note is required"),
+        note: z.string().min(1, { message: "Note is required" }),
         stability_duration: z
           .object({
             value: z.number().int().optional(),
             unit: codeSchema,
           })
-          .refine((data) => data.value !== undefined && data.value !== null),
+          .refine((data) => data.value !== undefined && data.value !== null, {
+            message: "Stability duration value is required",
+            path: ["value"],
+          }),
       }),
     )
     .default([]),
   definitional: z
     .object({
-      dosage_form: codeSchema.optional(),
+      dosage_form: codeSchema.optional().nullable(),
       intended_routes: z.array(codeSchema).default([]),
     })
     .nullable()
-    .optional()
-    .refine((data) => {
-      if (!data) return true; // definitional is optional
-      return data.dosage_form && data.dosage_form.code; // if definitional exists, dosage_form is required
-    }),
+    .optional(),
 });
 
 export default function ProductKnowledgeForm({
@@ -189,7 +190,9 @@ function ProductKnowledgeFormContent({
         alternate_identifier: existingData.alternate_identifier || "",
         category: existingData.category?.slug,
         code: existingData.code?.code ? existingData.code : null,
-        base_unit: existingData.base_unit?.code ? existingData.base_unit : null,
+        base_unit: existingData.base_unit?.code
+          ? existingData.base_unit
+          : undefined,
         names: existingData.names || [],
         storage_guidelines: existingData.storage_guidelines || [],
         definitional:
@@ -205,7 +208,7 @@ function ProductKnowledgeFormContent({
       names: [],
       storage_guidelines: [],
       code: null,
-      base_unit: null,
+      base_unit: undefined,
       definitional: null,
       status: ProductKnowledgeStatus.active,
       category: categorySlug,
@@ -471,32 +474,40 @@ function ProductKnowledgeFormContent({
                     </div>
                   </div>
 
-                  <div>
-                    <FormLabel>{t("base_unit")}</FormLabel>
-                    <div className="mt-2">
-                      <Select
-                        value={form.watch("base_unit")?.code || ""}
-                        onValueChange={(value) => {
-                          const selectedUnit = DOSAGE_UNITS_CODES.find(
-                            (unit) => unit.code === value,
-                          );
-                          if (selectedUnit)
-                            form.setValue("base_unit", selectedUnit);
-                        }}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder={t("select_base_unit")} />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {DOSAGE_UNITS_CODES.map((unit) => (
-                            <SelectItem key={unit.code} value={unit.code}>
-                              {unit.display}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
+                  <FormField
+                    control={form.control}
+                    name="base_unit"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-col">
+                        <FormLabel aria-required>{t("base_unit")}</FormLabel>
+                        <FormControl>
+                          <Select
+                            value={field.value?.code || ""}
+                            onValueChange={(value) => {
+                              const selectedUnit = DOSAGE_UNITS_CODES.find(
+                                (unit) => unit.code === value,
+                              );
+                              field.onChange(selectedUnit);
+                            }}
+                          >
+                            <SelectTrigger>
+                              <SelectValue
+                                placeholder={t("select_base_unit")}
+                              />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {DOSAGE_UNITS_CODES.map((unit) => (
+                                <SelectItem key={unit.code} value={unit.code}>
+                                  {unit.display}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
                 </div>
 
                 <div className="grid gap-4 md:grid-cols-2">
@@ -733,11 +744,7 @@ function ProductKnowledgeFormContent({
                                       }
                                     />
                                   </FormControl>
-                                  <FormMessage>
-                                    {form.formState.errors.storage_guidelines?.[
-                                      index
-                                    ]?.stability_duration && t("required")}
-                                  </FormMessage>
+                                  <FormMessage />
                                 </FormItem>
                               )}
                             />
@@ -819,7 +826,7 @@ function ProductKnowledgeFormContent({
               </div>
             </div>
 
-            {/* Product Definition Section */}
+            {/* Product Definition Section - UPDATED */}
             <div className="rounded-lg border border-gray-200 bg-white p-4">
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
@@ -848,6 +855,7 @@ function ProductKnowledgeFormContent({
                       size="sm"
                       onClick={() =>
                         form.setValue("definitional", {
+                          dosage_form: null,
                           intended_routes: [],
                         })
                       }
@@ -860,19 +868,21 @@ function ProductKnowledgeFormContent({
 
                 {form.watch("definitional") ? (
                   <div className="space-y-4">
+                    {/* Dosage Form - Optional */}
                     <div>
                       <FormField
                         control={form.control}
                         name="definitional.dosage_form"
                         render={() => (
                           <FormItem className="flex flex-col">
-                            <FormLabel aria-required>
-                              {t("dosage_form")}
-                            </FormLabel>
+                            <FormLabel>{t("dosage_form")}</FormLabel>
                             <FormControl>
                               <ValueSetSelect
                                 system="system-medication-form-codes"
-                                value={form.watch("definitional.dosage_form")}
+                                value={
+                                  form.watch("definitional.dosage_form") ||
+                                  undefined
+                                }
                                 placeholder={t("dosage_form_placeholder")}
                                 onSelect={(code) => {
                                   form.setValue("definitional.dosage_form", {
@@ -884,14 +894,13 @@ function ProductKnowledgeFormContent({
                                 showCode={true}
                               />
                             </FormControl>
+                            <FormMessage />
                           </FormItem>
                         )}
                       />
-                      <FormMessage>
-                        {form.formState.errors.definitional && t("required")}
-                      </FormMessage>
                     </div>
 
+                    {/* Intended Routes */}
                     <div className="space-y-4">
                       <div className="flex items-center justify-between">
                         <div>
@@ -950,13 +959,10 @@ function ProductKnowledgeFormContent({
                                           showCode={true}
                                         />
                                       </FormControl>
+                                      <FormMessage />
                                     </FormItem>
                                   )}
                                 />
-                                <FormMessage>
-                                  {form.formState.errors.definitional
-                                    ?.intended_routes?.[index] && t("required")}
-                                </FormMessage>
                               </div>
                               <Button
                                 type="button"


### PR DESCRIPTION
## Proposed Changes

Fixes #14023 

1. Customize the Name field's validation message in the FormField render by updating the FormMessage to display "Name is required" using a custom error message in the Zod schema and form configuration.
2. Ensure the Base Unit field displays a required message by adding a FormMessage with a custom validation message in the FormField render, and verify the Zod schema's refine condition triggers the UI error when empty.
3. Modify the Dosage Form field's rendering logic to only show the required message when explicitly set as required, and update the formSchema to ensure definitional.dosage_form remains optional without triggering a default required state on form creation.



https://github.com/user-attachments/assets/4831cc9f-8ea1-48ba-bbca-9292c086e879


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [X] Add specs that demonstrate the bug or test the new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [X] Request peer reviews.
- [X] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-field validation messages added across the Product Knowledge form (base unit, stability duration, dosage form, intended routes).
  * Base unit selector integrated into the form with inline error feedback and a concrete default value.
  * Product Definition section: improved add/remove behavior and clearer dosage-form handling.

* **Bug Fixes**
  * Prevented optional-field validation gaps that could block submission or show unclear errors; tightened form reliability and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->