### PR TITLE
workflow for opening and closing the PR based on issue, author

### DIFF
--- a/.github/workflows/pr-author-assigne.yml
+++ b/.github/workflows/pr-author-assigne.yml
@@ -1,0 +1,105 @@
+name: Auto-close invalid PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  issues: read
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Validate linked issue
+        id: validate
+        run: |
+          PR_BODY="${{ github.event.pull_request.body }}"
+
+          # Look for "Fixes #<number>", "Closes #<number>", or "Resolves #<number>"
+          ISSUE_REF=$(echo "$PR_BODY" | grep -Eo '(Fixes|Closes|Resolves)\s*#([0-9]+)' | head -n1 || true)
+
+          if [ -z "$ISSUE_REF" ]; then
+            echo "no_issue=true" >> $GITHUB_OUTPUT
+            echo "there is no issue"
+          else
+            ISSUE_NUMBER=$(echo "$ISSUE_REF" | grep -Eo '[0-9]+')
+            echo "no_issue=false" >> $GITHUB_OUTPUT
+            echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+            echo "issue_url=https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+            echo "there is issue"
+          fi
+
+      - name: Reopen PR if issue is now linked
+        if: steps.validate.outputs.no_issue == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Check PR state
+          STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')
+
+          if [ "$STATE" = "CLOSED" ]; then
+            gh pr reopen "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "Issue linked now — reopening PR."
+          else
+            echo "PR already open, nothing to do."
+          fi
+
+      - name: Close PR if no linked issue
+        if: steps.validate.outputs.no_issue == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "No linked issue, please do not open PRs if there's no corresponding issue."
+          exit 0
+
+      - name: Check if user is exempt (core team)
+        uses: actions/github-script@v7
+        id: check-core
+        with:
+         script: |
+            const prAuthor = context.payload.pull_request.user.login;
+
+            const response = await fetch(`https://raw.githubusercontent.com/ohcnetwork/leaderboard-data/main/contributors/${prAuthor}.md`);
+            if (response.ok) {
+              const userData = await response.text();
+              if (userData.includes('role: core')) {
+                core.notice(`Core member detected: ${prAuthor}, skipping validation.`);
+                core.setOutput("is_core", "true");
+                return;
+              }
+            }
+            core.setOutput("is_core", "false");
+
+      - name: Get issue details
+        if: steps.validate.outputs.no_issue == 'false'
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_JSON=$(gh api "${{ steps.validate.outputs.issue_url }}" --jq '{assignee: .assignee.login}')
+          echo "$ISSUE_JSON"
+          echo "issue_json=$ISSUE_JSON" >> $GITHUB_OUTPUT
+          ASSIGNEE=$(echo "$ISSUE_JSON" | jq -r '.assignee')
+          echo "$ASSIGNEE"
+          echo "assignee=$ASSIGNEE" >> $GITHUB_OUTPUT
+
+      - name: Close PR if issue unassigned
+        if: steps.issue.outputs.assignee == 'null' && steps.check-core.outputs.is_core == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "PR is unassigned. Please refrain from opening PRs until issue is assigned to you."
+          exit 0
+
+      - name: Close PR if author not same as assignee
+        if: steps.issue.outputs.assignee != 'null' && steps.issue.outputs.assignee != github.event.pull_request.user.login #&& steps.check-core.outputs.is_core == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "PR is assigned to someone else. Please refrain from opening PRs until issue is assigned to you."

--- a/.github/workflows/pr-author-assigne.yml
+++ b/.github/workflows/pr-author-assigne.yml
@@ -97,7 +97,7 @@ jobs:
           exit 0
 
       - name: Close PR if author not same as assignee
-        if: steps.issue.outputs.assignee != 'null' && steps.issue.outputs.assignee != github.event.pull_request.user.login #&& steps.check-core.outputs.is_core == 'false'
+        if: steps.issue.outputs.assignee != 'null' && steps.issue.outputs.assignee != github.event.pull_request.user.login && steps.check-core.outputs.is_core == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-author-assigne.yml
+++ b/.github/workflows/pr-author-assigne.yml
@@ -16,21 +16,20 @@ jobs:
       - name: Validate linked issue
         id: validate
         run: |
-          PR_BODY="${{ github.event.pull_request.body }}"
+            printf "%s" "${{ github.event.pull_request.body }}" > pr_body.txt
 
