### PR TITLE
fix: improve text wrapping for encounter class description (fixing the issue in old browser)

### DIFF
--- a/src/Utils/keyboardShortcutComponents.tsx
+++ b/src/Utils/keyboardShortcutComponents.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const keyboardShortcutBadgeVariants = cva(
-  "h-5 min-w-5 flex justify-center px-1 rounded border font-medium text-xs",
+  "h-5 min-w-5 flex justify-center px-1 rounded border font-medium text-xs inline-flex items-center",
   {
     variants: {
       variant: {
@@ -16,10 +16,10 @@ const keyboardShortcutBadgeVariants = cva(
         secondary: "bg-gray-50 text-gray-700",
       },
       position: {
-        "top-right": "absolute top-1 right-1",
-        "bottom-right": "absolute bottom-1 right-1",
-        "top-left": "absolute top-1 left-1",
-        "bottom-left": "absolute bottom-1 left-1",
+        "top-right": "absolute top-1 right-1 translate-x-0 translate-y-0",
+        "bottom-right": "absolute bottom-1 right-1 translate-x-0 translate-y-0",
+        "top-left": "absolute top-1 left-1 translate-x-0 translate-y-0",
+        "bottom-left": "absolute bottom-1 left-1 translate-x-0 translate-y-0",
       },
     },
     defaultVariants: {

--- a/src/Utils/keyboardShortcutComponents.tsx
+++ b/src/Utils/keyboardShortcutComponents.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const keyboardShortcutBadgeVariants = cva(
-  "h-5 min-w-5 flex justify-center px-1 rounded border font-medium text-xs inline-flex items-center",
+  "h-5 min-w-5 flex justify-center px-1 rounded border font-medium text-xs",
   {
     variants: {
       variant: {
@@ -16,10 +16,10 @@ const keyboardShortcutBadgeVariants = cva(
         secondary: "bg-gray-50 text-gray-700",
       },
       position: {
-        "top-right": "absolute top-1 right-1 translate-x-0 translate-y-0",
-        "bottom-right": "absolute bottom-1 right-1 translate-x-0 translate-y-0",
-        "top-left": "absolute top-1 left-1 translate-x-0 translate-y-0",
-        "bottom-left": "absolute bottom-1 left-1 translate-x-0 translate-y-0",
+        "top-right": "absolute top-1 right-1",
+        "bottom-right": "absolute bottom-1 right-1",
+        "top-left": "absolute top-1 left-1",
+        "bottom-left": "absolute bottom-1 left-1",
       },
     },
     defaultVariants: {

--- a/src/components/Encounter/CreateEncounterForm.tsx
+++ b/src/components/Encounter/CreateEncounterForm.tsx
@@ -242,7 +242,7 @@ export default function CreateEncounterForm({
                               <div className="text-sm font-bold">
                                 {t(`encounter_class__${value}`)}
                               </div>
-                              <div className="text-wrap text-center text-xs text-gray-500">
+                              <div className="whitespace-normal break-words text-center text-xs text-gray-500">
                                 {t(`encounter_class_description__${value}`)}
                               </div>
                             </div>


### PR DESCRIPTION
## Proposed Changes
This fixes the broken text-wrap in old browser

Before 
<img width="1279" height="644" alt="image" src="https://github.com/user-attachments/assets/d5c02385-6fec-4299-97b3-d8feb093cd73" />

After
<img width="1280" height="602" alt="image" src="https://github.com/user-attachments/assets/e411b2b8-7f9f-4f2c-b7f5-1d50201b9e69" />
 


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text wrapping for encounter class descriptions so longer descriptions wrap naturally and remain readable.
  * Adjusted keyboard shortcut badge layout and positioning so badges align consistently and their position transforms render more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->