### PR TITLE
Set home as default discharge disposition

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -79,9 +79,6 @@ REACT_DEFAULT_PAYMENT_TERMS=
 # Relative number of days to show in the encounters page by default.0 means today.
 REACT_ENCOUNTER_DEFAULT_DATE_FILTER=
 
-# Flag to enforce discharge disposition during patient discharge
-REACT_ENFORCE_DISCHARGE_DISPOSITION=
-
 # Relative number of days to show in the appointments page by default.0 means today, positive for future days, negative for past days.
 REACT_APPOINTMENTS_DEFAULT_DATE_FILTER=
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -103,14 +103,6 @@ const careConfig = {
     ),
   },
 
-  /**
-   * Flag to enforce discharge disposition during patient discharge
-   */
-  enforceDischargeDisposition: boolean(
-    "REACT_ENFORCE_DISCHARGE_DISPOSITION",
-    false,
-  ),
-
   careApps: env.REACT_ENABLED_APPS
     ? env.REACT_ENABLED_APPS.split(",").map((app) => {
         const [module, cdn] = app.split("@");

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -76,7 +76,6 @@ const envSchema = z
     REACT_DISABLE_PATIENT_LOGIN: booleanAsStringSchema.optional(),
     REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION: booleanAsStringSchema.optional(),
     REACT_APPOINTMENTS_DEFAULT_DATE_FILTER: numberAsString.optional(),
-    REACT_ENFORCE_DISCHARGE_DISPOSITION: booleanAsStringSchema.optional(),
     REACT_ENCOUNTER_DEFAULT_DATE_FILTER: numberAsString.optional(),
     REACT_OBSERVATION_PLOTS_CONFIG_URL: z.string().url().optional(),
     REACT_DEFAULT_COUNTRY: z.string().optional(),

--- a/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
@@ -21,6 +21,7 @@ import DischargeConfirmationDialog from "@/components/Patient/DischargeConfirmat
 
 import query from "@/Utils/request/query";
 import {
+  DEFAULT_DISCHARGE_DISPOSITION,
   ENCOUNTER_ADMIT_SOURCE,
   ENCOUNTER_DIET_PREFERENCE,
   ENCOUNTER_DISCHARGE_DISPOSITION,
@@ -80,7 +81,6 @@ export function validateEncounterQuestion(
   const errors: QuestionValidationError[] = [];
 
   if (
-    careConfig.enforceDischargeDisposition &&
     value?.status === "discharged" &&
     ["imp", "obsenc", "emer"].includes(value.encounter_class) &&
     !value?.hospitalization?.discharge_disposition
@@ -125,7 +125,7 @@ export function EncounterQuestion({
     hospitalization: {
       re_admission: false,
       admit_source: "other",
-      discharge_disposition: "home",
+      discharge_disposition: DEFAULT_DISCHARGE_DISPOSITION,
       diet_preference: "none",
     },
     facility: "",
@@ -181,7 +181,9 @@ export function EncounterQuestion({
   }, [encounterData]);
 
   useEffect(() => {
-    const formStateValue = (questionnaireResponse.values[0]?.value as any)?.[0];
+    const formStateValue = (
+      questionnaireResponse.values[0]?.value as EncounterEdit[]
+    )?.[0];
     if (formStateValue) {
       setEncounter(() => ({
         ...formStateValue,
@@ -196,6 +198,18 @@ export function EncounterQuestion({
     const newEncounter = { ...encounter, ...updates };
     if (["amb", "vr", "hh"].includes(newEncounter.encounter_class)) {
       newEncounter.hospitalization = {};
+    }
+
+    if (
+      ["imp", "obsenc", "emer"].includes(encounter.encounter_class) &&
+      newEncounter.status === "discharged"
+    ) {
+      newEncounter.hospitalization = {
+        ...newEncounter.hospitalization,
+        discharge_disposition:
+          newEncounter.hospitalization?.discharge_disposition ??
+          DEFAULT_DISCHARGE_DISPOSITION,
+      };
     }
 
     // Create the full encounter request object
@@ -404,12 +418,13 @@ export function EncounterQuestion({
                 <div className="space-y-2">
                   <Label>
                     {t("discharge_disposition")}
-                    {careConfig.enforceDischargeDisposition && (
-                      <span className="text-red-500">*</span>
-                    )}
+                    <span className="text-red-500">*</span>
                   </Label>
                   <Select
-                    value={encounter.hospitalization?.discharge_disposition}
+                    value={
+                      encounter.hospitalization?.discharge_disposition ??
+                      DEFAULT_DISCHARGE_DISPOSITION
+                    }
                     onValueChange={(value: EncounterDischargeDisposition) => {
                       if (!encounter.hospitalization) return;
                       handleUpdateEncounter({

--- a/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
@@ -2,8 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { cn } from "@/lib/utils";
-
 import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -37,17 +35,11 @@ import {
   type EncounterStatus,
 } from "@/types/emr/encounter/encounter";
 import encounterApi from "@/types/emr/encounter/encounterApi";
-import { QuestionValidationError } from "@/types/questionnaire/batch";
 import type {
   QuestionnaireResponse,
   ResponseValue,
 } from "@/types/questionnaire/form";
 import type { Question } from "@/types/questionnaire/question";
-import {
-  FieldDefinitions,
-  useFieldError,
-  validateFields,
-} from "@/types/questionnaire/validation";
 import careConfig from "@careConfig";
 
 interface EncounterQuestionProps {
@@ -64,31 +56,6 @@ interface EncounterQuestionProps {
   organizations?: string[];
   patientId?: string;
   facilityId: string;
-  errors?: QuestionValidationError[];
-}
-
-const ENCOUNTER_FIELDS: FieldDefinitions = {
-  DISCHARGE_DISPOSITION: {
-    key: "hospitalization.discharge_disposition",
-    required: true,
-  },
-} as const;
-
-export function validateEncounterQuestion(
-  value: EncounterEdit | undefined,
-  questionId: string,
-): QuestionValidationError[] {
-  const errors: QuestionValidationError[] = [];
-
-  if (
-    value?.status === "discharged" &&
-    ["imp", "obsenc", "emer"].includes(value.encounter_class) &&
-    !value?.hospitalization?.discharge_disposition
-  ) {
-    errors.push(...validateFields(value, questionId, ENCOUNTER_FIELDS));
-  }
-
-  return errors;
 }
 
 export function EncounterQuestion({
@@ -99,7 +66,6 @@ export function EncounterQuestion({
   encounterId,
   patientId = "",
   facilityId,
-  errors = [],
 }: EncounterQuestionProps) {
   // Fetch encounter data
   const { data: encounterData, isLoading } = useQuery({
@@ -111,7 +77,6 @@ export function EncounterQuestion({
     enabled: !!encounterId,
   });
   const { t } = useTranslation();
-  const { hasError } = useFieldError(questionnaireResponse.question_id, errors);
 
   const [encounter, setEncounter] = useState<EncounterEdit>({
     status: "unknown",
@@ -416,10 +381,7 @@ export function EncounterQuestion({
               encounter.hospitalization?.discharge_disposition) && (
               <>
                 <div className="space-y-2">
-                  <Label>
-                    {t("discharge_disposition")}
-                    <span className="text-red-500">*</span>
-                  </Label>
+                  <Label>{t("discharge_disposition")}</Label>
                   <Select
                     value={
                       encounter.hospitalization?.discharge_disposition ??
@@ -436,15 +398,7 @@ export function EncounterQuestion({
                     }}
                     disabled={disabled}
                   >
-                    <SelectTrigger
-                      className={cn(
-                        !encounter.hospitalization?.discharge_disposition &&
-                          hasError(
-                            ENCOUNTER_FIELDS.DISCHARGE_DISPOSITION.key,
-                          ) &&
-                          "ring-1 ring-red-500",
-                      )}
-                    >
+                    <SelectTrigger>
                       <SelectValue
                         placeholder={t("select_discharge_disposition")}
                       />
@@ -457,11 +411,6 @@ export function EncounterQuestion({
                       ))}
                     </SelectContent>
                   </Select>
-                  {hasError(ENCOUNTER_FIELDS.DISCHARGE_DISPOSITION.key) && (
-                    <p className="text-red-500 text-sm">
-                      {t("field_required")}
-                    </p>
-                  )}
                 </div>
 
                 {encounter.status === "discharged" && (

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -19,7 +19,6 @@ import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { dateQueryString } from "@/Utils/utils";
 import batchApi from "@/types/base/batch/batchApi";
-import { EncounterEdit } from "@/types/emr/encounter/encounter";
 import { MedicationRequestCreate } from "@/types/emr/medicationRequest/medicationRequest";
 import { MedicationStatementRequest } from "@/types/emr/medicationStatement";
 import { FileUploadQuestion } from "@/types/files/file";
@@ -43,7 +42,6 @@ import { CreateAppointmentQuestion } from "@/types/scheduling/schedule";
 
 import { QuestionRenderer } from "./QuestionRenderer";
 import { validateAppointmentQuestion } from "./QuestionTypes/AppointmentQuestion";
-import { validateEncounterQuestion } from "./QuestionTypes/EncounterQuestion";
 import { validateFileUploadQuestion } from "./QuestionTypes/FileQuestion";
 import { validateMedicationRequestQuestion } from "./QuestionTypes/MedicationRequestQuestion";
 import { validateMedicationStatementQuestion } from "./QuestionTypes/MedicationStatementQuestion";
@@ -298,10 +296,6 @@ const STRUCTURED_TYPE_VALIDATORS = {
       questionId,
       required ?? false,
     );
-  },
-  encounter: (response: ResponseValue | undefined, questionId: string) => {
-    const encounterData = (response?.value as EncounterEdit[]) || [];
-    return validateEncounterQuestion(encounterData[0], questionId);
   },
   medication_statement: (
     response: ResponseValue | undefined,

--- a/src/types/emr/encounter/encounter.ts
+++ b/src/types/emr/encounter/encounter.ts
@@ -72,6 +72,7 @@ export const ENCOUNTER_DISCHARGE_DISPOSITION = [
   "snf",
   "oth",
 ] as const;
+export const DEFAULT_DISCHARGE_DISPOSITION = "home";
 
 export const ENCOUNTER_PRIORITY = [
   "stat",

--- a/src/types/emr/encounter/encounter.ts
+++ b/src/types/emr/encounter/encounter.ts
@@ -61,12 +61,12 @@ export const ENCOUNTER_DIET_PREFERENCE = [
 
 export const ENCOUNTER_DISCHARGE_DISPOSITION = [
   "home",
-  "alt_home",
   "other_hcf",
-  "hosp",
-  "long",
   "aadvice",
   "exp",
+  "alt_home",
+  "hosp",
+  "long",
   "psy",
   "rehab",
   "snf",

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -22,7 +22,6 @@ interface ImportMetaEnv {
   readonly REACT_DEFAULT_ENCOUNTER_TYPE?: string;
   readonly REACT_ENCOUNTER_DEFAULT_DATE_FILTER?: string;
   readonly REACT_APPOINTMENTS_DEFAULT_DATE_FILTER?: string;
-  readonly REACT_ENFORCE_DISCHARGE_DISPOSITION?: string;
   readonly REACT_ALLOWED_ENCOUNTER_CLASSES?: string;
   readonly REACT_ALLOWED_LOCALES?: string;
   readonly REACT_ENABLED_APPS?: string;


### PR DESCRIPTION
## Proposed Changes

- This is a follow up to the previous PR (https://github.com/ohcnetwork/care_fe/pull/14218) for enforcing discharge disposition field through an env. This is a more cleaner and refined approach for making the discharge disposition mandatory.
- The default value is home.
- Removed the config to enforce discharge disposition
- Ordered the discharge disposition

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
