### PR TITLE
fix: limits in Locations

### DIFF
--- a/src/pages/Facility/settings/locations/LocationSettings.tsx
+++ b/src/pages/Facility/settings/locations/LocationSettings.tsx
@@ -65,11 +65,12 @@ export default function LocationSettings({
       queryParams: {
         mode: "kind",
         parent: "",
+        limit: 100,
       },
     }),
   });
 
-  const ITEMS_PER_PAGE = 9;
+  const ITEMS_PER_PAGE = 14;
 
   const {
     page: currentPage,
@@ -171,7 +172,7 @@ export default function LocationSettings({
         <div className="flex">
           {activeTab !== "map" && (
             <div className="w-64 shadow-lg bg-white rounded-lg hidden md:block flex-shrink-0">
-              <ScrollArea className="h-[calc(100vh-14rem)]">
+              <ScrollArea className="h-[calc(100vh-8rem)]">
                 <div className="p-4">
                   {parentLocations?.results?.length ? (
                     parentLocations.results.map((location) => (


### PR DESCRIPTION
## Proposed Changes

Fixes #14599 
- For pagination, limit set to default of 14
- Navbar listing limit set as 100

<img width="1157" height="1170" alt="Screenshot from 2025-12-03 16-27-31" src="https://github.com/user-attachments/assets/a15aea40-f239-47ea-a708-951172fe57d6" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Location listing pagination now displays 14 items per page (increased from 9)
  * Expanded the visible area of the location tree to display more content simultaneously
  * Enhanced API query capacity to fetch more location data, improving system performance and data handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->