### PR TITLE
Refactor ProductForm to initialize selected charge item definition directly

### DIFF
--- a/src/pages/Facility/settings/product/ProductForm.tsx
+++ b/src/pages/Facility/settings/product/ProductForm.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { navigate } from "raviger";
-import { useEffect, useImperativeHandle, useState } from "react";
+import { useImperativeHandle, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -171,8 +171,10 @@ export function ProductFormContent({
   const isEditMode = Boolean(productId);
   const [createCidOpen, setCreateCidOpen] = useState(false);
   const [selectedChargeItemDefinition, setSelectedChargeItemDefinition] =
-    useState<ChargeItemDefinitionRead | null>(null);
-  const [hasInitialized, setHasInitialized] = useState(false);
+    useState<ChargeItemDefinitionRead | null>(
+      (existingData?.charge_item_definition as ChargeItemDefinitionRead) ||
+        null,
+    );
 
   // Get product knowledge list for the dropdown
   const { data: productKnowledgeResponse } = useQuery({
@@ -210,16 +212,6 @@ export function ProductFormContent({
           ...(productKnowledgeResponse?.results || []),
           ...(existingProductKnowledge ? [existingProductKnowledge] : []),
         ];
-
-  // Set initial selected charge item definition when existing data loads
-  useEffect(() => {
-    if (existingData?.charge_item_definition && !hasInitialized && isEditMode) {
-      setSelectedChargeItemDefinition(
-        existingData.charge_item_definition as ChargeItemDefinitionRead,
-      );
-      setHasInitialized(true);
-    }
-  }, [existingData?.charge_item_definition, isEditMode]);
 
   const form = useForm({
     resolver: zodResolver(formSchema),


### PR DESCRIPTION
## Proposed Changes

Refactor ProductForm to initialize selected charge item definition directly from existing data, removing unnecessary useEffect and state for initialization.


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal state initialization logic in the product form, reducing unnecessary initialization steps and improving overall code efficiency without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->