### PR TITLE
Remove unnecessary geo-admin flag from role name in FacilityOrganizationUsers component

### DIFF
--- a/src/pages/Facility/settings/organizations/FacilityOrganizationUsers.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationUsers.tsx
@@ -148,7 +148,7 @@ export default function FacilityOrganizationUsers({
                 <UserCard
                   key={userRole.user.id}
                   user={userRole.user}
-                  roleName={userRole.role.name + `${isGeoAdmin}`}
+                  roleName={userRole.role.name}
                   facility={facilityId}
                   actions={
                     (isGeoAdmin || canManageFacilityOrganizationUsers) && (


### PR DESCRIPTION

<img width="885" height="454" alt="image" src="https://github.com/user-attachments/assets/3c9af25e-c882-467d-a9d4-2e2ba1ecc382" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected role label display in facility organization user settings to accurately show user roles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->