-          # Look for "Fixes #<number>", "Closes #<number>", or "Resolves #<number>"
-          ISSUE_REF=$(echo "$PR_BODY" | grep -Eo '(Fixes|Closes|Resolves)\s*#([0-9]+)' | head -n1 || true)
+            ISSUE_REF=$(grep -Eo '(Fixes|Closes|Resolves)\s*#([0-9]+)' pr_body.txt | head -n1 || true)
 
-          if [ -z "$ISSUE_REF" ]; then
-            echo "no_issue=true" >> $GITHUB_OUTPUT
-            echo "there is no issue"
-          else
-            ISSUE_NUMBER=$(echo "$ISSUE_REF" | grep -Eo '[0-9]+')
-            echo "no_issue=false" >> $GITHUB_OUTPUT
-            echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
-            echo "issue_url=https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER" >> $GITHUB_OUTPUT
-            echo "there is issue"
-          fi
+            if [ -z "$ISSUE_REF" ]; then
+              echo "no_issue=true" >> "$GITHUB_OUTPUT"
+              echo "there is no issue"
+            else
+              ISSUE_NUMBER=$(printf "%s" "$ISSUE_REF" | grep -Eo '[0-9]+')
+              echo "no_issue=false" >> "$GITHUB_OUTPUT"
+              echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+              echo "issue_url=https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+              echo "there is issue"
+            fi
 
       - name: Reopen PR if issue is now linked
         if: steps.validate.outputs.no_issue == 'false'
@@ -80,15 +79,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ISSUE_JSON=$(gh api "${{ steps.validate.outputs.issue_url }}" --jq '{assignee: .assignee.login}')
+          ISSUE_JSON=$(gh api "${{ steps.validate.outputs.issue_url }}" --jq '{assignee: (.assignee.login // "unassigned")}')
           echo "$ISSUE_JSON"
           echo "issue_json=$ISSUE_JSON" >> $GITHUB_OUTPUT
-          ASSIGNEE=$(echo "$ISSUE_JSON" | jq -r '.assignee')
+          ASSIGNEE=$(echo "$ISSUE_JSON" | jq -r '.assignee // "unassigned"')
           echo "$ASSIGNEE"
           echo "assignee=$ASSIGNEE" >> $GITHUB_OUTPUT
 
       - name: Close PR if issue unassigned
-        if: steps.issue.outputs.assignee == 'null' && steps.check-core.outputs.is_core == 'false'
+        if: steps.issue.outputs.assignee == 'unassigned' && steps.check-core.outputs.is_core == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -97,7 +96,7 @@ jobs:
           exit 0
 
       - name: Close PR if author not same as assignee
-        if: steps.issue.outputs.assignee != 'null' && steps.issue.outputs.assignee != github.event.pull_request.user.login && steps.check-core.outputs.is_core == 'false'
+        if: steps.issue.outputs.assignee != 'unassigned' && steps.issue.outputs.assignee != github.event.pull_request.user.login && steps.check-core.outputs.is_core == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-author-assigne.yml
+++ b/.github/workflows/pr-author-assigne.yml
@@ -42,7 +42,7 @@ jobs:
               issue_number: .data.repository.pullRequest.closingIssuesReferences.nodes[0].number // null,
               pr_association: .data.repository.pullRequest.authorAssociation,
               pr_author: .data.repository.pullRequest.author.login,
-              state: .data.repository.pullRequest.state
+              state: .data.repository.pullRequest.state,
               issue_state: .data.repository.pullRequest.closingIssuesReferences.nodes[0].state // null
             }')
 
@@ -62,7 +62,7 @@ jobs:
           echo "PR Author: ${{ steps.prinfo.outputs.pr_author }}"
           echo "PR Association: ${{ steps.prinfo.outputs.pr_association }}"
           echo "PR State: ${{ steps.prinfo.outputs.state }}"
-          echo "Issue State": ${{ steps.prinfo.outputs.issue_state }}"
+          echo "Issue State: ${{ steps.prinfo.outputs.issue_state }}"
 
       - name: Close PR if no linked issue
         if: steps.prinfo.outputs.issue_number == 'null' || steps.prinfo.outputs.issue_state == 'CLOSED'

