### PR TITLE
Share plug meta as props in PLUGIN_Component

### DIFF
--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -1,22 +1,26 @@
-import ErrorBoundary from "@/components/Common/ErrorBoundary";
-import Loading from "@/components/Common/Loading";
-import { PluginErrorBoundary } from "@/components/Common/PluginErrorBoundary";
-import { useQuery } from "@tanstack/react-query";
+import { CareAppsContext, useCareApps } from "@/hooks/useCareApps";
+import {
+  PluginManifest,
+  PluginManifestWithMeta,
+  SupportedPluginComponents,
+} from "@/pluginTypes";
 import {
   __federation_method_getRemote as getFederationRemote,
   __federation_method_setRemote as setFederationRemote,
   __federation_method_unwrapDefault as unwrapModule,
 } from "__federation__";
-import { Loader2Icon } from "lucide-react";
 import React, { Suspense, useEffect, useState } from "react";
 
-import { CareAppsContext, useCareApps } from "@/hooks/useCareApps";
-import query from "@/Utils/request/query";
-
-import { PluginManifest, SupportedPluginComponents } from "@/pluginTypes";
+import ErrorBoundary from "@/components/Common/ErrorBoundary";
+import Loading from "@/components/Common/Loading";
+import { PluginErrorBoundary } from "@/components/Common/PluginErrorBoundary";
 import plugConfigApi from "@/types/plugConfig/plugConfigApi";
+import query from "@/Utils/request/query";
+import { useQuery } from "@tanstack/react-query";
 import { t } from "i18next";
+import { Loader2Icon } from "lucide-react";
 import { z } from "zod";
