### PR TITLE
disable query retries

### DIFF
--- a/src/Utils/request/queryClient.ts
+++ b/src/Utils/request/queryClient.ts
@@ -19,16 +19,7 @@ declare module "@tanstack/react-query" {
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: (failureCount, error) => {
-        // Only retry network errors or server errors (502, 503, 504) up to 3 times
-        if (
-          error.message === "Network Error" ||
-          (error instanceof HTTPError && [502, 503, 504].includes(error.status))
-        ) {
-          return failureCount < 3;
-        }
-        return false;
-      },
+      retry: false,
       refetchOnWindowFocus: false,
     },
   },


### PR DESCRIPTION
### Issue

We were performing retries up-to 3 times so far for failed queries due to 502, 503, 504 status codes. However, this is is not needed.

### Proposed Changes

- This PR disables query retries entirely.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified request handling to disable automatic retries for failed queries. Previously, the system would attempt up to 3 retries for specific network errors and HTTP status codes. Automatic retries are now entirely disabled for all failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->