### PR TITLE
fix encounter show page overflow issue when appointment is associated

### DIFF
--- a/src/components/Common/Page.tsx
+++ b/src/components/Common/Page.tsx
@@ -10,13 +10,14 @@ interface PageProps extends PageTitleProps {
   className?: string;
   hideTitleOnPage?: boolean;
   shortCutContext?: string;
+  style?: React.CSSProperties;
 }
 
 export default function Page(props: PageProps) {
   useShortcutSubContext(props.shortCutContext);
 
   return (
-    <div className={cn("md:px-6 py-0", props.className)}>
+    <div className={cn("md:px-6 py-0", props.className)} style={props.style}>
       <div className="flex flex-col justify-between gap-2 px-3 md:flex-row md:items-center md:gap-6 md:px-0">
         <PageTitle
           changePageMetadata={props.changePageMetadata}

--- a/src/pages/Encounters/EncounterHistorySelector.tsx
+++ b/src/pages/Encounters/EncounterHistorySelector.tsx
@@ -381,7 +381,6 @@ const EncounterHistoryList = ({ onSelect }: Props) => {
 export default function EncounterHistorySelector() {
   const [isRailOpen, setIsRailOpen] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
-  const { showAppointmentEncounterHeader } = useEncounter();
 
   const { t } = useTranslation();
 
@@ -409,14 +408,7 @@ export default function EncounterHistorySelector() {
       </div>
       <div className="hidden lg:block pr-3">
         <RailPanel open={isRailOpen} onOpenChange={setIsRailOpen}>
-          <ScrollArea
-            className={cn(
-              "pr-3",
-              showAppointmentEncounterHeader
-                ? "h-[calc(100vh-12rem)]"
-                : "h-[calc(100vh-9rem)]",
-            )}
-          >
+          <ScrollArea className="pr-3 h-[calc(100vh-9rem-var(--encounter-header-offset))]">
             <EncounterHistoryList />
           </ScrollArea>
         </RailPanel>

--- a/src/pages/Encounters/EncounterHistorySelector.tsx
+++ b/src/pages/Encounters/EncounterHistorySelector.tsx
@@ -378,14 +378,10 @@ const EncounterHistoryList = ({ onSelect }: Props) => {
   );
 };
 
-export default function EncounterHistorySelector({
-  isRailOpen,
-  setIssRailOpen,
-}: {
-  isRailOpen: boolean;
-  setIssRailOpen: (open: boolean) => void;
-}) {
+export default function EncounterHistorySelector() {
+  const [isRailOpen, setIsRailOpen] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
+  const { primaryEncounter } = useEncounter();
 
   const { t } = useTranslation();
 
@@ -412,8 +408,15 @@ export default function EncounterHistorySelector({
         </Drawer>
       </div>
       <div className="hidden lg:block pr-3">
-        <RailPanel open={isRailOpen} onOpenChange={setIssRailOpen}>
-          <ScrollArea className="h-[calc(100vh-9rem)] pr-3">
+        <RailPanel open={isRailOpen} onOpenChange={setIsRailOpen}>
+          <ScrollArea
+            className={cn(
+              "pr-3",
+              primaryEncounter?.appointment?.id
+                ? "h-[calc(100vh-12rem)]"
+                : "h-[calc(100vh-9rem)]",
+            )}
+          >
             <EncounterHistoryList />
           </ScrollArea>
         </RailPanel>

--- a/src/pages/Encounters/EncounterHistorySelector.tsx
+++ b/src/pages/Encounters/EncounterHistorySelector.tsx
@@ -381,7 +381,7 @@ const EncounterHistoryList = ({ onSelect }: Props) => {
 export default function EncounterHistorySelector() {
   const [isRailOpen, setIsRailOpen] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
-  const { primaryEncounter } = useEncounter();
+  const { showAppointmentEncounterHeader } = useEncounter();
 
   const { t } = useTranslation();
 
@@ -412,7 +412,7 @@ export default function EncounterHistorySelector() {
           <ScrollArea
             className={cn(
               "pr-3",
-              primaryEncounter?.appointment?.id
+              showAppointmentEncounterHeader
                 ? "h-[calc(100vh-12rem)]"
                 : "h-[calc(100vh-9rem)]",
             )}

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -72,7 +72,6 @@ export const EncounterShow = (props: Props) => {
     isPatientLoading,
     canWriteSelectedEncounter,
     canWritePrimaryEncounter,
-    showAppointmentEncounterHeader,
   } = useEncounter();
 
   useSidebarAutoCollapse({ restore: false });
@@ -198,6 +197,14 @@ export const EncounterShow = (props: Props) => {
       title={t("encounter")}
       className="block md:px-1 -mt-4"
       hideTitleOnPage
+      style={
+        {
+          "--encounter-header-offset":
+            primaryEncounter?.appointment?.id && canWritePrimaryEncounter
+              ? "3rem"
+              : "0rem",
+        } as React.CSSProperties
+      }
     >
       {primaryEncounter &&
         primaryEncounter.appointment?.id &&
@@ -315,12 +322,7 @@ export const EncounterShow = (props: Props) => {
           <NavTabs
             showMoreAfterIndex={showMoreAfterIndex}
             className="@container w-full"
-            tabContentClassName={cn(
-              "flex-none overflow-x-auto overflow-y-hidden lg:overflow-y-auto",
-              showAppointmentEncounterHeader
-                ? "lg:h-[calc(100vh-17rem)]"
-                : "lg:h-[calc(100vh-14rem)]",
-            )}
+            tabContentClassName="flex-none overflow-x-auto overflow-y-hidden lg:overflow-y-auto lg:h-[calc(100vh-14rem-var(--encounter-header-offset))]"
             tabs={tabs}
             currentTab={props.tab}
             tabTriggerClassName="max-w-36"

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -76,7 +76,6 @@ export const EncounterShow = (props: Props) => {
 
   useSidebarAutoCollapse({ restore: false });
   const [actionsOpen, setActionsOpen] = useState(false);
-  const [isEncounterRailOpen, setIsEncounterRailOpen] = useState(true);
   const getShortcutDisplay = useEncounterShortcutDisplays();
 
   const { t } = useTranslation();
@@ -254,11 +253,8 @@ export const EncounterShow = (props: Props) => {
         />
         <PatientDeceasedInfo patient={patient} />
       </div>
-      <div className="flex flex-col gap-4 lg:gap-0 lg:flex-row mt-4">
-        <EncounterHistorySelector
-          isRailOpen={isEncounterRailOpen}
-          setIssRailOpen={setIsEncounterRailOpen}
-        />
+      <div className="flex flex-col gap-4 lg:gap-0 lg:flex-row mt-4 max-h-[calc(100vh-9rem)]">
+        <EncounterHistorySelector />
         <div className="w-full">
           <div className="hidden lg:block">
             {isSelectedEncounterLoading ? (
@@ -318,7 +314,12 @@ export const EncounterShow = (props: Props) => {
           <NavTabs
             showMoreAfterIndex={showMoreAfterIndex}
             className="@container w-full"
-            tabContentClassName="flex-none overflow-x-auto overflow-y-hidden lg:overflow-y-auto lg:h-[calc(100vh-14rem)]"
+            tabContentClassName={cn(
+              "flex-none overflow-x-auto overflow-y-hidden lg:overflow-y-auto",
+              primaryEncounter?.appointment?.id
+                ? "lg:h-[calc(100vh-17rem)]"
+                : "lg:h-[calc(100vh-14rem)]",
+            )}
             tabs={tabs}
             currentTab={props.tab}
             tabTriggerClassName="max-w-36"

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -72,6 +72,7 @@ export const EncounterShow = (props: Props) => {
     isPatientLoading,
     canWriteSelectedEncounter,
     canWritePrimaryEncounter,
+    showAppointmentEncounterHeader,
   } = useEncounter();
 
   useSidebarAutoCollapse({ restore: false });
@@ -316,7 +317,7 @@ export const EncounterShow = (props: Props) => {
             className="@container w-full"
             tabContentClassName={cn(
               "flex-none overflow-x-auto overflow-y-hidden lg:overflow-y-auto",
-              primaryEncounter?.appointment?.id
+              showAppointmentEncounterHeader
                 ? "lg:h-[calc(100vh-17rem)]"
                 : "lg:h-[calc(100vh-14rem)]",
             )}

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -261,7 +261,7 @@ export const EncounterShow = (props: Props) => {
         />
         <PatientDeceasedInfo patient={patient} />
       </div>
-      <div className="flex flex-col gap-4 lg:gap-0 lg:flex-row mt-4 max-h-[calc(100vh-9rem)]">
+      <div className="flex flex-col gap-4 lg:gap-0 lg:flex-row mt-4">
         <EncounterHistorySelector />
         <div className="w-full">
           <div className="hidden lg:block">

--- a/src/pages/Encounters/tabs/overview.tsx
+++ b/src/pages/Encounters/tabs/overview.tsx
@@ -24,7 +24,7 @@ export const EncounterOverviewTab = () => {
     selectedEncounterId: encounterId,
     canReadSelectedEncounter: canAccess,
     canWriteSelectedEncounter: canWrite,
-    primaryEncounter,
+    showAppointmentEncounterHeader,
   } = useEncounter();
 
   const { data: plotsConfig } = useQuery<ObservationPlotConfig>({
@@ -40,7 +40,7 @@ export const EncounterOverviewTab = () => {
       <div
         className={cn(
           "flex-1 xl:pr-3 overflow-y-auto",
-          primaryEncounter?.appointment?.id
+          showAppointmentEncounterHeader
             ? "xl:h-[calc(100vh-17rem)]"
             : "xl:h-[calc(100vh-14rem)]",
         )}
@@ -92,7 +92,7 @@ export const EncounterOverviewTab = () => {
       <ScrollArea
         className={cn(
           "w-72 hidden xl:block",
-          primaryEncounter?.appointment?.id
+          showAppointmentEncounterHeader
             ? "h-[calc(100vh-17rem)]"
             : "h-[calc(100vh-14rem)]",
         )}

--- a/src/pages/Encounters/tabs/overview.tsx
+++ b/src/pages/Encounters/tabs/overview.tsx
@@ -10,6 +10,7 @@ import { DiagnosisList } from "@/components/Patient/diagnosis/list";
 import { SymptomsList } from "@/components/Patient/symptoms/list";
 import { VitalsList } from "@/components/Patient/vitals/list";
 
+import { cn } from "@/lib/utils";
 import { ClinicalHistoryOverview } from "@/pages/Encounters/tabs/overview/clinical-history-overview";
 import { QuickActions } from "@/pages/Encounters/tabs/overview/quick-actions";
 import { SummaryPanel } from "@/pages/Encounters/tabs/overview/summary-panel";
@@ -23,6 +24,7 @@ export const EncounterOverviewTab = () => {
     selectedEncounterId: encounterId,
     canReadSelectedEncounter: canAccess,
     canWriteSelectedEncounter: canWrite,
+    primaryEncounter,
   } = useEncounter();
 
   const { data: plotsConfig } = useQuery<ObservationPlotConfig>({
@@ -35,7 +37,14 @@ export const EncounterOverviewTab = () => {
 
   return (
     <div className="flex gap-3 @max-md:w-full">
-      <div className="flex-1 xl:h-[calc(100vh-14rem)] xl:pr-3 overflow-y-auto">
+      <div
+        className={cn(
+          "flex-1 xl:pr-3 overflow-y-auto",
+          primaryEncounter?.appointment?.id
+            ? "xl:h-[calc(100vh-17rem)]"
+            : "xl:h-[calc(100vh-14rem)]",
+        )}
+      >
         <div className="flex flex-col gap-6">
           {canWrite && <QuickActions />}
           <ClinicalHistoryOverview />
@@ -80,7 +89,14 @@ export const EncounterOverviewTab = () => {
         </div>
       </div>
 
-      <ScrollArea className="w-72 h-[calc(100vh-14rem)] hidden xl:block">
+      <ScrollArea
+        className={cn(
+          "w-72 hidden xl:block",
+          primaryEncounter?.appointment?.id
+            ? "h-[calc(100vh-17rem)]"
+            : "h-[calc(100vh-14rem)]",
+        )}
+      >
         <SummaryPanel />
       </ScrollArea>
     </div>

--- a/src/pages/Encounters/tabs/overview.tsx
+++ b/src/pages/Encounters/tabs/overview.tsx
@@ -10,7 +10,6 @@ import { DiagnosisList } from "@/components/Patient/diagnosis/list";
 import { SymptomsList } from "@/components/Patient/symptoms/list";
 import { VitalsList } from "@/components/Patient/vitals/list";
 
-import { cn } from "@/lib/utils";
 import { ClinicalHistoryOverview } from "@/pages/Encounters/tabs/overview/clinical-history-overview";
 import { QuickActions } from "@/pages/Encounters/tabs/overview/quick-actions";
 import { SummaryPanel } from "@/pages/Encounters/tabs/overview/summary-panel";
@@ -24,7 +23,6 @@ export const EncounterOverviewTab = () => {
     selectedEncounterId: encounterId,
     canReadSelectedEncounter: canAccess,
     canWriteSelectedEncounter: canWrite,
-    showAppointmentEncounterHeader,
   } = useEncounter();
 
   const { data: plotsConfig } = useQuery<ObservationPlotConfig>({
@@ -37,14 +35,7 @@ export const EncounterOverviewTab = () => {
 
   return (
     <div className="flex gap-3 @max-md:w-full">
-      <div
-        className={cn(
-          "flex-1 xl:pr-3 overflow-y-auto",
-          showAppointmentEncounterHeader
-            ? "xl:h-[calc(100vh-17rem)]"
-            : "xl:h-[calc(100vh-14rem)]",
-        )}
-      >
+      <div className="flex-1 xl:pr-3 overflow-y-auto xl:h-[calc(100vh-14rem-var(--encounter-header-offset))]">
         <div className="flex flex-col gap-6">
           {canWrite && <QuickActions />}
           <ClinicalHistoryOverview />
@@ -89,14 +80,7 @@ export const EncounterOverviewTab = () => {
         </div>
       </div>
 
-      <ScrollArea
-        className={cn(
-          "w-72 hidden xl:block",
-          showAppointmentEncounterHeader
-            ? "h-[calc(100vh-17rem)]"
-            : "h-[calc(100vh-14rem)]",
-        )}
-      >
+      <ScrollArea className="w-72 hidden xl:block h-[calc(100vh-14rem-var(--encounter-header-offset))]">
         <SummaryPanel />
       </ScrollArea>
     </div>

--- a/src/pages/Encounters/utils/EncounterProvider.tsx
+++ b/src/pages/Encounters/utils/EncounterProvider.tsx
@@ -46,6 +46,8 @@ type EncounterContextType = {
   canWriteSelectedEncounter: boolean;
   canWriteClinicalData: boolean;
 
+  showAppointmentEncounterHeader: boolean;
+
   actions: {
     markAsCompleted: () => void;
     assignLocation: () => void;
@@ -224,6 +226,9 @@ export function EncounterProvider({
             setActiveAction(EncounterAction.Dispense);
           },
         },
+        showAppointmentEncounterHeader: !!(
+          primaryEncounter?.appointment?.id && canWritePrimaryEncounter
+        ),
       }}
     >
       {children}

--- a/src/pages/Encounters/utils/EncounterProvider.tsx
+++ b/src/pages/Encounters/utils/EncounterProvider.tsx
@@ -46,8 +46,6 @@ type EncounterContextType = {
   canWriteSelectedEncounter: boolean;
   canWriteClinicalData: boolean;
 
-  showAppointmentEncounterHeader: boolean;
-
   actions: {
     markAsCompleted: () => void;
     assignLocation: () => void;
@@ -226,9 +224,6 @@ export function EncounterProvider({
             setActiveAction(EncounterAction.Dispense);
           },
         },
-        showAppointmentEncounterHeader: !!(
-          primaryEncounter?.appointment?.id && canWritePrimaryEncounter
-        ),
       }}
     >
       {children}


### PR DESCRIPTION
### Issue

When appointment is associated to an encounter, the page has an overflow and breaks scroll behaviours within the encounter overview tab and other encounter tabs

https://github.com/user-attachments/assets/f2444fd4-75a2-4881-803c-1ad34c41bee2

### Proposed Changes

- Fixes the above mentioned issue by accounting for the height occupied by the appointment encounter header wherever calculated height is used within encounter show component

<img width="2053" height="1248" alt="image" src="https://github.com/user-attachments/assets/3e412aa6-516e-4298-96dc-09dfa03f1ef3" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified encounter history selector component by consolidating internal state management.
  * Enhanced layout system with dynamic CSS variables for improved responsiveness based on encounter context and permissions.
  * Improved component styling infrastructure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->