### PR TITLE
Fix "Last Active" Label Overflow

### DIFF
--- a/src/pages/Facility/settings/organizations/FacilityOrganizationUsers.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationUsers.tsx
@@ -130,12 +130,12 @@ export default function FacilityOrganizationUsers({
       </div>
 
       {isLoadingUsers ? (
-        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
           <CardGridSkeleton count={2} />
         </div>
       ) : (
         <div className="space-y-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 md:pb-6">
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 md:pb-6">
             {!users?.results?.length ? (
               <Card className="col-span-full">
                 <CardContent className="p-6 text-center text-gray-500">


### PR DESCRIPTION
Adjusted the column number per cards displayed for different screen size.

## Proposed Changes

Fixes #14025

- **Change**:
Simplifies grid column classes by removing 'lg:grid-cols-2' and relying only on 'xl:grid-cols-2' for user card layouts. This change standardizes the grid behavior across loading and loaded states.

Before:
<img width="944" height="472" alt="image" src="https://github.com/user-attachments/assets/1faccec8-2e46-4763-8455-72eb49a01b39" />

Now:
<img width="1009" height="908" alt="image" src="https://github.com/user-attachments/assets/7f33c52f-1611-433d-a8f4-e2a06654288a" />

### No more label overflow 😄

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified responsive grid layout for the organization user section to display in a single column on large screens, with two-column layout now appearing only on extra-large screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->