--- a/.github/workflows/pr-author-assigne.yml
+++ b/.github/workflows/pr-author-assigne.yml
@@ -13,41 +13,56 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - name: Validate linked issue
-        id: validate
-        run: |
-            printf "%s" "${{ github.event.pull_request.body }}" > pr_body.txt
-
-            ISSUE_REF=$(grep -Eo '(Fixes|Closes|Resolves)\s*#([0-9]+)' pr_body.txt | head -n1 || true)
-
-            if [ -z "$ISSUE_REF" ]; then
-              echo "no_issue=true" >> "$GITHUB_OUTPUT"
-              echo "there is no issue"
-            else
-              ISSUE_NUMBER=$(printf "%s" "$ISSUE_REF" | grep -Eo '[0-9]+')
-              echo "no_issue=false" >> "$GITHUB_OUTPUT"
-              echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-              echo "issue_url=https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-              echo "there is issue"
-            fi
-
-      - name: Reopen PR if issue is now linked
-        if: steps.validate.outputs.no_issue == 'false'
+      - name: Get the detaile about the PR author
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        id: prinfo
         run: |
-          # Check PR state
-          STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')
+          response=$(gh api graphql -f query='
+            query {
+              repository(owner: "ohcnetwork", name: "care_fe") {
+                pullRequest(number: '${{ github.event.pull_request.number }}') {
+                  author { login }
+                  authorAssociation
+                  state
+                  closingIssuesReferences(first: 5) {
+                    nodes {
+                      number
+                      title
+                      state
+                      assignees(first: 5) {
+                        nodes { login }
+                      }
+                    }
+                  }
+                }
+              }
+            }' --jq '{
+              assignees: (.data.repository.pullRequest.closingIssuesReferences.nodes[0].assignees.nodes // [] | map(.login)),
+              issue_number: .data.repository.pullRequest.closingIssuesReferences.nodes[0].number // null,
+              pr_association: .data.repository.pullRequest.authorAssociation,
+              pr_author: .data.repository.pullRequest.author.login,
+              state: .data.repository.pullRequest.state
+            }')
 
-          if [ "$STATE" = "CLOSED" ]; then
-            gh pr reopen "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "Issue linked now — reopening PR."
-          else
-            echo "PR already open, nothing to do."
-          fi
+          echo "OUTPUT: $response"
+
+          echo "assignees=$(echo "$response" | jq -rc '.assignees | join(",")')" >> $GITHUB_OUTPUT
+          echo "issue_number=$(echo "$response" | jq -r '.issue_number')" >> $GITHUB_OUTPUT
+          echo "pr_author=$(echo "$response" | jq -r '.pr_author')" >> $GITHUB_OUTPUT
+          echo "pr_association=$(echo "$response" | jq -r '.pr_association')" >> $GITHUB_OUTPUT
+          echo "state=$(echo "$response" | jq -r '.state')" >> $GITHUB_OUTPUT
+
+      - name: Use the extracted data
+        run: |
+          echo "Assignees: ${{ steps.prinfo.outputs.assignees }}"
+          echo "Issue Number: ${{ steps.prinfo.outputs.issue_number }}"
+          echo "PR Author: ${{ steps.prinfo.outputs.pr_author }}"
+          echo "PR Association: ${{ steps.prinfo.outputs.pr_association }}"
+          echo "PR State: ${{ steps.prinfo.outputs.state }}"
 
       - name: Close PR if no linked issue
-        if: steps.validate.outputs.no_issue == 'true'
+        if: steps.prinfo.outputs.issue_number == 'null' || steps.prinfo.outputs.issue_state == 'CLOSED'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -55,50 +70,42 @@ jobs:
           gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "No linked issue, please do not open PRs if there's no corresponding issue."
           exit 0
 
-      - name: Check if user is exempt (core team)
-        uses: actions/github-script@v7
-        id: check-core
-        with:
-         script: |
-            const prAuthor = context.payload.pull_request.user.login;
-
-            const response = await fetch(`https://raw.githubusercontent.com/ohcnetwork/leaderboard-data/main/contributors/${prAuthor}.md`);
-            if (response.ok) {
-              const userData = await response.text();
-              if (userData.includes('role: core')) {
-                core.notice(`Core member detected: ${prAuthor}, skipping validation.`);
-                core.setOutput("is_core", "true");
-                return;
-              }
-            }
-            core.setOutput("is_core", "false");
-
-      - name: Get issue details
-        if: steps.validate.outputs.no_issue == 'false'
-        id: issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE_JSON=$(gh api "${{ steps.validate.outputs.issue_url }}" --jq '{assignee: (.assignee.login // "unassigned")}')
-          echo "$ISSUE_JSON"
-          echo "issue_json=$ISSUE_JSON" >> $GITHUB_OUTPUT
-          ASSIGNEE=$(echo "$ISSUE_JSON" | jq -r '.assignee // "unassigned"')
-          echo "$ASSIGNEE"
-          echo "assignee=$ASSIGNEE" >> $GITHUB_OUTPUT
-
-      - name: Close PR if issue unassigned
-        if: steps.issue.outputs.assignee == 'unassigned' && steps.check-core.outputs.is_core == 'false'
+      - name: Reopen PR if issue is now linked
+        if: steps.prinfo.outputs.issue_number != 'null'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_STATE: ${{ steps.prinfo.outputs.state }}
         run: |
-          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "PR is unassigned. Please refrain from opening PRs until issue is assigned to you."
-          exit 0
+          if [ "$PR_STATE" = "CLOSED" ]; then
+            gh pr reopen "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "Issue linked now — reopening PR."
+          else
+            echo "PR already open, nothing to do."
+          fi
 
-      - name: Close PR if author not same as assignee
-        if: steps.issue.outputs.assignee != 'unassigned' && steps.issue.outputs.assignee != github.event.pull_request.user.login && steps.check-core.outputs.is_core == 'false'
+      - name: Validate PR assignment
+        if: steps.prinfo.outputs.pr_association != 'MEMBER' && steps.prinfo.outputs.pr_association != 'OWNER'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "PR is assigned to someone else. Please refrain from opening PRs until issue is assigned to you."
+            PR_AUTHOR="${{ steps.prinfo.outputs.pr_author }}"
+            ASSIGNEES="${{ steps.prinfo.outputs.assignees }}"
+
+            # Check if no assignee
+            if [ -z "$ASSIGNEES" ]; then
+              echo "PR is unassigned, closing..."
+              gh pr close "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" \
+              --comment "PR is unassigned. Please refrain from opening PRs until the issue is assigned to you."
+              exit 0
+            fi
+
+            # Check if PR author is not among assignees
+            if ! echo "$ASSIGNEES" | grep -qw "$PR_AUTHOR"; then
+              echo "PR author is not the assignee, closing..."
+              gh pr close "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" \
+              --comment "PR is assigned to someone else. Please refrain from opening PRs until the issue is assigned to you."
+              exit 0
+            fi
+
+            echo "PR author is assigned to the issue, all good."
+

--- a/.github/workflows/pr-author-assigne.yml
+++ b/.github/workflows/pr-author-assigne.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - name: Get the detaile about the PR author
+      - name: Get the details about the PR author
         env:
           GH_TOKEN: ${{ github.token }}
         id: prinfo
@@ -43,6 +43,7 @@ jobs:
               pr_association: .data.repository.pullRequest.authorAssociation,
               pr_author: .data.repository.pullRequest.author.login,
               state: .data.repository.pullRequest.state
+              issue_state: .data.repository.pullRequest.closingIssuesReferences.nodes[0].state // null
             }')
 
           echo "OUTPUT: $response"
@@ -52,6 +53,7 @@ jobs:
           echo "pr_author=$(echo "$response" | jq -r '.pr_author')" >> $GITHUB_OUTPUT
           echo "pr_association=$(echo "$response" | jq -r '.pr_association')" >> $GITHUB_OUTPUT
           echo "state=$(echo "$response" | jq -r '.state')" >> $GITHUB_OUTPUT
+          echo "issue_state=$(echo "$response" | jq -r '.issue_state')" >> $GITHUB_OUTPUT
 
       - name: Use the extracted data
         run: |
@@ -60,6 +62,7 @@ jobs:
           echo "PR Author: ${{ steps.prinfo.outputs.pr_author }}"
           echo "PR Association: ${{ steps.prinfo.outputs.pr_association }}"
           echo "PR State: ${{ steps.prinfo.outputs.state }}"
+          echo "Issue State": ${{ steps.prinfo.outputs.issue_state }}"
 
       - name: Close PR if no linked issue
         if: steps.prinfo.outputs.issue_number == 'null' || steps.prinfo.outputs.issue_state == 'CLOSED'
@@ -108,4 +111,3 @@ jobs:
             fi
 
             echo "PR author is assigned to the issue, all good."
-


### PR DESCRIPTION
## Proposed Changes

Fixes #14184 
- wrote the workflow for opening and closing the PR based on issue, author, assignee
- this workflow will close the PR if issue is not linked to the PR, Also close the PR if author of the PR is not equal to the assignee. of the issue  And it will reopen the PR if later author linked the issue to the PR

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ x ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated PR workflow that auto-closes PRs without a linked issue or proper assignee, reopens PRs when a valid issue is later linked, and exempts core contributors from these checks. The workflow logs its decisions and posts explanatory comments when closing or reopening PRs, and enforces that non-core authors must be listed as assignees to keep a PR open.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->