### PR TITLE
Added auto refresh toggle in Appoinments Page

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -127,4 +127,7 @@ REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=false
 # Auto refresh interval in seconds
 REACT_AUTO_REFRESH_INTERVAL=10
 
+# Default state of auto refresh
+REACT_AUTO_REFRESH_BY_DEFAULT=false
+
 

--- a/.example.env
+++ b/.example.env
@@ -124,4 +124,7 @@ REACT_CUSTOM_SHORTCUTS=
 # Set to "true" to enable automatic invoice creation after dispensing
 REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=false
 
+# Auto refresh time in seconds
+REACT_AUTO_REFRESH_INTERVAL=10
+
 

--- a/.example.env
+++ b/.example.env
@@ -124,7 +124,7 @@ REACT_CUSTOM_SHORTCUTS=
 # Set to "true" to enable automatic invoice creation after dispensing
 REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=false
 
-# Auto refresh time in seconds
+# Auto refresh interval in seconds
 REACT_AUTO_REFRESH_INTERVAL=10
 
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -113,7 +113,8 @@ const careConfig = {
    * Flag to make location field mandatory for payment reconciliation
    */
   paymentLocationRequired: booleanFromString(
-    env.REACT_PAYMENT_LOCATION_REQUIRED || "true",
+    env.REACT_PAYMENT_LOCATION_REQUIRED,
+    true,
   ),
 
   careApps: env.REACT_ENABLED_APPS
@@ -164,14 +165,16 @@ const careConfig = {
    * Disable patient login if set to "true"
    */
   disablePatientLogin: booleanFromString(
-    env.REACT_DISABLE_PATIENT_LOGIN || "false",
+    env.REACT_DISABLE_PATIENT_LOGIN,
+    false,
   ),
 
   /**
    * Enable auto refresh if set to "true"
    */
   enableAutoRefresh: booleanFromString(
-    env.REACT_AUTO_REFRESH_BY_DEFAULT || "false",
+    env.REACT_AUTO_REFRESH_BY_DEFAULT,
+    false,
   ),
 
   patientRegistration: {
@@ -192,7 +195,8 @@ const careConfig = {
     defaultGeoOrganization: env.REACT_PATIENT_REGISTRATION_DEFAULT_GEO_ORG,
 
     minimalPatientRegistration: booleanFromString(
-      env.REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION || "false",
+      env.REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION,
+      false,
     ),
   },
 
@@ -216,7 +220,8 @@ const careConfig = {
    * Enable automatic invoice sheet after dispensing items
    */
   enableAutoInvoiceAfterDispense: booleanFromString(
-    env.REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE || "false",
+    env.REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE,
+    false,
   ),
 } as const;
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -109,7 +109,7 @@ const careConfig = {
   },
 
   appointmentAndQueueRefreshInterval:
-    parseInt(env.REACT_AUTO_REFRESH_INTERVAL || "10") * 1000,
+    parseInt(env.REACT_AUTO_REFRESH_INTERVAL || "10", 10) * 1000,
 
   /**
    * Flag to make location field mandatory for payment reconciliation

--- a/care.config.ts
+++ b/care.config.ts
@@ -15,10 +15,6 @@ interface ILogo {
   dark: string;
 }
 
-const boolean = (key: string, fallback = false) => {
-  return booleanFromString(env[key], fallback);
-};
-
 const logo = (value?: string, fallback?: ILogo) => {
   if (!value) {
     return fallback;
@@ -101,8 +97,8 @@ const careConfig = {
       : 0,
 
     // Kill switch in-case the heatmap API doesn't scale as expected
-    useAvailabilityStatsAPI: boolean(
-      "REACT_APPOINTMENTS_USE_AVAILABILITY_STATS_API",
+    useAvailabilityStatsAPI: booleanFromString(
+      env.REACT_APPOINTMENTS_USE_AVAILABILITY_STATS_API,
       true,
     ),
   },
@@ -116,7 +112,9 @@ const careConfig = {
   /**
    * Flag to make location field mandatory for payment reconciliation
    */
-  paymentLocationRequired: boolean("REACT_PAYMENT_LOCATION_REQUIRED", true),
+  paymentLocationRequired: booleanFromString(
+    env.REACT_PAYMENT_LOCATION_REQUIRED || "true",
+  ),
 
   careApps: env.REACT_ENABLED_APPS
     ? env.REACT_ENABLED_APPS.split(",").map((app) => {
@@ -165,12 +163,16 @@ const careConfig = {
   /**
    * Disable patient login if set to "true"
    */
-  disablePatientLogin: boolean("REACT_DISABLE_PATIENT_LOGIN", false),
+  disablePatientLogin: booleanFromString(
+    env.REACT_DISABLE_PATIENT_LOGIN || "false",
+  ),
 
   /**
    * Enable auto refresh if set to "true"
    */
-  enableAutoRefresh: boolean("REACT_AUTO_REFRESH_BY_DEFAULT", false),
+  enableAutoRefresh: booleanFromString(
+    env.REACT_AUTO_REFRESH_BY_DEFAULT || "false",
+  ),
 
   patientRegistration: {
     /**
@@ -189,9 +191,8 @@ const careConfig = {
 
     defaultGeoOrganization: env.REACT_PATIENT_REGISTRATION_DEFAULT_GEO_ORG,
 
-    minimalPatientRegistration: boolean(
-      "REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION",
-      false,
+    minimalPatientRegistration: booleanFromString(
+      env.REACT_ENABLE_MINIMAL_PATIENT_REGISTRATION || "false",
     ),
   },
 
@@ -214,9 +215,8 @@ const careConfig = {
   /**
    * Enable automatic invoice sheet after dispensing items
    */
-  enableAutoInvoiceAfterDispense: boolean(
-    "REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE",
-    false,
+  enableAutoInvoiceAfterDispense: booleanFromString(
+    env.REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE || "false",
   ),
 } as const;
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -1,4 +1,4 @@
-import { booleanFromString } from "@/pages/Facility/queues/utils";
+import { booleanFromString } from "@/common/utils";
 import {
   ENCOUNTER_CLASS,
   EncounterClass,

--- a/care.config.ts
+++ b/care.config.ts
@@ -40,6 +40,8 @@ const careConfig = {
     ohcn: env.REACT_OHCN_URL || "https://ohc.network?ref=care",
   },
 
+  appointmentAndQueueRefreshInterval: 10000,
+
   mainLogo: logo(env.REACT_MAIN_LOGO, {
     light: "/images/care_logo.svg",
     dark: "/images/care_logo.svg",

--- a/care.config.ts
+++ b/care.config.ts
@@ -1,3 +1,4 @@
+import { booleanFromString } from "@/pages/Facility/queues/utils";
 import {
   ENCOUNTER_CLASS,
   EncounterClass,
@@ -15,9 +16,7 @@ interface ILogo {
 }
 
 const boolean = (key: string, fallback = false) => {
-  if (env[key] === "true") return true;
-  if (env[key] === "false") return false;
-  return fallback;
+  return booleanFromString(env[key], fallback);
 };
 
 const logo = (value?: string, fallback?: ILogo) => {
@@ -167,6 +166,11 @@ const careConfig = {
    * Disable patient login if set to "true"
    */
   disablePatientLogin: boolean("REACT_DISABLE_PATIENT_LOGIN", false),
+
+  /**
+   * Enable auto refresh if set to "true"
+   */
+  enableAutoRefresh: boolean("REACT_AUTO_REFRESH_BY_DEFAULT", false),
 
   patientRegistration: {
     /**

--- a/care.config.ts
+++ b/care.config.ts
@@ -108,6 +108,9 @@ const careConfig = {
     ),
   },
 
+  /**
+   * Auto refresh interval in milliseconds
+   */
   appointmentAndQueueRefreshInterval:
     parseInt(env.REACT_AUTO_REFRESH_INTERVAL || "10", 10) * 1000,
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -40,8 +40,6 @@ const careConfig = {
     ohcn: env.REACT_OHCN_URL || "https://ohc.network?ref=care",
   },
 
-  appointmentAndQueueRefreshInterval: 10000,
-
   mainLogo: logo(env.REACT_MAIN_LOGO, {
     light: "/images/care_logo.svg",
     dark: "/images/care_logo.svg",
@@ -109,6 +107,9 @@ const careConfig = {
       true,
     ),
   },
+
+  appointmentAndQueueRefreshInterval:
+    parseInt(env.REACT_AUTO_REFRESH_INTERVAL || "10") * 1000,
 
   /**
    * Flag to make location field mandatory for payment reconciliation

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -779,7 +779,7 @@
   "auto_generated_for_care": "Auto Generated for Care",
   "auto_maintained": "Auto maintained",
   "auto_refresh": "Auto Refresh",
-  "auto_refresh_tooltip": "Automatically refreshes the queue every 10 seconds. Disable to pause live updates.",
+  "auto_refresh_tooltip": "Automatically refreshes every {{interval}} seconds. Disable to pause live updates.",
   "autocomplete_options": "Autocomplete Options",
   "autofilled_fields": "Autofilled Fields",
   "availabilities": "Availabilities",

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -114,6 +114,7 @@ const envSchema = z
     REACT_CUSTOM_REMOTE_I18N_URL: z.string().url().optional(),
     REACT_CUSTOM_SHORTCUTS: customShortcutsSchemaString.optional(),
     REACT_AUTO_REFRESH_INTERVAL: numberAsString.optional(),
+    REACT_AUTO_REFRESH_BY_DEFAULT: booleanAsStringSchema.optional(),
   })
   .superRefine(async (data, ctx) => {
     const allowedClasses =

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -113,6 +113,7 @@ const envSchema = z
     REACT_PATIENT_REGISTRATION_DEFAULT_GEO_ORG: z.string().uuid().optional(),
     REACT_CUSTOM_REMOTE_I18N_URL: z.string().url().optional(),
     REACT_CUSTOM_SHORTCUTS: customShortcutsSchemaString.optional(),
+    REACT_AUTO_REFRESH_INTERVAL: numberAsString.optional(),
   })
   .superRefine(async (data, ctx) => {
     const allowedClasses =

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -19,7 +19,7 @@ export const formatDateTime = (date: DateLike, format?: string) => {
   return obj.format(DATE_TIME_FORMAT);
 };
 
-export function booleanFromString(str: string, fallback = false) {
+export function booleanFromString(str: string | undefined, fallback = false) {
   if (str === "true") return true;
   if (str === "false") return false;
   return fallback;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -18,3 +18,9 @@ export const formatDateTime = (date: DateLike, format?: string) => {
 
   return obj.format(DATE_TIME_FORMAT);
 };
+
+export function booleanFromString(str: string, fallback = false) {
+  if (str === "true") return true;
+  if (str === "false") return false;
+  return fallback;
+}

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -492,7 +492,7 @@ function AppointmentColumn(props: {
   patient?: string;
   resourceType: SchedulableResourceType;
   resourceIds: string[];
-  autoRefresh: string;
+  autoRefresh: "true" | "false";
 }) {
   const { facilityId } = useCurrentFacility();
   const { t } = useTranslation();
@@ -786,7 +786,7 @@ function AppointmentRow(props: {
   patient?: string;
   resourceType: SchedulableResourceType;
   resourceIds: string[];
-  autoRefresh: string;
+  autoRefresh: "true" | "false";
 }) {
   const { facilityId } = useCurrentFacility();
   const { t } = useTranslation();

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -3,7 +3,7 @@ import { CheckIcon } from "@radix-ui/react-icons";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { addDays, differenceInDays } from "date-fns";
 import { TFunction } from "i18next";
-import { FilterIcon } from "lucide-react";
+import { FilterIcon, InfoIcon } from "lucide-react";
 import { Link, navigate } from "raviger";
 import { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -96,6 +96,12 @@ import {
   FilterDateRange,
   shortDateRangeOptions,
 } from "@/components/ui/multi-filter/utils/Utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useAuthUser from "@/hooks/useAuthUser";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
@@ -395,6 +401,21 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
                 })
               }
             />
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="cursor-help hidden md:block">
+                    <InfoIcon className="size-4 text-gray-500" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t("auto_refresh_tooltip", {
+                    interval:
+                      careConfig.appointmentAndQueueRefreshInterval / 1000,
+                  })}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
           {activeTab === "list" && (
             <Button

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -551,9 +551,7 @@ function AppointmentColumn(props: {
     },
     enabled: !!props.resourceIds.length && props.canViewAppointments,
     refetchInterval:
-      props.autoRefresh === true
-        ? careConfig.appointmentAndQueueRefreshInterval
-        : false,
+      props.autoRefresh && careConfig.appointmentAndQueueRefreshInterval,
   });
 
   const appointments =
@@ -824,9 +822,7 @@ function AppointmentRow(props: {
     }),
     enabled: !!props.resourceIds.length && props.canViewAppointments,
     refetchInterval:
-      props.autoRefresh === true
-        ? careConfig.appointmentAndQueueRefreshInterval
-        : false,
+      props.autoRefresh && careConfig.appointmentAndQueueRefreshInterval,
   });
 
   const appointments = data?.results ?? [];

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -40,6 +40,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSidebar } from "@/components/ui/sidebar";
+import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -384,6 +385,17 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
         </div>
 
         <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+          <div className="flex items-center justify-between gap-2">
+            <Label className="text-sm font-medium">{t("auto_refresh")}</Label>
+            <Switch
+              checked={qParams.autoRefresh === "true"}
+              onCheckedChange={(checked) =>
+                updateQuery({
+                  autoRefresh: checked ? "true" : "false",
+                })
+              }
+            />
+          </div>
           {activeTab === "list" && (
             <Button
               variant="outline"
@@ -439,6 +451,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
                 tags={selectedTags.map((tag) => tag.id)}
                 tags_behavior={qParams.tags_behavior}
                 patient={qParams.patient}
+                autoRefresh={qParams.autoRefresh}
               />
             ))}
           </div>
@@ -461,6 +474,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
           patient={qParams.patient}
           resourceType={resourceType}
           resourceIds={resourceId ? [resourceId] : practitionerIds}
+          autoRefresh={qParams.autoRefresh}
         />
       )}
     </Page>
@@ -478,6 +492,7 @@ function AppointmentColumn(props: {
   patient?: string;
   resourceType: SchedulableResourceType;
   resourceIds: string[];
+  autoRefresh: string;
 }) {
   const { facilityId } = useCurrentFacility();
   const { t } = useTranslation();
@@ -535,6 +550,10 @@ function AppointmentColumn(props: {
       return currentOffset < lastPage.count ? currentOffset : null;
     },
     enabled: !!props.resourceIds.length && props.canViewAppointments,
+    refetchInterval:
+      props.autoRefresh === "true"
+        ? careConfig.appointmentAndQueueRefreshInterval
+        : false,
   });
 
   const appointments =
@@ -767,6 +786,7 @@ function AppointmentRow(props: {
   patient?: string;
   resourceType: SchedulableResourceType;
   resourceIds: string[];
+  autoRefresh: string;
 }) {
   const { facilityId } = useCurrentFacility();
   const { t } = useTranslation();
@@ -803,6 +823,10 @@ function AppointmentRow(props: {
       },
     }),
     enabled: !!props.resourceIds.length && props.canViewAppointments,
+    refetchInterval:
+      props.autoRefresh === "true"
+        ? careConfig.appointmentAndQueueRefreshInterval
+        : false,
   });
 
   const appointments = data?.results ?? [];

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -451,7 +451,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
                 tags={selectedTags.map((tag) => tag.id)}
                 tags_behavior={qParams.tags_behavior}
                 patient={qParams.patient}
-                autoRefresh={qParams.autoRefresh}
+                autoRefresh={JSON.parse(qParams.autoRefresh || "false")}
               />
             ))}
           </div>
@@ -474,7 +474,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
           patient={qParams.patient}
           resourceType={resourceType}
           resourceIds={resourceId ? [resourceId] : practitionerIds}
-          autoRefresh={qParams.autoRefresh}
+          autoRefresh={JSON.parse(qParams.autoRefresh || "false")}
         />
       )}
     </Page>
@@ -492,7 +492,7 @@ function AppointmentColumn(props: {
   patient?: string;
   resourceType: SchedulableResourceType;
   resourceIds: string[];
-  autoRefresh: "true" | "false";
+  autoRefresh: boolean;
 }) {
   const { facilityId } = useCurrentFacility();
   const { t } = useTranslation();
@@ -551,7 +551,7 @@ function AppointmentColumn(props: {
     },
     enabled: !!props.resourceIds.length && props.canViewAppointments,
     refetchInterval:
-      props.autoRefresh === "true"
+      props.autoRefresh === true
         ? careConfig.appointmentAndQueueRefreshInterval
         : false,
   });
@@ -786,7 +786,7 @@ function AppointmentRow(props: {
   patient?: string;
   resourceType: SchedulableResourceType;
   resourceIds: string[];
-  autoRefresh: "true" | "false";
+  autoRefresh: boolean;
 }) {
   const { facilityId } = useCurrentFacility();
   const { t } = useTranslation();
@@ -824,7 +824,7 @@ function AppointmentRow(props: {
     }),
     enabled: !!props.resourceIds.length && props.canViewAppointments,
     refetchInterval:
-      props.autoRefresh === "true"
+      props.autoRefresh === true
         ? careConfig.appointmentAndQueueRefreshInterval
         : false,
   });

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -84,6 +84,7 @@ import {
   formatPatientAge,
 } from "@/Utils/utils";
 
+import { booleanFromString } from "@/common/utils";
 import { ScheduleResourceIcon } from "@/components/Schedule/ScheduleResourceIcon";
 import {
   dateFilter,
@@ -103,7 +104,6 @@ import {
 } from "@/components/ui/tooltip";
 import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useAuthUser from "@/hooks/useAuthUser";
-import { booleanFromString } from "@/pages/Facility/queues/utils";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import careConfig from "@careConfig";
 import { PractitionerSelector } from "./components/PractitionerSelector";

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -104,6 +104,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useAuthUser from "@/hooks/useAuthUser";
+import { booleanFromString } from "@/pages/Facility/queues/utils";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import { PractitionerSelector } from "./components/PractitionerSelector";
 
@@ -331,6 +332,11 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
     return <Loading />;
   }
 
+  const shouldAutoRefresh = booleanFromString(
+    qParams.autoRefresh ?? "",
+    careConfig.enableAutoRefresh,
+  );
+
   return (
     <Page
       title={t("appointments")}
@@ -394,7 +400,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
           <div className="flex items-center justify-between gap-2">
             <Label className="text-sm font-medium">{t("auto_refresh")}</Label>
             <Switch
-              checked={qParams.autoRefresh === "true"}
+              checked={shouldAutoRefresh}
               onCheckedChange={(checked) =>
                 updateQuery({
                   autoRefresh: checked ? "true" : "false",
@@ -472,7 +478,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
                 tags={selectedTags.map((tag) => tag.id)}
                 tags_behavior={qParams.tags_behavior}
                 patient={qParams.patient}
-                autoRefresh={JSON.parse(qParams.autoRefresh || "false")}
+                autoRefresh={shouldAutoRefresh}
               />
             ))}
           </div>
@@ -495,7 +501,7 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
           patient={qParams.patient}
           resourceType={resourceType}
           resourceIds={resourceId ? [resourceId] : practitionerIds}
-          autoRefresh={JSON.parse(qParams.autoRefresh || "false")}
+          autoRefresh={shouldAutoRefresh}
         />
       )}
     </Page>

--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -45,6 +45,7 @@ import { TokenStatus } from "@/types/tokens/token/token";
 import tokenQueueApi from "@/types/tokens/tokenQueue/tokenQueueApi";
 import query from "@/Utils/request/query";
 import { dateQueryString } from "@/Utils/utils";
+import careConfig from "@careConfig";
 import { useQuery } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
 import { ChevronLeft, Edit3, InfoIcon, SettingsIcon } from "lucide-react";
@@ -178,7 +179,12 @@ export function ManageQueuePage({
                         <InfoIcon className="size-4 text-gray-500" />
                       </span>
                     </TooltipTrigger>
-                    <TooltipContent>{t("auto_refresh_tooltip")}</TooltipContent>
+                    <TooltipContent>
+                      {t("auto_refresh_tooltip", {
+                        interval:
+                          careConfig.appointmentAndQueueRefreshInterval / 1000,
+                      })}
+                    </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
               </div>

--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -279,7 +279,7 @@ export function ManageQueuePage({
           onTabChange={(tab) => {
             navigate(tab, {
               query: {
-                autoRefresh: shouldAutoRefresh ? "true" : "false",
+                autoRefresh: shouldAutoRefresh.toString(),
               },
             });
           }}

--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -1,3 +1,4 @@
+import { booleanFromString } from "@/common/utils";
 import { AnimatedCounter } from "@/components/Common/AnimatedCounter";
 import BackButton from "@/components/Common/BackButton";
 import Loading from "@/components/Common/Loading";
@@ -51,7 +52,7 @@ import { formatDate } from "date-fns";
 import { ChevronLeft, Edit3, InfoIcon, SettingsIcon } from "lucide-react";
 import { useNavigate, useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
-import { booleanFromString, getTokenQueueStatusCount } from "./utils";
+import { getTokenQueueStatusCount } from "./utils";
 
 interface ManageQueuePageProps {
   facilityId: string;

--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -51,7 +51,7 @@ import { formatDate } from "date-fns";
 import { ChevronLeft, Edit3, InfoIcon, SettingsIcon } from "lucide-react";
 import { useNavigate, useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
-import { getTokenQueueStatusCount } from "./utils";
+import { booleanFromString, getTokenQueueStatusCount } from "./utils";
 
 interface ManageQueuePageProps {
   facilityId: string;
@@ -71,8 +71,8 @@ export function ManageQueuePage({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const resource = useScheduleResource();
-  const [{ autoRefresh }, setQueryParams] = useQueryParams<{
-    autoRefresh: string;
+  const [qParams, setQueryParams] = useQueryParams<{
+    autoRefresh?: string;
   }>();
   const { data: queue, isLoading: isQueueLoading } = useQuery({
     queryKey: ["tokenQueue", facilityId, queueId],
@@ -106,6 +106,11 @@ export function ManageQueuePage({
     // TODO: build appropriate loading skeleton...
     return <Loading />;
   }
+
+  const shouldAutoRefresh = booleanFromString(
+    qParams.autoRefresh ?? "",
+    careConfig.enableAutoRefresh,
+  );
 
   return (
     <Page
@@ -163,7 +168,7 @@ export function ManageQueuePage({
           <div className="flex gap-5 items-center justify-center">
             <div className="hidden sm:flex flex-col-reverse sm:flex-row gap-2 items-center text-black font-medium text-md">
               <Switch
-                checked={autoRefresh === "true"}
+                checked={shouldAutoRefresh}
                 onCheckedChange={(checked) =>
                   setQueryParams({
                     autoRefresh: checked ? "true" : "false",
@@ -202,7 +207,7 @@ export function ManageQueuePage({
                       {t("auto_refresh")}
                     </Label>
                     <Switch
-                      checked={autoRefresh === "true"}
+                      checked={shouldAutoRefresh}
                       onCheckedChange={(checked) =>
                         setQueryParams({
                           autoRefresh: checked ? "true" : "false",
@@ -273,7 +278,7 @@ export function ManageQueuePage({
           onTabChange={(tab) => {
             navigate(tab, {
               query: {
-                autoRefresh,
+                autoRefresh: shouldAutoRefresh ? "true" : "false",
               },
             });
           }}

--- a/src/pages/Facility/queues/utils.ts
+++ b/src/pages/Facility/queues/utils.ts
@@ -2,6 +2,7 @@ import { TokenStatus } from "@/types/tokens/token/token";
 import tokenApi from "@/types/tokens/token/tokenApi";
 import { TokenQueueSummary } from "@/types/tokens/tokenQueue/tokenQueue";
 import query from "@/Utils/request/query";
+import careConfig from "@careConfig";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useQueryParams } from "raviger";
 export function getTokenQueueStatusCount(
@@ -45,6 +46,9 @@ export function useTokenListInfiniteQuery({
       const currentOffset = allPages.length * PAGE_SIZE;
       return currentOffset < lastPage.count ? currentOffset : null;
     },
-    refetchInterval: autoRefresh === "true" ? 10000 : false,
+    refetchInterval:
+      autoRefresh === "true"
+        ? careConfig.appointmentAndQueueRefreshInterval
+        : false,
   });
 }

--- a/src/pages/Facility/queues/utils.ts
+++ b/src/pages/Facility/queues/utils.ts
@@ -52,3 +52,9 @@ export function useTokenListInfiniteQuery({
         : false,
   });
 }
+
+export function booleanFromString(str: string, fallback = false) {
+  if (str === "true") return true;
+  if (str === "false") return false;
+  return fallback;
+}

--- a/src/pages/Facility/queues/utils.ts
+++ b/src/pages/Facility/queues/utils.ts
@@ -52,9 +52,3 @@ export function useTokenListInfiniteQuery({
         : false,
   });
 }
-
-export function booleanFromString(str: string, fallback = false) {
-  if (str === "true") return true;
-  if (str === "false") return false;
-  return fallback;
-}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -33,6 +33,8 @@ interface ImportMetaEnv {
   readonly REACT_DISABLE_PATIENT_LOGIN?: string;
   readonly REACT_CUSTOM_REMOTE_I18N_URL?: string;
   readonly REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE?: string;
+  readonly REACT_AUTO_REFRESH_INTERVAL?: string;
+  readonly REACT_AUTO_REFRESH_BY_DEFAULT?: string;
 
   // Plugins related envs...
   readonly REACT_SENTRY_DSN?: string;


### PR DESCRIPTION
## Proposed Changes
- Fix : #14611 
- Added a Auto refresh toggle switch in Appointments page to refetch the data every 10sec gap

Screenshot:
<img width="1563" height="904" alt="image" src="https://github.com/user-attachments/assets/0343d81c-26ac-40f2-9155-28e7d71b20c1" />

<img width="1563" height="904" alt="image" src="https://github.com/user-attachments/assets/d953e4c7-062a-42c7-98b8-6db8c905cae7" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an auto-refresh toggle in appointments and queue views with a configurable default.
  * Added a configurable refresh interval (default 10s) used by relevant components.

* **Chores**
  * Applied auto-refresh consistently across appointment and queue components.
  * Environment validation and typings updated to accept new refresh settings.

* **Documentation**
  * Tooltip/localized text now displays the configured refresh interval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->