### PR TITLE
appointments page: cache filtered by resources in filters cache

### DIFF
--- a/src/components/Common/ResourceCategoryList.tsx
+++ b/src/components/Common/ResourceCategoryList.tsx
@@ -220,7 +220,7 @@ export function ResourceCategoryList({
         facilityId,
         categorySlug,
         qParams.searchCategory,
-        qParams.page,
+        qParams.page ?? "1",
       ],
       queryFn: query.debounced(resourceCategoryApi.list, {
         pathParams: { facilityId },

--- a/src/hooks/useFilters.tsx
+++ b/src/hooks/useFilters.tsx
@@ -86,6 +86,12 @@ export default function useFilters({
 
     const qParamKeys = Object.keys(qParams);
 
+    const defaults = Object.fromEntries(
+      Object.entries(defaultQueryParams).filter(
+        ([key]) => qParams[key] == undefined,
+      ),
+    );
+
     // If we navigate to a path that has query params set on mount,
     // skip restoring the cache, instead update the cache with new filters.
     if (qParamKeys.length) {
@@ -95,22 +101,12 @@ export default function useFilters({
 
     const cache = FiltersCache.get();
     if (!cache) {
+      setQueryParams({ ...defaults });
       return;
     }
 
     // Restore cache
-    setQueryParams(cache);
-  }, []);
-
-  useEffect(() => {
-    const defaults = Object.fromEntries(
-      Object.entries(defaultQueryParams).filter(
-        ([key]) => qParams[key] === undefined,
-      ),
-    );
-    if (Object.keys(defaults).length > 0) {
-      updateQuery(defaults);
-    }
+    setQueryParams({ ...defaults, ...cache });
   }, []);
 
   const FilterBadge = ({ name, value, paramKey }: FilterBadgeProps) => {

--- a/src/hooks/useFilters.tsx
+++ b/src/hooks/useFilters.tsx
@@ -76,21 +76,24 @@ export default function useFilters({
   const removeFilter = (param: string) => removeFilters([param]);
 
   useEffect(() => {
+    const defaults = Object.fromEntries(
+      Object.entries(defaultQueryParams).filter(
+        ([key]) => qParams[key] === undefined,
+      ),
+    );
+
     if (disableCache) {
       // Clean-up any existing cache if present for this path.
       FiltersCache.invalidate();
+
+      // Set default query params if they are not present
+      setQueryParams({ ...defaults });
 
       // Skip cache restoration logic for this usage.
       return;
     }
 
     const qParamKeys = Object.keys(qParams);
-
-    const defaults = Object.fromEntries(
-      Object.entries(defaultQueryParams).filter(
-        ([key]) => qParams[key] === undefined,
-      ),
-    );
 
     // If we navigate to a path that has query params set on mount,
     // skip restoring the cache, instead update the cache with new filters.

--- a/src/hooks/useFilters.tsx
+++ b/src/hooks/useFilters.tsx
@@ -88,7 +88,7 @@ export default function useFilters({
 
     const defaults = Object.fromEntries(
       Object.entries(defaultQueryParams).filter(
-        ([key]) => qParams[key] == undefined,
+        ([key]) => qParams[key] === undefined,
       ),
     );
 

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -152,17 +152,22 @@ interface Props {
 
 const getDefaultDateFilter = () => {
   const defaultDays = careConfig.appointments.defaultDateFilter;
+  const today = new Date();
 
   if (defaultDays === 0) {
     return {
-      date_from: dateQueryString(new Date()),
-      date_to: dateQueryString(new Date()),
+      date_from: dateQueryString(today),
+      date_to: dateQueryString(today),
     };
   }
 
+  // Past or future days based on configuration
+  const fromDate = defaultDays > 0 ? today : addDays(today, defaultDays);
+  const toDate = defaultDays > 0 ? addDays(today, defaultDays) : today;
+
   return {
-    date_from: dateQueryString(addDays(new Date(), defaultDays)),
-    date_to: dateQueryString(addDays(new Date(), defaultDays)),
+    date_from: dateQueryString(fromDate),
+    date_to: dateQueryString(toDate),
   };
 };
 

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -1,4 +1,3 @@
-import careConfig from "@careConfig";
 import { CheckIcon } from "@radix-ui/react-icons";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { addDays, differenceInDays } from "date-fns";
@@ -98,6 +97,7 @@ import {
 import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useAuthUser from "@/hooks/useAuthUser";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+import careConfig from "@careConfig";
 import { PractitionerSelector } from "./components/PractitionerSelector";
 
 type AppointmentStatusGroup = {
@@ -150,16 +150,39 @@ interface Props {
   resourceId?: string;
 }
 
+const getDefaultDateFilter = () => {
+  const defaultDays = careConfig.appointments.defaultDateFilter;
+
+  if (defaultDays === 0) {
+    return {
+      date_from: dateQueryString(new Date()),
+      date_to: dateQueryString(new Date()),
+    };
+  }
+
+  return {
+    date_from: dateQueryString(addDays(new Date(), defaultDays)),
+    date_to: dateQueryString(addDays(new Date(), defaultDays)),
+  };
+};
+
 export default function AppointmentsPage({ resourceType, resourceId }: Props) {
   const { t } = useTranslation();
   const authUser = useAuthUser();
+
+  const practitionerFilterEnabled =
+    resourceType === SchedulableResourceType.Practitioner && !resourceId;
+
   const { qParams, updateQuery, resultsPerPage, Pagination } = useFilters({
     limit: 15,
+    defaultQueryParams: {
+      ...(practitionerFilterEnabled ? { practitioners: authUser.id } : {}),
+      ...getDefaultDateFilter(),
+    },
+    cacheBlacklist: ["date_from", "date_to"],
   });
 
   useShortcutSubContext();
-  const practitionerFilterEnabled =
-    resourceType === SchedulableResourceType.Practitioner && !resourceId;
 
   const [activeTab, setActiveTab] = useView("appointments", "board");
   const { open: isSidebarOpen } = useSidebar();
@@ -191,40 +214,6 @@ export default function AppointmentsPage({ resourceType, resourceId }: Props) {
   const practitioners = schedulableUserResources?.filter((r) =>
     practitionerIds.includes(r.id),
   );
-
-  useEffect(() => {
-    // Set default date range if no dates are present
-    if (!qParams.date_from && !qParams.date_to) {
-      const today = new Date();
-      const defaultDays = careConfig.appointments.defaultDateFilter;
-
-      if (defaultDays === 0) {
-        // Today only
-        qParams.date_from = dateQueryString(today);
-        qParams.date_to = dateQueryString(today);
-      } else {
-        // Past or future days based on configuration
-        const fromDate = defaultDays > 0 ? today : addDays(today, defaultDays);
-        const toDate = defaultDays > 0 ? addDays(today, defaultDays) : today;
-        qParams.date_from = dateQueryString(fromDate);
-        qParams.date_to = dateQueryString(toDate);
-      }
-    }
-
-    // Only update if there are changes
-    if (Object.keys(qParams).length > 0) {
-      updateQuery({ ...qParams });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [qParams.date_from, qParams.date_to]);
-
-  useEffect(() => {
-    if (!qParams.practitioners && practitionerFilterEnabled) {
-      updateQuery({
-        practitioners: authUser.id,
-      });
-    }
-  }, []);
 
   // Enabled only if filtered by a practitioner and a single day
   const slotsFilterEnabled =


### PR DESCRIPTION
## Proposed Changes

- Fixes #14621

<img width="1127" height="410" alt="image" src="https://github.com/user-attachments/assets/997ea8eb-28e0-4de6-87dd-32ea08eb4646" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve and merge default filter values with cached values on load; handle cache-disabled and empty-cache cases so defaults apply.
  * Ensure appointments page consistently applies default date and practitioner filters when practitioner filtering is enabled.
  * Standardize pagination defaults so listings behave correctly when page is missing.

* **Refactor**
  * Consolidated filter initialization into a single merge-based flow, removing redundant post-mount updates and direct parameter mutations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->