+import { PlugConfigMeta } from "./types/plugConfig";
 
 // Import the remote component synchronously
 export default function PluginEngine({
@@ -24,7 +28,9 @@ export default function PluginEngine({
 }: {
   children: React.ReactNode;
 }) {
-  const [pluginManifests, setPluginManifests] = useState<PluginManifest[]>([]);
+  const [pluginManifests, setPluginManifests] = useState<
+    PluginManifestWithMeta[]
+  >([]);
 
   // Fetch enabled plugins from the backend API
   const { data: enabledPlugins } = useQuery({
@@ -49,15 +55,19 @@ export default function PluginEngine({
           }
 
           setFederationRemote(plugin.slug, {
-            url: () => Promise.resolve(plugin.meta.url),
+            url: () => Promise.resolve(plugin.meta.url as string),
             format: "esm",
             from: "vite",
             externalType: "promise",
           });
 
           return await getFederationRemote(plugin.slug, "./manifest")
-            .then((manifest) => {
-              return manifest;
+            .then((module) => {
+              const manifest = unwrapModule<PluginManifest>(module);
+              return {
+                ...manifest,
+                meta: plugin.meta,
+              } as PluginManifestWithMeta;
             })
             .catch((e) =>
               console.error(
@@ -67,11 +77,8 @@ export default function PluginEngine({
             );
         }),
       );
-      const filteredManifests = manifests.filter(
-        (m): m is PluginManifest => m !== undefined,
-      );
-      const availablePlugins = filteredManifests.map((manifest) =>
-        unwrapModule(manifest),
+      const availablePlugins = manifests.filter(
+        (m): m is PluginManifestWithMeta => m !== undefined,
       );
 
       if (availablePlugins.length === 0) {
@@ -80,7 +87,7 @@ export default function PluginEngine({
       }
 
       console.log(
-        `Loading ${filteredManifests.length} plugins; available plugins`,
+        `Loading ${availablePlugins.length} plugins; available plugins`,
         availablePlugins,
       );
       setPluginManifests(availablePlugins);
@@ -108,7 +115,7 @@ export default function PluginEngine({
 }
 
 type PluginProps<K extends keyof SupportedPluginComponents> =
-  React.ComponentProps<SupportedPluginComponents[K]>;
+  SupportedPluginComponents[K] extends React.FC<infer P> ? P : never;
 
 export function PLUGIN_Component<K extends keyof SupportedPluginComponents>({
   __name,
@@ -119,9 +126,13 @@ export function PLUGIN_Component<K extends keyof SupportedPluginComponents>({
   return (
     <>
       {plugins.map((plugin) => {
-        const Component = plugin.components?.[
-          __name
-        ] as React.ComponentType<unknown>;
+        const Component = plugin.components?.[__name] as React.ComponentType<
+          PluginProps<K> & { __meta: PlugConfigMeta }
+        >;
+        const propsWithMeta = {
+          ...props,
+          __meta: plugin.meta,
+        } as PluginProps<K> & { __meta: PlugConfigMeta };
 
         if (!Component) {
           return null;
@@ -141,7 +152,7 @@ export function PLUGIN_Component<K extends keyof SupportedPluginComponents>({
                 </div>
               }
             >
-              <Component {...props} />
+              <Component {...propsWithMeta} />
             </React.Suspense>
           </PluginErrorBoundary>
         );

--- a/src/hooks/useCareApps.tsx
+++ b/src/hooks/useCareApps.tsx
@@ -3,10 +3,10 @@ import { Suspense, createContext, useContext } from "react";
 
 import { PluginErrorBoundary } from "@/components/Common/PluginErrorBoundary";
 import { PluginEncounterTabProps } from "@/pages/Encounters/EncounterShow";
-import { PluginManifest } from "@/pluginTypes";
+import { PluginManifestWithMeta } from "@/pluginTypes";
 import { t } from "i18next";
 
-export const CareAppsContext = createContext<PluginManifest[]>([]);
+export const CareAppsContext = createContext<PluginManifestWithMeta[]>([]);
 
 export const useCareApps = () => {
   const ctx = useContext(CareAppsContext);

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -5,6 +5,7 @@ import { DeviceDetail } from "@/types/device/device";
 import { EncounterRead } from "@/types/emr/encounter/encounter";
 import { PatientRead } from "@/types/emr/patient/patient";
 import { FacilityRead } from "@/types/facility/facility";
+import { PlugConfigMeta } from "@/types/plugConfig";
 import { UserReadMinimal } from "@/types/user/user";
 import { LazyExoticComponent } from "react";
 import { UseFormReturn } from "react-hook-form";
@@ -123,6 +124,10 @@ export type PluginManifest = {
     LazyComponent<React.FC<PluginEncounterTabProps>>
   >;
   devices?: readonly PluginDeviceManifest[];
+};
+
+export type PluginManifestWithMeta = PluginManifest & {
+  meta: PlugConfigMeta;
 };
 
 export { pluginMap };

--- a/src/types/plugConfig.ts
+++ b/src/types/plugConfig.ts
@@ -1,6 +1,13 @@
+export interface PlugConfigMeta {
+  url?: string;
+  name?: string;
+  config?: {
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
 export interface PlugConfig {
   slug: string;
-  meta: {
-    [key: string]: any;
-  };
+  meta: PlugConfigMeta;
 }


### PR DESCRIPTION
## Proposed Changes

- Share plug meta as props in PLUGIN_Component
- Currently when a plug needs to be customized, we are using env to do that, for which multiple deployments is needed. To fix this issue, envs can be passed in config in meta in plugs.

_To test, use the following config:_
```json
{
  "url": "https://72cbd9f9.care-abdm-fe-2dk.pages.dev/assets/remoteEntry.js",
  "name": "care_abdm_fe",
  "config": {
    "enforceAbhaNumberLinking": true
  }
}
```



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured plugin system initialization workflow to embed and propagate plugin metadata throughout the application lifecycle, enabling improved plugin integration and enhanced runtime capabilities
  * Enhanced URL handling for plugin remote configuration to ensure more reliable federation setup and stability
  * Updated component invocation architecture to pass plugin metadata to components, providing better access to configuration and runtime information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->