### PR TITLE
Added missing description for book appointment sheet

### DIFF
--- a/src/pages/Appointments/BookAppointment/BookAppointmentSheet.tsx
+++ b/src/pages/Appointments/BookAppointment/BookAppointmentSheet.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
@@ -36,6 +37,7 @@ export default function BookAppointmentSheet({
         <SheetHeader>
           <SheetTitle>{t("book_appointment")}</SheetTitle>
         </SheetHeader>
+        <SheetDescription />
         <div className="flex flex-col gap-4 mt-6">
           <Tabs defaultValue="appointment">
             <TabsList className="w-full justify-evenly sm:justify-start border-b rounded-none bg-transparent p-0 h-auto overflow-x-auto">


### PR DESCRIPTION
## Proposed Changes

Fixes #14074 
- Added `SheetDescription />` inside Sheet component for BookAppointmentsSheet
@BookAppointmentSheet.tsx:

<img width="238" height="25" alt="image" src="https://github.com/user-attachments/assets/b6f5c7db-293d-4d79-ab7b-39735b735a4a" />

<img width="370" height="21" alt="image" src="https://github.com/user-attachments/assets/ad513106-4c2f-45eb-90bf-e860dc7f575c" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
