### PR TITLE
Fix LocationPicker fetch logic to display correct accessible locations

### DIFF
--- a/src/components/Location/LocationPicker.tsx
+++ b/src/components/Location/LocationPicker.tsx
@@ -73,11 +73,11 @@ export function LocationPicker({
     queryFn: query(locationApi.list, {
       pathParams: { facility_id: facilityId },
       queryParams: {
-        parent: currentParent || "",
+        parent: currentParent ? currentParent : undefined,
         mode: "kind",
         ordering: "sort_index",
         status: "active",
-        mine: true,
+        mine: currentParent ? undefined : true,
       },
     }),
   });


### PR DESCRIPTION
## Proposed Changes

Fixes #14328
- Made mine and parent parameters conditional in `LocationPicker` so root fetch uses `mine: true` and child-level fetch uses only parent, fixing missing locations.

**Screen Recording**

https://github.com/user-attachments/assets/47e5968a-6fd2-4509-9c9f-7712b54494e4



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location picker behavior to correctly filter locations at different hierarchy levels, ensuring proper parameter handling when navigating between root and sublevel locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->