### PR TITLE
fixed-redundant-patient-home-button

### DIFF
--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -39,20 +39,6 @@ export const PatientInfoHoverCard = ({
         <Button variant="outline" className="text-gray-950" asChild>
           <Link
             basePath="/"
-            href={`/facility/${facilityId}/patients/verify?${new URLSearchParams(
-              {
-                phone_number: patient.phone_number,
-                year_of_birth: patient.year_of_birth.toString(),
-                partial_id: patient.id.slice(0, 5),
-              },
-            ).toString()}`}
-          >
-            {t("patient_home")}
-          </Link>
-        </Button>
-        <Button variant="outline" className="text-gray-950" asChild>
-          <Link
-            basePath="/"
             href={
               facilityId
                 ? `/facility/${facilityId}/patient/${patient.id}`


### PR DESCRIPTION
## Proposed Changes

Fixes #14009 
- Removed the redundant "Patient Home" button from the Patient Home page
- The "Patient Home" button was dummy and was of no use.

<img width="1897" height="1029" alt="Screenshot 2025-10-29 103854" src="https://github.com/user-attachments/assets/49205972-018e-4b93-ace5-447d4f021a50" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
