### PR TITLE
Fix: Clear validation errors when switching contact point types in Add Device form

### DIFF
--- a/src/pages/Facility/settings/devices/components/DeviceForm.tsx
+++ b/src/pages/Facility/settings/devices/components/DeviceForm.tsx
@@ -460,6 +460,7 @@ export default function DeviceForm({ facilityId, device, onSuccess }: Props) {
                         if (isPhone(value) !== isPhone(field.value)) {
                           form.setValue(`contact.${index}.value`, "");
                         }
+                        form.clearErrors(`contact.${index}.value`);
 
                         field.onChange(value);
                       }}

--- a/tests/facility/settings/devices/deviceCreation.spec.ts
+++ b/tests/facility/settings/devices/deviceCreation.spec.ts
@@ -207,4 +207,31 @@ test.describe("Facility Devices Management", () => {
       .getByText("This field is required");
     await expect(registeredNameError).toBeVisible();
   });
+
+  test("Clear validation error when switching contact point type", async ({
+    page,
+  }) => {
+    // Navigate to Add Device form
+    await page.getByRole("link", { name: "Add Device" }).click();
+
+    // Add a contact point
+    await page.getByRole("button", { name: "Add Contact Point" }).click();
+
+    // Select Email type
+    await page.getByRole("combobox", { name: "Select contact system" }).click();
+    await page.getByRole("option", { name: "Email" }).click();
+
+    // Enter invalid email
+    await page.getByPlaceholder("name@example.com").fill("invalid-email");
+
+    // Verify validation error appears
+    await expect(page.getByText("Invalid email")).toBeVisible();
+
+    // Switch to URL type
+    await page.getByRole("combobox", { name: "Select contact system" }).click();
+    await page.getByRole("option", { name: "URL" }).click();
+
+    // Verify validation error is gone
+    await expect(page.getByText("Invalid email")).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
## Proposed Changes

Fixes #13463
- This PR ensures validation errors (e.g., "Invalid email") are cleared when the user switches to a different type (e.g., URL), so only the validation rules of the currently selected type apply.

[Screencast from 2025-12-06 15-55-00.webm](https://github.com/user-attachments/assets/f53a768f-24fd-43cd-adc3-d0ed57f0cfba)



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors for contact information are now cleared when switching contact type in device settings, preventing stale error messages and improving form behavior.

* **Tests**
  * Added a test verifying validation messages are removed when changing a contact type during device creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->