### PR TITLE
Fix: “Last Active” label overflow

### DIFF
--- a/src/components/Users/UserListAndCard.tsx
+++ b/src/components/Users/UserListAndCard.tsx
@@ -39,19 +39,36 @@ export const UserStatusIndicator = ({
   const { t } = useTranslation();
 
   return (
-    <span className={cn(addPadding ? "px-3 py-1" : "py-px", className)}>
+    // make this an inline-flex container so the badge can be constrained/truncated
+    <span
+      className={cn(
+        addPadding ? "px-3 py-1" : "py-px",
+        className,
+        "inline-flex",
+      )}
+    >
       {isUserOnline(user) || isAuthUser ? (
-        <Badge variant="primary" className="whitespace-nowrap">
+        // limit badge width and allow truncation if necessary
+        <Badge
+          variant="primary"
+          className="whitespace-nowrap max-w-[9rem] truncate"
+        >
           <span className="inline-block size-2 shrink-0 rounded-full bg-green-500" />
           <span>{t("online")}</span>
         </Badge>
       ) : user.last_login ? (
-        <Badge variant="yellow" className="whitespace-nowrap">
+        <Badge
+          variant="yellow"
+          className="whitespace-nowrap max-w-[9rem] truncate"
+        >
           <span className="inline-block size-2 shrink-0 rounded-full bg-yellow-500" />
           <RelativeDateTooltip date={user.last_login} />
         </Badge>
       ) : (
-        <Badge variant="secondary" className="whitespace-nowrap">
+        <Badge
+          variant="secondary"
+          className="whitespace-nowrap max-w-[9rem] truncate"
+        >
           <span className="inline-block size-2 shrink-0 rounded-full bg-gray-500" />
           <span className="hidden lg:inline">{t("never_logged_in")}</span>
           <span className="lg:hidden">{t("never")}</span>
@@ -66,8 +83,9 @@ export function UserCard(props: UserCardProps) {
   const { t } = useTranslation();
 
   return (
+    // ensure content overflow is clipped at the card level
     <Card key={user.id} className={cn("h-full", user.deleted && "opacity-60")}>
-      <CardContent className="p-4 flex flex-col h-full justify-between">
+      <CardContent className="p-4 flex flex-col h-full justify-between overflow-hidden">
         <div className="flex items-start gap-3">
           <Avatar
             name={`${user.first_name} ${user.last_name}`}
@@ -75,13 +93,16 @@ export function UserCard(props: UserCardProps) {
             className="h-12 w-12 sm:h-14 sm:w-14 text-xl sm:text-2xl flex-shrink-0"
           />
 
+          {/* make this column shrinkable (min-w-0) so children can truncate correctly */}
           <div className="flex flex-col min-w-0 flex-1">
             <div className="flex flex-col gap-1">
-              <div className="flex items-start justify-between">
-                <h1 className="text-base font-bold break-words pr-2">
+              {/* Add min-w-0 and full width to the row so the status can be constrained */}
+              <div className="flex items-start justify-between min-w-0 w-full">
+                <h1 className="text-base font-bold break-words pr-2 min-w-0">
                   {formatName(user)}
                 </h1>
-                <span className="text-sm text-gray-500">
+                {/* prevent the status from growing and pushing layout; keep it shrink-0 */}
+                <span className="text-sm text-gray-500 flex-shrink-0 ml-2">
                   <UserStatusIndicator user={user} />
                 </span>
               </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #14025
- update css on the UserListAndCard.tsx file so "Last Active" not overflow.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized user status badge display with improved truncation handling
  * Enhanced layout stability in user cards to prevent content overflow
  * Improved visual consistency of status indicators across the user list

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->