### PR TITLE
Fixed some warnings and errors of main pages.

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -444,6 +444,7 @@ const PatientBasicsContent = ({
                 tabIndex={0}
                 placeholder={t("type_name")}
                 {...field}
+                value={field.value ?? ""}
               />
             </FormControl>
             <FormMessage />
@@ -616,6 +617,7 @@ const PatientBasicsContent = ({
               <FormLabel>{t("blood_group")}</FormLabel>
               <Select
                 {...field}
+                value={field.value ?? ""}
                 onValueChange={field.onChange}
                 defaultValue={field.value}
               >
@@ -649,7 +651,11 @@ const PatientBasicsContent = ({
                 <FormLabel aria-required>{config.display}</FormLabel>
                 <FormDescription>{config.description}</FormDescription>
                 <FormControl>
-                  <Input {...field} placeholder={t("enter_identifier_value")} />
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    placeholder={t("enter_identifier_value")}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -778,6 +784,7 @@ const AdditionalDetailsContent = ({
             <FormControl>
               <Input
                 {...field}
+                value={field.value ?? ""}
                 placeholder={t("enter_pincode")}
                 onChange={(e) => {
                   const value = e.target.value
@@ -828,7 +835,11 @@ const AdditionalDetailsContent = ({
                 <FormLabel>{config.display}</FormLabel>
                 <FormDescription>{config.description}</FormDescription>
                 <FormControl>
-                  <Input {...field} placeholder={t("enter_identifier_value")} />
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    placeholder={t("enter_identifier_value")}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
@@ -183,7 +183,7 @@ export default function PaymentsData({
           </Select>
           <div className="w-full sm:w-fit">
             <Select
-              value={qParams.ordering}
+              value={qParams.ordering || ""}
               onValueChange={(value) => {
                 updateQuery({ ordering: value });
               }}

--- a/src/pages/Facility/settings/locations/components/LocationTable.tsx
+++ b/src/pages/Facility/settings/locations/components/LocationTable.tsx
@@ -38,7 +38,7 @@ import { LocationList, LocationTypeIcons } from "@/types/location/location";
 import locationApi from "@/types/location/locationApi";
 
 // Animated version of TableRow
-const AnimatedTableRow = motion(TableRow);
+const AnimatedTableRow = motion.create(TableRow);
 
 interface Props {
   locations: LocationList[];


### PR DESCRIPTION
## Proposed Changes

Fixes #14099
Fixes #14100

- Replaced `motion()` with `motion.create()` for compatibility with newer Framer Motion versions.
- Added default empty string ("") values for all form fields to prevent `uncontrolled → controlled` state transitions.
- Ensured all `<Select>` components have a default "" value instead of `undefined` to eliminate related React warnings.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
