### PR TITLE
Clean up: Remove view toggle from PK, AD, CID list views

### DIFF
--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { FilterSelect } from "@/components/ui/filter-select";
@@ -166,8 +165,6 @@ export function ActivityDefinitionList({
     },
   });
 
-  const [viewMode, setViewMode] = useState<"table" | "cards">("table");
-
   // Fetch activity definitions for current category
   const {
     data: activityDefinitionsResponse,
@@ -202,72 +199,42 @@ export function ActivityDefinitionList({
 
   return (
     <div>
-      {/* Header with filters and view toggle */}
-      <div className="flex flex-col lg:flex-row justify-between items-start gap-4 mb-6">
-        <div className="flex flex-col sm:flex-row gap-4 flex-1">
-          {/* Search */}
-          <div className="relative w-full sm:w-auto">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-              <CareIcon icon="l-search" className="size-5" />
-            </span>
-            <Input
-              placeholder={t("search_activity_definition")}
-              value={qParams.search || ""}
-              onChange={(e) =>
-                updateQuery({ search: e.target.value || undefined })
-              }
-              className="w-full sm:w-[300px] pl-10"
-            />
-          </div>
-
-          {/* Status Filter */}
-          <div className="w-full sm:w-auto">
-            <FilterSelect
-              value={qParams.status || ""}
-              onValueChange={(value) => updateQuery({ status: value })}
-              options={Object.values(Status)}
-              label={t("status")}
-              onClear={() => updateQuery({ status: undefined })}
-            />
-          </div>
-
-          {/* classification Filter */}
-          <div className="w-full sm:w-auto">
-            <FilterSelect
-              value={qParams.classification || ""}
-              onValueChange={(value) => updateQuery({ classification: value })}
-              options={Object.values(Classification)}
-              label={t("category")}
-              onClear={() => updateQuery({ classification: undefined })}
-            />
-          </div>
+      <div className="flex flex-col sm:flex-row gap-4 mb-6">
+        <div className="relative w-full sm:w-auto">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            <CareIcon icon="l-search" className="size-5" />
+          </span>
+          <Input
+            placeholder={t("search_activity_definition")}
+            value={qParams.search || ""}
+            onChange={(e) =>
+              updateQuery({ search: e.target.value || undefined })
+            }
+            className="w-full sm:w-[300px] pl-10"
+          />
         </div>
 
-        {/* View Toggle - Desktop only */}
-        <div className="hidden lg:flex items-center space-x-2">
-          <span className="text-sm text-gray-500">{t("view")}:</span>
-          <div className="flex border rounded-lg">
-            <Button
-              variant={viewMode === "table" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("table")}
-              className="rounded-r-none"
-            >
-              <CareIcon icon="l-table" className="h-4 w-4" />
-            </Button>
-            <Button
-              variant={viewMode === "cards" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("cards")}
-              className="rounded-l-none"
-            >
-              <CareIcon icon="l-th-large" className="h-4 w-4" />
-            </Button>
-          </div>
+        <div className="w-full sm:w-auto">
+          <FilterSelect
+            value={qParams.status || ""}
+            onValueChange={(value) => updateQuery({ status: value })}
+            options={Object.values(Status)}
+            label={t("status")}
+            onClear={() => updateQuery({ status: undefined })}
+          />
+        </div>
+
+        <div className="w-full sm:w-auto">
+          <FilterSelect
+            value={qParams.classification || ""}
+            onValueChange={(value) => updateQuery({ classification: value })}
+            options={Object.values(Classification)}
+            label={t("category")}
+            onClear={() => updateQuery({ classification: undefined })}
+          />
         </div>
       </div>
 
-      {/* Results count */}
       {activityDefinitionsResponse && activityDefinitionsResponse.count > 0 && (
         <div className="mb-4 text-sm text-gray-600">
           {t("showing")} {activityDefinitions.length} {t("of")}{" "}
@@ -275,7 +242,6 @@ export function ActivityDefinitionList({
         </div>
       )}
 
-      {/* Content */}
       {isLoadingActivityDefinitions ? (
         <TableSkeleton count={5} />
       ) : activityDefinitions.length === 0 ? (
@@ -288,38 +254,34 @@ export function ActivityDefinitionList({
         />
       ) : (
         <>
-          {/* Desktop Table View */}
-          {viewMode === "table" && (
-            <div className="hidden lg:block">
-              <div className="border rounded-lg overflow-hidden">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-[30%]">{t("title")}</TableHead>
-                      <TableHead className="w-[15%]">
-                        {t("classification")}
-                      </TableHead>
-                      <TableHead className="w-[15%]">{t("status")}</TableHead>
-                      <TableHead className="w-[15%]">{t("kind")}</TableHead>
-                      <TableHead className="w-[5%]">{t("actions")}</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {activityDefinitions.map((definition) => (
-                      <ActivityDefinitionTableRow
-                        key={definition.slug}
-                        definition={definition}
-                        facilityId={facilityId}
-                      />
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+          <div className="hidden lg:block">
+            <div className="border rounded-lg overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[30%]">{t("title")}</TableHead>
+                    <TableHead className="w-[15%]">
+                      {t("classification")}
+                    </TableHead>
+                    <TableHead className="w-[15%]">{t("status")}</TableHead>
+                    <TableHead className="w-[15%]">{t("kind")}</TableHead>
+                    <TableHead className="w-[5%]">{t("actions")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {activityDefinitions.map((definition) => (
+                    <ActivityDefinitionTableRow
+                      key={definition.slug}
+                      definition={definition}
+                      facilityId={facilityId}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
             </div>
-          )}
+          </div>
 
-          {/* Mobile Card View */}
-          <div className={`${viewMode === "cards" ? "block" : "lg:hidden"}`}>
+          <div className="lg:hidden">
             <div className="grid gap-3">
               {activityDefinitions.map((definition) => (
                 <ActivityDefinitionCard

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
@@ -199,7 +199,9 @@ export function ActivityDefinitionList({
 
   return (
     <div>
+      {/* Header with filters and view toggle */}
       <div className="flex flex-col sm:flex-row gap-4 mb-6">
+        {/* Search */}
         <div className="relative w-full sm:w-auto">
           <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
             <CareIcon icon="l-search" className="size-5" />
@@ -214,6 +216,7 @@ export function ActivityDefinitionList({
           />
         </div>
 
+        {/* Status Filter */}
         <div className="w-full sm:w-auto">
           <FilterSelect
             value={qParams.status || ""}
@@ -224,6 +227,7 @@ export function ActivityDefinitionList({
           />
         </div>
 
+        {/* classification Filter */}
         <div className="w-full sm:w-auto">
           <FilterSelect
             value={qParams.classification || ""}
@@ -235,6 +239,7 @@ export function ActivityDefinitionList({
         </div>
       </div>
 
+      {/* Results count */}
       {activityDefinitionsResponse && activityDefinitionsResponse.count > 0 && (
         <div className="mb-4 text-sm text-gray-600">
           {t("showing")} {activityDefinitions.length} {t("of")}{" "}
@@ -242,6 +247,7 @@ export function ActivityDefinitionList({
         </div>
       )}
 
+      {/* Content */}
       {isLoadingActivityDefinitions ? (
         <TableSkeleton count={5} />
       ) : activityDefinitions.length === 0 ? (
@@ -254,6 +260,7 @@ export function ActivityDefinitionList({
         />
       ) : (
         <>
+          {/* Desktop Table View */}
           <div className="hidden lg:block">
             <div className="border rounded-lg overflow-hidden">
               <Table>
@@ -281,6 +288,7 @@ export function ActivityDefinitionList({
             </div>
           </div>
 
+          {/* Mobile Card View */}
           <div className="lg:hidden">
             <div className="grid gap-3">
               {activityDefinitions.map((definition) => (

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { FilterSelect } from "@/components/ui/filter-select";
@@ -153,8 +152,6 @@ export function ChargeItemList({
     },
   });
 
-  const [viewMode, setViewMode] = useState<"table" | "cards">("table");
-
   // Fetch charge items for current category
   const { data: chargeItemsResponse, isLoading: isLoadingChargeItems } =
     useQuery({
@@ -189,61 +186,32 @@ export function ChargeItemList({
 
   return (
     <div>
-      {/* Header with filters and view toggle */}
-      <div className="flex flex-col lg:flex-row justify-between items-start gap-4 mb-6">
-        <div className="flex flex-col sm:flex-row gap-4 flex-1">
-          {/* Search */}
-          <div className="relative w-full sm:w-auto">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-              <CareIcon icon="l-search" className="size-5" />
-            </span>
-            <Input
-              placeholder={t("search_definitions")}
-              value={qParams.search || ""}
-              onChange={(e) =>
-                updateQuery({ search: e.target.value || undefined })
-              }
-              className="w-full sm:w-[300px] pl-10"
-            />
-          </div>
-
-          {/* Status Filter */}
-          <div className="w-full sm:w-auto">
-            <FilterSelect
-              value={qParams.status || ""}
-              onValueChange={(value) => updateQuery({ status: value })}
-              options={Object.values(ChargeItemDefinitionStatus)}
-              label={t("status")}
-              onClear={() => updateQuery({ status: undefined })}
-            />
-          </div>
+      <div className="flex flex-col sm:flex-row gap-4 mb-6">
+        <div className="relative w-full sm:w-auto">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            <CareIcon icon="l-search" className="size-5" />
+          </span>
+          <Input
+            placeholder={t("search_definitions")}
+            value={qParams.search || ""}
+            onChange={(e) =>
+              updateQuery({ search: e.target.value || undefined })
+            }
+            className="w-full sm:w-[300px] pl-10"
+          />
         </div>
 
-        {/* View Toggle - Desktop only */}
-        <div className="hidden lg:flex items-center space-x-2">
-          <span className="text-sm text-gray-500">{t("view")}:</span>
-          <div className="flex border rounded-lg">
-            <Button
-              variant={viewMode === "table" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("table")}
-              className="rounded-r-none"
-            >
-              <CareIcon icon="l-table" className="h-4 w-4" />
-            </Button>
-            <Button
-              variant={viewMode === "cards" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("cards")}
-              className="rounded-l-none"
-            >
-              <CareIcon icon="l-th-large" className="h-4 w-4" />
-            </Button>
-          </div>
+        <div className="w-full sm:w-auto">
+          <FilterSelect
+            value={qParams.status || ""}
+            onValueChange={(value) => updateQuery({ status: value })}
+            options={Object.values(ChargeItemDefinitionStatus)}
+            label={t("status")}
+            onClear={() => updateQuery({ status: undefined })}
+          />
         </div>
       </div>
 
-      {/* Results count */}
       {chargeItemsResponse && chargeItemsResponse.count > 0 && (
         <div className="mb-4 text-sm text-gray-600">
           {t("showing")} {chargeItems.length} {t("of")}{" "}
@@ -251,7 +219,6 @@ export function ChargeItemList({
         </div>
       )}
 
-      {/* Content */}
       {isLoadingChargeItems ? (
         <TableSkeleton count={5} />
       ) : chargeItems.length === 0 ? (
@@ -262,40 +229,36 @@ export function ChargeItemList({
         />
       ) : (
         <>
-          {/* Desktop Table View */}
-          {viewMode === "table" && (
-            <div className="hidden lg:block">
-              <div className="border rounded-lg overflow-hidden">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-[35%]">{t("title")}</TableHead>
-                      <TableHead className="w-[15%]">{t("status")}</TableHead>
-                      <TableHead className="w-[20%]">{t("category")}</TableHead>
-                      <TableHead className="w-[15%]">
-                        {t("price_components")}
-                      </TableHead>
-                      <TableHead className="w-[15%] text-center">
-                        {t("actions")}
-                      </TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {chargeItems.map((definition) => (
-                      <ChargeItemTableRow
-                        key={definition.slug}
-                        definition={definition}
-                        facilityId={facilityId}
-                      />
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+          <div className="hidden lg:block">
+            <div className="border rounded-lg overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[35%]">{t("title")}</TableHead>
+                    <TableHead className="w-[15%]">{t("status")}</TableHead>
+                    <TableHead className="w-[20%]">{t("category")}</TableHead>
+                    <TableHead className="w-[15%]">
+                      {t("price_components")}
+                    </TableHead>
+                    <TableHead className="w-[15%] text-center">
+                      {t("actions")}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {chargeItems.map((definition) => (
+                    <ChargeItemTableRow
+                      key={definition.slug}
+                      definition={definition}
+                      facilityId={facilityId}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
             </div>
-          )}
+          </div>
 
-          {/* Mobile Card View */}
-          <div className={`${viewMode === "cards" ? "block" : "lg:hidden"}`}>
+          <div className="lg:hidden">
             <div className="grid gap-3">
               {chargeItems.map((definition) => (
                 <ChargeItemCard

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
@@ -212,6 +212,7 @@ export function ChargeItemList({
         </div>
       </div>
 
+      {/* Results count */}
       {chargeItemsResponse && chargeItemsResponse.count > 0 && (
         <div className="mb-4 text-sm text-gray-600">
           {t("showing")} {chargeItems.length} {t("of")}{" "}
@@ -219,6 +220,7 @@ export function ChargeItemList({
         </div>
       )}
 
+      {/* Content */}
       {isLoadingChargeItems ? (
         <TableSkeleton count={5} />
       ) : chargeItems.length === 0 ? (

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
@@ -1,12 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { navigate } from "raviger";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { FilterSelect } from "@/components/ui/filter-select";
@@ -182,8 +181,6 @@ export function ProductKnowledgeList({
     },
   });
 
-  const [viewMode, setViewMode] = useState<"table" | "cards">("table");
-
   // Fetch product knowledge for current category
   const { data: productsResponse, isLoading: isLoadingProducts } = useQuery({
     queryKey: ["productKnowledge", facilityId, categorySlug, qParams],
@@ -215,72 +212,42 @@ export function ProductKnowledgeList({
 
   return (
     <div>
-      {/* Header with filters and view toggle */}
-      <div className="flex flex-col lg:flex-row justify-between items-start gap-4 mb-6">
-        <div className="flex flex-col sm:flex-row gap-4 flex-1">
-          {/* Search */}
-          <div className="relative w-full sm:w-auto">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-              <CareIcon icon="l-search" className="size-5" />
-            </span>
-            <Input
-              placeholder={t("search_products")}
-              value={qParams.search || ""}
-              onChange={(e) =>
-                updateQuery({ search: e.target.value || undefined })
-              }
-              className="w-full sm:w-[300px] pl-10"
-            />
-          </div>
-
-          {/* Status Filter */}
-          <div className="w-full sm:w-auto">
-            <FilterSelect
-              value={qParams.status || ""}
-              onValueChange={(value) => updateQuery({ status: value })}
-              options={Object.values(ProductKnowledgeStatus)}
-              label={t("status")}
-              onClear={() => updateQuery({ status: undefined })}
-            />
-          </div>
-
-          {/* Product Type Filter */}
-          <div className="w-full sm:w-auto">
-            <FilterSelect
-              value={qParams.product_type || ""}
-              onValueChange={(value) => updateQuery({ product_type: value })}
-              options={Object.values(ProductKnowledgeType)}
-              label={t("product_type")}
-              onClear={() => updateQuery({ product_type: undefined })}
-            />
-          </div>
+      <div className="flex flex-col sm:flex-row gap-4 mb-6">
+        <div className="relative w-full sm:w-auto">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            <CareIcon icon="l-search" className="size-5" />
+          </span>
+          <Input
+            placeholder={t("search_products")}
+            value={qParams.search || ""}
+            onChange={(e) =>
+              updateQuery({ search: e.target.value || undefined })
+            }
+            className="w-full sm:w-[300px] pl-10"
+          />
         </div>
 
-        {/* View Toggle - Desktop only */}
-        <div className="hidden lg:flex items-center space-x-2">
-          <span className="text-sm text-gray-500">{t("view")}:</span>
-          <div className="flex border rounded-lg">
-            <Button
-              variant={viewMode === "table" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("table")}
-              className="rounded-r-none"
-            >
-              <CareIcon icon="l-table" className="h-4 w-4" />
-            </Button>
-            <Button
-              variant={viewMode === "cards" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("cards")}
-              className="rounded-l-none"
-            >
-              <CareIcon icon="l-th-large" className="h-4 w-4" />
-            </Button>
-          </div>
+        <div className="w-full sm:w-auto">
+          <FilterSelect
+            value={qParams.status || ""}
+            onValueChange={(value) => updateQuery({ status: value })}
+            options={Object.values(ProductKnowledgeStatus)}
+            label={t("status")}
+            onClear={() => updateQuery({ status: undefined })}
+          />
+        </div>
+
+        <div className="w-full sm:w-auto">
+          <FilterSelect
+            value={qParams.product_type || ""}
+            onValueChange={(value) => updateQuery({ product_type: value })}
+            options={Object.values(ProductKnowledgeType)}
+            label={t("product_type")}
+            onClear={() => updateQuery({ product_type: undefined })}
+          />
         </div>
       </div>
 
-      {/* Results count */}
       {productsResponse && productsResponse.count > 0 && (
         <div className="mb-4 text-sm text-gray-600">
           {t("showing")} {products.length} {t("of")} {productsResponse.count}{" "}
@@ -288,7 +255,6 @@ export function ProductKnowledgeList({
         </div>
       )}
 
-      {/* Content */}
       {isLoadingProducts ? (
         <TableSkeleton count={5} />
       ) : products.length === 0 ? (
@@ -301,37 +267,33 @@ export function ProductKnowledgeList({
         />
       ) : (
         <>
-          {/* Desktop Table View */}
-          {viewMode === "table" && (
-            <div className="hidden lg:block">
-              <div className="border rounded-lg overflow-hidden">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-[35%]">{t("name")}</TableHead>
-                      <TableHead className="w-[15%]">
-                        {t("product_type")}
-                      </TableHead>
-                      <TableHead className="w-[15%]">{t("status")}</TableHead>
-                      <TableHead className="w-[5%]">{t("actions")}</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {products.map((product) => (
-                      <ProductKnowledgeTableRow
-                        key={product.id}
-                        product={product}
-                        facilityId={facilityId}
-                      />
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+          <div className="hidden lg:block">
+            <div className="border rounded-lg overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[35%]">{t("name")}</TableHead>
+                    <TableHead className="w-[15%]">
+                      {t("product_type")}
+                    </TableHead>
+                    <TableHead className="w-[15%]">{t("status")}</TableHead>
+                    <TableHead className="w-[5%]">{t("actions")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {products.map((product) => (
+                    <ProductKnowledgeTableRow
+                      key={product.id}
+                      product={product}
+                      facilityId={facilityId}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
             </div>
-          )}
+          </div>
 
-          {/* Mobile Card View */}
-          <div className={`${viewMode === "cards" ? "block" : "lg:hidden"}`}>
+          <div className="lg:hidden">
             <div className="grid gap-3">
               {products.map((product) => (
                 <ProductKnowledgeCard

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
@@ -212,7 +212,9 @@ export function ProductKnowledgeList({
 
   return (
     <div>
+      {/* Header with filters and view toggle */}
       <div className="flex flex-col sm:flex-row gap-4 mb-6">
+        {/* Search */}
         <div className="relative w-full sm:w-auto">
           <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
             <CareIcon icon="l-search" className="size-5" />
@@ -227,6 +229,7 @@ export function ProductKnowledgeList({
           />
         </div>
 
+        {/* Status Filter */}
         <div className="w-full sm:w-auto">
           <FilterSelect
             value={qParams.status || ""}
@@ -237,6 +240,7 @@ export function ProductKnowledgeList({
           />
         </div>
 
+        {/* Product Type Filter */}
         <div className="w-full sm:w-auto">
           <FilterSelect
             value={qParams.product_type || ""}
@@ -248,6 +252,7 @@ export function ProductKnowledgeList({
         </div>
       </div>
 
+      {/* Results count */}
       {productsResponse && productsResponse.count > 0 && (
         <div className="mb-4 text-sm text-gray-600">
           {t("showing")} {products.length} {t("of")} {productsResponse.count}{" "}
@@ -255,6 +260,7 @@ export function ProductKnowledgeList({
         </div>
       )}
 
+      {/* Content */}
       {isLoadingProducts ? (
         <TableSkeleton count={5} />
       ) : products.length === 0 ? (
@@ -267,6 +273,7 @@ export function ProductKnowledgeList({
         />
       ) : (
         <>
+          {/* Desktop Table View */}
           <div className="hidden lg:block">
             <div className="border rounded-lg overflow-hidden">
               <Table>
@@ -293,6 +300,7 @@ export function ProductKnowledgeList({
             </div>
           </div>
 
+          {/* Mobile Card View */}
           <div className="lg:hidden">
             <div className="grid gap-3">
               {products.map((product) => (


### PR DESCRIPTION
## Proposed Changes

Fixes #14557

- Removed view toggle buttons from Product Knowledge, Activity Definition, and Charge Item Definition list views
- Removed `viewMode` state and related UI components, as responsive breakpoints automatically handle table/card view switching
- Cleaned up unused imports (`useState`, `Button`)
- Simplified header layout by removing unnecessary wrapper divs

Tagging: @ohcnetwork/care-fe-code-reviewers

## Screenshot
<img width="1512" height="941" alt="Screenshot 2025-12-01 at 12 37 52 PM" src="https://github.com/user-attachments/assets/6bcd0920-ed24-418d-84fe-658ab7d8e490" />

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed view toggle controls across three list pages to streamline the interface.

* **UI/UX Improvements**
  * Consolidated header controls into a more compact layout.
  * Desktop now shows a consistent table view; mobile shows cards automatically.
  * Reintroduced classification filter on the Activity Definition list.
  * Added product-type filter to Product Knowledge; search and status filters remain functional across all lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->