### PR TITLE
fix: filed_by in responses and observations

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -438,7 +438,6 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
           <span className="text-gray-600">{t("filed_by")}</span>{" "}
           <span className="font-medium text-gray-700">
             {formatName(item.created_by)}
-            {item.created_by?.user_type && ` (${item.created_by.user_type})`}
           </span>
         </div>
         <div>

--- a/src/pages/Encounters/tabs/observations.tsx
+++ b/src/pages/Encounters/tabs/observations.tsx
@@ -174,11 +174,11 @@ export const EncounterObservationsTab = () => {
                         <div className="font-medium text-sm text-gray-600">
                           {item.main_code.display || item.main_code.code}
                         </div>
-                        {item.created_by && (
+                        {item.data_entered_by && (
                           <div className="text-gray-600 text-sm">
                             {t("filed_by")}{" "}
                             <span className="font-medium text-gray-800">
-                              {formatName(item.created_by)}
+                              {formatName(item.data_entered_by)}
                             </span>
                           </div>
                         )}

--- a/src/pages/Encounters/tabs/observations.tsx
+++ b/src/pages/Encounters/tabs/observations.tsx
@@ -8,14 +8,15 @@ import { Card } from "@/components/ui/card";
 
 import { formatValue } from "@/components/Facility/ConsultationDetails/QuestionnaireResponsesList";
 
+import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
+import { ObservationWithUser } from "@/types/emr/observation";
+import patientApi from "@/types/emr/patient/patientApi";
 import query from "@/Utils/request/query";
 import { HTTPError, PaginatedResponse } from "@/Utils/request/types";
-import { useEncounter } from "@/pages/Encounters/utils/EncounterProvider";
-import { Observation } from "@/types/emr/observation";
-import patientApi from "@/types/emr/patient/patientApi";
+import { formatName } from "@/Utils/utils";
 
 interface GroupedObservations {
-  [key: string]: Observation[];
+  [key: string]: ObservationWithUser[];
 }
 
 function getDateKey(date: string) {
@@ -55,7 +56,7 @@ function formatDisplayTime(dateStr: string) {
 }
 
 function groupObservationsByDate(
-  observations: Observation[],
+  observations: ObservationWithUser[],
 ): GroupedObservations {
   return observations.reduce((groups: GroupedObservations, observation) => {
     const dateKey = getDateKey(observation.effective_datetime);
@@ -77,7 +78,7 @@ export const EncounterObservationsTab = () => {
   const { ref, inView } = useInView();
 
   const { data, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } =
-    useInfiniteQuery<PaginatedResponse<Observation>, HTTPError>({
+    useInfiniteQuery<PaginatedResponse<ObservationWithUser>, HTTPError>({
       queryKey: ["infinite-observations", patientId, encounterId],
       queryFn: async ({ pageParam = 0 }) => {
         const response = await query(patientApi.listObservations, {
@@ -89,7 +90,7 @@ export const EncounterObservationsTab = () => {
             offset: String(pageParam),
           },
         })({ signal: new AbortController().signal });
-        return response as PaginatedResponse<Observation>;
+        return response as PaginatedResponse<ObservationWithUser>;
       },
       initialPageParam: 0,
       getNextPageParam: (lastPage, allPages) => {
@@ -143,7 +144,7 @@ export const EncounterObservationsTab = () => {
                     new Date(b.effective_datetime).getTime() -
                     new Date(a.effective_datetime).getTime(),
                 )
-                .map((item: Observation) => (
+                .map((item: ObservationWithUser) => (
                   <div key={item.id} className="flex gap-4">
                     <div className="p-1 h-fit text-sm text-gray-700 bg-gray-100 rounded-md font-medium">
                       {formatDisplayTime(item.effective_datetime)}:
@@ -173,6 +174,14 @@ export const EncounterObservationsTab = () => {
                         <div className="font-medium text-sm text-gray-600">
                           {item.main_code.display || item.main_code.code}
                         </div>
+                        {item.created_by && (
+                          <div className="text-gray-600 text-sm">
+                            {t("filed_by")}{" "}
+                            <span className="font-medium text-gray-800">
+                              {formatName(item.created_by)}
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </Card>
                   </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #14560 
- fixed filed_by in responses
- added filed_by in observations

<img width="905" height="387" alt="Screenshot from 2025-12-01 14-44-31" src="https://github.com/user-attachments/assets/c94338b3-25dc-43ed-a085-a7179980a96e" />
<img width="1140" height="621" alt="Screenshot from 2025-12-01 14-44-44" src="https://github.com/user-attachments/assets/5f29537b-df2d-4784-a688-9717366f6cb2" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Removed the extra user type suffix from the "filed by" display in consultation details.
* Observations list now shows the creator's name with proper formatting and a localized "filed by" label.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->