### PR TITLE
Fix: Align "Create Discount Code" and "Create Discount Component" buttons with proper spacing (#14041)

### DIFF
--- a/src/pages/Facility/settings/billing/discount/discount-codes/DiscountCodeSettings.tsx
+++ b/src/pages/Facility/settings/billing/discount/discount-codes/DiscountCodeSettings.tsx
@@ -90,20 +90,17 @@ export function DiscountCodeSettings() {
 
   return (
     <>
-      <Page
-        title={t("discount_codes")}
-        options={
-          <div className="flex flex-col lg:flex-row items-center gap-2 ">
-            <Input
-              placeholder={t("search")}
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="w-full lg:w-[300px]"
-            />
-            <CreateDiscountCodeSheet />
-          </div>
-        }
-      >
+      <Page title={t("discount_codes")}>
+        <div className="flex flex-col lg:flex-row items-start lg:items-center justify-start lg:justify-between gap-2 mt-2 px-3 lg:px-0">
+          <Input
+            placeholder={t("search")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full lg:w-[300px]"
+          />
+          <CreateDiscountCodeSheet />
+        </div>
+
         <div className="rounded-md border overflow-hidden mt-4">
           <Table>
             <TableHeader>

--- a/src/pages/Facility/settings/billing/discount/discount-components/DiscountComponentSettings.tsx
+++ b/src/pages/Facility/settings/billing/discount/discount-components/DiscountComponentSettings.tsx
@@ -96,20 +96,17 @@ export function DiscountComponentSettings() {
 
   return (
     <>
-      <Page
-        title={t("discount_monetary_components")}
-        options={
-          <div className="flex flex-col lg:flex-row items-center gap-2">
-            <Input
-              placeholder={t("search")}
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="w-full lg:w-[300px]"
-            />
-            <CreateDiscountMonetaryComponentSheet />
-          </div>
-        }
-      >
+      <Page title={t("discount_monetary_components")}>
+        <div className="flex flex-col lg:flex-row items-start lg:items-center justify-start lg:justify-between gap-2 mt-2 px-3 lg:px-0">
+          <Input
+            placeholder={t("search")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full lg:w-[300px]"
+          />
+          <CreateDiscountMonetaryComponentSheet />
+        </div>
+
         <div className="rounded-md border overflow-hidden mt-4">
           <Table>
             <TableHeader>


### PR DESCRIPTION
## Proposed Changes

This PR fixes the UI alignment and spacing issue for the "Create Discount Code" and "Create Discount Component" buttons, which were previously misaligned and overflowing

Fixes #14041 
- Added a responsive flex layout to align the search input and create button.
- Used Tailwind classes for better responsiveness and spacing:
- Applied the same layout pattern in both DiscountCodeSettings.tsx and DiscountMonetaryComponentSettings.tsx components for consistent styling across the facility billing pages.

`DiscountMonetaryComponentSettings.tsx`
**Before:**
<img width="1560" height="883" alt="image" src="https://github.com/user-attachments/assets/5491fe7e-047c-4891-ae3f-708cc38d64f4" />
**After:**
<img width="675" height="391" alt="image" src="https://github.com/user-attachments/assets/5fee82d0-09e4-4b15-9036-80dd42a617a4" />

`DiscountCodeSettings.tsx`
**Before:**
<img width="1131" height="820" alt="image" src="https://github.com/user-attachments/assets/8b4b3b64-ae41-491d-8443-84e86fbbd159" />
**After:**
<img width="681" height="408" alt="image" src="https://github.com/user-attachments/assets/e2fabd47-3185-4f17-95b4-4710d68dadd8" />

**Mobile View:** Unchanged

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the layout structure of discount code and monetary component settings pages to improve code organization while maintaining the same user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->