### PR TITLE
Fixes keyboard navigation for search input bar component

### DIFF
--- a/src/components/Common/SearchInput.tsx
+++ b/src/components/Common/SearchInput.tsx
@@ -179,7 +179,6 @@ export default function SearchInput({
   const [searchValue, setSearchValue] = useState("");
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [focusedIndex, setFocusedIndex] = useState(0);
 
   // Safe access to options
   const safeOptions = useMemo(() => options || [], [options]);
@@ -195,7 +194,7 @@ export default function SearchInput({
       setSelectedOptionIndex(index);
       const option = safeOptions[index];
       setSearchValue(option.value || "");
-      setFocusedIndex(safeOptions.findIndex((op) => op.key === option.key));
+
       setOpen(false);
       inputRef.current?.focus();
 
@@ -219,12 +218,6 @@ export default function SearchInput({
   );
 
   useEffect(() => {
-    if (open) {
-      setFocusedIndex(0);
-    }
-  }, [open]);
-
-  useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
@@ -241,37 +234,11 @@ export default function SearchInput({
           setSearchValue("");
         }
       }
-
-      if (open) {
-        if (e.key === "ArrowDown") {
-          setFocusedIndex((prevIndex) =>
-            prevIndex === unselectedOptions.length - 1 ? 0 : prevIndex + 1,
-          );
-        } else if (e.key === "ArrowUp") {
-          setFocusedIndex((prevIndex) =>
-            prevIndex === 0 ? unselectedOptions.length - 1 : prevIndex - 1,
-          );
-        } else if (e.key === "Enter") {
-          if (focusedIndex >= 0 && focusedIndex < unselectedOptions.length) {
-            const selectedOptionIndex = options.findIndex(
-              (option) => option.key === unselectedOptions[focusedIndex].key,
-            );
-            handleOptionChange(selectedOptionIndex);
-          }
-        }
-      }
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [
-    focusedIndex,
-    open,
-    handleOptionChange,
-    safeOptions,
-    unselectedOptions,
-    options,
-  ]);
+  }, [open]);
 
   useEffect(() => {
     if (autoFocus) {
@@ -365,6 +332,7 @@ export default function SearchInput({
                             return (
                               <CommandItem
                                 key={option.key}
+                                value={option.key}
                                 onSelect={() =>
                                   handleOptionChange(
                                     safeOptions.findIndex(
@@ -374,27 +342,17 @@ export default function SearchInput({
                                     ),
                                   )
                                 }
-                                className={cn(
-                                  "flex items-center p-2 rounded-md cursor-pointer",
-                                  {
-                                    "bg-gray-100": focusedIndex === index,
-                                    "hover:bg-secondary-100": true,
-                                  },
-                                )}
-                                onMouseEnter={() => setFocusedIndex(index)}
-                                onMouseLeave={() => setFocusedIndex(-1)}
+                                className="group flex items-center p-2 rounded-md cursor-pointer hover:bg-secondary-100"
                               >
                                 <span className="flex-1 text-sm">
                                   {t(option.display)}
                                 </span>
-                                {focusedIndex === index && (
-                                  <kbd
-                                    className="ml-2 border border-gray-300 rounded px-1 bg-white text-xs text-gray-500"
-                                    title="Press Enter to select"
-                                  >
-                                    ⏎ Enter
-                                  </kbd>
-                                )}
+                                <kbd
+                                  className="ml-2 border border-gray-300 rounded px-1 bg-white text-xs text-gray-500 hidden group-data-[selected=true]:block"
+                                  title="Press Enter to select"
+                                >
+                                  ⏎ Enter
+                                </kbd>
                               </CommandItem>
                             );
                           })}


### PR DESCRIPTION
## Proposed Changes

Fixes #13039 
- Switched to simpler CommandItem behavior for focus/selection
- Enter selection is handled by CommandItem’s built-in behavior, triggered when the item is clicked or selected
- The old version maintained focusedIndex and updated it on ArrowUp, ArrowDown, and Enter. The new version removes this state entirely, eliminating custom index-tracking logic.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ x

https://github.com/user-attachments/assets/d0bd3d85-b3c9-4678-9560-dae85f8334e1

 ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ x ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified selection and focus handling for the search input to give more consistent option highlighting and reduce flicker when opening.
  * Consolidated option highlighting to group-based styling and removed per-item focus state.

* **Bug Fix**
  * Improved keyboard and mouse interactions so navigation and selection feel more reliable; global shortcut (Ctrl/Cmd+K) behavior unchanged.
  * Enter hint visibility now follows group selection state for clearer affordance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->