### PR TITLE
Added archive support for system generated patient identifier

### DIFF
--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -549,7 +549,6 @@ export default function PatientIdentifierConfigForm({
               )}
 
               {/* Status Section */}
-
               <div>
                 <h2 className="text-lg font-semibold mb-1">{t("status")}</h2>
                 <FormDescription>{t("status_help")}</FormDescription>

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -549,43 +549,42 @@ export default function PatientIdentifierConfigForm({
               )}
 
               {/* Status Section */}
-              {!isAutoMaintained && (
-                <div>
-                  <h2 className="text-lg font-semibold mb-1">{t("status")}</h2>
-                  <FormDescription>{t("status_help")}</FormDescription>
-                  <div className="max-w-xs">
-                    <FormField
-                      control={form.control}
-                      name="status"
-                      render={({ field }) => (
-                        <FormItem className="mt-2">
-                          <FormLabel>{t("status")}</FormLabel>
-                          <FormControl>
-                            <Select
-                              onValueChange={field.onChange}
-                              value={field.value}
-                            >
-                              <SelectTrigger ref={field.ref}>
-                                <SelectValue placeholder={t("select_status")} />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {Object.values(
-                                  PatientIdentifierConfigStatus,
-                                ).map((status) => (
+
+              <div>
+                <h2 className="text-lg font-semibold mb-1">{t("status")}</h2>
+                <FormDescription>{t("status_help")}</FormDescription>
+                <div className="max-w-xs">
+                  <FormField
+                    control={form.control}
+                    name="status"
+                    render={({ field }) => (
+                      <FormItem className="mt-2">
+                        <FormLabel>{t("status")}</FormLabel>
+                        <FormControl>
+                          <Select
+                            onValueChange={field.onChange}
+                            value={field.value}
+                          >
+                            <SelectTrigger ref={field.ref}>
+                              <SelectValue placeholder={t("select_status")} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {Object.values(PatientIdentifierConfigStatus).map(
+                                (status) => (
                                   <SelectItem key={status} value={status}>
                                     {t(status)}
                                   </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </div>
+                                ),
+                              )}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
                 </div>
-              )}
+              </div>
             </div>
             <Button
               type="submit"

--- a/tests/admin/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
+++ b/tests/admin/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
@@ -1,0 +1,150 @@
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+
+// Use the authenticated state
+test.use({ storageState: "tests/.auth/user.json" });
+
+const useOptions = ["usual", "official", "temp", "secondary", "old"];
+const statusOptions = ["Draft", "Active", "Inactive"];
+const serialNumberModes = ["User entered", "Auto-generated"];
+
+test.describe("Patient Identifier Config - Create", () => {
+  let use: string;
+  let displayName: string;
+  let description: string;
+  let systemUrl: string;
+  let regex: string;
+  let retrievalOption: boolean;
+  let uniqueOption: boolean;
+  let serialNumberMode: string;
+  let status: string;
+
+  test.beforeEach(async ({ page }) => {
+    use = faker.helpers.arrayElement(useOptions);
+    displayName = faker.lorem.words(2);
+    description = faker.lorem.sentence();
+    systemUrl = faker.internet.url();
+    regex = "^[A-Z0-9]+$";
+    retrievalOption = faker.datatype.boolean();
+    uniqueOption = faker.datatype.boolean();
+    serialNumberMode = faker.helpers.arrayElement(serialNumberModes);
+    status = faker.helpers.arrayElement(statusOptions);
+
+    const targetUrl = `/admin/patient_identifier_config`;
+    await page.goto(targetUrl);
+  });
+
+  test("should create a Patient Identifier Config with all fields", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("button", { name: "Add patient identifier config" })
+      .click();
+
+    await page.getByRole("combobox").filter({ hasText: "usual" }).click();
+    await page.getByRole("option", { name: use }).click();
+
+    await page.getByRole("textbox", { name: "Display" }).fill(displayName);
+    await page.getByRole("textbox", { name: "Description" }).fill(description);
+    await page.getByRole("textbox", { name: "System" }).fill(systemUrl);
+    await page.getByRole("textbox", { name: "Regex" }).fill(regex);
+    if (retrievalOption) {
+      await page
+        .getByRole("switch", { name: "Retrieve with year of birth" })
+        .click();
+    }
+    if (uniqueOption) {
+      await page.getByRole("switch", { name: "Unique" }).click();
+    }
+    if (serialNumberMode === "Auto-generated") {
+      await page.getByRole("radio", { name: "Auto-generated" }).click();
+    }
+
+    await page.getByRole("combobox").filter({ hasText: "Draft" }).click();
+    await page.getByRole("option", { name: status, exact: true }).click();
+
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // Verify that the new config appears in the list
+    await page
+      .getByRole("textbox", { name: "Search configs" })
+      .fill(displayName);
+
+    const tableBody = await page.locator('[data-slot="table-body"]');
+
+    await expect(tableBody).toContainText(displayName);
+    await expect(tableBody).toContainText(systemUrl);
+    await expect(tableBody).toContainText(use);
+    await expect(tableBody).toContainText(status);
+  });
+
+  test("should show validation error for missing required fields", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("button", { name: "Add patient identifier config" })
+      .click();
+
+    await expect(page.getByRole("button", { name: "Create" })).toBeDisabled();
+
+    await page.getByRole("textbox", { name: "Display" }).fill(displayName);
+    await page.getByRole("button", { name: "Create" }).click();
+    const descriptionError = page
+      .getByRole("textbox", { name: "Description" })
+      .locator("..")
+      .locator('[data-slot="form-message"]');
+    await expect(descriptionError).toHaveText("This field is required");
+
+    const systemError = page
+      .getByRole("textbox", { name: "System" })
+      .locator("..")
+      .locator('[data-slot="form-message"]');
+    await expect(systemError).toHaveText("This field is required");
+  });
+
+  test("should not allow duplicate system URL", async ({ page }) => {
+    await page
+      .getByRole("button", { name: "Add patient identifier config" })
+      .click();
+
+    //Create a config first
+    await page.getByRole("combobox").filter({ hasText: "usual" }).click();
+    await page.getByRole("option", { name: use }).click();
+
+    await page.getByRole("textbox", { name: "Display" }).fill(displayName);
+    await page.getByRole("textbox", { name: "Description" }).fill(description);
+    await page.getByRole("textbox", { name: "System" }).fill(systemUrl);
+
+    await page.getByRole("combobox").filter({ hasText: "Draft" }).click();
+    await page.getByRole("option", { name: status, exact: true }).click();
+
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // Try to create another config with the same system URL
+    await page
+      .getByRole("button", { name: "Add patient identifier config" })
+      .click();
+
+    await page.getByRole("combobox").filter({ hasText: "usual" }).click();
+    await page.getByRole("option", { name: use }).click();
+
+    const newDisplayName = faker.lorem.words(2);
+    const newDescription = faker.lorem.sentence();
+
+    await page.getByRole("textbox", { name: "Display" }).fill(newDisplayName);
+    await page
+      .getByRole("textbox", { name: "Description" })
+      .fill(newDescription);
+    await page.getByRole("textbox", { name: "System" }).fill(systemUrl);
+
+    await page.getByRole("combobox").filter({ hasText: "Draft" }).click();
+    await page.getByRole("option", { name: status, exact: true }).click();
+
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(
+      page.getByText(
+        "A patient identifier config with this system already exists",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/tests/admin/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
+++ b/tests/admin/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
@@ -70,7 +70,7 @@ test.describe("Patient Identifier Config - Create", () => {
       .getByRole("textbox", { name: "Search configs" })
       .fill(displayName);
 
-    const tableBody = await page.locator('[data-slot="table-body"]');
+    const tableBody = page.locator('[data-slot="table-body"]');
 
     await expect(tableBody).toContainText(displayName);
     await expect(tableBody).toContainText(systemUrl);

--- a/tests/admin/patientIdentifierConfig/patientIdentifierConfigEdit.spec.ts
+++ b/tests/admin/patientIdentifierConfig/patientIdentifierConfigEdit.spec.ts
@@ -1,0 +1,72 @@
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+
+// Use the authenticated state
+test.use({ storageState: "tests/.auth/user.json" });
+
+const useOptions = ["usual", "official", "temp", "secondary", "old"];
+const statusOptions = ["Draft", "Active", "Inactive"];
+
+test.describe("Patient Identifier Config - Edit", () => {
+  let use: string;
+  let displayName: string;
+  let description: string;
+  let systemUrl: string;
+  let status: string;
+
+  test.beforeEach(async ({ page }) => {
+    use = faker.helpers.arrayElement(useOptions);
+    displayName = faker.lorem.words(2);
+    description = faker.lorem.sentence();
+    systemUrl = faker.internet.url();
+    status = faker.helpers.arrayElement(statusOptions);
+
+    const targetUrl = `/admin/patient_identifier_config`;
+    await page.goto(targetUrl);
+  });
+
+  test("should edit a patient identifier config", async ({ page }) => {
+    await page
+      .getByRole("button", { name: "Add patient identifier config" })
+      .click();
+
+    await page.getByRole("combobox").filter({ hasText: "usual" }).click();
+    await page.getByRole("option", { name: use }).click();
+
+    await page.getByRole("textbox", { name: "Display" }).fill(displayName);
+    await page.getByRole("textbox", { name: "Description" }).fill(description);
+    await page.getByRole("textbox", { name: "System" }).fill(systemUrl);
+
+    await page.getByRole("combobox").filter({ hasText: "Draft" }).click();
+    await page.getByRole("option", { name: status, exact: true }).click();
+
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // Verify that the new config appears in the list
+    await page
+      .getByRole("textbox", { name: "Search configs" })
+      .fill(displayName);
+
+    // Now edit the created config
+    await page.getByRole("button", { name: "Edit" }).first().click();
+
+    await page
+      .getByRole("textbox", { name: "Display" })
+      .fill(`${displayName}-edited`);
+    await page
+      .getByRole("textbox", { name: "Description" })
+      .fill(`${description}-edited`);
+    await page.getByRole("button", { name: "Update" }).click();
+
+    // Verify that the edited config appears in the list
+    await page
+      .getByRole("textbox", { name: "Search configs" })
+      .fill(`${displayName}-edited`);
+
+    const tableBody = page.locator('[data-slot="table-body"]');
+    await expect(tableBody).toContainText(`${displayName}-edited`);
+    await expect(tableBody).toContainText(systemUrl);
+    await expect(tableBody).toContainText(use);
+    await expect(tableBody).toContainText(status);
+  });
+});


### PR DESCRIPTION
## Proposed Changes

Fixes #14294 
- Added status dropdown for system generated patient identifiers


https://github.com/user-attachments/assets/0353e55f-78fb-4f0e-a51b-865878988a80


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Status field in Patient Identifier Config is now always visible and accessible, regardless of configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->