### PR TITLE
Fixed missing description warning

### DIFF
--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
@@ -353,6 +354,9 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
             <SheetTitle className="text-lg font-medium text-center">
               {title || t("history")}
             </SheetTitle>
+            <SheetDescription className="sr-only">
+              {title || t("history")}
+            </SheetDescription>
           </SheetHeader>
           {structuredTypes.length > 1 && (
             <Tabs


### PR DESCRIPTION
## Proposed Changes

Fixes #14112 
- Added `SheetDescription` for `sr-only` fixing the missing description warning

<img width="1918" height="955" alt="Screenshot 2025-10-27 at 4 00 29 PM" src="https://github.com/user-attachments/assets/da9a1d9c-a12f-438d-96af-eb386abe27bd" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
