### PR TITLE
fix/tags are reflecting without refresh in service req table

### DIFF
--- a/src/components/ServiceRequest/ServiceRequestTable.tsx
+++ b/src/components/ServiceRequest/ServiceRequestTable.tsx
@@ -107,47 +107,9 @@ export default function ServiceRequestTable({
                     entityId={request.id}
                     facilityId={facilityId}
                     currentTags={request.tags ?? []}
-                    onUpdate={(
-                      updatedTags?: { id: string; display: string }[],
-                    ) => {
-                      try {
-                        queryClient.setQueryData(
-                          ["serviceRequests", facilityId, locationId],
-                          (oldData: any) => {
-                            if (!oldData) return oldData;
-
-                            if (Array.isArray(oldData)) {
-                              return oldData.map((r) =>
-                                r.id === request.id
-                                  ? { ...r, tags: updatedTags ?? r.tags }
-                                  : r,
-                              );
-                            }
-
-                            if (oldData?.data && Array.isArray(oldData.data)) {
-                              return {
-                                ...oldData,
-                                data: oldData.data.map((r: any) =>
-                                  r.id === request.id
-                                    ? { ...r, tags: updatedTags ?? r.tags }
-                                    : r,
-                                ),
-                              };
-                            }
-                            return oldData;
-                          },
-                        );
-                      } catch (err) {
-                        console.warn(
-                          "cache update for serviceRequests failed",
-                          err,
-                        );
-                      }
-
+                    onUpdate={() => {
                       queryClient.invalidateQueries({
-                        queryKey: ["serviceRequests", facilityId],
-
-                        exact: false,
+                        queryKey: ["serviceRequests", facilityId, locationId],
                       });
                     }}
                     patientId={request.encounter.patient.id}

--- a/src/components/ServiceRequest/ServiceRequestTable.tsx
+++ b/src/components/ServiceRequest/ServiceRequestTable.tsx
@@ -97,7 +97,7 @@ export default function ServiceRequestTable({
               </TableCell>
               <TableCell>
                 <div className="flex flex-wrap gap-1">
-                  {request.tags.map((tag) => (
+                  {(request.tags ?? []).map((tag) => (
                     <Badge key={tag.id} variant="secondary" className="text-xs">
                       {tag.display}
                     </Badge>
@@ -109,12 +109,15 @@ export default function ServiceRequestTable({
                     currentTags={request.tags ?? []}
                     onUpdate={() => {
                       queryClient.invalidateQueries({
+                        queryKey: ["serviceRequests"],
+                      });
+                      queryClient.invalidateQueries({
                         queryKey: ["serviceRequests", facilityId, locationId],
                       });
                     }}
                     patientId={request.encounter.patient.id}
                     trigger={
-                      request.tags && request.tags.length > 0 ? (
+                      (request.tags?.length ?? 0) > 0 ? (
                         <Button variant="outline" size="xs">
                           <Hash className="size-3" /> {t("tags")}
                         </Button>

--- a/src/components/ServiceRequest/ServiceRequestTable.tsx
+++ b/src/components/ServiceRequest/ServiceRequestTable.tsx
@@ -107,9 +107,47 @@ export default function ServiceRequestTable({
                     entityId={request.id}
                     facilityId={facilityId}
                     currentTags={request.tags ?? []}
-                    onUpdate={() => {
+                    onUpdate={(
+                      updatedTags?: { id: string; display: string }[],
+                    ) => {
+                      try {
+                        queryClient.setQueryData(
+                          ["serviceRequests", facilityId, locationId],
+                          (oldData: any) => {
+                            if (!oldData) return oldData;
+
+                            if (Array.isArray(oldData)) {
+                              return oldData.map((r) =>
+                                r.id === request.id
+                                  ? { ...r, tags: updatedTags ?? r.tags }
+                                  : r,
+                              );
+                            }
+
+                            if (oldData?.data && Array.isArray(oldData.data)) {
+                              return {
+                                ...oldData,
+                                data: oldData.data.map((r: any) =>
+                                  r.id === request.id
+                                    ? { ...r, tags: updatedTags ?? r.tags }
+                                    : r,
+                                ),
+                              };
+                            }
+                            return oldData;
+                          },
+                        );
+                      } catch (err) {
+                        console.warn(
+                          "cache update for serviceRequests failed",
+                          err,
+                        );
+                      }
+
                       queryClient.invalidateQueries({
-                        queryKey: ["serviceRequests", facilityId, locationId],
+                        queryKey: ["serviceRequests", facilityId],
+
+                        exact: false,
                       });
                     }}
                     patientId={request.encounter.patient.id}


### PR DESCRIPTION
## Proposed Changes

Fixes #14526

- updated the ServiceRequestTable.tsx file onupdate to ensure that while tag is changing it should also reflect on frontend without refreshing the page
- the code which is updated on the file is given below

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tag rendering so requests without tags display and behave correctly.
  * Ensured the Tags button appears and works reliably when tags are missing or empty.
  * Service request list now refreshes immediately after tag assignments so updates appear consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->