### PR TITLE
Fix min height of the medication valuesetselect drawer

### DIFF
--- a/src/components/Questionnaire/MedicationValueSetSelect.tsx
+++ b/src/components/Questionnaire/MedicationValueSetSelect.tsx
@@ -214,7 +214,7 @@ export default function MedicationValueSetSelect({
             </Button>
           )}
         </DrawerTrigger>
-        <DrawerContent className="max-h-[85vh] px-0 pb-0 rounded-t-lg">
+        <DrawerContent className="min-h-[60vh] max-h-[85vh] px-0 pb-0 rounded-t-lg">
           <DrawerHeader className="p-0 mt-1.5">
             <MedicationValueSetSelectTabs
               activeTab={activeTab}


### PR DESCRIPTION
## Proposed Changes

Add min height to drawer of `MedicationValueSetSelect`

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the minimum height of the Medication Value Set drawer to 60vh, making the panel taller on desktop and tablet for improved readability and easier browsing of options.
  * Retains the existing maximum height behavior to prevent overflow on smaller screens.
  * Enhances visual consistency and reduces unnecessary scrolling without altering functionality or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->