### PR TITLE
Add service requests in treatment summary

### DIFF
--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -1,24 +1,13 @@
-import careConfig from "@careConfig";
-import { useQuery } from "@tanstack/react-query";
-import { format } from "date-fns";
-import { Loader } from "lucide-react";
-import { useTranslation } from "react-i18next";
-import { formatPhoneNumberIntl } from "react-phone-number-input";
+import { formatDosage, formatSig } from "@/components/Medicine/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatDateTime, formatName, formatPatientAge } from "@/Utils/utils";
 
 import PrintPreview from "@/CAREUI/misc/PrintPreview";
-
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-
+import { getPermissions } from "@/common/Permissions";
 import Loading from "@/components/Common/Loading";
 import PrintTable from "@/components/Common/PrintTable";
 import QuestionnaireResponsesList from "@/components/Facility/ConsultationDetails/QuestionnaireResponsesList";
 import { getFrequencyDisplay } from "@/components/Medicine/MedicationsTable";
-import { formatDosage, formatSig } from "@/components/Medicine/utils";
-
-import { getPermissions } from "@/common/Permissions";
-
-import query from "@/Utils/request/query";
-import { formatDateTime, formatName, formatPatientAge } from "@/Utils/utils";
 import { usePermissions } from "@/context/PermissionContext";
 import allergyIntoleranceApi from "@/types/emr/allergyIntolerance/allergyIntoleranceApi";
 import diagnosisApi from "@/types/emr/diagnosis/diagnosisApi";
@@ -28,7 +17,15 @@ import { displayMedicationName } from "@/types/emr/medicationRequest/medicationR
 import medicationRequestApi from "@/types/emr/medicationRequest/medicationRequestApi";
 import medicationStatementApi from "@/types/emr/medicationStatement/medicationStatementApi";
 import patientApi from "@/types/emr/patient/patientApi";
+import serviceRequestApi from "@/types/emr/serviceRequest/serviceRequestApi";
 import symptomApi from "@/types/emr/symptom/symptomApi";
+import query from "@/Utils/request/query";
+import careConfig from "@careConfig";
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { Loader } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { formatPhoneNumberIntl } from "react-phone-number-input";
 
 interface TreatmentSummaryProps {
   facilityId?: string;
@@ -153,6 +150,20 @@ export default function TreatmentSummary({
       enabled: !!patientId,
     });
 
+  const { data: serviceRequests, isLoading: serviceRequestsLoading } = useQuery(
+    {
+      queryKey: ["service_requests", patientId, encounterId],
+      queryFn: query.paginated(serviceRequestApi.listServiceRequest, {
+        pathParams: { facilityId: facilityId || "" },
+        queryParams: {
+          encounter: encounterId,
+        },
+        pageSize: 100,
+      }),
+      enabled: !!encounterId && !!facilityId,
+    },
+  );
+
   if (encounterLoading) {
     return <Loading />;
   }
@@ -171,7 +182,8 @@ export default function TreatmentSummary({
     diagnosesLoading ||
     symptomsLoading ||
     medicationsLoading ||
-    medicationStatementLoading;
+    medicationStatementLoading ||
+    serviceRequestsLoading;
 
   if (isLoading) {
     return (
@@ -579,6 +591,26 @@ export default function TreatmentSummary({
                       reason: medication.reason,
                       notes: medication.note,
                       logged_by: formatName(medication.created_by),
+                    }))}
+                  />
+                </SectionLayout>
+              )}
+
+              {/* Service Requests */}
+              {serviceRequests?.count != 0 && (
+                <SectionLayout title={t("service_requests")}>
+                  <PrintTable
+                    headers={[
+                      { key: "title" },
+                      { key: "service_type" },
+                      { key: "status" },
+                      { key: "priority" },
+                    ]}
+                    rows={serviceRequests?.results.map((request) => ({
+                      title: request.title,
+                      service_type: t(request.category),
+                      status: t(request.status),
+                      priority: t(request.priority),
                     }))}
                   />
                 </SectionLayout>


### PR DESCRIPTION
## Proposed Changes

Fixes #14380
- Added service requests in treatment summary

<img width="794" height="658" alt="image" src="https://github.com/user-attachments/assets/c5f5a0d2-dbcc-4ad9-ae0e-1884dba6c01f" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Service Requests" section to the treatment summary view, displaying service request details including title, service type, status, and priority in a structured table format. This section is now included in the print-preview treatment summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->