### PR TITLE
Fix: Show "Planned Location" for future locations instead of "Current Location"

### DIFF
--- a/src/components/Location/LocationCardWrapper.tsx
+++ b/src/components/Location/LocationCardWrapper.tsx
@@ -57,7 +57,8 @@ export function LocationCardWrapper({
   const isPlannedLocation =
     status === "planned" ||
     (status === "active" &&
-      new Date(locationHistory.start_datetime) > new Date());
+      new Date(locationHistory.start_datetime).getTime() >
+        new Date().getTime() + 5 * 60 * 1000);
 
   useEffect(() => {
     if (isEditing && editingState.timeConfig.status === "active") {

--- a/src/components/Location/LocationCardWrapper.tsx
+++ b/src/components/Location/LocationCardWrapper.tsx
@@ -54,6 +54,11 @@ export function LocationCardWrapper({
   const showEndTimeField =
     status === "planned" || status === "completed" || isCompletingStay;
 
+  const isPlannedLocation =
+    status === "planned" ||
+    (status === "active" &&
+      new Date(locationHistory.start_datetime) > new Date());
+
   useEffect(() => {
     if (isEditing && editingState.timeConfig.status === "active") {
       setEditingState((prev) => ({
@@ -96,9 +101,7 @@ export function LocationCardWrapper({
       <div className="border border-gray-200 rounded-lg bg-gray-50 px-2 py-1">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-medium text-gray-600">
-            {status === "active"
-              ? t("current_location")
-              : t("planned_location")}
+            {isPlannedLocation ? t("planned_location") : t("current_location")}
           </h3>
         </div>
         <LocationCard locationHistory={locationHistory} status={status} />


### PR DESCRIPTION
## Proposed Changes

Fixes #14606

- Fixed location label to correctly display "Planned Location" for future locations instead of showing "Current Location" for both
- Added logic to detect if a location is planned based on start time being in the future
- Updated `LocationCardWrapper` component to dynamically set label based on location timing

**Technical Details:**
- Added `isPlannedLocation` check that evaluates if status is "planned" OR if status is "active" but start time is in the future
- Updated label rendering to use `isPlannedLocation` condition instead of just checking status

## Screenshots

### - **Before**
<img width="1512" height="794" alt="Screenshot 2025-12-04 at 7 04 41 PM" src="https://github.com/user-attachments/assets/fc155789-7e36-4915-a4fd-6a1f29c18e62" />

### - **After**
<img width="1512" height="903" alt="Screenshot 2025-12-04 at 7 56 07 PM" src="https://github.com/user-attachments/assets/214d18b0-36e8-417d-8f6c-f7e01c5c0aba" />
<img width="1512" height="903" alt="Screenshot 2025-12-04 at 8 00 12 PM" src="https://github.com/user-attachments/assets/27a050fd-cfe1-4d6b-9455-88651ae7332a" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Location labeling now correctly shows scheduled/future-start locations as "planned" instead of "current".
  * Title rendering updated to use a derived flag that treats near-future starts as planned.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->