### PR TITLE
Feat - Redesigned Medication History

### DIFF
--- a/src/components/HistoricalRecordSelector/RecordItem.tsx
+++ b/src/components/HistoricalRecordSelector/RecordItem.tsx
@@ -27,15 +27,15 @@ export function RecordItem<T>({
   };
 
   return (
-    <TableRow className="divide-x">
-      <TableCell>
+    <TableRow className="border-0">
+      <TableCell className="border-0 bg-transparent p-2 w-12">
         <Checkbox
           checked={isSelected}
           onCheckedChange={handleToggle}
-          className="mr-1 size-5"
+          className="size-5"
         />
       </TableCell>
-      {displayFields.map((field, index) => {
+      {displayFields.map((field, idx, arr) => {
         const value = record[field.key as keyof T];
         const displayValue = field.render
           ? field.key == ""
@@ -47,8 +47,9 @@ export function RecordItem<T>({
           <TableCell
             key={field.key.toString()}
             className={cn(
-              "p-2 text-sm whitespace-pre-wrap",
-              index % 2 === 1 && "bg-white",
+              "p-2 text-sm whitespace-pre-wrap border border-gray-200 bg-white",
+              idx === 0 && "rounded-l-md",
+              idx === arr.length - 1 && "rounded-r-md",
             )}
           >
             <div className="text-sm">{displayValue}</div>

--- a/src/components/HistoricalRecordSelector/RecordItem.tsx
+++ b/src/components/HistoricalRecordSelector/RecordItem.tsx
@@ -35,7 +35,7 @@ export function RecordItem<T>({
           className="size-5"
         />
       </TableCell>
-      {displayFields.map((field, idx, arr) => {
+      {displayFields.map((field) => {
         const value = record[field.key as keyof T];
         const displayValue = field.render
           ? field.key == ""
@@ -48,10 +48,10 @@ export function RecordItem<T>({
             key={field.key.toString()}
             className={cn(
               "p-2 text-sm whitespace-pre-wrap border border-gray-200 bg-white",
-              idx % 2 === 0 ? "bg-gray-100" : "bg-white",
-              isSelected && idx === arr.length - 1 && "bg-primary-100",
-              idx === 0 && "rounded-l-md",
-              idx === arr.length - 1 && "rounded-r-md",
+              "[&:nth-child(even)]:bg-gray-100",
+              "[&:nth-child(2)]:rounded-l-md",
+              "[&:nth-last-child(1)]:rounded-r-md",
+              isSelected && "[&:nth-last-child(1)]:bg-primary-100",
             )}
           >
             <div className="text-sm">{displayValue}</div>

--- a/src/components/HistoricalRecordSelector/RecordItem.tsx
+++ b/src/components/HistoricalRecordSelector/RecordItem.tsx
@@ -28,7 +28,7 @@ export function RecordItem<T>({
 
   return (
     <TableRow className="border-0">
-      <TableCell className="border-0 bg-transparent p-2 w-12">
+      <TableCell className="border-0 bg-transparent !p-2 w-12">
         <Checkbox
           checked={isSelected}
           onCheckedChange={handleToggle}

--- a/src/components/HistoricalRecordSelector/RecordItem.tsx
+++ b/src/components/HistoricalRecordSelector/RecordItem.tsx
@@ -6,7 +6,7 @@ import { TableCell, TableRow } from "@/components/ui/table";
 export interface DisplayField<T> {
   key: keyof T | string;
   label: string;
-  render?: (value: any) => string;
+  render?: (value: any) => React.ReactNode;
 }
 
 interface RecordItemProps<T> {
@@ -48,6 +48,8 @@ export function RecordItem<T>({
             key={field.key.toString()}
             className={cn(
               "p-2 text-sm whitespace-pre-wrap border border-gray-200 bg-white",
+              idx % 2 === 0 ? "bg-gray-100" : "bg-white",
+              isSelected && idx === arr.length - 1 && "bg-primary-100",
               idx === 0 && "rounded-l-md",
               idx === arr.length - 1 && "rounded-r-md",
             )}

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -1,16 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { t } from "i18next";
-import { ChevronsDownUp, ChevronsUpDown, Clock } from "lucide-react";
+import { Clock } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import {
   Sheet,
   SheetContent,
@@ -60,7 +57,6 @@ interface DateGroupedRecords<T extends BaseRecord> {
 interface RecordState<T extends BaseRecord> {
   selectedRecords: Record<string, T[]>;
   dateGroupedRecords: DateGroupedRecords<T>[];
-  expandedDates: Set<string>;
   currentOffset: Record<string, number>;
 }
 
@@ -70,7 +66,6 @@ function useRecordState<T extends BaseRecord>() {
   const [state, setState] = useState<RecordState<T>>({
     selectedRecords: {},
     dateGroupedRecords: [],
-    expandedDates: new Set(),
     currentOffset: {},
   });
 
@@ -78,7 +73,6 @@ function useRecordState<T extends BaseRecord>() {
     setState({
       selectedRecords: {},
       dateGroupedRecords: [],
-      expandedDates: new Set(),
       currentOffset: {},
     });
   }, []);
@@ -245,17 +239,6 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
           return new Date(b.date).getTime() - new Date(a.date).getTime();
         }),
     });
-
-    // Expand the first 5 date groups on initial load
-    if (
-      !state.currentOffset[activeType] ||
-      state.currentOffset[activeType] === 0
-    ) {
-      const top5Dates = new Set(
-        sortedGroups.slice(0, 5).map((group) => group.date),
-      );
-      updateState({ expandedDates: top5Dates });
-    }
   }, [
     isOpen,
     recordsData,
@@ -299,7 +282,6 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
       updateState({
         selectedRecords: {},
         dateGroupedRecords: [],
-        expandedDates: new Set(),
         currentOffset: {
           ...state.currentOffset,
           [type]: 0,
@@ -314,19 +296,6 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
     resetState();
     setActiveType(structuredTypes[0]?.type || "");
   }, [structuredTypes, resetState]);
-
-  const handleExpandDate = useCallback(
-    (date: string, isOpen: boolean) => {
-      const newSet = new Set(state.expandedDates);
-      if (isOpen) {
-        newSet.add(date);
-      } else {
-        newSet.delete(date);
-      }
-      updateState({ expandedDates: newSet });
-    },
-    [state.expandedDates, updateState],
-  );
 
   const activeTypeConfig = useMemo(
     () => structuredTypes.find((st) => st.type === activeType),
@@ -349,8 +318,8 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
       </SheetTrigger>
       <SheetContent className="w-full sm:max-w-3xl p-0 overflow-y-auto">
         <div className="flex flex-col gap-2 p-2">
-          <SheetHeader className="p-0">
-            <SheetTitle className="text-lg font-medium text-center">
+          <SheetHeader className="px-2 py-0">
+            <SheetTitle className="text-lg font-medium">
               {title || t("history")}
             </SheetTitle>
           </SheetHeader>
@@ -360,9 +329,13 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
               onValueChange={handleTabChange}
               className="w-full"
             >
-              <TabsList className="w-full">
+              <TabsList className="w-full justify-evenly sm:justify-start border-b rounded-none bg-transparent p-0 h-auto overflow-x-auto">
                 {structuredTypes.map(({ type }) => (
-                  <TabsTrigger key={type} value={type} className="flex-1">
+                  <TabsTrigger
+                    key={type}
+                    value={type}
+                    className="border-b-3 px-1.5 sm:px-2.5 py-2 text-gray-600 font-semibold hover:text-gray-900 data-[state=active]:border-b-primary-700 data-[state=active]:text-primary-800 data-[state=active]:bg-transparent data-[state=active]:shadow-none rounded-none"
+                  >
                     {type}
                   </TabsTrigger>
                 ))}
@@ -371,7 +344,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
           )}
         </div>
 
-        <div className="space-y-0">
+        <div className="space-y-0 p-2">
           {state.dateGroupedRecords.length === 0 ? (
             <div className="flex flex-col items-center justify-center p-8 text-center">
               <Clock className="size-8 text-gray-400 mb-2" />
@@ -379,85 +352,71 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
             </div>
           ) : (
             state.dateGroupedRecords.map(({ date, records }) => (
-              <Collapsible
-                key={date}
-                open={state.expandedDates.has(date)}
-                onOpenChange={(isOpen) => handleExpandDate(date, isOpen)}
-                className=""
-              >
-                <div className="border rounded-md m-2 bg-gray-50 border-gray-200">
-                  <CollapsibleTrigger className="w-full">
-                    <div className="flex justify-between items-center p-1 cursor-pointer">
-                      <div className="flex items-center gap-2">
-                        <Checkbox
-                          checked={records.every((record) =>
-                            (state.selectedRecords[activeType] || []).includes(
-                              record,
+              <div key={date} className="my-4">
+                <div className="px-2">
+                  <p className="text-sm text-gray-500">{date}</p>
+                </div>
+                <div className="overflow-x-auto p-2">
+                  {isLoadingRecords ? (
+                    <div className="space-y-2 p-2">
+                      <Skeleton className="h-8 w-full" />
+                    </div>
+                  ) : records.length ? (
+                    <Table className="w-full border-separate border-spacing-y-2">
+                      <TableHeader>
+                        <TableRow className="border-0">
+                          <TableHead className="border-0 bg-transparent p-2 w-12">
+                            <Checkbox
+                              checked={records.every((record) =>
+                                (
+                                  state.selectedRecords[activeType] || []
+                                ).includes(record),
+                              )}
+                              onCheckedChange={() => {
+                                handleSelectAllInDateGroup(date, records);
+                              }}
+                              className="size-5"
+                            />
+                          </TableHead>
+                          {activeTypeConfig?.displayFields.map(
+                            (field, idx, arr) => (
+                              <TableHead
+                                key={String(field.label)}
+                                className={cn(
+                                  "border border-gray-200 bg-gray-50",
+                                  idx === 0 && "rounded-l-md",
+                                  idx === arr.length - 1 && "rounded-r-md",
+                                )}
+                              >
+                                {field.label}
+                              </TableHead>
                             ),
                           )}
-                          onCheckedChange={() => {
-                            handleSelectAllInDateGroup(date, records);
-                          }}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                          }}
-                          className="ml-1 size-5"
-                        />
-                        <div className="flex items-center gap-2 mt-1">
-                          <div className="w-1 h-5 bg-emerald-600 rounded-full" />
-                          <p className="text-sm text-gray-500">{date}</p>
-                        </div>
-                      </div>
-                      {state.expandedDates.has(date) ? (
-                        <ChevronsDownUp className="size-4 text-gray-400" />
-                      ) : (
-                        <ChevronsUpDown className="size-4 text-gray-400" />
-                      )}
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {records.map((record: T, index: number) => (
+                          <RecordItem
+                            key={index}
+                            record={record}
+                            isSelected={(
+                              state.selectedRecords[activeType] || []
+                            ).includes(record)}
+                            onToggleSelect={handleToggleSelect}
+                            displayFields={
+                              activeTypeConfig?.displayFields || []
+                            }
+                          />
+                        ))}
+                      </TableBody>
+                    </Table>
+                  ) : (
+                    <div className="pb-4 text-center text-sm text-gray-500">
+                      No records found
                     </div>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <div className="overflow-x-auto p-2">
-                      {isLoadingRecords ? (
-                        <div className="space-y-2 p-2">
-                          <Skeleton className="h-8 w-full" />
-                        </div>
-                      ) : records.length ? (
-                        <Table className="w-full p-2 border rounded-md">
-                          <TableHeader>
-                            <TableRow className="divide-x">
-                              <TableHead className="w-fit"></TableHead>
-                              {activeTypeConfig?.displayFields.map((field) => (
-                                <TableHead key={String(field.label)}>
-                                  {field.label}
-                                </TableHead>
-                              ))}
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody className="[&_tr:last-child]:border-1">
-                            {records.map((record: T, index: number) => (
-                              <RecordItem
-                                key={index}
-                                record={record}
-                                isSelected={(
-                                  state.selectedRecords[activeType] || []
-                                ).includes(record)}
-                                onToggleSelect={handleToggleSelect}
-                                displayFields={
-                                  activeTypeConfig?.displayFields || []
-                                }
-                              />
-                            ))}
-                          </TableBody>
-                        </Table>
-                      ) : (
-                        <div className="pb-4 text-center text-sm text-gray-500">
-                          No records found
-                        </div>
-                      )}
-                    </div>
-                  </CollapsibleContent>
+                  )}
                 </div>
-              </Collapsible>
+              </div>
             ))
           )}
         </div>

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -4,8 +4,6 @@ import { t } from "i18next";
 import { Clock, Files } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { cn } from "@/lib/utils";
-
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -378,20 +376,14 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
                               className="size-5"
                             />
                           </TableHead>
-                          {activeTypeConfig?.displayFields.map(
-                            (field, idx, arr) => (
-                              <TableHead
-                                key={String(field.label)}
-                                className={cn(
-                                  "border border-gray-200 bg-gray-50",
-                                  idx === 0 && "rounded-l-md",
-                                  idx === arr.length - 1 && "rounded-r-md",
-                                )}
-                              >
-                                {field.label}
-                              </TableHead>
-                            ),
-                          )}
+                          {activeTypeConfig?.displayFields.map((field) => (
+                            <TableHead
+                              key={String(field.label)}
+                              className="border border-gray-200 bg-gray-50 [&:nth-child(2)]:rounded-l-md [&:nth-last-child(1)]:rounded-r-md"
+                            >
+                              {field.label}
+                            </TableHead>
+                          ))}
                         </TableRow>
                       </TableHeader>
                       <TableBody>
@@ -436,7 +428,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
               <Button
                 variant="ghost"
                 onClick={handleLoadMore}
-                className="w-1/8 font-semibold underline p-0 justify-start"
+                className="font-semibold underline justify-start"
               >
                 {t("load_more")}
               </Button>

--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { t } from "i18next";
-import { Clock } from "lucide-react";
+import { Clock, Files } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -354,7 +354,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
             state.dateGroupedRecords.map(({ date, records }) => (
               <div key={date} className="my-4">
                 <div className="px-2">
-                  <p className="text-sm text-gray-500">{date}</p>
+                  <p className="text-sm text-indigo-700 font-medium">{date}</p>
                 </div>
                 <div className="overflow-x-auto p-2">
                   {isLoadingRecords ? (
@@ -424,7 +424,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
           {isLoadingRecords && <Skeleton className="h-8 w-full" />}
         </div>
 
-        <div className="sticky bottom-0 bg-white flex flex-col gap-2 p-4 border-t">
+        <div className="sticky bottom-0 bg-white p-4 border-t">
           {state.dateGroupedRecords.length > 0 &&
             (isLoadingRecords ? (
               <div className="flex justify-center p-4">
@@ -434,31 +434,40 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
               recordsData.count >
                 (state.currentOffset[activeType] || 0) + LIMIT ? (
               <Button
-                variant="outline"
+                variant="ghost"
                 onClick={handleLoadMore}
-                className="w-full"
+                className="w-1/8 font-semibold underline p-0 justify-start"
               >
                 {t("load_more")}
               </Button>
             ) : null)}
-          <div className="text-sm">
-            <span className="font-medium">
-              {(state.selectedRecords[activeType] || []).length} {activeType}
-            </span>{" "}
-            {t("selected")}
-          </div>
-          <div className="flex gap-2">
-            <Button variant="outline" onClick={handleClose}>
-              {t("cancel")}
-            </Button>
-            <Button
-              onClick={handleAddSelected}
-              disabled={(state.selectedRecords[activeType] || []).length === 0}
-              className="bg-emerald-600 hover:bg-emerald-700"
-              data-cy="add-selected-records"
-            >
-              {t("add_selected")}
-            </Button>
+          <div className="flex justify-between items-center gap-2 w-full">
+            <div className="text-sm">
+              <span className="font-medium">
+                {(state.selectedRecords[activeType] || []).length} {activeType}
+              </span>{" "}
+              {t("selected")}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                className="font-semibold underline"
+                onClick={handleClose}
+              >
+                {t("cancel")}
+              </Button>
+              <Button
+                onClick={handleAddSelected}
+                disabled={
+                  (state.selectedRecords[activeType] || []).length === 0
+                }
+                className="bg-emerald-600 hover:bg-emerald-700"
+                data-cy="add-selected-records"
+              >
+                <Files className="size-4" />
+                {t("add_selected")}
+              </Button>
+            </div>
           </div>
         </div>
       </SheetContent>

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -32,13 +32,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+import { Avatar } from "@/components/Common/Avatar";
 import { ComboboxQuantityInput } from "@/components/Common/ComboboxQuantityInput";
 import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import UserSelector from "@/components/Common/UserSelector";
 import { HistoricalRecordSelector } from "@/components/HistoricalRecordSelector";
 import InstructionsPopover from "@/components/Medicine/InstructionsPopover";
 import { getFrequencyDisplay } from "@/components/Medicine/MedicationsTable";
-import { formatDosage } from "@/components/Medicine/utils";
 import { EntitySelectionDrawer } from "@/components/Questionnaire/EntitySelectionDrawer";
 import MedicationValueSetSelect from "@/components/Questionnaire/MedicationValueSetSelect";
 import { FieldError } from "@/components/Questionnaire/QuestionTypes/FieldError";
@@ -471,36 +471,39 @@ export function MedicationRequestQuestion({
               },
               {
                 key: "dosage_instruction",
-                label: t("dosage"),
+                label: t("frequency"),
                 render: (instructions) => {
-                  const dosage = formatDosage(instructions[0]) || "";
-
                   const frequency =
-                    getFrequencyDisplay(instructions[0]?.timing)?.meaning || "";
-
-                  const duration = instructions?.[0]?.timing?.repeat
-                    ?.bounds_duration
-                    ? `${instructions[0].timing.repeat.bounds_duration.value} ${instructions[0].timing.repeat.bounds_duration.unit}`
-                    : "";
-
-                  return `${dosage}\n${frequency}\n${duration}`;
+                    getFrequencyDisplay(instructions[0]?.timing)?.meaning ||
+                    "-";
+                  return frequency;
                 },
               },
               {
                 key: "dosage_instruction",
-                label: t("instructions"),
-                render: (instructions) =>
-                  instructions?.[0]?.additional_instruction?.[0]?.display,
-              },
-              {
-                key: "note",
-                label: t("notes"),
-                render: (note) => note,
+                label: t("duration"),
+                render: (instructions) => {
+                  const duration =
+                    instructions?.[0]?.timing?.repeat?.bounds_duration;
+                  if (!duration?.value) return "-";
+                  return `${duration.value} ${duration.unit}`;
+                },
               },
               {
                 key: "created_by",
                 label: t("prescribed_by"),
-                render: (created_by) => formatName(created_by),
+                render: (created_by) => (
+                  <div className="flex items-center gap-2">
+                    <Avatar
+                      imageUrl={created_by?.profile_picture_url}
+                      name={formatName(created_by, true)}
+                      className="size-6 rounded-full"
+                    />
+                    <span className="text-sm truncate">
+                      {formatName(created_by)}
+                    </span>
+                  </div>
+                ),
               },
             ],
             queryKey: ["medication_requests", patientId],
@@ -527,23 +530,34 @@ export function MedicationRequestQuestion({
               },
               {
                 key: "dosage_text",
-                label: t("dosage"),
+                label: t("frequency"),
                 render: (dosage) => dosage,
               },
               {
-                key: "status",
-                label: t("status"),
-                render: (status) => t(status),
-              },
-              {
-                key: "note",
-                label: t("notes"),
-                render: (note) => note || "-",
+                key: "dosage_instruction",
+                label: t("duration"),
+                render: (instructions) => {
+                  const duration =
+                    instructions?.[0]?.timing?.repeat?.bounds_duration;
+                  if (!duration?.value) return "-";
+                  return `${duration.value} ${duration.unit}`;
+                },
               },
               {
                 key: "created_by",
                 label: t("prescribed_by"),
-                render: (created_by) => formatName(created_by),
+                render: (created_by) => (
+                  <div className="flex items-center gap-2">
+                    <Avatar
+                      imageUrl={created_by?.profile_picture_url}
+                      name={formatName(created_by, true)}
+                      className="size-6 rounded-full"
+                    />
+                    <span className="text-sm truncate">
+                      {formatName(created_by)}
+                    </span>
+                  </div>
+                ),
               },
             ],
             queryKey: ["medication_statements", patientId],


### PR DESCRIPTION
## Proposed Changes
- Redesigned the Medication History Tab  including Past Prescriptions and Medication Statement tabs

`Past Prescriptions` Tab
<img width="1210" height="932" alt="Screenshot 2025-10-23 at 3 16 56 PM" src="https://github.com/user-attachments/assets/5c0477e9-f228-4948-9977-f6da91961a82" />

`Medication Statement` Tab
<img width="1208" height="929" alt="Screenshot 2025-10-23 at 3 20 00 PM" src="https://github.com/user-attachments/assets/4619e369-1439-44dc-9a48-0eea008a4c4a" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
