### PR TITLE
fix(sidebar): correctly highlight Accounts item on account detail pages

### DIFF
--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight } from "lucide-react";
 import { ActiveLink, useFullPath } from "raviger";
-import { Fragment, ReactNode, useMemo, useState } from "react";
+import { Fragment, ReactNode, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -48,17 +48,26 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
   const isCollapsed = state === "collapsed";
 
   const fullPath = useFullPath();
-  const fullPathMap = useMemo(
-    () =>
-      fullPath.split("/").reduce(
-        (acc, part) => ({
-          ...acc,
-          [part]: true,
-        }),
-        {} as Record<string, boolean>,
-      ),
-    [fullPath],
-  );
+
+  const normalize = (s: string) => s.replace(/\/+$/, "");
+
+  function matchPath(itemUrl: string, currentPath: string) {
+    const base = normalize(itemUrl);
+    const current = normalize(currentPath);
+
+    // exact or deeper prefix match: /a/b  matches /a/b and /a/b/...
+    if (current === base || current.startsWith(base + "/")) return true;
+
+    // special-case: treat "accounts" link as matching "account/:id"
+    // e.g. /.../billing/accounts should match /.../billing/account/<id>
+    if (base.endsWith("/accounts")) {
+      const singular = base.replace(/\/accounts$/, "/account");
+      if (current === singular || current.startsWith(singular + "/"))
+        return true;
+    }
+
+    return false;
+  }
 
   return (
     <SidebarGroup>
@@ -121,11 +130,9 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                                   >
                                     <ActiveLink
                                       href={subItem.url}
-                                      className="w-full"
-                                      activeClass={cn(
-                                        subItem.url
-                                          .split("/")
-                                          .every((part) => fullPathMap[part]) &&
+                                      className={cn(
+                                        "w-full",
+                                        matchPath(subItem.url, fullPath) &&
                                           "bg-white text-green-700 shadow",
                                       )}
                                       exactActiveClass="bg-white text-green-700 shadow"


### PR DESCRIPTION
## Proposed Changes

Fixes #14374

- Fixed the Accounts sidebar menu item not highlighting on account detail pages (`/billing/account/:id`)
- Added a `matchPath` helper to correctly detect active states when plural/singular route mismatch occurs
- Updated the `ActiveLink` logic in `nav-main.tsx` to use the improved matching

Tagging: @ohcnetwork/care-fe-code-reviewers


## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update product documentation.
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [X] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized navigation active state detection for improved performance and maintainability while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->