### PR TITLE
hide complete dispense button if already in one of completed statuses

### DIFF
--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -275,7 +275,7 @@ interface Props {
   facilityId: string;
   patientId: string;
   locationId: string;
-  status?: MedicationDispenseStatus;
+  status: MedicationDispenseStatus;
 }
 
 export default function DispensedMedicationList({
@@ -441,17 +441,20 @@ export default function DispensedMedicationList({
             </div>
           </div>
 
-          {selectedMedications.length > 0 && (
-            <Button
-              onClick={() =>
-                completeMedications({ signal: new AbortController().signal })
-              }
-              disabled={isPending}
-            >
-              {t("complete_dispense")}
-              <ShortcutBadge actionId="dispense-button" />
-            </Button>
-          )}
+          {selectedMedications.length > 0 &&
+            (status === MedicationDispenseStatus.preparation ||
+              status === MedicationDispenseStatus.in_progress ||
+              status === MedicationDispenseStatus.on_hold) && (
+              <Button
+                onClick={() =>
+                  completeMedications({ signal: new AbortController().signal })
+                }
+                disabled={isPending}
+              >
+                {t("complete_dispense")}
+                <ShortcutBadge actionId="dispense-button" />
+              </Button>
+            )}
         </div>
       </div>
 

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -443,8 +443,7 @@ export default function DispensedMedicationList({
 
           {selectedMedications.length > 0 &&
             (status === MedicationDispenseStatus.preparation ||
-              status === MedicationDispenseStatus.in_progress ||
-              status === MedicationDispenseStatus.on_hold) && (
+              status === MedicationDispenseStatus.in_progress) && (
               <Button
                 onClick={() =>
                   completeMedications({ signal: new AbortController().signal })


### PR DESCRIPTION
## Proposed Changes

### Issue

- "Complete dispense" button shown in completed statuses as well

### Before 

<img width="2051" height="1106" alt="image" src="https://github.com/user-attachments/assets/12b3a379-e46a-4d6d-a9dd-31cce4423368" />


### After 

<img width="2055" height="896" alt="image" src="https://github.com/user-attachments/assets/2fea5ff7-bb7e-45f6-b8ab-60e45cdbefa2" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "complete dispense" action now only appears when medication batches are in Preparation or In Progress, preventing it from showing for other statuses.
* **Chores**
  * The medication list now always receives a status value to ensure consistent display and query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->