### PR TITLE
Fix failing Patient Identifier Config Tests

### DIFF
--- a/tests/admin/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
+++ b/tests/admin/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
@@ -65,6 +65,9 @@ test.describe("Patient Identifier Config - Create", () => {
 
     await page.getByRole("button", { name: "Create" }).click();
 
+    await page.getByRole("combobox").filter({ hasText: "Status" }).click();
+    await page.getByRole("option", { name: status, exact: true }).click();
+
     // Verify that the new config appears in the list
     await page
       .getByRole("textbox", { name: "Search configs" })

--- a/tests/admin/patientIdentifierConfig/patientIdentifierConfigEdit.spec.ts
+++ b/tests/admin/patientIdentifierConfig/patientIdentifierConfigEdit.spec.ts
@@ -42,6 +42,9 @@ test.describe("Patient Identifier Config - Edit", () => {
 
     await page.getByRole("button", { name: "Create" }).click();
 
+    await page.getByRole("combobox").filter({ hasText: "Status" }).click();
+    await page.getByRole("option", { name: status, exact: true }).click();
+
     // Verify that the new config appears in the list
     await page
       .getByRole("textbox", { name: "Search configs" })
@@ -57,6 +60,9 @@ test.describe("Patient Identifier Config - Edit", () => {
       .getByRole("textbox", { name: "Description" })
       .fill(`${description}-edited`);
     await page.getByRole("button", { name: "Update" }).click();
+
+    await page.getByRole("combobox").filter({ hasText: "Status" }).click();
+    await page.getByRole("option", { name: status, exact: true }).click();
 
     // Verify that the edited config appears in the list
     await page


### PR DESCRIPTION
## Proposed Changes

Fixes #14511 
- Applied created PIC status before searching

Playwright Test Report - 
<img width="997" height="781" alt="Screenshot 2025-11-26 at 2 03 37 PM" src="https://github.com/user-attachments/assets/c0a28db3-2b30-4896-81a5-9205a5ef3127" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for patient identifier configuration workflows by adding explicit status confirmation steps following creation and editing operations, ensuring proper UI state validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->