### PR TITLE
added search by patient id

### DIFF
--- a/src/pages/Facility/billing/account/AccountList.tsx
+++ b/src/pages/Facility/billing/account/AccountList.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
+import PatientIdentifierFilter from "@/components/Patient/PatientIdentifierFilter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -186,18 +187,31 @@ export function AccountList({
               </div>
             </div>
             <div className="relative sm:max-w-xs w-[calc(100%)]">
-              <CareIcon
-                icon="l-search"
-                className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-gray-500"
-              />
-              <Input
-                placeholder={t("search_accounts")}
-                value={qParams.search || ""}
-                onChange={(e) =>
-                  updateQuery({ search: e.target.value || undefined })
-                }
-                className="pl-10"
-              />
+              <div className="flex flex-col sm:flex-row gap-2 w-full">
+                <Input
+                  className="h-9 w-full sm:w-64"
+                  placeholder={t("search_accounts")}
+                  value={qParams.search || ""}
+                  onChange={(e) => {
+                    updateQuery({
+                      search: e.target.value,
+                      patient: undefined,
+                    });
+                  }}
+                />
+                <div className="w-full sm:w-64">
+                  <PatientIdentifierFilter
+                    onSelect={(patientId) => {
+                      updateQuery({
+                        patient: patientId,
+                        search: undefined,
+                      });
+                    }}
+                    placeholder={t("search_patients")}
+                    patientId={qParams.patient}
+                  />
+                </div>
+              </div>
             </div>
           </div>
           <div className="flex flex-wrap gap-4">


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
-used PatientIdentifierfilter.tsx component to add featire to search by patient id in the accounts page

Tagging: @ohcnetwork/care-fe-code-reviewers
Screenshot of the accounts page after updation:
<img width="2880" height="1644" alt="image" src="https://github.com/user-attachments/assets/e362c1ae-6e10-42d0-90a5-c8a57fdc8eb8" />


## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced account search with a dual-filter system combining account search and patient identifier filtering in a responsive layout.
  * Search and patient filters now work independently—entering a search clears the patient selection, and selecting a patient clears the search field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->