### PR TITLE
Tests for queues creation and editing

### DIFF
--- a/tests/facility/queues/queueCreation.spec.ts
+++ b/tests/facility/queues/queueCreation.spec.ts
@@ -17,6 +17,14 @@ async function createQueue(page: Page, queueName: string) {
   await expect(page.getByText(queueName)).toBeVisible();
 }
 
+async function openQueueEditMenu(page: Page, queueName: string) {
+  const row = page.getByRole("row", {
+    name: new RegExp(`\\b${queueName}\\b`),
+  });
+  await row.locator("td").last().getByRole("button").click();
+  await page.getByRole("menuitem", { name: /edit queue name/i }).click();
+}
+
 test.describe("Queue Creation & Editing", () => {
   let facilityId: string;
 
@@ -37,11 +45,7 @@ test.describe("Queue Creation & Editing", () => {
     const updatedQueueName = faker.lorem.word();
     await createQueue(page, queueName);
     await test.step("Open queue edit menu", async () => {
-      const row = page.getByRole("row", {
-        name: new RegExp(`\\b${queueName}\\b`),
-      });
-      await row.locator("td").last().getByRole("button").click();
-      await page.getByRole("menuitem", { name: /edit queue name/i }).click();
+      await openQueueEditMenu(page, queueName);
     });
 
     await test.step("Update queue name", async () => {
@@ -68,11 +72,7 @@ test.describe("Queue Creation & Editing", () => {
     const queueName = faker.lorem.word();
     await createQueue(page, queueName);
     await test.step("Open queue edit menu", async () => {
-      const row = page.getByRole("row", {
-        name: new RegExp(`\\b${queueName}\\b`),
-      });
-      await row.locator("td").last().getByRole("button").click();
-      await page.getByRole("menuitem", { name: /edit queue name/i }).click();
+      await openQueueEditMenu(page, queueName);
     });
 
     await test.step("Verify update button is disabled", async () => {
@@ -87,11 +87,7 @@ test.describe("Queue Creation & Editing", () => {
     await createQueue(page, queueName);
 
     await test.step("Open queue edit menu", async () => {
-      const row = page.getByRole("row", {
-        name: new RegExp(`\\b${queueName}\\b`),
-      });
-      await row.locator("td").last().getByRole("button").click();
-      await page.getByRole("menuitem", { name: /edit queue name/i }).click();
+      await openQueueEditMenu(page, queueName);
     });
 
     await test.step("Clear queue name field and attempt update", async () => {

--- a/tests/facility/queues/queueCreation.spec.ts
+++ b/tests/facility/queues/queueCreation.spec.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import type { Locator, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { getFacilityId } from "tests/support/facilityId";
 
@@ -87,7 +87,7 @@ test.describe("Queue Creation & Editing", () => {
     await createQueue(page, queueName);
 
     await test.step("Open queue edit menu", async () => {
-      const row: Locator = page.getByRole("row", {
+      const row = page.getByRole("row", {
         name: new RegExp(`\\b${queueName}\\b`),
       });
       await row.locator("td").last().getByRole("button").click();

--- a/tests/facility/queues/queueCreation.spec.ts
+++ b/tests/facility/queues/queueCreation.spec.ts
@@ -1,0 +1,96 @@
+import { faker } from "@faker-js/faker";
+import type { Locator } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { getFacilityId } from "tests/support/facilityId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("Queue Creation & Editing", () => {
+  let facilityId: string;
+  let queueName: string;
+  let updatedQueueName: string;
+  let row: Locator;
+
+  test.beforeEach(async ({ page }) => {
+    facilityId = getFacilityId();
+
+    await page.goto(`/facility/${facilityId}/queues`);
+  });
+
+  test("should create a new queue", async ({ page }) => {
+    queueName = faker.lorem.word();
+
+    await page.getByRole("button", { name: /create queue/i }).click();
+    await page.getByRole("textbox", { name: /queue name/i }).fill(queueName);
+    await page.getByRole("button", { name: /create queue/i }).click();
+    await expect(
+      page
+        .locator("li[data-sonner-toast]")
+        .getByText("Queue created successfully"),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(queueName)).toBeVisible();
+  });
+
+  test("should edit queue name", async ({ page }) => {
+    updatedQueueName = faker.lorem.word();
+
+    await test.step("Open queue edit menu", async () => {
+      row = page.getByRole("row", {
+        name: new RegExp(`\\b${queueName}\\b`),
+      });
+      await row.locator("td").last().getByRole("button").click();
+      await page.getByRole("menuitem", { name: /edit queue name/i }).click();
+    });
+
+    await test.step("Update queue name", async () => {
+      await page
+        .getByRole("textbox", { name: /queue name/i })
+        .fill(updatedQueueName);
+      await page.getByRole("button", { name: /update queue/i }).click();
+    });
+
+    await test.step("Verify queue name updated", async () => {
+      await expect(
+        page
+          .locator("li[data-sonner-toast]")
+          .getByText("Queue updated successfully"),
+      ).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText(updatedQueueName)).toBeVisible();
+      await expect(page.getByText(queueName)).not.toBeVisible();
+    });
+  });
+
+  test("should not allow editing queue name when no changes made", async ({
+    page,
+  }) => {
+    await test.step("Open queue edit menu", async () => {
+      row = page.getByRole("row", {
+        name: new RegExp(`\\b${updatedQueueName}\\b`),
+      });
+      await row.locator("td").last().getByRole("button").click();
+      await page.getByRole("menuitem", { name: "Edit queue name" }).click();
+    });
+
+    await test.step("Verify update button is disabled", async () => {
+      await expect(
+        page.getByRole("button", { name: /update queue/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  test("should not allow editing queue name when invalid", async ({ page }) => {
+    await test.step("Open queue edit menu", async () => {
+      await row.locator("td").last().getByRole("button").click();
+      await page.getByRole("menuitem", { name: /edit queue name/i }).click();
+    });
+
+    await test.step("Clear queue name field and attempt update", async () => {
+      await page.getByRole("textbox", { name: /queue name/i }).fill("");
+      await page.getByRole("button", { name: /update queue/i }).click();
+    });
+
+    await test.step("Verify error message appears", async () => {
+      await expect(page.getByText(/queue name is required/i)).toBeVisible();
+    });
+  });
+});

--- a/tests/facility/queues/queueCreation.spec.ts
+++ b/tests/facility/queues/queueCreation.spec.ts
@@ -1,15 +1,24 @@
 import { faker } from "@faker-js/faker";
-import type { Locator } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { getFacilityId } from "tests/support/facilityId";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
+async function createQueue(page: Page, queueName: string) {
+  await page.getByRole("button", { name: /create queue/i }).click();
+  await page.getByRole("textbox", { name: /queue name/i }).fill(queueName);
+  await page.getByRole("button", { name: /create queue/i }).click();
+  await expect(
+    page
+      .locator("li[data-sonner-toast]")
+      .getByText(/queue created successfully/i),
+  ).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText(queueName)).toBeVisible();
+}
+
 test.describe("Queue Creation & Editing", () => {
   let facilityId: string;
-  let queueName: string;
-  let updatedQueueName: string;
-  let row: Locator;
 
   test.beforeEach(async ({ page }) => {
     facilityId = getFacilityId();
@@ -18,24 +27,17 @@ test.describe("Queue Creation & Editing", () => {
   });
 
   test("should create a new queue", async ({ page }) => {
-    queueName = faker.lorem.word();
+    const queueName = faker.lorem.word();
 
-    await page.getByRole("button", { name: /create queue/i }).click();
-    await page.getByRole("textbox", { name: /queue name/i }).fill(queueName);
-    await page.getByRole("button", { name: /create queue/i }).click();
-    await expect(
-      page
-        .locator("li[data-sonner-toast]")
-        .getByText("Queue created successfully"),
-    ).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(queueName)).toBeVisible();
+    await createQueue(page, queueName);
   });
 
   test("should edit queue name", async ({ page }) => {
-    updatedQueueName = faker.lorem.word();
-
+    const queueName = faker.lorem.word();
+    const updatedQueueName = faker.lorem.word();
+    await createQueue(page, queueName);
     await test.step("Open queue edit menu", async () => {
-      row = page.getByRole("row", {
+      const row = page.getByRole("row", {
         name: new RegExp(`\\b${queueName}\\b`),
       });
       await row.locator("td").last().getByRole("button").click();
@@ -53,7 +55,7 @@ test.describe("Queue Creation & Editing", () => {
       await expect(
         page
           .locator("li[data-sonner-toast]")
-          .getByText("Queue updated successfully"),
+          .getByText(/queue updated successfully/i),
       ).toBeVisible({ timeout: 10000 });
       await expect(page.getByText(updatedQueueName)).toBeVisible();
       await expect(page.getByText(queueName)).not.toBeVisible();
@@ -63,12 +65,14 @@ test.describe("Queue Creation & Editing", () => {
   test("should not allow editing queue name when no changes made", async ({
     page,
   }) => {
+    const queueName = faker.lorem.word();
+    await createQueue(page, queueName);
     await test.step("Open queue edit menu", async () => {
-      row = page.getByRole("row", {
-        name: new RegExp(`\\b${updatedQueueName}\\b`),
+      const row = page.getByRole("row", {
+        name: new RegExp(`\\b${queueName}\\b`),
       });
       await row.locator("td").last().getByRole("button").click();
-      await page.getByRole("menuitem", { name: "Edit queue name" }).click();
+      await page.getByRole("menuitem", { name: /edit queue name/i }).click();
     });
 
     await test.step("Verify update button is disabled", async () => {
@@ -79,7 +83,13 @@ test.describe("Queue Creation & Editing", () => {
   });
 
   test("should not allow editing queue name when invalid", async ({ page }) => {
+    const queueName = faker.lorem.word();
+    await createQueue(page, queueName);
+
     await test.step("Open queue edit menu", async () => {
+      const row: Locator = page.getByRole("row", {
+        name: new RegExp(`\\b${queueName}\\b`),
+      });
       await row.locator("td").last().getByRole("button").click();
       await page.getByRole("menuitem", { name: /edit queue name/i }).click();
     });


### PR DESCRIPTION
## Proposed Changes

Fixes #14373 
- Wrote tests for creating queues
- Also for editing queues
- <img width="1224" height="270" alt="image" src="https://github.com/user-attachments/assets/65105c5f-fc27-4ac9-b06d-3617adc5c67f" />
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for facility queue flows: creating queues (randomized names), renaming, validation for empty/invalid names, ensuring update is disabled when no changes are made, and verifying success notifications plus visibility/absence of old or updated queue names across flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->