### PR TITLE
## Fix: Proper empty-state handling for service points (Issue #14502)

### DIFF
--- a/src/pages/Facility/queues/AssignToServicePointDialog.tsx
+++ b/src/pages/Facility/queues/AssignToServicePointDialog.tsx
@@ -110,6 +110,8 @@ export function AssignToServicePointDialog({
               </span>
             </div>
           ))}
+          {/* If this resource doesn’t have any service points, show a simple empty state
+              so the dialog doesn’t appear blank or broken. */}
           {assignedServicePoints.length === 0 && (
             <div className="flex items-center space-x-3 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors">
               <RadioGroupItem value="none" id="none" disabled />
@@ -126,7 +128,12 @@ export function AssignToServicePointDialog({
           <Button
             onClick={handleConfirm}
             className="w-full"
-            disabled={!selectedSubQueueId || isPending}
+            // Disable the action when nothing is selected or when the resource has no service points at all.
+            disabled={
+              !selectedSubQueueId ||
+              isPending ||
+              assignedServicePoints.length === 0
+            }
           >
             <UserCheck className="size-4 mr-2" />
             {t("call_patient")}

--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -301,28 +301,37 @@ function ManageServicePointsDialog({
           <DialogTitle>{t("assigned_service_points")}</DialogTitle>
         </DialogHeader>
         <div>
-          {allServicePoints.map((subQueue) => {
-            const isSelected = assignedServicePointIds.includes(subQueue.id);
-            return (
-              <div
-                key={subQueue.id}
-                className="flex items-center justify-between rounded-sm w-full p-3 hover:bg-gray-100 cursor-pointer"
-                onClick={() => {
-                  toggleServicePoint(subQueue.id, !isSelected);
-                }}
-              >
-                <div className="flex items-center space-x-3">
-                  <Checkbox
-                    checked={isSelected}
-                    onCheckedChange={(checked) =>
-                      toggleServicePoint(subQueue.id, checked as boolean)
-                    }
-                  />
-                  <span className="text-sm font-medium">{subQueue.name}</span>
+          {/* When a resource has zero service points, show a clear message instead of an empty dialog body. */}
+          {allServicePoints.length === 0 ? (
+            <div className="flex items-center justify-center p-6">
+              <span className="text-sm text-gray-500">
+                {t("no_service_points_available")}
+              </span>
+            </div>
+          ) : (
+            allServicePoints.map((subQueue) => {
+              const isSelected = assignedServicePointIds.includes(subQueue.id);
+              return (
+                <div
+                  key={subQueue.id}
+                  className="flex items-center justify-between rounded-sm w-full p-3 hover:bg-gray-100 cursor-pointer"
+                  onClick={() => {
+                    toggleServicePoint(subQueue.id, !isSelected);
+                  }}
+                >
+                  <div className="flex items-center space-x-3">
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={(checked) =>
+                        toggleServicePoint(subQueue.id, checked as boolean)
+                      }
+                    />
+                    <span className="text-sm font-medium">{subQueue.name}</span>
+                  </div>
                 </div>
-              </div>
-            );
-          })}
+              );
+            })
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -24,6 +24,26 @@ export const ServicePointsDropDown = () => {
     return <Loading />;
   }
 
+  // When a resource has no service points, render a simple fallback message.
+  // This avoids showing an empty or broken dropdown and makes the empty state explicit. (fixes the empty-state issue in #14502).
+  if (allServicePoints.length === 0) {
+    return (
+      <div className="flex">
+        <div className="flex gap-1 rounded-md border border-gray-300 p-1.5 bg-white items-center justify-center w-full">
+          <span className="text-sm font-medium text-gray-500">
+            {t("no_service_points_available")}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          disabled
+          className="rounded-l-none w-10 h-11 border border-gray-300 bg-gray-50 cursor-not-allowed opacity-50"
+        >
+          <ChevronDownIcon />
+        </Button>
+      </div>
+    );
+  }
   const activeServicePointCount = allServicePoints.filter((subQueue) =>
     assignedServicePointIds.includes(subQueue.id),
   ).length;


### PR DESCRIPTION
HI @rithviknishad ! and Team👋,

This PR improves how the Queue Board behaves when a resource has no service points configured.  
Instead of rendering blank or broken UI, the screens now show clear, user-friendly empty states.

---

## What changed

### `ServicePointsDropDown`
- Added an explicit check for empty arrays.
- Shows a simple “No service points available” fallback message.
- Disables the dropdown trigger when there’s nothing a user can select.

### `ManageServicePointsDialog`
- Added a proper empty-state message when a resource has no service points.
- Prevents the dialog from appearing blank and makes the UX clearer.

### `AssignToServicePointDialog`
- This dialog already handled empty states.
- Added a condition to keep the action button disabled when no service points exist.

---

## Why this is needed

The backend returns an empty array (`[]`) when a resource has no service points.  
Previously, components were only checking for `null` or `undefined`, so an empty array passed through and caused:

- blank dropdown menus,  
- empty dialogs,  
- buttons that looked active but had nothing to operate on.

By adding explicit `allServicePoints.length === 0` checks, each component now shows a meaningful empty-state and avoids broken UI.

---

## Testing

- Verified the dropdown shows a fallback message instead of an empty menu.
- Confirmed the Manage dialog displays a clear empty-state message.
- Checked that action buttons stay disabled when no service points exist.
- Ensured normal behavior is unchanged when service points are available.

---

## Notes

I’ve kept the changes scoped, simple, and consistent across all three components.  
I’m happy to continue contributing and help with future improvements or related work across the repo whenever needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented empty-state messaging in queue management dialogs and dropdown selectors when no service points are available, providing users with clear guidance and improving the overall user experience during queue configuration.
  * Enhanced form validation to prevent queue confirmation when no service points have been assigned, ensuring configurations remain valid and complete before saving.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## 📝 Merge Checklist  
(Please check only items that apply)

- [x] I have manually tested this change  
- [x] The UI works as expected when service points are empty  
- [x] No breaking changes introduced  
- [x] PR description clearly explains the fix  
- [ ] Tests added (not required for this PR, so leaving unchecked)
