### PR TITLE
updated #14120 show severity in patient dashboard

### DIFF
--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -449,8 +449,8 @@ export default function TreatmentSummary({
                       verification: t(symptom.verification_status),
                       onset: symptom.onset?.onset_datetime
                         ? new Date(
-                            symptom.onset.onset_datetime,
-                          ).toLocaleDateString()
+                          symptom.onset.onset_datetime,
+                        ).toLocaleDateString()
                         : "-",
                       notes: symptom.note,
                       logged_by: formatName(symptom.created_by),
@@ -466,6 +466,7 @@ export default function TreatmentSummary({
                     headers={[
                       { key: "diagnosis" },
                       { key: "status" },
+                      { key: "severity" },
                       { key: "verification" },
                       { key: "onset" },
                       { key: "notes" },
@@ -474,11 +475,10 @@ export default function TreatmentSummary({
                     rows={diagnoses?.results.map((diagnosis) => ({
                       diagnosis: diagnosis.code.display,
                       status: t(diagnosis.clinical_status),
+                      severity: t(diagnosis.severity || "moderate"),
                       verification: t(diagnosis.verification_status),
                       onset: diagnosis.onset?.onset_datetime
-                        ? new Date(
-                            diagnosis.onset.onset_datetime,
-                          ).toLocaleDateString()
+                        ? new Date(diagnosis.onset.onset_datetime).toLocaleDateString()
                         : undefined,
                       notes: diagnosis.note,
                       logged_by: formatName(diagnosis.created_by),
@@ -520,14 +520,13 @@ export default function TreatmentSummary({
                         dosage: dosage,
                         frequency: instruction?.as_needed_boolean
                           ? `${t("as_needed_prn")} (${instruction?.as_needed_for?.display ?? "-"})` +
-                            (instruction?.additional_instruction?.length
-                              ? `, ${additionalInstructions}`
-                              : "")
-                          : `${frequency?.meaning ?? "-"}${
-                              instruction?.additional_instruction?.length
-                                ? `, ${additionalInstructions}`
-                                : ""
-                            }`,
+                          (instruction?.additional_instruction?.length
+                            ? `, ${additionalInstructions}`
+                            : "")
+                          : `${frequency?.meaning ?? "-"}${instruction?.additional_instruction?.length
+                            ? `, ${additionalInstructions}`
+                            : ""
+                          }`,
                         duration: duration
                           ? `${duration.value} ${duration.unit}`
                           : "-",
@@ -603,3 +602,6 @@ export default function TreatmentSummary({
     </div>
   );
 }
+  );
+}
+

--- a/src/components/Patient/diagnosis/DiagnosisTable.tsx
+++ b/src/components/Patient/diagnosis/DiagnosisTable.tsx
@@ -23,6 +23,7 @@ import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFac
 import {
   DIAGNOSIS_CLINICAL_STATUS_COLORS,
   DIAGNOSIS_VERIFICATION_STATUS_COLORS,
+  DIAGNOSIS_SEVERITY_COLORS,
   type Diagnosis,
 } from "@/types/emr/diagnosis/diagnosis";
 
@@ -50,6 +51,11 @@ const DiagnosisCard = ({
           >
             {t(diagnosis.clinical_status)}
           </Badge>
+          {diagnosis.severity && (
+            <Badge variant={DIAGNOSIS_SEVERITY_COLORS[diagnosis.severity]}>
+              {t(diagnosis.severity)}
+            </Badge>
+          )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -107,7 +113,7 @@ const DiagnosisCard = ({
           <Badge
             variant={
               DIAGNOSIS_VERIFICATION_STATUS_COLORS[
-                diagnosis.verification_status
+              diagnosis.verification_status
               ]
             }
           >
@@ -175,11 +181,11 @@ export const DiagnosisTable = ({
             onViewEncounter={
               showViewEncounter
                 ? () =>
-                    navigate(
-                      facilityId
-                        ? `/facility/${facilityId}/patient/${patientId}/encounter/${diagnosis.encounter}/updates`
-                        : `/organization/organizationId/patient/${patientId}/encounter/${diagnosis.encounter}/updates`,
-                    )
+                  navigate(
+                    facilityId
+                      ? `/facility/${facilityId}/patient/${patientId}/encounter/${diagnosis.encounter}/updates`
+                      : `/organization/organizationId/patient/${patientId}/encounter/${diagnosis.encounter}/updates`,
+                  )
                 : undefined
             }
           />
@@ -217,11 +223,11 @@ export const DiagnosisTable = ({
                 onViewEncounter={
                   showViewEncounter
                     ? () =>
-                        navigate(
-                          facilityId
-                            ? `/facility/${facilityId}/patient/${patientId}/encounter/${diagnosis.encounter}/updates`
-                            : `/organization/organizationId/patient/${patientId}/encounter/${diagnosis.encounter}/updates`,
-                        )
+                      navigate(
+                        facilityId
+                          ? `/facility/${facilityId}/patient/${patientId}/encounter/${diagnosis.encounter}/updates`
+                          : `/organization/organizationId/patient/${patientId}/encounter/${diagnosis.encounter}/updates`,
+                      )
                     : undefined
                 }
                 columns={[
@@ -237,7 +243,7 @@ export const DiagnosisTable = ({
                       <Badge
                         variant={
                           DIAGNOSIS_CLINICAL_STATUS_COLORS[
-                            diagnosis.clinical_status
+                          diagnosis.clinical_status
                           ]
                         }
                       >
@@ -251,7 +257,7 @@ export const DiagnosisTable = ({
                       <Badge
                         variant={
                           DIAGNOSIS_VERIFICATION_STATUS_COLORS[
-                            diagnosis.verification_status
+                          diagnosis.verification_status
                           ]
                         }
                       >
@@ -280,3 +286,4 @@ export const DiagnosisTable = ({
     </>
   );
 };
+

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -86,11 +86,44 @@ const DIAGNOSIS_INITIAL_VALUE: Omit<DiagnosisRequest, "encounter"> = {
   code: { code: "", display: "", system: "" },
   clinical_status: "active",
   verification_status: "confirmed",
+  severity: "moderate",
   category: "encounter_diagnosis",
   onset: { onset_datetime: dateQueryString(new Date()) },
   severity: "moderate",
   dirty: true,
 };
+
+function SeveritySelect({
+  severity,
+  onValueChange,
+  disabled,
+}: {
+  severity?: DiagnosisSeverity;
+  onValueChange: (value: DiagnosisSeverity) => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Select value={severity} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger className="h-8 md:h-9">
+        <SelectValue
+          placeholder={
+            <span className="text-gray-500">
+              {t("diagnosis_severity_placeholder")}
+            </span>
+          }
+        />
+      </SelectTrigger>
+      <SelectContent>
+        {DIAGNOSIS_SEVERITY.map((severity) => (
+          <SelectItem key={severity} value={severity} className="capitalize">
+            {t(severity)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
 
 function ClinicalStatusSelect({
   status,
@@ -274,10 +307,10 @@ function DiagnosisDetailsForm({
       <div className="space-y-2">
         <Label className="text-sm">{t("severity")}</Label>
         <SeveritySelect
-          severity={diagnosis.severity || "moderate"}
+          severity={diagnosis.severity}
           onValueChange={(value) =>
             onUpdate({
-              severity: value as DiagnosisRequest["severity"],
+              severity: value,
             })
           }
           disabled={disabled}
@@ -301,6 +334,7 @@ function convertToDiagnosisRequest(diagnosis: Diagnosis): DiagnosisRequest {
     code: diagnosis.code,
     clinical_status: diagnosis.clinical_status,
     verification_status: diagnosis.verification_status,
+    severity: diagnosis.severity,
     onset: diagnosis.onset
       ? {
         ...diagnosis.onset,

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -57,9 +57,11 @@ import { Code } from "@/types/base/code/code";
 import {
   DIAGNOSIS_CLINICAL_STATUS,
   DIAGNOSIS_VERIFICATION_STATUS,
+  DIAGNOSIS_SEVERITY,
   Diagnosis,
   DiagnosisClinicalStatus,
   DiagnosisRequest,
+  DiagnosisSeverity,
   Onset,
 } from "@/types/emr/diagnosis/diagnosis";
 import diagnosisApi from "@/types/emr/diagnosis/diagnosisApi";
@@ -86,6 +88,7 @@ const DIAGNOSIS_INITIAL_VALUE: Omit<DiagnosisRequest, "encounter"> = {
   verification_status: "confirmed",
   category: "encounter_diagnosis",
   onset: { onset_datetime: dateQueryString(new Date()) },
+  severity: "moderate",
   dirty: true,
 };
 
@@ -153,6 +156,38 @@ function VerificationStatusSelect({
               </SelectItem>
             ),
         )}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function SeveritySelect({
+  severity,
+  onValueChange,
+  disabled,
+}: {
+  severity: DiagnosisSeverity;
+  onValueChange: (value: DiagnosisSeverity) => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Select value={severity} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger className="h-8 md:h-9">
+        <SelectValue
+          placeholder={
+            <span className="text-gray-500">
+              {t("diagnosis_severity_placeholder")}
+            </span>
+          }
+        />
+      </SelectTrigger>
+      <SelectContent>
+        {DIAGNOSIS_SEVERITY.map((severity) => (
+          <SelectItem key={severity} value={severity} className="capitalize">
+            {t(severity)}
+          </SelectItem>
+        ))}
       </SelectContent>
     </Select>
   );
@@ -237,6 +272,18 @@ function DiagnosisDetailsForm({
         />
       </div>
       <div className="space-y-2">
+        <Label className="text-sm">{t("severity")}</Label>
+        <SeveritySelect
+          severity={diagnosis.severity || "moderate"}
+          onValueChange={(value) =>
+            onUpdate({
+              severity: value as DiagnosisRequest["severity"],
+            })
+          }
+          disabled={disabled}
+        />
+      </div>
+      <div className="space-y-2">
         <Label className="text-sm">{t("notes")}</Label>
         <DiagnosisNotesInput
           note={diagnosis.note}
@@ -256,11 +303,11 @@ function convertToDiagnosisRequest(diagnosis: Diagnosis): DiagnosisRequest {
     verification_status: diagnosis.verification_status,
     onset: diagnosis.onset
       ? {
-          ...diagnosis.onset,
-          onset_datetime: diagnosis.onset.onset_datetime
-            ? format(new Date(diagnosis.onset.onset_datetime), "yyyy-MM-dd")
-            : "",
-        }
+        ...diagnosis.onset,
+        onset_datetime: diagnosis.onset.onset_datetime
+          ? format(new Date(diagnosis.onset.onset_datetime), "yyyy-MM-dd")
+          : "",
+      }
       : undefined,
     recorded_date: diagnosis.recorded_date,
     category: diagnosis.category,
@@ -269,6 +316,7 @@ function convertToDiagnosisRequest(diagnosis: Diagnosis): DiagnosisRequest {
     created_by: diagnosis.created_by,
     created_date: diagnosis.created_date,
     dirty: false,
+    severity: diagnosis.severity || "moderate",
   };
 }
 
@@ -411,10 +459,10 @@ export function DiagnosisQuestion({
       const newDiagnoses = sortedDiagnoses.map((d, i) =>
         i === index
           ? {
-              ...d,
-              verification_status: "entered_in_error" as const,
-              dirty: true,
-            }
+            ...d,
+            verification_status: "entered_in_error" as const,
+            dirty: true,
+          }
           : d,
       ) as DiagnosisRequest[];
       updateQuestionnaireResponseCB(
@@ -562,6 +610,9 @@ export function DiagnosisQuestion({
                   <TableHead className="w-[15%] text-center">
                     {t("verification")}
                   </TableHead>
+                  <TableHead className="w-[15%] text-center">
+                    {t("severity")}
+                  </TableHead>
                   <TableHead className="w-[5%] text-center">
                     {t("action")}
                   </TableHead>
@@ -578,7 +629,7 @@ export function DiagnosisQuestion({
                     disabled={
                       disabled ||
                       patientDiagnoses?.results[index]?.verification_status ===
-                        "entered_in_error"
+                      "entered_in_error"
                     }
                     onUpdate={(updates) =>
                       handleUpdateDiagnosis(index, updates)
@@ -601,7 +652,7 @@ export function DiagnosisQuestion({
                 disabled={
                   disabled ||
                   patientDiagnoses?.results[index]?.verification_status ===
-                    "entered_in_error"
+                  "entered_in_error"
                 }
                 onUpdate={(updates) => handleUpdateDiagnosis(index, updates)}
                 onRemove={() => handleRemoveDiagnosis(index)}
@@ -711,6 +762,17 @@ const DiagnosisTableRow = ({
               })
             }
             isExistingRecord={!!diagnosis.id}
+            disabled={disabled}
+          />
+        </TableCell>
+        <TableCell className="py-1">
+          <SeveritySelect
+            severity={diagnosis.severity}
+            onValueChange={(value) =>
+              onUpdate?.({
+                severity: value as DiagnosisRequest["severity"],
+              })
+            }
             disabled={disabled}
           />
         </TableCell>
@@ -851,9 +913,9 @@ const DiagnosisItem: React.FC<DiagnosisItemProps> = ({
                     {t("diagnosed_on")}{" "}
                     {diagnosis.onset?.onset_datetime
                       ? format(
-                          new Date(diagnosis.onset.onset_datetime),
-                          "MMMM d, yyyy",
-                        )
+                        new Date(diagnosis.onset.onset_datetime),
+                        "MMMM d, yyyy",
+                      )
                       : ""}
                     {" · "}
                     {t(diagnosis.clinical_status)}
@@ -868,7 +930,7 @@ const DiagnosisItem: React.FC<DiagnosisItemProps> = ({
             <CardContent className="p-3 pt-2 space-y-3 rounded-lg bg-gray-50">
               <DiagnosisDetailsForm
                 diagnosis={diagnosis}
-                onUpdate={onUpdate || (() => {})}
+                onUpdate={onUpdate || (() => { })}
                 disabled={disabled}
               />
             </CardContent>

--- a/src/types/emr/diagnosis/diagnosis.ts
+++ b/src/types/emr/diagnosis/diagnosis.ts
@@ -42,6 +42,10 @@ export const DIAGNOSIS_VERIFICATION_STATUS = [
 export type DiagnosisVerificationStatus =
   (typeof DIAGNOSIS_VERIFICATION_STATUS)[number];
 
+export const DIAGNOSIS_SEVERITY = ["severe", "moderate", "mild"] as const;
+
+export type DiagnosisSeverity = (typeof DIAGNOSIS_SEVERITY)[number];
+
 export type Onset = {
   onset_datetime?: string;
   onset_age?: string;
@@ -54,6 +58,7 @@ export interface Diagnosis {
   code: Code;
   clinical_status: DiagnosisClinicalStatus;
   verification_status: DiagnosisVerificationStatus;
+  severity: DiagnosisSeverity;
   onset?: Onset;
   recorded_date?: string;
   note?: string;
@@ -77,6 +82,7 @@ export interface DiagnosisRequest {
   note?: string;
   category: DiagnosisCategory;
   encounter: string;
+  severity: DiagnosisSeverity;
   dirty: boolean;
   created_by?: UserReadMinimal;
   created_date?: string;
@@ -100,3 +106,9 @@ export const DIAGNOSIS_VERIFICATION_STATUS_COLORS = {
   refuted: "destructive",
   entered_in_error: "destructive",
 } as const;
+
+export const DIAGNOSIS_SEVERITY_COLORS = {
+  severe: "destructive",
+  moderate: "yellow",
+  mild: "blue",
+} as const satisfies Record<DiagnosisSeverity, string>;

--- a/src/types/emr/diagnosis/diagnosis.ts
+++ b/src/types/emr/diagnosis/diagnosis.ts
@@ -39,11 +39,26 @@ export const DIAGNOSIS_VERIFICATION_STATUS = [
   "entered_in_error",
 ] as const;
 
+export const DIAGNOSIS_SEVERITY = [
+  "mild",
+  "moderate",
+  "severe",
+] as const;
+
+export const DIAGNOSIS_SEVERITY_COLORS = {
+  mild: "outline",
+  moderate: "yellow",
+  severe: "destructive",
+} as const;
+
 export type DiagnosisVerificationStatus =
   (typeof DIAGNOSIS_VERIFICATION_STATUS)[number];
 
+<<<<<<< Updated upstream
 export const DIAGNOSIS_SEVERITY = ["severe", "moderate", "mild"] as const;
 
+=======
+>>>>>>> Stashed changes
 export type DiagnosisSeverity = (typeof DIAGNOSIS_SEVERITY)[number];
 
 export type Onset = {
@@ -58,7 +73,11 @@ export interface Diagnosis {
   code: Code;
   clinical_status: DiagnosisClinicalStatus;
   verification_status: DiagnosisVerificationStatus;
+<<<<<<< Updated upstream
   severity: DiagnosisSeverity;
+=======
+  severity?: DiagnosisSeverity;
+>>>>>>> Stashed changes
   onset?: Onset;
   recorded_date?: string;
   note?: string;
@@ -76,6 +95,7 @@ export interface DiagnosisRequest {
   id?: string;
   clinical_status: DiagnosisClinicalStatus;
   verification_status: DiagnosisVerificationStatus;
+  severity?: DiagnosisSeverity;
   code: Code;
   onset?: Onset;
   recorded_date?: string;


### PR DESCRIPTION
## Proposed Changes

Fixes #14120 

- Added severity field to Diagnosis system to track condition severity levels
- Implemented severity selection in DiagnosisQuestion component with "mild", "moderate", "severe" options
- Added severity column to Treatment Summary view
- Updated TypeScript types to include severity field with proper type safety
- Added color-coded severity indicators following existing design patterns

### Implementation Details:
1. Added DiagnosisSeverity type and constants to diagnosis.ts
2. Added severity field to Diagnosis and DiagnosisRequest interfaces
3. Added SeveritySelect component with proper translations
4. Updated Treatment Summary to display severity information
5. Added default "moderate" severity for new diagnoses

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [X] Add specs that demonstrate the bug or test the new feature.
- [X] Update [product documentation](https://docs.ohc.network).
- [X] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [X] Request peer reviews.
- [X] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.
