### PR TITLE
Fix conditional rendering in PatientInfoHoverCard to ensure facilityID

### DIFF
--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -41,7 +41,7 @@ export const PatientInfoHoverCard = ({
         </div>
       </div>
       <div className="flex items-center gap-2">
-        {!isPatientHomePage && (
+        {!isPatientHomePage && facilityId && (
           <Button variant="outline" className="text-gray-950" asChild>
             <Link
               basePath="/"

--- a/tests/facility/patient/patientHome/patientinfoHoverCard.spec.ts
+++ b/tests/facility/patient/patientHome/patientinfoHoverCard.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { getFacilityId } from "tests/support/facilityId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("PatientInfoHoverCard Conditional Rendering", () => {
+  test.beforeEach(async ({ page }) => {
+    const facilityId = getFacilityId();
+    await page.goto(`/facility/${facilityId}/encounters/patients/all`);
+  });
+
+  test("should not show Patient Home button on patient home page", async ({
+    page,
+  }) => {
+    await page.getByRole("link", { name: "Patient Home" }).first().click();
+
+    // Wait for patient info hover card trigger
+    await page
+      .locator("[data-slot='patient-info-hover-card-trigger']")
+      .last()
+      .click();
+
+    // Verify that Patient Home button is NOT visible (because its home page)
+    await expect(
+      page.getByRole("link", { name: "Patient Home" }),
+    ).not.toBeVisible();
+
+    // But View Profile button should still be visible
+    await expect(page.getByRole("link", { name: "View Profile" })).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});

--- a/tests/organization/patient/encounter/patientInfoHoverCard.spec.ts
+++ b/tests/organization/patient/encounter/patientInfoHoverCard.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("PatientInfoHoverCard Conditional Rendering", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("tab", { name: "Governance" }).click();
+    await page
+      .getByRole("link", { name: /Government$/ })
+      .first()
+      .click();
+    await page.getByRole("menuitem", { name: "patients" }).click();
+  });
+
+  test("should NOT show Patient Home button in encounter accessed via organization route", async ({
+    page,
+  }) => {
+    await page.waitForLoadState("networkidle");
+    await page.locator("[data-slot='card-content']").first().click();
+
+    await page.getByRole("tab", { name: "Encounters" }).click();
+
+    await page.getByRole("link", { name: "View Encounter" }).click();
+
+    await page.getByRole("link", { name: /view encounter/i }).first();
+
+    // Verify URL contains organizationId and NOT facilityId
+    expect(page.url()).toContain(`/organization/organizationId/patient/`);
+    expect(page.url()).not.toContain("/facility/");
+
+    // Wait for patient info hover card trigger
+    await page
+      .locator("[data-slot='patient-info-hover-card-trigger']")
+      .last()
+      .click();
+
+    // Verify that Patient Home button is NOT visible (because facilityId is not available)
+    await expect(
+      page.getByRole("link", { name: "Patient Home" }),
+    ).not.toBeVisible();
+
+    // But View Profile button should still be visible
+    await expect(page.getByRole("link", { name: "View Profile" })).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});


### PR DESCRIPTION
## Proposed Changes
Checks if there is "facilityID" for rendering the home button 

Fixes #14493 
Accessing via `organization/organizationId/patient`
<img width="974" height="309" alt="image" src="https://github.com/user-attachments/assets/24285d12-70f1-4dad-b7a4-e9ee18f7ccd9" />

Accessing via `facility`
<img width="974" height="309" alt="image" src="https://github.com/user-attachments/assets/11f13c26-ca4d-4d63-8fbb-95437147d396" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Action button no longer appears without a valid facility context; it now only displays when facility context is present.

* **Tests**
  * Added end-to-end tests validating the Patient Info Hover Card’s conditional rendering across facility and organization routes (ensures "Patient Home" is hidden where appropriate and "View Profile" remains visible).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->