### PR TITLE
Fix pagination issue in the Product suppliers page

### DIFF
--- a/src/pages/Admin/organizations/AdminOrganizationView.tsx
+++ b/src/pages/Admin/organizations/AdminOrganizationView.tsx
@@ -207,7 +207,7 @@ export default function AdminOrganizationView({ id, organizationType }: Props) {
               </Card>
             )}
           </div>
-          {children?.count && children.count > resultsPerPage && (
+          {children && children.count > resultsPerPage && (
             <div className="flex justify-center">
               <Pagination totalCount={children.count} />
             </div>

--- a/src/pages/Admin/organizations/AdminOrganizationView.tsx
+++ b/src/pages/Admin/organizations/AdminOrganizationView.tsx
@@ -139,7 +139,7 @@ export default function AdminOrganizationView({ id, organizationType }: Props) {
   });
 
   const { data: children, isLoading } = useQuery({
-    queryKey: ["organization", "list", organizationType, id, qParams.search],
+    queryKey: ["organization", "list", organizationType, id, qParams],
     queryFn: query.debounced(organizationApi.list, {
       pathParams: { id: id },
       queryParams: {
@@ -207,7 +207,7 @@ export default function AdminOrganizationView({ id, organizationType }: Props) {
               </Card>
             )}
           </div>
-          {children && children.count > resultsPerPage && (
+          {children?.count && children.count > resultsPerPage && (
             <div className="flex justify-center">
               <Pagination totalCount={children.count} />
             </div>


### PR DESCRIPTION
Fixes : #14462
- The qParams weren’t included in the query key, so the data wasn’t fetched correctly based on pagination. I’ve now added the qParams to the query key.

ScreenRecord :




https://github.com/user-attachments/assets/c8179f0e-3a81-41cb-b617-bfe197921b44

Tagging: @ohcnetwork/care-fe-code-reviewers
## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized organization list data refresh logic to ensure more up-to-date information across pagination and filtering changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->