### PR TITLE
Remove unused facilityId prop from QuestionnaireEditor component

### DIFF
--- a/src/components/HistoricalRecordSelector/index.tsx
+++ b/src/components/HistoricalRecordSelector/index.tsx
@@ -51,6 +51,7 @@ interface HistoricalRecordSelectorProps<T extends BaseRecord> {
   onAddSelected: (selected: T[]) => void;
   buttonLabel?: string;
   title?: string;
+  disableAPI?: boolean;
 }
 
 interface DateGroupedRecords<T extends BaseRecord> {
@@ -143,6 +144,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
   onAddSelected,
   buttonLabel,
   title,
+  disableAPI = false,
 }: HistoricalRecordSelectorProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeType, setActiveType] = useState<string>(
@@ -180,7 +182,7 @@ export function HistoricalRecordSelector<T extends BaseRecord>({
         count: response.count,
       };
     },
-    enabled: isOpen,
+    enabled: isOpen && !disableAPI,
     staleTime: 0,
   });
 

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -598,6 +598,7 @@ export function DiagnosisQuestion({
         ]}
         buttonLabel={t("diagnosis_history")}
         onAddSelected={handleAddHistoricalDiagnoses}
+        disableAPI={isPreview}
       />
 
       {sortedDiagnoses.length > 0 && (

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -563,6 +563,7 @@ export function MedicationRequestQuestion({
         ]}
         buttonLabel={t("medication_history")}
         onAddSelected={handleAddHistoricalMedications}
+        disableAPI={isPreview}
       />
       {medications.length > 0 && (
         <div className="md:overflow-x-auto w-auto">

--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -435,6 +435,7 @@ export function MedicationStatementQuestion({
         ]}
         buttonLabel={t("medication_history")}
         onAddSelected={handleAddHistoricalMedications}
+        disableAPI={isPreview}
       />
 
       {medications.length > 0 && (

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -847,6 +847,7 @@ export function SymptomQuestion({
         ]}
         buttonLabel={t("symptom_history")}
         onAddSelected={handleAddHistoricalSymptoms}
+        disableAPI={isPreview}
       />
       {symptoms.length > 0 && (
         <>

--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -1356,7 +1356,6 @@ export default function QuestionnaireEditor({ id }: QuestionnaireEditorProps) {
                 patientId="preview"
                 subjectType={form.watch("subject_type")}
                 encounterId="preview"
-                facilityId="preview"
               />
             </CardContent>
           </Card>


### PR DESCRIPTION
## Proposed Changes

Fixes #13135
Remove unused facilityId prop from QuestionnaireEditor component

**Before**
<img width="2139" height="582" alt="image" src="https://github.com/user-attachments/assets/eeedaafd-1527-4f9b-a529-ff3b94f753a1" />

**After**
<img width="2139" height="582" alt="image" src="https://github.com/user-attachments/assets/3d7d989b-dc2f-4b99-b584-71c9cfcb7337" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Questionnaire preview no longer sends an unintended preview-specific identifier, improving preview data consistency.

* **New Features**
  * Historical Record selector gains an option to disable background API fetching.
  * In preview mode, diagnosis, medication (request/statement), and symptom questions suppress remote lookups to speed and stabilize previews.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->