### PR TITLE
Icon for qnr responses in clinical history page

### DIFF
--- a/src/pages/Patient/History/ResponsesHistory.tsx
+++ b/src/pages/Patient/History/ResponsesHistory.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 
+import { HealthWorkerIcon } from "@/CAREUI/icons/CustomIcons";
 import { EncounterResponsesTab } from "@/pages/Encounters/tabs/responses";
 
 export const ResponsesHistory = ({ patientId }: { patientId: string }) => {
@@ -7,11 +8,7 @@ export const ResponsesHistory = ({ patientId }: { patientId: string }) => {
   return (
     <div className="h-[calc(100vh-12rem)] flex flex-col pb-10">
       <div className="flex items-center gap-2 mb-5">
-        <img
-          src="/images/icons/diagnosis.svg"
-          alt="diagnosis"
-          className="size-9 bg-cyan-200 border border-cyan-400 rounded-md p-1.5"
-        />
+        <HealthWorkerIcon className="size-8 bg-teal-200 border border-teal-500 text-teal-800 rounded-md p-1" />
         <h4 className="text-xl">{t("questionnaire_responses")}</h4>
       </div>
       <EncounterResponsesTab patientId={patientId} />


### PR DESCRIPTION

### Before
<img width="1383" height="611" alt="Screenshot 2025-10-14 at 12 25 55 AM" src="https://github.com/user-attachments/assets/b5a4aabb-ddc2-4aa9-babc-cf8e218360f5" />

### After

<img width="1383" height="611" alt="Screenshot 2025-10-14 at 12 25 13 AM" src="https://github.com/user-attachments/assets/0cd00392-f7d4-4a58-b56d-c7d06bea22a0" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the icon in Patient History → Responses to use the standard Health Worker icon for improved visual consistency.
  * Refined styling around the header icon for a cleaner, more cohesive look.
  * No changes to functionality or data; this is a visual update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->