### PR TITLE
Fix: Service Request Question: Locations not shown once added

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -128,7 +128,6 @@ interface ServiceRequestFormProps {
   questionId?: string;
   index?: number;
   isPreview?: boolean;
-  activityDefinition?: ActivityDefinitionReadSpec;
   facilityId?: string;
 }
 
@@ -142,10 +141,16 @@ function ServiceRequestForm({
   questionId,
   index,
   isPreview = false,
-  activityDefinition,
   facilityId = "",
 }: ServiceRequestFormProps) {
   const { t } = useTranslation();
+  const { data: locations } = useQuery({
+    queryKey: ["locations", facilityId],
+    queryFn: query(locationApi.list, {
+      pathParams: { facility_id: facilityId },
+      queryParams: { limit: 100 },
+    }),
+  });
 
   const renderInfoSection = () => (
     <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-x-4 gap-y-2 w-full">
@@ -199,19 +204,24 @@ function ServiceRequestForm({
         <span className="font-medium text-sm text-gray-700">
           {t("locations")}:
         </span>
-        {activityDefinition?.locations &&
-          activityDefinition?.locations.length > 0 &&
-          activityDefinition?.locations.map((location) => {
+        {serviceRequest.service_request.locations.length === 0 ? (
+          <span className="text-sm text-gray-500">{t("no_locations")}</span>
+        ) : (
+          serviceRequest.service_request.locations.map((loc) => {
+            const location = locations?.results.find(
+              (l: LocationList) => l.id === loc,
+            );
             return (
               <Badge
-                key={location.id}
+                key={location?.id}
                 variant="outline"
                 className="bg-gray-50 text-gray-700 border-gray-200"
               >
-                {location?.name || location.id}
+                {location?.name}
               </Badge>
             );
-          })}
+          })
+        )}
       </div>
     </div>
   );
@@ -488,10 +498,6 @@ export function ServiceRequestQuestion({
   });
 
   useEffect(() => {
-    console.log("selectedActivityDefinition", selectedActivityDefinition);
-  }, [selectedActivityDefinition]);
-
-  useEffect(() => {
     if (selectedActivityDefinition && selectedActivityDefinitionData) {
       const newServiceRequest: ServiceRequestApplyActivityDefinitionSpec = {
         service_request: {
@@ -700,7 +706,6 @@ export function ServiceRequestQuestion({
       {previewServiceRequest && !isLoadingSelectedAD && (
         <ServiceRequestForm
           serviceRequest={previewServiceRequest}
-          activityDefinition={selectedActivityDefinitionData}
           onUpdate={handlePreviewServiceRequestUpdate}
           onRemove={() => {
             setPreviewServiceRequest(null);

--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -144,12 +144,13 @@ function ServiceRequestForm({
   facilityId = "",
 }: ServiceRequestFormProps) {
   const { t } = useTranslation();
-  const { data: locations } = useQuery({
+  const { data: locations, isLoading: isLocationsLoading } = useQuery({
     queryKey: ["locations", facilityId],
-    queryFn: query(locationApi.list, {
+    queryFn: query.paginated(locationApi.list, {
       pathParams: { facility_id: facilityId },
-      queryParams: { limit: 100 },
+      pageSize: 100,
     }),
+    enabled: !!facilityId,
   });
 
   const renderInfoSection = () => (
@@ -204,7 +205,9 @@ function ServiceRequestForm({
         <span className="font-medium text-sm text-gray-700">
           {t("locations")}:
         </span>
-        {serviceRequest.service_request.locations.length === 0 ? (
+        {isLocationsLoading ? (
+          <span className="text-sm text-gray-500">{t("loading")}</span>
+        ) : serviceRequest.service_request.locations.length === 0 ? (
           <span className="text-sm text-gray-500">{t("no_locations")}</span>
         ) : (
           serviceRequest.service_request.locations.map((loc) => {


### PR DESCRIPTION
## Proposed Changes

- Fixes #14626
- removed passing of activityDefinition in servicerequestform since we are already pre-filling the locations in service request on time of activity definition selection so form should use those locations  to render location 

https://github.com/user-attachments/assets/8cdd26a3-c3c1-418f-a959-ac51ea1ffded



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes (there is seperate PR opened for service request create playwright )


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined location lookup: forms now fetch and map locations by facility, improving badge display and preview rendering.
  * Preview flow updated to use the new lookup-based rendering (no direct injection of upstream definition data).
  * Improved UI states for loading and no-locations, and removed debug output during selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->