### PR TITLE
fix: intersects_any to has_tag

### DIFF
--- a/src/types/base/condition/condition.ts
+++ b/src/types/base/condition/condition.ts
@@ -8,7 +8,6 @@ import { z } from "zod";
 export enum ConditionOperation {
   equality = "equality",
   in_range = "in_range",
-  intersects_any = "intersects_any",
   has_tag = "has_tag",
 }
 


### PR DESCRIPTION
## Proposed Changes

Fixes #14408
- In condition.ts file Updated intersects_any to has_tag

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the available condition operation types. The `intersects_any` operation has been removed, simplifying the set of supported condition operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->