### PR TITLE
share sonner package in federation

### DIFF
--- a/plugins/fixSonnerPackageJson.ts
+++ b/plugins/fixSonnerPackageJson.ts
@@ -1,0 +1,38 @@
+import { existsSync } from "fs";
+import path from "path";
+import type { Plugin } from "vite";
+
+/**
+ * This is a workaround to fix the sonner package.json resolution issue.
+ *
+ * Fixes the resolution issue where vite-plugin-federation tries to resolve
+ * "sonner/package.json" which doesn't exist in the package exports.
+ * This plugin intercepts the resolution and returns the actual package.json file path.
+ */
+export function fixSonnerPackageJson(): Plugin {
+  const packageJsonPath = path.resolve(
+    process.cwd(),
+    "node_modules/sonner/package.json",
+  );
+
+  return {
+    name: "fix-sonner-package-json",
+    enforce: "pre",
+    resolveId(id) {
+      // Intercept requests for sonner/package.json
+      if (
+        id === "sonner/package.json" ||
+        id.endsWith("/sonner/package.json") ||
+        (id.includes("sonner") &&
+          id.includes("package.json") &&
+          !id.includes("node_modules"))
+      ) {
+        // Return the actual file path if it exists
+        if (existsSync(packageJsonPath)) {
+          return packageJsonPath;
+        }
+      }
+      return null;
+    },
+  };
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,3 +1,5 @@
+import { type UserConfig, defineConfig, loadEnv } from "vite";
+
 import federation from "@originjs/vite-plugin-federation";
 import reactScan from "@react-scan/vite-plugin-react-scan";
 import tailwindcss from "@tailwindcss/vite";
@@ -6,12 +8,11 @@ import DOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
 import { marked } from "marked";
 import path from "path";
-import { defineConfig, loadEnv, type UserConfig } from "vite";
 import checker from "vite-plugin-checker";
 import { VitePWA } from "vite-plugin-pwa";
 import { viteStaticCopy } from "vite-plugin-static-copy";
-
 import { careConsoleArt } from "./plugins/careConsoleArt";
+import { fixSonnerPackageJson } from "./plugins/fixSonnerPackageJson";
 import { treeShakeCareIcons } from "./plugins/treeShakeCareIcons";
 import validateEnv from "./scripts/validate-env";
 
@@ -51,6 +52,7 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
     },
     plugins: [
       careConsoleArt(),
+      fixSonnerPackageJson(),
       tailwindcss(),
       federation({
         name: "core",
@@ -62,6 +64,8 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
           "react-dom",
           "react-i18next",
           "@tanstack/react-query",
+          "raviger",
+          "sonner",
         ],
       }),
       viteStaticCopy({


### PR DESCRIPTION
## Proposed Changes

Fixes #14242
This fixes the `toast not showing up in plugs` issue. This PR shares the sonner package so that the plugs also can use the Toaster provider initialised in the host (core). But there is an issue while sharing the sonner package, sonner doesn't expose the package.json which is required by the vite federation for sharing the module properly, so to fix this issue, added a vite plugin to manually intercept the access of sonner's package.json and mapped it to the package.json in the node_modules.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration for improved dependency resolution.
  * Expanded supported shared packages in the bundling system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->