### PR TITLE
Fixed buttons overflowing for card and unnecessary overflow for medium screen role listing 

### DIFF
--- a/src/pages/Admin/Roles/RolesIndex.tsx
+++ b/src/pages/Admin/Roles/RolesIndex.tsx
@@ -163,7 +163,7 @@ export default function RolesIndex() {
       title={t("roles")}
       hideTitleOnPage
       className={cn(
-        "w-full mt-3 overflow-y-auto",
+        "w-full overflow-y-auto",
         isSidebarOpen
           ? "md:max-w-[calc(100vw-20rem)]"
           : "md:max-w-[calc(100vw-5rem)]",

--- a/src/pages/Admin/Roles/RolesIndex.tsx
+++ b/src/pages/Admin/Roles/RolesIndex.tsx
@@ -34,6 +34,8 @@ import {
 import useFilters from "@/hooks/useFilters";
 
 import query from "@/Utils/request/query";
+import { useSidebar } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 import RoleForm from "@/pages/Admin/Roles/RoleForm";
 import { RoleRead } from "@/types/emr/role/role";
 import roleApi from "@/types/emr/role/roleApi";
@@ -53,19 +55,18 @@ function RoleCard({
       <CardContent className="p-6">
         <div className="mb-4 flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
-            <div className="flex flex-col sm:flex-row sm:justify-between gap-1 mb-2">
+            <div className="flex flex-col sm:flex-row sm:justify-between gap-1 mb-3">
               <h3
                 className="font-medium text-gray-900 mb-2 truncate"
                 title={role.name}
               >
                 {role.name}
               </h3>
-              <div className="flex gap-2 shrink-0 w-full sm:w-auto">
+              <div className="flex gap-2">
                 <Button
                   variant="outline"
                   size="sm"
                   onClick={() => onClone(role)}
-                  className="shrink-0 w-full sm:w-auto"
                 >
                   <CareIcon icon="l-copy" className="size-4" />
                   {t("clone")}
@@ -74,7 +75,6 @@ function RoleCard({
                   variant="outline"
                   size="sm"
                   onClick={() => onEdit(role)}
-                  className="shrink-0 w-full sm:w-auto"
                 >
                   <CareIcon icon="l-edit" className="size-4" />
                   {t("edit")}
@@ -115,6 +115,7 @@ export default function RolesIndex() {
     limit: 15,
     disableCache: true,
   });
+  const { open: isSidebarOpen } = useSidebar();
 
   const [selectedRole, setSelectedRole] = React.useState<RoleRead | null>(null);
   const [mode, setMode] = React.useState<"add" | "edit" | "clone">("add");
@@ -158,7 +159,16 @@ export default function RolesIndex() {
   };
 
   return (
-    <Page title={t("roles")} hideTitleOnPage>
+    <Page
+      title={t("roles")}
+      hideTitleOnPage
+      className={cn(
+        "w-full mt-3 overflow-y-auto",
+        isSidebarOpen
+          ? "md:max-w-[calc(100vw-20rem)]"
+          : "md:max-w-[calc(100vw-5rem)]",
+      )}
+    >
       <div className="container mx-auto">
         <div className="mb-4">
           <h1 className="text-2xl font-bold text-gray-700">{t("roles")}</h1>


### PR DESCRIPTION
- Added max-w according to isSidebarOpen 
- Fixed butons overflowing for card view 

### Issue 
<img width="642" height="817" alt="Screenshot 2025-10-16 at 5 44 16 PM" src="https://github.com/user-attachments/assets/1ec6f133-0057-477f-9ed9-f5d6c0ebd8dd" />

### Fix
<img width="642" height="817" alt="Screenshot 2025-10-16 at 5 43 57 PM" src="https://github.com/user-attachments/assets/b58c5f45-3d59-434c-992d-0b6de498ac14" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout responsiveness based on sidebar visibility, adjusting content width for better space utilization across mobile and desktop views.
  * Enhanced button sizing flexibility and refined spacing in the Roles interface for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->