### PR TITLE
Refactor Diagnostic Report components to improve conditional rendering

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -5168,6 +5168,7 @@
   "tendered": "Tendered",
   "test": "Test",
   "test_results": "Test Results",
+  "test_results_actions": "Test Results actions",
   "test_results_entry": "Test Results Entry",
   "test_type": "Type of test done",
   "tested_on": "Tested on",

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
@@ -187,7 +187,7 @@ export default function DiagnosticReportView({
                     <Button
                       variant="outline"
                       size="icon"
-                      aria-label="Test Results Actions"
+                      aria-label={t("test_results_actions")}
                     >
                       <MoreVertical className="size-4" />
                     </Button>

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
@@ -184,7 +184,11 @@ export default function DiagnosticReportView({
                 <CardTitle>{t("test_results")}</CardTitle>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="outline" size="icon">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      aria-label="Test Results Actions"
+                    >
                       <MoreVertical className="size-4" />
                     </Button>
                   </DropdownMenuTrigger>

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
@@ -177,42 +177,44 @@ export default function DiagnosticReportView({
         )}
 
         {/* Test Results */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <CardTitle>{t("test_results")}</CardTitle>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" size="icon">
-                    <MoreVertical className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <ObservationHistorySheet
-                    patientId={report.encounter.patient.id}
-                    diagnosticReportId={diagnosticReportId}
-                  >
-                    <DropdownMenuItem
-                      onSelect={(e) => e.preventDefault()}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                      }}
+        {report.observations && report.observations.length > 0 && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle>{t("test_results")}</CardTitle>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" size="icon">
+                      <MoreVertical className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <ObservationHistorySheet
+                      patientId={report.encounter.patient.id}
+                      diagnosticReportId={diagnosticReportId}
                     >
-                      {t("view_observation_history")}
-                    </DropdownMenuItem>
-                  </ObservationHistorySheet>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <DiagnosticReportResultsTable
-              observations={report.observations.filter(
-                (obs) => obs.status !== ObservationStatus.ENTERED_IN_ERROR,
-              )}
-            />
-          </CardContent>
-        </Card>
+                      <DropdownMenuItem
+                        onSelect={(e) => e.preventDefault()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                      >
+                        {t("view_observation_history")}
+                      </DropdownMenuItem>
+                    </ObservationHistorySheet>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <DiagnosticReportResultsTable
+                observations={report.observations.filter(
+                  (obs) => obs.status !== ObservationStatus.ENTERED_IN_ERROR,
+                )}
+              />
+            </CardContent>
+          </Card>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
@@ -598,8 +598,8 @@ export default function ServiceRequestShow({
             </Card>
           )}
 
-          {observationRequirements.length > 0 && (
-            <div className="space-y-3 pt-5">
+          <div className="space-y-3 pt-5">
+            {observationRequirements.length > 0 && (
               <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold">{t("test_results")}</h2>
                 <DropdownMenu>
@@ -627,22 +627,22 @@ export default function ServiceRequestShow({
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              {(!diagnosticReports.length ||
-                diagnosticReports[0]?.status !==
-                  DiagnosticReportStatus.final) && (
-                <DiagnosticReportForm
-                  patientId={request.encounter.patient.id}
-                  facilityId={facilityId}
-                  serviceRequestId={serviceRequestId}
-                  observationDefinitions={observationRequirements}
-                  diagnosticReports={diagnosticReports}
-                  activityDefinition={activityDefinition}
-                  specimens={request.specimens || []}
-                  disableEdit={disableEdit}
-                />
-              )}
-            </div>
-          )}
+            )}
+            {(!diagnosticReports.length ||
+              diagnosticReports[0]?.status !==
+                DiagnosticReportStatus.final) && (
+              <DiagnosticReportForm
+                patientId={request.encounter.patient.id}
+                facilityId={facilityId}
+                serviceRequestId={serviceRequestId}
+                observationDefinitions={observationRequirements}
+                diagnosticReports={diagnosticReports}
+                activityDefinition={activityDefinition}
+                specimens={request.specimens || []}
+                disableEdit={disableEdit}
+              />
+            )}
+          </div>
 
           {diagnosticReports.length > 0 && (
             <DiagnosticReportReview

--- a/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
@@ -524,13 +524,21 @@ export function DiagnosticReportForm({
         );
 
       // If there's a conclusion, we must have results first
-      if (conclusion.trim() && !hasObservationValue) {
+      if (
+        conclusion.trim() &&
+        !hasObservationValue &&
+        observationDefinitions.length > 0
+      ) {
         toast.error(t("cannot_add_conclusion_without_results"));
         return;
       }
 
-      // Results are mandatory, unless an observation is being deleted
-      if (!hasObservationValue && !hasDeletions) {
+      // Results are mandatory if observation definitions exist, unless an observation is being deleted
+      if (
+        !hasObservationValue &&
+        !hasDeletions &&
+        observationDefinitions.length > 0
+      ) {
         toast.error(t("please_fill_all_results"));
         return;
       }
@@ -839,7 +847,7 @@ export function DiagnosticReportForm({
               <div className="flex items-center gap-2">
                 <CardTitle>
                   <p className="flex items-center gap-1.5">
-                    <NotepadText className="size-[24px] text-gray-950 font-normal text-base stroke-[1.5px]" />{" "}
+                    <NotepadText className="size-6 text-gray-950 font-normal text-base stroke-[1.5px]" />{" "}
                     <span className="text-base/9 text-gray-950 font-medium">
                       {t("test_results_entry")}
                     </span>
@@ -1209,7 +1217,7 @@ export function DiagnosticReportForm({
                       : t("no_test_results_recorded")}
                   </p>
                 </div>
-                <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
+                <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4 justify-center">
                   {activityDefinition?.diagnostic_report_codes &&
                     activityDefinition.diagnostic_report_codes.length > 0 && (
                       <div className="flex-1 min-w-0">

--- a/src/pages/Facility/services/serviceRequests/components/DiagnosticReportReview.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/DiagnosticReportReview.tsx
@@ -153,10 +153,11 @@ export function DiagnosticReportReview({
     );
   }
 
-  // Don't show the report review if there are no observations and no files
+  // Don't show the report review if there are no observations and no files and no conclusion
   if (
     (!fullReport?.observations || fullReport.observations.length === 0) &&
-    (!files?.results || files.results.length === 0)
+    (!files?.results || files.results.length === 0) &&
+    !fullReport?.conclusion
   ) {
     return null;
   }
@@ -175,7 +176,7 @@ export function DiagnosticReportReview({
               <div className="flex items-center gap-2">
                 <CardTitle>
                   <p className="flex items-center gap-1.5">
-                    <FileCheck2 className="size-[24px] text-gray-950 font-normal text-base stroke-[1.5px]" />{" "}
+                    <FileCheck2 className="size-6 text-gray-950 font-normal text-base stroke-[1.5px]" />{" "}
                     <span className="text-base/9 text-gray-950 font-medium">
                       {t("result_review")}
                     </span>


### PR DESCRIPTION
## Proposed Changes
This solves creating a report without `Observation Requirements`. 

Fixes #14630 
<img width="1182" height="667" alt="image" src="https://github.com/user-attachments/assets/34d3e5c4-5983-4cce-936a-6d7792dc04a2" />

<img width="1182" height="667" alt="image" src="https://github.com/user-attachments/assets/0832d46d-45ec-4b8e-af74-862c019b54fa" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test results card now only displays when observations exist, preventing empty sections
  * Review panel hidden when there are no observations, files, or conclusion

* **Improvements**
  * Diagnostic report form can render independently of observation requirements
  * Stronger validation: conclusions and saves require observation results when definitions exist
  * Observation-history action moved into the report menu and refined menu behavior

* **Style**
  * Updated icon sizing and alignment for consistent visuals

* **Documentation**
  * Added new translation key for test results actions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->