### PR TITLE
fix(encounter): add missing useEffect dependencies for permission check

### DIFF
--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -108,8 +108,7 @@ export const EncounterShow = (props: Props) => {
       toast.error(t("permission_denied_encounter"));
       goBack("/");
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPrimaryEncounterLoading, isPatientLoading]);
+  }, [isPrimaryEncounterLoading, isPatientLoading, canAccess, t, goBack]);
 
   if (
     isPrimaryEncounterLoading ||


### PR DESCRIPTION
## Proposed Changes

Fixes #14395
- Added missing dependencies (canAccess, goBack, t) to the useEffect hook in EncounterShow.tsx
- Removed the eslint-disable-next-line react-hooks/exhaustive-deps comment
- Ensures permission checks rerun when permission state changes, preventing stale closures

Verification :
- I verified the fix by simulating a real-time permission change. When canAccess switched from true → false at runtime, the updated useEffect re-ran immediately, triggering the correct redirect and translated permission-denied toast.

Video demonstration: 


https://github.com/user-attachments/assets/2bd4291b-dcd3-4113-98a3-72452ccc86fe


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [X] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug in the encounter details view where permission checks and navigation were not properly responding to changes in user access permissions and authentication state, ensuring reliable and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->