### PR TITLE
Remove security headers from dev environment

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -220,15 +220,6 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
           "**/test-results/**",
         ],
       },
-      headers: {
-        "Strict-Transport-Security":
-          "max-age=31536000; includeSubDomains; preload",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-Content-Type-Options": "nosniff",
-        "Referrer-Policy": "strict-origin-when-cross-origin",
-        "Permissions-Policy": "geolocation=(self), microphone=(self)",
-      },
     },
     preview: {
       headers: {


### PR DESCRIPTION
Fixes https://github.com/ohcnetwork/care_fe/issues/14499

## Proposed Changes

- Removes security headers from the dev environment
- Why do we need security headers in the dev env??


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed security headers from the local development server configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->