### PR TITLE
Added link to receipt page when clicked on payment history items

### DIFF
--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -1094,6 +1094,11 @@ export function InvoiceShow({
         facilityId={facilityId}
         invoice={invoice}
         accountId={invoice.account.id}
+        onSuccess={() => {
+          navigate(
+            `/facility/${facilityId}/billing/invoice/${invoiceId}/print`,
+          );
+        }}
       />
 
       <AlertDialog

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -960,7 +960,8 @@ export function InvoiceShow({
                 </div>
               ) : (
                 payments.results.map((payment, index) => (
-                  <div
+                  <Link
+                    href={`/facility/${facilityId}/billing/payments/${payment.id}/print`}
                     key={payment.id}
                     className="relative flex items-start py-8 px-3  group"
                   >
@@ -1011,7 +1012,7 @@ export function InvoiceShow({
                         </Badge>
                       </div>
                     </div>
-                  </div>
+                  </Link>
                 ))
               )}
             </div>
@@ -1094,11 +1095,6 @@ export function InvoiceShow({
         facilityId={facilityId}
         invoice={invoice}
         accountId={invoice.account.id}
-        onSuccess={() => {
-          navigate(
-            `/facility/${facilityId}/billing/invoice/${invoiceId}/print`,
-          );
-        }}
       />
 
       <AlertDialog


### PR DESCRIPTION
## Proposed Changes

Fixes #14500
- Redirect to print page once payment is recorded in invoice

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment history items are now clickable and open the payment print view for quick access.
  * Invoice and payment operations continue to navigate to the print view upon completion, streamlining the billing workflow.

(✏️ Tip: You can customize this high-level summary in your review settings.)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->