### PR TITLE
Pre-select first slot when booking an appointment

### DIFF
--- a/src/pages/Appointments/BookAppointment/AppointmentSlotPicker.tsx
+++ b/src/pages/Appointments/BookAppointment/AppointmentSlotPicker.tsx
@@ -78,19 +78,16 @@ export function AppointmentSlotPicker({
     }
   };
 
-  const slotGroups = useMemo(
-    () => groupSlotsByAvailability(slotsQuery.data || []),
-    [slotsQuery.data],
-  );
+  const { slotGroups, availableSlots } = useMemo(() => {
+    const slotGroups = groupSlotsByAvailability(slotsQuery.data || []);
+    const availableSlots = slotGroups.flatMap((group) => group.slots);
+    return { slotGroups, availableSlots };
+  }, [slotsQuery.data]);
 
   // Pre-select the first slot for current date if there are any slots available
   useEffect(() => {
-    const availableSlots = slotGroups.flatMap((group) => group.slots);
-
-    if (availableSlots.length > 0) {
-      onSlotSelect(availableSlots[0].id);
-    }
-  }, [slotGroups, onSlotSelect, slotsQuery.data]);
+    onSlotSelect(availableSlots?.[0]?.id);
+  }, [availableSlots, onSlotSelect]);
 
   return (
     <div
@@ -105,7 +102,7 @@ export function AppointmentSlotPicker({
         </span>
         {!!slotsQuery.data?.length && (
           <span className="text-sm font-medium text-gray-700">
-            {slotGroups.length} {t("available_time_slots")}
+            {availableSlots.length} {t("available_time_slots")}
           </span>
         )}
       </div>

--- a/src/pages/Appointments/BookAppointment/AppointmentSlotPicker.tsx
+++ b/src/pages/Appointments/BookAppointment/AppointmentSlotPicker.tsx
@@ -19,7 +19,7 @@ import {
   TokenSlot,
 } from "@/types/scheduling/schedule";
 import scheduleApi from "@/types/scheduling/scheduleApi";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 interface AppointmentSlotPickerProps {
   facilityId: string;
@@ -78,16 +78,19 @@ export function AppointmentSlotPicker({
     }
   };
 
+  const slotGroups = useMemo(
+    () => groupSlotsByAvailability(slotsQuery.data || []),
+    [slotsQuery.data],
+  );
+
   // Pre-select the first slot for current date if there are any slots available
   useEffect(() => {
-    if (slotsQuery.data) {
-      onSlotSelect(slotsQuery.data[0]?.id);
-    }
-  }, [slotsQuery.data]);
+    const availableSlots = slotGroups.flatMap((group) => group.slots);
 
-  const totalSlots = groupSlotsByAvailability(slotsQuery.data || []).flatMap(
-    (group) => group.slots,
-  ).length;
+    if (availableSlots.length > 0) {
+      onSlotSelect(availableSlots[0].id);
+    }
+  }, [slotGroups, onSlotSelect, slotsQuery.data]);
 
   return (
     <div
@@ -102,7 +105,7 @@ export function AppointmentSlotPicker({
         </span>
         {!!slotsQuery.data?.length && (
           <span className="text-sm font-medium text-gray-700">
-            {totalSlots} {t("available_time_slots")}
+            {slotGroups.length} {t("available_time_slots")}
           </span>
         )}
       </div>
@@ -166,34 +169,32 @@ export function AppointmentSlotPicker({
             </div>
           )}
           {!!slotsQuery.data?.length &&
-            groupSlotsByAvailability(slotsQuery.data).map(
-              ({ availability, slots }) => (
-                <div key={availability.name} className="flex flex-col">
-                  <div className="flex flex-row gap-2 items-center mb-2 mt-2 sm:mt-0">
-                    <ClipboardCheck size={16} />
-                    <span className="text-sm font-medium text-gray-700">
-                      {availability.name}
-                    </span>
-                  </div>
-                  <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-1 xl:grid-cols-3 2xl:grid-cols-5 gap-2">
-                    {slots.map((slot) => (
-                      <TokenSlotButton
-                        key={slot.id}
-                        slot={slot}
-                        availability={availability}
-                        selectedSlotId={selectedSlotId}
-                        onClick={() => {
-                          handleSlotSelect(
-                            selectedSlotId === slot.id ? undefined : slot.id,
-                          );
-                        }}
-                      />
-                    ))}
-                  </div>
-                  <Separator className="my-6" />
+            slotGroups.map(({ availability, slots }) => (
+              <div key={availability.name} className="flex flex-col">
+                <div className="flex flex-row gap-2 items-center mb-2 mt-2 sm:mt-0">
+                  <ClipboardCheck size={16} />
+                  <span className="text-sm font-medium text-gray-700">
+                    {availability.name}
+                  </span>
                 </div>
-              ),
-            )}
+                <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-1 xl:grid-cols-3 2xl:grid-cols-5 gap-2">
+                  {slots.map((slot) => (
+                    <TokenSlotButton
+                      key={slot.id}
+                      slot={slot}
+                      availability={availability}
+                      selectedSlotId={selectedSlotId}
+                      onClick={() => {
+                        handleSlotSelect(
+                          selectedSlotId === slot.id ? undefined : slot.id,
+                        );
+                      }}
+                    />
+                  ))}
+                </div>
+                <Separator className="my-6" />
+              </div>
+            ))}
         </div>
       )}
     </div>

--- a/src/pages/Appointments/BookAppointment/AppointmentSlotPicker.tsx
+++ b/src/pages/Appointments/BookAppointment/AppointmentSlotPicker.tsx
@@ -78,9 +78,12 @@ export function AppointmentSlotPicker({
     }
   };
 
+  // Pre-select the first slot for current date if there are any slots available
   useEffect(() => {
-    onSlotSelect(undefined);
-  }, [selectedDate]);
+    if (slotsQuery.data) {
+      onSlotSelect(slotsQuery.data[0]?.id);
+    }
+  }, [slotsQuery.data]);
 
   const totalSlots = groupSlotsByAvailability(slotsQuery.data || []).flatMap(
     (group) => group.slots,

--- a/src/pages/Appointments/utils.ts
+++ b/src/pages/Appointments/utils.ts
@@ -26,7 +26,12 @@ export const groupSlotsByAvailability = (slots: TokenSlot[]) => {
   }[] = [];
 
   for (const slot of slots) {
+    // skip past slots
     if (isPast(slot.end_datetime)) {
+      continue;
+    }
+    // skip fully allocated slots
+    if (slot.allocated === slot.availability.tokens_per_slot) {
       continue;
     }
     const availability = slot.availability;

--- a/src/pages/Encounters/utils/EncounterProvider.tsx
+++ b/src/pages/Encounters/utils/EncounterProvider.tsx
@@ -276,6 +276,7 @@ export function EncounterProvider({
           setOpen={(open) => {
             setActiveAction(open ? EncounterAction.ManageDepartments : null);
           }}
+          trigger={<span />}
         />
       )}
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #14265
- Hides past and fully filled slots

When slots are available

<img width="2056" height="907" alt="image" src="https://github.com/user-attachments/assets/ee60a2cd-cb2f-4d9e-8ea5-4dec0dd8cb24" />


When no slots available:

<img width="2056" height="878" alt="image" src="https://github.com/user-attachments/assets/f006cfca-0010-42c0-bb2e-14b1b06240a8" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Past or fully booked times are excluded so only bookable slots are shown.
  * Date changes no longer clear a valid selection.
  * Department sheet trigger behavior adjusted to improve how the sheet opens.

* **New Features**
  * First available time is auto-selected when slot data loads.
  * Available time slots count now reflects only currently bookable slots and grouped availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->