### PR TITLE
Fix OTP label accessibility on Patient Login 

### DIFF
--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -702,6 +702,7 @@ const Login = (props: LoginProps) => {
                             </Label>
                             <div className="flex justify-center">
                               <InputOTP
+                                id="otp"
                                 value={otp}
                                 maxLength={5}
                                 pattern={REGEXP_ONLY_DIGITS}


### PR DESCRIPTION
## Proposed Changes
Fixes #14069 
- Added `id="otp"` attribute to `InputOTP` component to match the label's `htmlFor="otp"` attribute.
- Fixes accessibility issue preventing screen readers from properly associating the label with the OTP input fields
- Resolves DevTools accessibility `error: "Incorrect use of <label for=FORM_ELEMENT>"`

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
