### PR TITLE
feat: add configuration for automatic invoice creation after dispensing items

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -121,7 +121,6 @@ REACT_CUSTOM_REMOTE_I18N_URL=
 # ]'
 REACT_CUSTOM_SHORTCUTS=
 
-# Enable automatic invoice sheet after dispensing items (default: false)
 # Set to "true" to enable automatic invoice creation after dispensing
 REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=false
 

--- a/.example.env
+++ b/.example.env
@@ -121,4 +121,8 @@ REACT_CUSTOM_REMOTE_I18N_URL=
 # ]'
 REACT_CUSTOM_SHORTCUTS=
 
+# Enable automatic invoice sheet after dispensing items (default: false)
+# Set to "true" to enable automatic invoice creation after dispensing
+REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=false
+
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -200,6 +200,14 @@ const careConfig = {
    * System identifier for patient phone number configuration
    */
   phoneNumberConfigSystem: "system.care.ohc.network/patient-phone-number",
+
+  /**
+   * Enable automatic invoice sheet after dispensing items
+   */
+  enableAutoInvoiceAfterDispense: boolean(
+    "REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE",
+    false,
+  ),
 } as const;
 
 export default careConfig;

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -83,6 +83,7 @@ const envSchema = z
     REACT_APPOINTMENTS_DEFAULT_DATE_FILTER: numberAsString.optional(),
     REACT_PAYMENT_LOCATION_REQUIRED: booleanAsStringSchema.optional(),
     REACT_ENCOUNTER_DEFAULT_DATE_FILTER: numberAsString.optional(),
+    REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE: booleanAsStringSchema.optional(),
     REACT_OBSERVATION_PLOTS_CONFIG_URL: z.string().url().optional(),
     REACT_DEFAULT_COUNTRY: z.string().optional(),
     REACT_DEFAULT_COUNTRY_NAME: z.string().optional(),

--- a/src/components/Consumable/DispenseButton.tsx
+++ b/src/components/Consumable/DispenseButton.tsx
@@ -108,6 +108,7 @@ export const DispenseButton = ({
             setShowDrawer(false);
 
             if (!careConfig.enableAutoInvoiceAfterDispense) {
+              setExtractedChargeItems([]);
               return;
             }
 

--- a/src/components/Consumable/DispenseButton.tsx
+++ b/src/components/Consumable/DispenseButton.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
+import careConfig from "@careConfig";
+
 import { LocationSelectorDialog } from "@/components/ui/sidebar/facility/location/location-switcher";
 
 import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
@@ -104,6 +106,11 @@ export const DispenseButton = ({
           onDispenseComplete={async (chargeItems: ChargeItemRead[]) => {
             setExtractedChargeItems(chargeItems);
             setShowDrawer(false);
+
+            if (!careConfig.enableAutoInvoiceAfterDispense) {
+              return;
+            }
+
             const result = await refetchAccount();
             const fetchedAccountId = result.data?.results?.[0]?.id;
 

--- a/src/components/Consumable/DispenseButton.tsx
+++ b/src/components/Consumable/DispenseButton.tsx
@@ -104,14 +104,12 @@ export const DispenseButton = ({
             path: getLocationPath(location),
           }}
           onDispenseComplete={async (chargeItems: ChargeItemRead[]) => {
-            setExtractedChargeItems(chargeItems);
             setShowDrawer(false);
 
             if (!careConfig.enableAutoInvoiceAfterDispense) {
-              setExtractedChargeItems([]);
               return;
             }
-
+            setExtractedChargeItems(chargeItems);
             const result = await refetchAccount();
             const fetchedAccountId = result.data?.results?.[0]?.id;
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -32,6 +32,7 @@ interface ImportMetaEnv {
   readonly REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION?: string;
   readonly REACT_DISABLE_PATIENT_LOGIN?: string;
   readonly REACT_CUSTOM_REMOTE_I18N_URL?: string;
+  readonly REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE?: string;
 
   // Plugins related envs...
   readonly REACT_SENTRY_DSN?: string;


### PR DESCRIPTION
## Proposed Changes

Fixes #14316
Made the automatic invoice sheet feature configurable via an environment variable.

To enable: Set REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=true in your .env file 
To disable (default): Set REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=false or leave it unset

When disabled, dispensing completes without automatically opening the invoice sheet. 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to automatically generate invoices after dispensing items; disabled by default and can be enabled via environment/config.

* **Chores**
  * Environment and config validation updated so the new setting is recognized.
  * Public environment declarations updated to expose the new setting for runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->