### PR TITLE
show - for medication without charge item

### DIFF
--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -1,17 +1,3 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "raviger";
-import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
-
-import { groupItemsByTime } from "@/lib/time";
-
-import CareIcon from "@/CAREUI/icons/CareIcon";
-
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import { EmptyState } from "@/components/ui/empty-state";
 import {
   Select,
   SelectContent,
@@ -28,27 +14,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-import { TableSkeleton } from "@/components/Common/SkeletonLoading";
-
-import useFilters from "@/hooks/useFilters";
-
-import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
-import mutate from "@/Utils/request/mutate";
-import query from "@/Utils/request/query";
-import { useShortcutSubContext } from "@/context/ShortcutContext";
-import ViewDefaultAccountButton from "@/pages/Facility/billing/account/ViewDefaultAccountButton";
-import { CreateInvoiceSheet } from "@/pages/Facility/billing/account/components/CreateInvoiceSheet";
 import {
   AccountBillingStatus,
   AccountStatus,
 } from "@/types/billing/account/Account";
-import accountApi from "@/types/billing/account/accountApi";
 import {
   ChargeItemRead,
   ChargeItemStatus,
 } from "@/types/billing/chargeItem/chargeItem";
-import { InvoiceStatus } from "@/types/billing/invoice/invoice";
 import {
   MEDICATION_DISPENSE_STATUS_COLORS,
   MedicationDispenseCategory,
@@ -57,8 +30,30 @@ import {
   MedicationDispenseUpdate,
   MedicationDispenseUpsert,
 } from "@/types/emr/medicationDispense/medicationDispense";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+import CareIcon from "@/CAREUI/icons/CareIcon";
+import { TableSkeleton } from "@/components/Common/SkeletonLoading";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { EmptyState } from "@/components/ui/empty-state";
+import { useShortcutSubContext } from "@/context/ShortcutContext";
+import useFilters from "@/hooks/useFilters";
+import { groupItemsByTime } from "@/lib/time";
+import { CreateInvoiceSheet } from "@/pages/Facility/billing/account/components/CreateInvoiceSheet";
+import ViewDefaultAccountButton from "@/pages/Facility/billing/account/ViewDefaultAccountButton";
+import accountApi from "@/types/billing/account/accountApi";
+import { InvoiceStatus } from "@/types/billing/invoice/invoice";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+import mutate from "@/Utils/request/mutate";
+import query from "@/Utils/request/query";
 import { PillIcon } from "lucide-react";
+import { Link } from "raviger";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 interface MedicationTableProps {
   facilityId: string;
@@ -241,9 +236,13 @@ function MedicationTable({
                   {new Date(medication.when_prepared).toLocaleDateString()}
                 </TableCell>
                 <TableCell>
-                  <Badge variant={isPaid ? "green" : "destructive"}>
-                    {isPaid ? t("paid") : t("unpaid")}
-                  </Badge>
+                  {!medication.charge_item ? (
+                    "-"
+                  ) : (
+                    <Badge variant={isPaid ? "green" : "destructive"}>
+                      {isPaid ? t("paid") : t("unpaid")}
+                    </Badge>
+                  )}
                 </TableCell>
                 <TableCell>
                   {medication?.charge_item?.paid_invoice && (


### PR DESCRIPTION
## Proposed Changes

Fixes #14385
- show - for medication without charge item

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated payment status display in the Dispensed Medication List to show a dash when charge information is unavailable, otherwise displaying the existing paid/unpaid indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->