### PR TITLE
label the pr if it is auto close

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -78,12 +78,40 @@ jobs:
                 state: 'closed'
               });
 
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['auto-closed-checklist']
+              });
+
               core.setFailed('Checklist incomplete. PR closed.');
-            } else if (checked.length > 0 && prState === 'closed') {
+            } 
+            else if (checked.length > 0 && prState === 'closed') {
+
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+
+              const wasAutoClosed = labels.some(l => l.name === 'auto-closed-checklist');
+              if (!wasAutoClosed) {
+                  console.log('PR was manually closed — skipping reopen.');
+                  return;
+              }
+
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.payload.pull_request.number,
                 state: 'open'
+              });
+
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'auto-closed-checklist'
               });
             }


### PR DESCRIPTION
## Proposed Changes
Labeling the PR that are auto closed due to unchecked list. so that manual closed PR don't get open when checklist is edited

Fixes #14210
- Labeling the PR that are closed by the github bot due to unchecked checklist
- Then if checklist is edited later then if PR is autoclosed then open it otherwise don't open it
- https://github.com/ohcnetwork/care_fe/pull/14143#issuecomment-3452826403

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
