### PR TITLE
Bug Fix: Aligns the "Mark as Deceased" Checkbox

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -841,9 +841,8 @@ const AdditionalDetailsContent = ({
           <p className="text-sm font-medium text-black">
             {t("deceased_status")}
           </p>
-          <div className="flex items-start gap-2">
+          <div className="flex items-center gap-2">
             <Checkbox
-              className="mt-2"
               checked={form.watch("is_deceased")}
               onCheckedChange={(checked) => {
                 form.setValue("is_deceased", !!checked);


### PR DESCRIPTION
## Proposed Changes

Fixes #14036

In the "Register New Patient" form, under the "Deceased Status" section, the check icon inside the "Mark as deceased" checkbox was misaligned. A top margin was applied directly to the checkbox element, causing it to be pushed down and not vertically centered with its corresponding label.

### Before:
<img width="586" height="232" alt="image" src="https://github.com/user-attachments/assets/f9fadaee-eea0-4b80-bd6c-8c5a19a8687f" />

### Changes:
1. Removed Margin from Checkbox: The mt-2 class was removed from the Checkbox component in PatientRegistration.tsx.
2. Centered Container Items: The parent div that contains both the checkbox and the label was updated from items-start to items-center.

### After:
<img width="694" height="310" alt="image" src="https://github.com/user-attachments/assets/9b17af18-e729-4663-b5ad-85046800c085" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
