### PR TITLE
Add loading state for stock in DispenseDrawer + Auto Lot select

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2701,6 +2701,7 @@
   "loading_observation_definition": "Loading observation definition...",
   "loading_organizations": "Loading organizations...",
   "loading_queues": "Loading queues...",
+  "loading_stock": "Loading stock...",
   "local_body": "Local body",
   "local_ip_address": "Local IP Address",
   "local_ip_address_example": "e.g. 192.168.0.123",

--- a/src/components/Consumable/DispenseDrawer.tsx
+++ b/src/components/Consumable/DispenseDrawer.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
-import { Check, LocateFixed, XIcon } from "lucide-react";
+import { Check, Loader2, LocateFixed, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
@@ -213,6 +213,27 @@ export default function DispenseDrawer({
 
     fetchMissingInventories();
   }, [productKnowledgeInventoriesMap, facilityId, currentLocation.id]);
+
+  // Auto-select single lot if only one inventory is available
+  useEffect(() => {
+    fields.forEach((field, index) => {
+      const inventories =
+        productKnowledgeInventoriesMap[field.productKnowledge?.id];
+      const currentLots = form.watch(`items.${index}.lots`);
+
+      if (
+        inventories?.length === 1 &&
+        !currentLots.some((lot) => lot.selectedInventoryId)
+      ) {
+        form.setValue(`items.${index}.lots`, [
+          {
+            selectedInventoryId: inventories[0].id,
+            quantity: 1,
+          },
+        ]);
+      }
+    });
+  }, [productKnowledgeInventoriesMap, fields, form]);
 
   const { mutate: dispense, isPending } = useMutation({
     mutationFn: mutate(batchApi.batchRequest),
@@ -645,9 +666,23 @@ export default function DispenseDrawer({
                                 <TableCell className="font-medium text-gray-950 text-base">
                                   {productKnowledge.name}
                                 </TableCell>
-                                {!productKnowledgeInventoriesMap[
+                                {productKnowledgeInventoriesMap[
                                   productKnowledge.id
-                                ]?.length ? (
+                                ] === undefined ? (
+                                  <TableCell
+                                    colSpan={4}
+                                    className="text-center"
+                                  >
+                                    <div className="flex items-center justify-center py-3 gap-2">
+                                      <Loader2 className="size-4 animate-spin" />
+                                      <span className="text-sm text-gray-500">
+                                        {t("loading_stock")}
+                                      </span>
+                                    </div>
+                                  </TableCell>
+                                ) : !productKnowledgeInventoriesMap[
+                                    productKnowledge.id
+                                  ]?.length ? (
                                   <TableCell
                                     colSpan={4}
                                     className="text-center"

--- a/src/components/Consumable/DispenseDrawer.tsx
+++ b/src/components/Consumable/DispenseDrawer.tsx
@@ -219,9 +219,10 @@ export default function DispenseDrawer({
     fields.forEach((field, index) => {
       const inventories =
         productKnowledgeInventoriesMap[field.productKnowledge?.id];
-      const currentLots = form.watch(`items.${index}.lots`);
+      const currentLots = form.getValues(`items.${index}.lots`);
 
       if (
+        inventories !== undefined &&
         inventories?.length === 1 &&
         !currentLots.some((lot) => lot.selectedInventoryId)
       ) {


### PR DESCRIPTION
## Proposed Changes

Fixes #14336
- Introduced a loading indicator in the DispenseDrawer component when stock data is being fetched.
- Added a new translation key "loading_stock" to the en.json file for better user feedback during loading states.
- Auto selection of lot, if only one stock (lot) is there 



https://github.com/user-attachments/assets/1fbcdba3-8eb2-404d-8c1a-516e10a29d2e




Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loading state indicator when retrieving stock information.
  * Automatically selects the sole available lot for an item to streamline dispensing.
  * Added the "Loading stock..." text to display during stock data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->