### PR TITLE
Reduce the facility cache expiry

### DIFF
--- a/src/pages/Facility/utils/useCurrentFacility.tsx
+++ b/src/pages/Facility/utils/useCurrentFacility.tsx
@@ -28,7 +28,7 @@ export default function useCurrentFacility() {
     queryFn: query(facilityApi.get, {
       pathParams: { facilityId: facilityId ?? "" },
     }),
-    staleTime: 1000 * 60 * 30, // cache for 30 minutes
+    staleTime: 1000 * 60 * 5, // cache for 5 minutes
   });
 
   return { facilityId, facility, isFacilityLoading };

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -128,6 +128,10 @@ export default function PatientIdentifierConfigForm({
     ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["patientIdentifierConfig"] });
+      queryClient.invalidateQueries({
+        queryKey: ["facility"],
+        exact: false,
+      });
       onSuccess?.();
     },
   });
@@ -142,6 +146,10 @@ export default function PatientIdentifierConfigForm({
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["patientIdentifierConfig"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["facility"],
+        exact: false,
       });
       onSuccess?.();
     },


### PR DESCRIPTION
## Proposed Changes

Fixes #14598
- Reduced the facility cache time to 5mins; When patient identifiers config is changed, previously it was taking around 30mins to take effect, as facility details were cached.
- Invalidated the facility cache on patient identifiers creation and updation

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Facility information now refreshes more frequently to ensure users view the most current data
  * Patient identifier configuration updates now automatically refresh facility data to maintain consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->