### PR TITLE
feat: sync labels to linked issue

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -89,7 +89,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           PR_LABELS=$(gh pr view $PR_NUMBER --repo $REPO --json labels --jq '.labels[].name' | tr '\n' ' ')
-          ISSUE_NUMBER=$(gh pr view $PR_NUMBER --repo $REPO --json body --jq '.body' | grep -oP '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\K\d+' | head -1 || echo "")
+          ISSUE_NUMBER=$(gh pr view $PR_NUMBER --repo $REPO --json body --jq '.body' | grep -oiP '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\K\d+' | head -1 || echo "")
 
           if [[ -n "$ISSUE_NUMBER" && -n "$PR_LABELS" ]]; then
             for label in $PR_LABELS; do

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -81,3 +81,18 @@ jobs:
           gh pr edit $PR_NUMBER --remove-label "changes required" --repo $REPO 2>/dev/null || true
           gh pr edit $PR_NUMBER --add-label "needs testing" --repo $REPO
           gh pr edit $PR_NUMBER --add-label "needs review" --repo $REPO
+
+      - name: Sync Labels to Linked Issue
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_LABELS=$(gh pr view $PR_NUMBER --repo $REPO --json labels --jq '.labels[].name' | tr '\n' ' ')
+          ISSUE_NUMBER=$(gh pr view $PR_NUMBER --repo $REPO --json body --jq '.body' | grep -oP '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\K\d+' | head -1 || echo "")
+
+          if [[ -n "$ISSUE_NUMBER" && -n "$PR_LABELS" ]]; then
+            for label in $PR_LABELS; do
+              gh issue edit $ISSUE_NUMBER --add-label "$label" --repo $REPO 2>/dev/null || true
+            done
+          fi


### PR DESCRIPTION
## Proposed Changes

Fixes: #14471
Ensure both PR and Issue has the same labels for easy tracking (request from aravind)

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PR automation now includes a "Sync Labels to Linked Issue" step that detects a linked issue from the PR and applies the PR's labels to that issue, running as part of the existing review workflow to keep labels consistent across related items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->