### PR TITLE
enable when: bypass required and clear answers for not enabled qns

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
@@ -113,7 +113,6 @@ export const QuestionGroup = memo(function QuestionGroup({
   isSubQuestion = false,
 }: QuestionGroupProps) {
   const isEnabled = isQuestionEnabled(question, questionnaireResponses);
-  question._is_enabled = isEnabled;
 
   const clearDependentQuestionResponse = (dependentQuestion: Question) => {
     const dependentQuestionResponse = questionnaireResponses.find(

--- a/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionGroup.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useEffect } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -113,6 +113,25 @@ export const QuestionGroup = memo(function QuestionGroup({
   isSubQuestion = false,
 }: QuestionGroupProps) {
   const isEnabled = isQuestionEnabled(question, questionnaireResponses);
+  question._is_enabled = isEnabled;
+
+  const clearDependentQuestionResponse = (dependentQuestion: Question) => {
+    const dependentQuestionResponse = questionnaireResponses.find(
+      (v) => v.question_id === dependentQuestion.id,
+    );
+    if (dependentQuestionResponse) {
+      updateQuestionnaireResponseCB([], dependentQuestion.id);
+    }
+    dependentQuestion.questions?.forEach((q) => {
+      clearDependentQuestionResponse(q);
+    });
+  };
+
+  useEffect(() => {
+    if (!isEnabled) {
+      clearDependentQuestionResponse(question);
+    }
+  }, [isEnabled]);
 
   if (!isEnabled) {
     return null;

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -45,6 +45,7 @@ import { validateAppointmentQuestion } from "./QuestionTypes/AppointmentQuestion
 import { validateFileUploadQuestion } from "./QuestionTypes/FileQuestion";
 import { validateMedicationRequestQuestion } from "./QuestionTypes/MedicationRequestQuestion";
 import { validateMedicationStatementQuestion } from "./QuestionTypes/MedicationStatementQuestion";
+import { isQuestionEnabled } from "./QuestionTypes/QuestionGroup";
 import { QuestionnaireSearch } from "./QuestionnaireSearch";
 import { FIXED_QUESTIONNAIRES } from "./data/StructuredFormData";
 import { getStructuredRequests } from "./structured/handlers";
@@ -574,7 +575,7 @@ export function QuestionnaireForm({
           return;
         }
 
-        if (q.required && q._is_enabled) {
+        if (q.required && isQuestionEnabled(q, form.responses)) {
           // Handle appointment validation
           const response = form.responses.find((r) => r.question_id === q.id);
           const hasValue = response?.values?.some(
@@ -602,7 +603,11 @@ export function QuestionnaireForm({
           }
         }
 
-        if (q.type === "structured" && q.structured_type && q._is_enabled) {
+        if (
+          q.type === "structured" &&
+          q.structured_type &&
+          isQuestionEnabled(q, form.responses)
+        ) {
           const response = form.responses.find((r) => r.question_id === q.id);
           const validator =
             STRUCTURED_TYPE_VALIDATORS[
@@ -686,13 +691,15 @@ export function QuestionnaireForm({
             encounter: encounterId,
             patient: patientId,
             results: validResponses
-              .filter((response) => {
-                const question = findQuestionById(
-                  form.questionnaire.questions,
-                  response.question_id,
-                ) as Question;
-                return question?._is_enabled ?? true;
-              })
+              .filter((response) =>
+                isQuestionEnabled(
+                  findQuestionById(
+                    form.questionnaire.questions,
+                    response.question_id,
+                  ) as Question,
+                  form.responses,
+                ),
+              )
               .map((response) => ({
                 question_id: response.question_id,
                 values: response.values.map((value) => {

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -45,7 +45,6 @@ import { validateAppointmentQuestion } from "./QuestionTypes/AppointmentQuestion
 import { validateFileUploadQuestion } from "./QuestionTypes/FileQuestion";
 import { validateMedicationRequestQuestion } from "./QuestionTypes/MedicationRequestQuestion";
 import { validateMedicationStatementQuestion } from "./QuestionTypes/MedicationStatementQuestion";
-import { isQuestionEnabled } from "./QuestionTypes/QuestionGroup";
 import { QuestionnaireSearch } from "./QuestionnaireSearch";
 import { FIXED_QUESTIONNAIRES } from "./data/StructuredFormData";
 import { getStructuredRequests } from "./structured/handlers";
@@ -575,7 +574,7 @@ export function QuestionnaireForm({
           return;
         }
 
-        if (q.required) {
+        if (q.required && q._is_enabled) {
           // Handle appointment validation
           const response = form.responses.find((r) => r.question_id === q.id);
           const hasValue = response?.values?.some(
@@ -603,7 +602,7 @@ export function QuestionnaireForm({
           }
         }
 
-        if (q.type === "structured" && q.structured_type) {
+        if (q.type === "structured" && q.structured_type && q._is_enabled) {
           const response = form.responses.find((r) => r.question_id === q.id);
           const validator =
             STRUCTURED_TYPE_VALIDATORS[
@@ -687,15 +686,13 @@ export function QuestionnaireForm({
             encounter: encounterId,
             patient: patientId,
             results: validResponses
-              .filter((response) =>
-                isQuestionEnabled(
-                  findQuestionById(
-                    form.questionnaire.questions,
-                    response.question_id,
-                  ) as Question,
-                  form.responses,
-                ),
-              )
+              .filter((response) => {
+                const question = findQuestionById(
+                  form.questionnaire.questions,
+                  response.question_id,
+                ) as Question;
+                return question?._is_enabled ?? true;
+              })
               .map((response) => ({
                 question_id: response.question_id,
                 values: response.values.map((value) => {

--- a/src/types/questionnaire/question.ts
+++ b/src/types/questionnaire/question.ts
@@ -155,7 +155,6 @@ export interface Question {
   unit?: Code;
   questions?: Question[];
   formula?: string;
-  _is_enabled?: boolean;
 }
 
 export const findQuestionById = (

--- a/src/types/questionnaire/question.ts
+++ b/src/types/questionnaire/question.ts
@@ -155,6 +155,7 @@ export interface Question {
   unit?: Code;
   questions?: Question[];
   formula?: string;
+  _is_enabled?: boolean;
 }
 
 export const findQuestionById = (


### PR DESCRIPTION
## Proposed Changes

Fixes #14235 
- Bypass required error if the question is not enabled
- If user selects an option that enables a question and then changes the original option, should reset all user selections for the enabled question

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now only checks required fields for enabled questions
  * Dependent questionnaire responses are automatically cleared when a question is disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->