### PR TITLE
fix env example for otp resend timeout

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -67,7 +67,7 @@ REACT_DEFAULT_COUNTRY=
 # Maps fallback URL template (default:"https://www.openstreetmap.org/?mlat={lat}&mlon={long}&zoom=15")
 REACT_MAPS_FALLBACK_URL_TEMPLATE=
 
-# OTP resend timeout in seconds (eg. 90 seconds) (default : 120 seconds)
+# OTP resend timeout in seconds (eg. 90 seconds) (default : 30 seconds)
 REACT_APP_RESEND_OTP_TIMEOUT=
 
 # Maximum image upload size allowed (in megabytes)


### PR DESCRIPTION
## Proposed Changes

- fix env example for otp resend timeout



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OTP resend timeout configuration documentation to reflect a 30-second timeout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->