### PR TITLE
fix: charge item in activity definition creation

### DIFF
--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -906,6 +906,11 @@ function ActivityDefinitionFormContent({
                             "no_charge_item_definitions_found_for",
                           noItemsFound: "no_charge_item_definitions_found",
                         }}
+                        mapper={(item) => ({
+                          id: item.id,
+                          title: item.title,
+                          slug: item.slug,
+                        })}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## Proposed Changes

Fixes 
- When a charge item definition was selected in the Activity Definition Creation page, it used to display the category. Fixed it to show the selected charge item definition.

<img width="845" height="176" alt="image" src="https://github.com/user-attachments/assets/3ace53a4-472d-433b-bccc-85af3a1e922a" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
