### PR TITLE
fix: highlight in locations dropdown

### DIFF
--- a/src/components/Location/LocationSearch.tsx
+++ b/src/components/Location/LocationSearch.tsx
@@ -63,7 +63,7 @@ export function LocationSearch({
     enabled: facilityId !== "preview",
   });
   const commandContent = (
-    <Command className="pt-1">
+    <Command className="pt-1" shouldFilter={false}>
       <CommandInput
         placeholder="Search locations..."
         value={search}

--- a/src/components/Location/LocationSearch.tsx
+++ b/src/components/Location/LocationSearch.tsx
@@ -76,7 +76,7 @@ export function LocationSearch({
         {locations?.results.map((location) => (
           <CommandItem
             key={location.id}
-            value={location.name}
+            value={location.id}
             onSelect={() => {
               onSelect(location);
               setOpen(false);


### PR DESCRIPTION
## Proposed Changes

Fixes #14618 
- only the hovered location is highlighted in the locations dropdown

<img width="903" height="735" alt="image" src="https://github.com/user-attachments/assets/af643ad7-3b2d-4dd3-9219-8c73a2f3488a" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined location selection to use unique identifiers for improved consistency and tracking in the location search.
  * Adjusted location search behavior to prevent internal filtering so the full set of results is presented for selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->