### PR TITLE
Fixed the Nan in the Supply Deleveries

### DIFF
--- a/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
+++ b/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
@@ -168,39 +168,36 @@ export function SupplyDeliveryTable({
               <TableCell className="border-x p-3 text-gray-950">
                 <MonetaryDisplay
                   amount={
-                    delivery.supplied_inventory_item?.product.charge_item_definition?.price_components.filter(
+                    delivery.supplied_inventory_item?.product.charge_item_definition?.price_components?.filter(
                       (c) =>
                         c.monetary_component_type ===
                         MonetaryComponentType.base,
-                    )[0].amount
+                    )?.[0]?.amount
                   }
                 />
               </TableCell>
               <TableCell className="border-x p-3 text-gray-950">
                 <MonetaryDisplay
-                  amount={String(
-                    delivery.supplied_inventory_item?.product.charge_item_definition?.price_components
-                      .filter(
-                        (c) =>
-                          c.monetary_component_type ===
-                          MonetaryComponentType.tax,
-                      )
-                      .reduce((acc, curr) => acc + Number(curr.amount || 0), 0),
-                  )}
+                  amount={delivery.supplied_inventory_item?.product.charge_item_definition?.price_components
+                    ?.filter(
+                      (c) =>
+                        c.monetary_component_type === MonetaryComponentType.tax,
+                    )
+                    ?.reduce((acc, curr) => acc + Number(curr.amount || 0), 0)
+                    ?.toString()}
                   hideCurrency
                 />
               </TableCell>
               <TableCell className="border-x p-3 text-gray-950">
                 <MonetaryDisplay
-                  amount={String(
-                    delivery.supplied_inventory_item?.product.charge_item_definition?.price_components
-                      .filter(
-                        (c) =>
-                          c.monetary_component_type ===
-                          MonetaryComponentType.discount,
-                      )
-                      .reduce((acc, curr) => acc + Number(curr.amount || 0), 0),
-                  )}
+                  amount={delivery.supplied_inventory_item?.product.charge_item_definition?.price_components
+                    ?.filter(
+                      (c) =>
+                        c.monetary_component_type ===
+                        MonetaryComponentType.discount,
+                    )
+                    ?.reduce((acc, curr) => acc + Number(curr.amount || 0), 0)
+                    ?.toString()}
                   hideCurrency
                 />
               </TableCell>


### PR DESCRIPTION
## Proposed Changes

Fixes #14321

- Fixed NaN display in Tax and Disc columns when ChargeItem is not applicable in Purchase Delivery table
- Added optional chaining (`?.`) to safely handle null/undefined `charge_item_definition` and `price_components`
- Replaced `String()` wrapper with `?.toString()` to allow MonetaryDisplay component to show "-" placeholder instead of "NaN"
- Applied consistent null-safety handling across Base, Tax, and Discount columns in SupplyDeliveryTable component

### Technical Details
- **Root Cause**: Code was attempting to access `.price_components.filter()` without checking if `charge_item_definition` or `price_components` exist
- **Solution**: Used optional chaining to gracefully handle undefined values, allowing the MonetaryDisplay component to show its default "-" fallback


### Before
- Tax and Disc columns showed "NaN" when items lacked charge item definitions


### After  
- Tax and Disc columns show "-" when charge item definitions are not applicable


Tagging: @ohcnetwork/care-fe-code-reviewers

### Screenshots
<img width="1869" height="960" alt="Screenshot from 2025-11-17 23-57-15" src="https://github.com/user-attachments/assets/4a472e12-ae20-4de0-a3ce-afb011b2b87b" />



## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved supply delivery table reliability with enhanced handling of pricing information when data is incomplete or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->