### PR TITLE
Gracefully handle errors from plugins

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2104,6 +2104,7 @@
   "error_generating_svg": "Error generating SVG",
   "error_in_createUpload": "Error in createUpload",
   "error_loading_definitions": "Error loading the definitions",
+  "error_loading_encounter_tab": "Error loading encounter tab",
   "error_loading_observation_definition": "Error loading observation definition",
   "error_loading_pdf": "Error loading PDF",
   "error_loading_product": "Error Loading Product",

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -14,6 +14,7 @@ import query from "@/Utils/request/query";
 
 import { PluginManifest, SupportedPluginComponents } from "@/pluginTypes";
 import plugConfigApi from "@/types/plugConfig/plugConfigApi";
+import { t } from "i18next";
 
 export class PluginErrorBoundary extends React.Component<
   { children: React.ReactNode; pluginName: string; fallback?: React.ReactNode },
@@ -151,7 +152,7 @@ export function PLUGIN_Component<K extends keyof SupportedPluginComponents>({
                     aria-label="Loading"
                     className="size-4 animate-spin"
                   />
-                  <p className="text-sm text-gray-600">Loading</p>
+                  <p className="text-sm text-gray-600">{t("loading")}</p>
                 </div>
               }
             >

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -15,8 +15,8 @@ import query from "@/Utils/request/query";
 import { PluginManifest, SupportedPluginComponents } from "@/pluginTypes";
 import plugConfigApi from "@/types/plugConfig/plugConfigApi";
 
-class PluginErrorBoundary extends React.Component<
-  { children: React.ReactNode; pluginName: string },
+export class PluginErrorBoundary extends React.Component<
+  { children: React.ReactNode; pluginName: string; fallback?: React.ReactNode },
   { hasError: boolean }
 > {
   constructor(props: { children: React.ReactNode; pluginName: string }) {
@@ -38,7 +38,7 @@ class PluginErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return null;
+      return this.props.fallback || null;
     }
 
     return this.props.children;

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -15,6 +15,36 @@ import query from "@/Utils/request/query";
 import { PluginManifest, SupportedPluginComponents } from "@/pluginTypes";
 import plugConfigApi from "@/types/plugConfig/plugConfigApi";
 
+class PluginErrorBoundary extends React.Component<
+  { children: React.ReactNode; pluginName: string },
+  { hasError: boolean }
+> {
+  constructor(props: { children: React.ReactNode; pluginName: string }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error(
+      `[Plugin Error] Plugin "${this.props.pluginName}" encountered an error:`,
+      error,
+      errorInfo,
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
 // Import the remote component synchronously
 export default function PluginEngine({
   children,
@@ -112,9 +142,11 @@ export function PLUGIN_Component<K extends keyof SupportedPluginComponents>({
         }
 
         return (
-          <React.Suspense key={plugin.plugin} fallback={<div>Loading...</div>}>
-            <Component {...props} />
-          </React.Suspense>
+          <PluginErrorBoundary key={plugin.plugin} pluginName={plugin.plugin}>
+            <React.Suspense fallback={<div>Loading...</div>}>
+              <Component {...props} />
+            </React.Suspense>
+          </PluginErrorBoundary>
         );
       })}
     </>

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -16,6 +16,7 @@ import query from "@/Utils/request/query";
 import { PluginManifest, SupportedPluginComponents } from "@/pluginTypes";
 import plugConfigApi from "@/types/plugConfig/plugConfigApi";
 import { t } from "i18next";
+import { z } from "zod";
 
 // Import the remote component synchronously
 export default function PluginEngine({
@@ -37,10 +38,16 @@ export default function PluginEngine({
 
       const manifests = await Promise.all(
         enabledPlugins.configs.map(async (plugin) => {
-          if (!plugin.meta.url) {
-            console.error(`Plugin ${plugin.slug} is missing a URL in meta`);
+          if (
+            !plugin.meta.url ||
+            !z.string().url().safeParse(plugin.meta.url).success
+          ) {
+            console.error(
+              `Plugin ${plugin.slug} has an invalid URL (${plugin.meta.url}) in meta`,
+            );
             return undefined;
           }
+
           setFederationRemote(plugin.slug, {
             url: () => Promise.resolve(plugin.meta.url),
             format: "esm",
@@ -65,6 +72,12 @@ export default function PluginEngine({
       const availablePlugins = filteredManifests.map((manifest) =>
         unwrapModule(manifest),
       );
+
+      if (availablePlugins.length === 0) {
+        console.log("No plugins found");
+        return;
+      }
+
       console.log(
         `Loading ${filteredManifests.length} plugins; available plugins`,
         availablePlugins,

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -1,13 +1,13 @@
+import ErrorBoundary from "@/components/Common/ErrorBoundary";
+import Loading from "@/components/Common/Loading";
 import { useQuery } from "@tanstack/react-query";
 import {
   __federation_method_getRemote as getFederationRemote,
   __federation_method_setRemote as setFederationRemote,
   __federation_method_unwrapDefault as unwrapModule,
 } from "__federation__";
+import { Loader2Icon } from "lucide-react";
 import React, { Suspense, useEffect, useState } from "react";
-
-import ErrorBoundary from "@/components/Common/ErrorBoundary";
-import Loading from "@/components/Common/Loading";
 
 import { CareAppsContext, useCareApps } from "@/hooks/useCareApps";
 import query from "@/Utils/request/query";
@@ -143,7 +143,18 @@ export function PLUGIN_Component<K extends keyof SupportedPluginComponents>({
 
         return (
           <PluginErrorBoundary key={plugin.plugin} pluginName={plugin.plugin}>
-            <React.Suspense fallback={<div>Loading...</div>}>
+            <React.Suspense
+              fallback={
+                <div className="flex items-center justify-center gap-2">
+                  <Loader2Icon
+                    role="status"
+                    aria-label="Loading"
+                    className="size-4 animate-spin"
+                  />
+                  <p className="text-sm text-gray-600">Loading</p>
+                </div>
+              }
+            >
               <Component {...props} />
             </React.Suspense>
           </PluginErrorBoundary>

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -1,5 +1,6 @@
 import ErrorBoundary from "@/components/Common/ErrorBoundary";
 import Loading from "@/components/Common/Loading";
+import { PluginErrorBoundary } from "@/components/Common/PluginErrorBoundary";
 import { useQuery } from "@tanstack/react-query";
 import {
   __federation_method_getRemote as getFederationRemote,
@@ -15,36 +16,6 @@ import query from "@/Utils/request/query";
 import { PluginManifest, SupportedPluginComponents } from "@/pluginTypes";
 import plugConfigApi from "@/types/plugConfig/plugConfigApi";
 import { t } from "i18next";
-
-export class PluginErrorBoundary extends React.Component<
-  { children: React.ReactNode; pluginName: string; fallback?: React.ReactNode },
-  { hasError: boolean }
-> {
-  constructor(props: { children: React.ReactNode; pluginName: string }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error(
-      `[Plugin Error] Plugin "${this.props.pluginName}" encountered an error:`,
-      error,
-      errorInfo,
-    );
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return this.props.fallback || null;
-    }
-
-    return this.props.children;
-  }
-}
 
 // Import the remote component synchronously
 export default function PluginEngine({

--- a/src/components/Common/PluginErrorBoundary.tsx
+++ b/src/components/Common/PluginErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export class PluginErrorBoundary extends React.Component<
+  { children: React.ReactNode; pluginName: string; fallback?: React.ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: {
+    children: React.ReactNode;
+    pluginName: string;
+    fallback?: React.ReactNode;
+  }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error(
+      `[Plugin Error] Plugin "${this.props.pluginName}" encountered an error:`,
+      error,
+      errorInfo,
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/hooks/useCareApps.tsx
+++ b/src/hooks/useCareApps.tsx
@@ -1,8 +1,8 @@
 import { CableIcon, Loader2Icon } from "lucide-react";
 import { Suspense, createContext, useContext } from "react";
 
+import { PluginErrorBoundary } from "@/components/Common/PluginErrorBoundary";
 import { PluginEncounterTabProps } from "@/pages/Encounters/EncounterShow";
-import { PluginErrorBoundary } from "@/PluginEngine";
 import { PluginManifest } from "@/pluginTypes";
 import { t } from "i18next";
 

--- a/src/hooks/useCareApps.tsx
+++ b/src/hooks/useCareApps.tsx
@@ -4,6 +4,7 @@ import { Suspense, createContext, useContext } from "react";
 import { PluginEncounterTabProps } from "@/pages/Encounters/EncounterShow";
 import { PluginErrorBoundary } from "@/PluginEngine";
 import { PluginManifest } from "@/pluginTypes";
+import { t } from "i18next";
 
 export const CareAppsContext = createContext<PluginManifest[]>([]);
 
@@ -41,7 +42,9 @@ const withSuspense = (
               aria-label="Error"
               className="size-4 text-red-500"
             />
-            <p className="text-sm text-gray-600">Error Loading Encounter Tab</p>
+            <p className="text-sm text-gray-600">
+              {t("error_loading_encounter_tab")}
+            </p>
           </div>
         }
       >
@@ -53,7 +56,7 @@ const withSuspense = (
                 aria-label="Loading"
                 className="size-4 animate-spin"
               />
-              <p className="text-sm text-gray-600">Loading</p>
+              <p className="text-sm text-gray-600">{t("loading")}</p>
             </div>
           }
         >

--- a/src/hooks/useCareApps.tsx
+++ b/src/hooks/useCareApps.tsx
@@ -1,6 +1,8 @@
+import { CableIcon, Loader2Icon } from "lucide-react";
 import { Suspense, createContext, useContext } from "react";
 
 import { PluginEncounterTabProps } from "@/pages/Encounters/EncounterShow";
+import { PluginErrorBoundary } from "@/PluginEngine";
 import { PluginManifest } from "@/pluginTypes";
 
 export const CareAppsContext = createContext<PluginManifest[]>([]);
@@ -25,13 +27,39 @@ export const useCareApps = () => {
 
 const withSuspense = (
   Component: React.ComponentType<PluginEncounterTabProps>,
+  pluginName: string,
 ) => {
   // eslint-disable-next-line react/display-name
   return (props: PluginEncounterTabProps) => {
     return (
-      <Suspense fallback={<div>Loading...</div>}>
-        <Component {...props} />
-      </Suspense>
+      <PluginErrorBoundary
+        pluginName={pluginName}
+        fallback={
+          <div className="flex items-center justify-center gap-2 py-6">
+            <CableIcon
+              role="status"
+              aria-label="Error"
+              className="size-4 text-red-500"
+            />
+            <p className="text-sm text-gray-600">Error Loading Encounter Tab</p>
+          </div>
+        }
+      >
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center gap-2">
+              <Loader2Icon
+                role="status"
+                aria-label="Loading"
+                className="size-4 animate-spin"
+              />
+              <p className="text-sm text-gray-600">Loading</p>
+            </div>
+          }
+        >
+          <Component {...props} />
+        </Suspense>
+      </PluginErrorBoundary>
     );
   };
 };
@@ -43,7 +71,7 @@ export const useCareAppEncounterTabs = () => {
     (acc, app) => {
       const appTabs = Object.entries(app.encounterTabs ?? {}).reduce(
         (acc, [key, Component]) => {
-          return { ...acc, [key]: withSuspense(Component) };
+          return { ...acc, [key]: withSuspense(Component, app.plugin) };
         },
         {},
       );

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -7,6 +7,7 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import HttpApi from "i18next-http-backend";
 import resourcesToBackend from "i18next-resources-to-backend";
 import { initReactI18next } from "react-i18next";
+import { z } from "zod";
 
 export const LANGUAGES = {
   en: "English",
@@ -30,7 +31,10 @@ const namespaceToUrl = (namespace: string) => {
     (config) => config.meta?.name === namespace || config.slug === namespace,
   );
 
-  if (pluginConfig?.meta?.url) {
+  if (
+    pluginConfig?.meta?.url &&
+    z.string().url().safeParse(pluginConfig.meta.url).success
+  ) {
     const url = new URL(pluginConfig.meta.url);
     return url.origin.toString();
   }


### PR DESCRIPTION
## Proposed Changes

- add error boundary for plugin components
- add error boundary to plugin encounter tabs
- show spinner for loading plugin component

<img width="1038" height="439" alt="image" src="https://github.com/user-attachments/assets/d72dd7b4-dfad-4698-8271-35bc8edfc662" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced plugin loading with per-plugin error handling to avoid full-page failures.
  * Localized messages for encounter tab loading and errors, including "Error loading encounter tab".
  * New visual loading indicator shown while plugins initialize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->