### PR TITLE
Removed unnecessary scrollbars in notes tab and Encounters

### DIFF
--- a/src/components/Notes/NoteManager.tsx
+++ b/src/components/Notes/NoteManager.tsx
@@ -503,7 +503,7 @@ export function NoteManager({
   const totalMessages = messagesData?.pages[0]?.count ?? 0;
 
   return (
-    <div className="flex h-[calc(100vh-13rem)] overflow-hidden lg:h-[calc(100vh-13rem)]">
+    <div className="flex h-[calc(100vh-15rem)] overflow-hidden">
       {/* Desktop Sidebar */}
       <div className="hidden lg:flex lg:w-80 lg:flex-col lg:border-r border-gray-200">
         <div className="p-4 border-b border-gray-200">

--- a/src/components/Patient/PatientDetailsTab/PatientNotes.tsx
+++ b/src/components/Patient/PatientDetailsTab/PatientNotes.tsx
@@ -4,7 +4,7 @@ import { PatientProps } from ".";
 
 export const PatientNotesTab = (props: PatientProps) => {
   return (
-    <div className="border border-r mt-1 md:mt-4 rounded-lg overflow-hidden max-w-5xl">
+    <div className="w-full flex flex-col h-[calc(100vh-18rem)] border border-r mt-1 md:mt-4 rounded-lg overflow-hidden">
       <NoteManager
         canAccess={true}
         canWrite={true}

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -201,8 +201,8 @@ export const EncounterShow = (props: Props) => {
         {
           "--encounter-header-offset":
             primaryEncounter?.appointment?.id && canWritePrimaryEncounter
-              ? "3rem"
-              : "0rem",
+              ? "3.5rem"
+              : "0.5rem",
         } as React.CSSProperties
       }
     >


### PR DESCRIPTION
## Proposed Changes

Fixes #14303 
- removed unnecessary scrollbars in notes tab of both encounters and patient profile page
- adjusted scroll in the entire Encounters page

<img width="1202" height="818" alt="image" src="https://github.com/user-attachments/assets/4312bd4d-605a-4e3d-a010-47dbfbdf17a2" />

<img width="1565" height="730" alt="image" src="https://github.com/user-attachments/assets/32fb4b47-9022-4ffe-9678-880edac1d37c" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted container height calculations and responsive layout styling in Note Manager and Patient Notes components for improved viewport accommodation.
  * Updated header offset spacing logic in Encounter views based on appointment status for enhanced layout consistency.
  * Enhanced flex layout properties for better content distribution across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->