### PR TITLE
Fix: ExcalidrawEditor shows unsaved changes dialog even when no changes were made by the use

### DIFF
--- a/src/components/Common/Drawings/ExcalidrawEditor.tsx
+++ b/src/components/Common/Drawings/ExcalidrawEditor.tsx
@@ -7,7 +7,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -57,6 +57,8 @@ export default function ExcalidrawEditor({
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const { goBack } = useAppHistory();
 
+  const ElementsRef = useRef<readonly ExcalidrawElement[] | null>(null);
+
   const { mutate: saveDrawing } = useMutation({
     mutationFn: mutate(metaArtifactApi.upsert),
     onSuccess: () => {
@@ -81,6 +83,7 @@ export default function ExcalidrawEditor({
     }
     setName(data.name);
     setElements(data.object_value.elements);
+    ElementsRef.current = data.object_value.elements;
     setIsDirty(false);
   }, [data]);
 
@@ -205,8 +208,12 @@ export default function ExcalidrawEditor({
           }}
           onChange={debounce((newElements) => {
             setElements(newElements);
-            if (!isDirty && hashKey(newElements) !== hashKey(elements)) {
-              setIsDirty(true);
+            if (!isDirty && ElementsRef.current) {
+              const hasChanged =
+                hashKey(newElements) !== hashKey(ElementsRef.current);
+              if (hasChanged) {
+                setIsDirty(true);
+              }
             }
           }, 100)}
         />


### PR DESCRIPTION

## Proposed Changes
This pull request refactors the way drawing changes are tracked in the `ExcalidrawEditor` component. The main improvement is the introduction of a persistent reference to the initial drawing elements, which makes it easier and more reliable to detect when the user has made changes to the drawing. This helps prevent false positives when checking whether the drawing is "dirty" (i.e., modified).

Fixes #[13913](https://github.com/ohcnetwork/care_fe/issues/13913)

**Change tracking improvements:**

* Added a `useRef` called `ElementsRef` to store the initial drawing elements for change detection instead of comparing against the current state. 
* Updated the effect that loads drawing data to also update `ElementsRef.current` with the initial elements.
* Changed the logic in the `onChange` handler to compare new elements against `ElementsRef.current` rather than the current state, improving dirty state accuracy.

Demo:

https://github.com/user-attachments/assets/ca5d10e1-a10d-404f-9a84-069caf67223e


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection in the drawing editor to flag “unsaved changes” only when real edits occur.
  * Reduces unnecessary prompts and prevents missed updates by comparing against the last loaded state.
  * Enhances reliability of autosave and save prompts when switching drawings or navigating away.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->