### PR TITLE
Fix: Medication name not being display in treatment summary

### DIFF
--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -24,6 +24,7 @@ import allergyIntoleranceApi from "@/types/emr/allergyIntolerance/allergyIntoler
 import diagnosisApi from "@/types/emr/diagnosis/diagnosisApi";
 import { completedEncounterStatus } from "@/types/emr/encounter/encounter";
 import encounterApi from "@/types/emr/encounter/encounterApi";
+import { displayMedicationName } from "@/types/emr/medicationRequest/medicationRequest";
 import medicationRequestApi from "@/types/emr/medicationRequest/medicationRequestApi";
 import medicationStatementApi from "@/types/emr/medicationStatement/medicationStatementApi";
 import patientApi from "@/types/emr/patient/patientApi";
@@ -519,7 +520,7 @@ export default function TreatmentSummary({
                       const remarks = formatSig(instruction);
                       const notes = medication.note;
                       return {
-                        medicine: medication.medication?.display,
+                        medicine: displayMedicationName(medication),
                         status: t(`medication_status__${medication.status}`),
                         dosage: dosage,
                         frequency: instruction?.as_needed_boolean


### PR DESCRIPTION
## Proposed Changes

- Fixes #14343

<img width="762" height="254" alt="Screenshot 2025-11-14 at 7 41 05 PM" src="https://github.com/user-attachments/assets/56886b26-4bfd-48c2-9f54-26c662308bb4" />
<img width="762" height="254" alt="Screenshot 2025-11-14 at 7 40 50 PM" src="https://github.com/user-attachments/assets/9490391a-6bf3-49e5-aa0d-facce8e0878b" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes (I'm not sure if I need to write test for minor fixes. Please let me know I'll add the test accordingly)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved medication name rendering in the treatment summary to ensure consistent and proper display of medication information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->