### PR TITLE
Added created and updated info in invoice

### DIFF
--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -83,6 +83,7 @@ import dayjs from "@/Utils/dayjs";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { formatDateTime, formatName } from "@/Utils/utils";
 import { format } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { formatPhoneNumberIntl } from "react-phone-number-input";
@@ -1183,6 +1184,29 @@ export function InvoiceShow({
           queryClient.invalidateQueries({ queryKey: ["invoice", invoiceId] });
         }}
       />
+
+      <div className="p-2">
+        <div className="space-y-2">
+          <div>
+            <p className="text-sm text-gray-500">{t("last_modified_by")}</p>
+            <p className="text-sm font-semibold">
+              {formatName(invoice.updated_by)}
+            </p>
+            <p className="text-xs text-gray-500">
+              {formatDateTime(invoice.modified_date)}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">{t("created_by")}</p>
+            <p className="text-sm font-semibold">
+              {formatName(invoice.created_by)}
+            </p>
+            <p className="text-xs text-gray-500">
+              {formatDateTime(invoice.created_date)}
+            </p>
+          </div>
+        </div>
+      </div>
 
       {sourceUrl && (
         <Alert className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 max-w-2xl w-full mx-auto shadow-lg rounded-lg p-0 bg-white border border-gray-200">

--- a/src/types/billing/invoice/invoice.ts
+++ b/src/types/billing/invoice/invoice.ts
@@ -2,6 +2,7 @@ import { MonetaryComponent } from "@/types/base/monetaryComponent/monetaryCompon
 import { AccountRead } from "@/types/billing/account/Account";
 import { ChargeItemRead } from "@/types/billing/chargeItem/chargeItem";
 import { PaymentReconciliationRead } from "@/types/billing/paymentReconciliation/paymentReconciliation";
+import { UserReadMinimal } from "@/types/user/user";
 
 export enum InvoiceStatus {
   draft = "draft",
@@ -41,6 +42,10 @@ export interface InvoiceRead extends InvoiceBase {
   total_net: number;
   total_gross: number;
   payment_reconciliations?: PaymentReconciliationRead[];
+  created_date: string;
+  created_by: UserReadMinimal;
+  modified_date: string;
+  updated_by: UserReadMinimal;
 }
 
 export interface InvoiceCancel {


### PR DESCRIPTION
## Proposed Changes

Fixes #14537
- Added created by, created date, updated by and modified date in See Invoice page.

<img width="1610" height="925" alt="Screenshot from 2025-11-28 17-27-42" src="https://github.com/user-attachments/assets/f17897ab-88d7-4af5-8780-7dbef0daa247" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoices now display audit trail information including the user who created the invoice with its creation date, and the user who last modified it with the modification date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->