### PR TITLE
Minor bug fixes: date filter translations, invoice url and more

### DIFF
--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -37,7 +37,8 @@ const PATHS_WITHOUT_SIDEBAR = [
   "/login",
   "/session-expired",
   // Pattern matches (using regex)
-  /^\/facility\/[^/]+\/services_requests\/[^/]+$/,
+  /^\/facility\/[^/]+\/service_requests\/[^/]+$/,
+  /^\/facility\/[^/]+\/locations\/[^/]+\/service_requests\/[^/]+$/,
   /^\/facility\/[^/]+\/locations\/[^/]+\/internal_transfers\/to_receive\/[^/]+$/,
   /^\/facility\/[^/]+\/locations\/[^/]+\/internal_transfers\/to_dispatch\/[^/]+$/,
   /^\/facility\/[^/]+\/locations\/[^/]+\/internal_transfers\/create_delivery$/,

--- a/src/Routers/routes/FacilityRoutes.tsx
+++ b/src/Routers/routes/FacilityRoutes.tsx
@@ -52,7 +52,7 @@ const FacilityRoutes: AppRoutes = {
   "/facility/:facilityId/services/:serviceId*": ({ facilityId, serviceId }) => (
     <ServiceLayout facilityId={facilityId} serviceId={serviceId} />
   ),
-  "/facility/:facilityId/services_requests/:serviceRequestId": ({
+  "/facility/:facilityId/service_requests/:serviceRequestId": ({
     facilityId,
     serviceRequestId,
   }) => (

--- a/src/components/Billing/ChargeItems/ChargeItemsSection.tsx
+++ b/src/components/Billing/ChargeItems/ChargeItemsSection.tsx
@@ -32,7 +32,6 @@ interface ChargeItemsSectionProps {
   sourceUrl?: string;
   encounterId?: string;
   disableCreateChargeItems?: boolean;
-  locationId?: string;
   viewOnly?: boolean;
 }
 
@@ -44,7 +43,6 @@ export function ChargeItemsSection({
   sourceUrl,
   encounterId,
   disableCreateChargeItems = false,
-  locationId,
   viewOnly = false,
 }: ChargeItemsSectionProps) {
   const { t } = useTranslation();
@@ -96,7 +94,7 @@ export function ChargeItemsSection({
     <>
       <Card className="bg-white shadow-sm rounded-md p-1">
         <CardHeader className="p-2 bg-gray-50">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row gap-2 items-center justify-between">
             <CardTitle>{t("charge_items")}</CardTitle>
             <div className="flex items-center gap-2">
               {(chargeItems?.results ?? []).filter(
@@ -139,10 +137,7 @@ export function ChargeItemsSection({
             <ChargeItemCard
               key={chargeItem.id}
               chargeItem={chargeItem}
-              serviceResourceId={resourceId}
-              serviceResourceType={serviceResourceType}
-              locationId={locationId}
-              patientId={patientId}
+              sourceUrl={sourceUrl}
             />
           ))}
         </CardContent>

--- a/src/components/Billing/Invoice/AddChargeItemSheet.tsx
+++ b/src/components/Billing/Invoice/AddChargeItemSheet.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
@@ -62,7 +63,7 @@ export default function AddChargeItemSheet({
   const [isAddChargeItemsOpen, setIsAddChargeItemsOpen] = React.useState(false);
   const queryClient = useQueryClient();
   const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
-    limit: 13,
+    limit: 15,
     disableCache: true,
   });
   useShortcutSubContext("facility:billing:invoice");
@@ -164,20 +165,19 @@ export default function AddChargeItemSheet({
         </SheetHeader>
 
         <div className="mt-6">
-          <div className="flex flex-col sm:flex-row gap-2 justify-between items-center mb-2">
+          <div className="flex justify-between items-center mb-2">
             <Input
               placeholder={t("search_charge_items")}
               value={qParams.search || ""}
               onChange={(e) =>
                 updateQuery({ search: e.target.value || undefined })
               }
-              className="w-full sm:max-w-xs"
+              className="max-w-xs"
             />
             <Button
               variant="outline"
               size="sm"
               onClick={() => setIsAddChargeItemsOpen(true)}
-              className="w-full sm:w-auto"
             >
               <PlusIcon className="size-4 mr-2" />
               {t("other_charge_items")}
@@ -188,7 +188,7 @@ export default function AddChargeItemSheet({
           {isLoading ? (
             <TableSkeleton count={5} />
           ) : (
-            <div className="py-2">
+            <ScrollArea className="max-h-[calc(100vh-20rem)] scroll-y-auto py-2">
               <div className="rounded-md border">
                 <Table>
                   <TableHeader>
@@ -244,12 +244,12 @@ export default function AddChargeItemSheet({
                   </TableBody>
                 </Table>
               </div>
-            </div>
+            </ScrollArea>
           )}
 
           <Pagination totalCount={response?.count || 0} />
         </div>
-        <SheetFooter className="flex flex-row justify-end gap-2">
+        <SheetFooter>
           <Button
             variant="outline"
             onClick={() => setOpen(false)}

--- a/src/components/Billing/Invoice/AddChargeItemSheet.tsx
+++ b/src/components/Billing/Invoice/AddChargeItemSheet.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
@@ -63,7 +62,7 @@ export default function AddChargeItemSheet({
   const [isAddChargeItemsOpen, setIsAddChargeItemsOpen] = React.useState(false);
   const queryClient = useQueryClient();
   const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
-    limit: 15,
+    limit: 13,
     disableCache: true,
   });
   useShortcutSubContext("facility:billing:invoice");
@@ -165,19 +164,20 @@ export default function AddChargeItemSheet({
         </SheetHeader>
 
         <div className="mt-6">
-          <div className="flex justify-between items-center mb-2">
+          <div className="flex flex-col sm:flex-row gap-2 justify-between items-center mb-2">
             <Input
               placeholder={t("search_charge_items")}
               value={qParams.search || ""}
               onChange={(e) =>
                 updateQuery({ search: e.target.value || undefined })
               }
-              className="max-w-xs"
+              className="w-full sm:max-w-xs"
             />
             <Button
               variant="outline"
               size="sm"
               onClick={() => setIsAddChargeItemsOpen(true)}
+              className="w-full sm:w-auto"
             >
               <PlusIcon className="size-4 mr-2" />
               {t("other_charge_items")}
@@ -188,7 +188,7 @@ export default function AddChargeItemSheet({
           {isLoading ? (
             <TableSkeleton count={5} />
           ) : (
-            <ScrollArea className="max-h-[calc(100vh-20rem)] scroll-y-auto py-2">
+            <div className="py-2">
               <div className="rounded-md border">
                 <Table>
                   <TableHeader>
@@ -244,12 +244,12 @@ export default function AddChargeItemSheet({
                   </TableBody>
                 </Table>
               </div>
-            </ScrollArea>
+            </div>
           )}
 
           <Pagination totalCount={response?.count || 0} />
         </div>
-        <SheetFooter>
+        <SheetFooter className="flex flex-row justify-end gap-2">
           <Button
             variant="outline"
             onClick={() => setOpen(false)}

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -690,6 +690,7 @@ const PatientBasicsContent = ({
               </FormLabel>
               <FormControl>
                 <TagSelectorPopover
+                  facilityId={facilityId}
                   selected={selectedTags}
                   onChange={(tags) => {
                     field.onChange(tags.map((tag) => tag.id));

--- a/src/components/ServiceRequest/ServiceRequestTable.tsx
+++ b/src/components/ServiceRequest/ServiceRequestTable.tsx
@@ -43,7 +43,7 @@ export default function ServiceRequestTable({
   const handleViewDetails = (request: ServiceRequestReadSpec) => {
     const baseUrl = locationId
       ? `/facility/${facilityId}/locations/${locationId}/service_requests`
-      : `/facility/${facilityId}/services_requests`;
+      : `/facility/${facilityId}/service_requests`;
     navigate(`${baseUrl}/${request.id}`);
   };
 

--- a/src/components/ui/multi-filter/dateFilter.tsx
+++ b/src/components/ui/multi-filter/dateFilter.tsx
@@ -350,7 +350,11 @@ export const SelectedDateBadge = ({
     <DropdownMenu>
       <DropdownMenuTrigger asChild className="text-sm underline cursor-pointer">
         {isRangeSelected ? (
-          <span>{t(isRangeSelected.label)}</span>
+          <span>
+            {t(isRangeSelected.label, {
+              ...(isRangeSelected.count && { count: isRangeSelected.count }),
+            })}
+          </span>
         ) : selected.from && selected.to && !isSameDate ? (
           <span>
             {(() => {

--- a/src/components/ui/multi-filter/dateFilter.tsx
+++ b/src/components/ui/multi-filter/dateFilter.tsx
@@ -351,9 +351,7 @@ export const SelectedDateBadge = ({
       <DropdownMenuTrigger asChild className="text-sm underline cursor-pointer">
         {isRangeSelected ? (
           <span>
-            {t(isRangeSelected.label, {
-              ...(isRangeSelected.count && { count: isRangeSelected.count }),
-            })}
+            {t(isRangeSelected.label, { count: isRangeSelected?.count })}
           </span>
         ) : selected.from && selected.to && !isSameDate ? (
           <span>

--- a/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
@@ -171,7 +171,7 @@ export function ChargeItemsTable({
     if (!item.service_resource || !item.service_resource_id) return "";
     switch (item.service_resource) {
       case ChargeItemServiceResource.service_request:
-        return `/facility/${facilityId}/services_requests/${item.service_resource_id}`;
+        return `/facility/${facilityId}/service_requests/${item.service_resource_id}`;
       case ChargeItemServiceResource.appointment:
         return `/facility/${facilityId}/patient/${patientId}/appointments/${item.service_resource_id}`;
       default:

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -297,7 +297,7 @@ export function InvoiceShow({
     if (sourceUrl?.includes("medication_dispense")) {
       return t("medication_dispense_invoice_alert");
     }
-    if (sourceUrl?.includes("services_requests")) {
+    if (sourceUrl?.includes("service_requests")) {
       return t("service_request_invoice_alert");
     }
     if (sourceUrl?.includes("encounter")) {

--- a/src/pages/Facility/services/pharmacy/PrescriptionsView.tsx
+++ b/src/pages/Facility/services/pharmacy/PrescriptionsView.tsx
@@ -37,6 +37,7 @@ export default function PrescriptionsView({
     queryKey: ["patient", patientId],
     queryFn: query(patientApi.getPatient, {
       pathParams: { id: patientId ?? "" },
+      silent: true,
     }),
     enabled: !!patientId,
   });

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
@@ -477,7 +477,6 @@ export default function ServiceRequestShow({
               encounterId={request.encounter.id}
               serviceResourceType={ChargeItemServiceResource.service_request}
               sourceUrl={`/facility/${facilityId}${locationId ? `/locations/${locationId}` : ""}/services_requests/${serviceRequestId}`}
-              locationId={locationId}
               patientId={request.encounter.patient.id}
               viewOnly={disableEdit}
             />

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
@@ -476,7 +476,7 @@ export default function ServiceRequestShow({
               resourceId={serviceRequestId}
               encounterId={request.encounter.id}
               serviceResourceType={ChargeItemServiceResource.service_request}
-              sourceUrl={`/facility/${facilityId}${locationId ? `/locations/${locationId}` : ""}/services_requests/${serviceRequestId}`}
+              sourceUrl={`/facility/${facilityId}${locationId ? `/locations/${locationId}` : ""}/service_requests/${serviceRequestId}`}
               patientId={request.encounter.patient.id}
               viewOnly={disableEdit}
             />

--- a/src/pages/Facility/services/serviceRequests/components/ChargeItemCard.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/ChargeItemCard.tsx
@@ -20,29 +20,19 @@ import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import {
   CHARGE_ITEM_STATUS_COLORS,
   ChargeItemRead,
-  ChargeItemServiceResource,
 } from "@/types/billing/chargeItem/chargeItem";
 import { InvoiceStatus } from "@/types/billing/invoice/invoice";
 import { Link } from "raviger";
 interface ChargeItemCardProps {
   chargeItem: ChargeItemRead;
-  serviceResourceId: string;
-  serviceResourceType: ChargeItemServiceResource;
-  locationId?: string;
-  patientId?: string;
+  sourceUrl?: string;
 }
 
-export function ChargeItemCard({
-  chargeItem,
-  serviceResourceId,
-  serviceResourceType,
-  locationId,
-  patientId,
-}: ChargeItemCardProps) {
+export function ChargeItemCard({ chargeItem, sourceUrl }: ChargeItemCardProps) {
   const isPaid = chargeItem.paid_invoice?.status === InvoiceStatus.balanced;
   const { facilityId } = useCurrentFacility();
   const invoiceUrl = chargeItem.paid_invoice
-    ? `/facility/${facilityId}/billing/invoices/${chargeItem.paid_invoice.id}?sourceUrl=/facility/${facilityId}/${locationId ? `locations/${locationId}/` : ""}${patientId ? `patient/${patientId}/` : ""}${serviceResourceType === ChargeItemServiceResource.service_request ? "service_requests/" : "appointments/"}${serviceResourceId}`
+    ? `/facility/${facilityId}/billing/invoices/${chargeItem.paid_invoice.id}?sourceUrl=${sourceUrl}`
     : null;
 
   return (

--- a/src/pages/Facility/services/serviceRequests/components/ChargeItemCard.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/ChargeItemCard.tsx
@@ -22,7 +22,7 @@ import {
   ChargeItemRead,
 } from "@/types/billing/chargeItem/chargeItem";
 import { InvoiceStatus } from "@/types/billing/invoice/invoice";
-import { Link } from "raviger";
+import { navigate } from "raviger";
 interface ChargeItemCardProps {
   chargeItem: ChargeItemRead;
   sourceUrl?: string;
@@ -76,11 +76,13 @@ export function ChargeItemCard({ chargeItem, sourceUrl }: ChargeItemCardProps) {
             )}
           </div>
           {invoiceUrl ? (
-            <Button asChild variant="outline" size="xs">
-              <Link href={invoiceUrl}>
-                {t("invoice")}
-                <CareIcon icon="l-external-link-alt" className="size-6" />
-              </Link>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => navigate(invoiceUrl)}
+            >
+              {t("invoice")}
+              <CareIcon icon="l-external-link-alt" className="size-6" />
             </Button>
           ) : (
             <Badge variant={CHARGE_ITEM_STATUS_COLORS[chargeItem.status]}>

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -349,6 +349,7 @@ export function MonetaryComponentSelector({
       return <></>;
     }
     return listComponents.map((component, idx) => {
+      const isSelected = isComponentSelected(component, tempSelectedComponents);
       return (
         <div
           key={`${component.title}-${component.code?.code || idx}`}
@@ -357,7 +358,7 @@ export function MonetaryComponentSelector({
           )}
         >
           <Checkbox
-            checked={isComponentSelected(component, tempSelectedComponents)}
+            checked={isSelected}
             onCheckedChange={(checked) =>
               handleTempToggle(component, checked as boolean)
             }
@@ -812,7 +813,10 @@ export function ChargeItemDefinitionForm({
   const availableDiscounts = [
     ...facilityData.discount_monetary_components,
     ...facilityData.instance_discount_monetary_components,
-  ];
+  ].map((component) => ({
+    ...component,
+    ...(component?.amount != null && { amount: String(component.amount) }),
+  }));
   const availableTaxes = [...facilityData.instance_tax_monetary_components];
 
   const mrpCode = facilityData.instance_informational_codes.find(

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -815,7 +815,8 @@ export function ChargeItemDefinitionForm({
     ...facilityData.instance_discount_monetary_components,
   ].map((component) => ({
     ...component,
-    ...(component?.amount != null && { amount: String(component.amount) }),
+    amount:
+      component?.amount != null ? String(component.amount) : component.amount,
   }));
   const availableTaxes = [...facilityData.instance_tax_monetary_components];
 


### PR DESCRIPTION
## Proposed Changes

- Translation for date filter (last 3 months instead of last months)
- Ensure discount amount was string (fixes discount selector checkbox in Charge Item Definition form for amount based discounts).
- Adjusted ChargeItemCard to just pass in sourceUrl (going from SR -> Invoice link **after** invoice has been created results in "back to Appointments" badge on the bottom with a broken link, fixes that).
- Replace instances of service_requests with service_requests.
- Prescriptions detail view, made patient query silent; ensure no error message is shown if user has no permission to view patient data
- Fixes #14346
- Fixes #14325

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified charge item cards to accept a single source URL and made the charge items section layout more responsive.
  * Streamlined invoice link behavior and navigation for charge items.
  * Optimized selection logic and normalized discount amount formatting in definition forms.
* **New Features**
  * Tag selector now respects the current facility context.
* **Localization**
  * Date preset badges now show counts.
* **Stability**
  * Pharmacy prescriptions data fetch made quieter on non-critical errors.
* **Routing**
  * Standardized service request URL patterns and related navigation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->