### PR TITLE
remove the hardcoded "General OP"

### DIFF
--- a/src/pages/Appointments/components/AppointmentTokenCard.tsx
+++ b/src/pages/Appointments/components/AppointmentTokenCard.tsx
@@ -127,16 +127,9 @@ const TokenCard = ({
             </div>
           </div>
           <div className="flex flex-col gap-2 items-end">
-            <div className="flex items-end justify-between gap-4">
-              <div className="flex-shrink-0">
-                <div className="text-sm whitespace-nowrap text-center bg-gray-100 px-3 pb-2 pt-2 -mt-4 font-medium text-gray-700 rounded-md rounded-t-none border border-gray-200">
-                  <p>{t("general_op")}</p>
-                </div>
-              </div>
-            </div>
             {token && (
               <div className="items-end">
-                <Label className="text-gray-600 text-sm whitespace-nowrap justify-end mt-4">
+                <Label className="text-gray-600 text-sm whitespace-nowrap justify-end">
                   {t("token_no")}
                 </Label>
                 <p className="text-2xl font-bold justify-end flex">
@@ -144,10 +137,11 @@ const TokenCard = ({
                 </p>
               </div>
             )}
-            <div className="mt-4">
+            <div>
               <QRCodeSVG
                 size={isLargeScreen ? 96 : 60}
                 value={patient?.id || ""}
+                className="ml-2"
               />
             </div>
           </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #14350 
For now i have removed the hard-coded "General OP" from the UI.

<img width="453" height="198" alt="image" src="https://github.com/user-attachments/assets/a683b25b-5825-4023-8186-196165190177" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved appointment card layout by reducing unnecessary vertical spacing around key elements.
  * Enhanced visual alignment of token information and QR code display in the card structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->