### PR TITLE
fix: Service Request Question: Locations not shown once added

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -198,22 +198,15 @@ function ServiceRequestForm({
         <span className="font-medium text-sm text-gray-700">
           {t("locations")}:
         </span>
-        {(() => {
-          const locations = serviceRequest.activity_definition_data?.locations;
-          return (
-            locations &&
-            locations.length > 0 &&
-            locations.map((location) => (
-              <Badge
-                key={location.id}
-                variant="outline"
-                className="bg-gray-50 text-gray-700 border-gray-200"
-              >
-                {location.name}
-              </Badge>
-            ))
-          );
-        })()}
+        {serviceRequest.activity_definition_data?.locations?.map((location) => (
+          <Badge
+            key={location.id}
+            variant="outline"
+            className="bg-gray-50 text-gray-700 border-gray-200"
+          >
+            {location.name}
+          </Badge>
+        ))}
       </div>
     </div>
   );

--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -57,6 +57,7 @@ interface ServiceRequestApplyActivityDefinitionSpec extends Omit<
   > & {
     requester: UserReadMinimal;
   };
+  activity_definition_data?: ActivityDefinitionReadSpec;
 }
 
 interface ServiceRequestQuestionProps {
@@ -128,7 +129,6 @@ interface ServiceRequestFormProps {
   questionId?: string;
   index?: number;
   isPreview?: boolean;
-  activityDefinition?: ActivityDefinitionReadSpec;
   facilityId?: string;
 }
 
@@ -142,7 +142,6 @@ function ServiceRequestForm({
   questionId,
   index,
   isPreview = false,
-  activityDefinition,
   facilityId = "",
 }: ServiceRequestFormProps) {
   const { t } = useTranslation();
@@ -199,19 +198,22 @@ function ServiceRequestForm({
         <span className="font-medium text-sm text-gray-700">
           {t("locations")}:
         </span>
-        {activityDefinition?.locations &&
-          activityDefinition?.locations.length > 0 &&
-          activityDefinition?.locations.map((location) => {
-            return (
+        {(() => {
+          const locations = serviceRequest.activity_definition_data?.locations;
+          return (
+            locations &&
+            locations.length > 0 &&
+            locations.map((location) => (
               <Badge
                 key={location.id}
                 variant="outline"
                 className="bg-gray-50 text-gray-700 border-gray-200"
               >
-                {location?.name || location.id}
+                {location.name}
               </Badge>
-            );
-          })}
+            ))
+          );
+        })()}
       </div>
     </div>
   );
@@ -488,10 +490,6 @@ export function ServiceRequestQuestion({
   });
 
   useEffect(() => {
-    console.log("selectedActivityDefinition", selectedActivityDefinition);
-  }, [selectedActivityDefinition]);
-
-  useEffect(() => {
     if (selectedActivityDefinition && selectedActivityDefinitionData) {
       const newServiceRequest: ServiceRequestApplyActivityDefinitionSpec = {
         service_request: {
@@ -514,6 +512,7 @@ export function ServiceRequestQuestion({
         },
         activity_definition: selectedActivityDefinition,
         encounter: encounterId,
+        activity_definition_data: selectedActivityDefinitionData,
       };
 
       setPreviewServiceRequest(newServiceRequest);
@@ -700,7 +699,6 @@ export function ServiceRequestQuestion({
       {previewServiceRequest && !isLoadingSelectedAD && (
         <ServiceRequestForm
           serviceRequest={previewServiceRequest}
-          activityDefinition={selectedActivityDefinitionData}
           onUpdate={handlePreviewServiceRequestUpdate}
           onRemove={() => {
             setPreviewServiceRequest(null);

--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -194,20 +194,25 @@ function ServiceRequestForm({
           </Badge>
         </div>
       )}
-      <div className="flex items-center gap-2 flex-wrap col-span-1 sm:col-span-2 xl:col-span-4">
-        <span className="font-medium text-sm text-gray-700">
-          {t("locations")}:
-        </span>
-        {serviceRequest.activity_definition_data?.locations?.map((location) => (
-          <Badge
-            key={location.id}
-            variant="outline"
-            className="bg-gray-50 text-gray-700 border-gray-200"
-          >
-            {location.name}
-          </Badge>
-        ))}
-      </div>
+      {serviceRequest.activity_definition_data?.locations &&
+        serviceRequest.activity_definition_data.locations.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap col-span-1 sm:col-span-2 xl:col-span-4">
+            <span className="font-medium text-sm text-gray-700">
+              {t("locations")}:
+            </span>
+            {serviceRequest.activity_definition_data.locations.map(
+              (location) => (
+                <Badge
+                  key={location.id}
+                  variant="outline"
+                  className="bg-gray-50 text-gray-700 border-gray-200"
+                >
+                  {location.name}
+                </Badge>
+              ),
+            )}
+          </div>
+        )}
     </div>
   );
 

--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -57,6 +57,7 @@ interface ServiceRequestApplyActivityDefinitionSpec extends Omit<
   > & {
     requester: UserReadMinimal;
   };
+  locationData?: LocationList[];
 }
 
 interface ServiceRequestQuestionProps {
@@ -195,24 +196,27 @@ function ServiceRequestForm({
           </Badge>
         </div>
       )}
-      <div className="flex items-center gap-2 flex-wrap col-span-1 sm:col-span-2 xl:col-span-4">
-        <span className="font-medium text-sm text-gray-700">
-          {t("locations")}:
-        </span>
-        {activityDefinition?.locations &&
-          activityDefinition?.locations.length > 0 &&
-          activityDefinition?.locations.map((location) => {
-            return (
-              <Badge
-                key={location.id}
-                variant="outline"
-                className="bg-gray-50 text-gray-700 border-gray-200"
-              >
-                {location?.name || location.id}
-              </Badge>
-            );
-          })}
-      </div>
+      {(serviceRequest.locationData || activityDefinition?.locations) &&
+        (serviceRequest.locationData || activityDefinition?.locations)!.length >
+          0 && (
+          <div className="flex items-center gap-2 flex-wrap col-span-1 sm:col-span-2 xl:col-span-4">
+            <span className="font-medium text-sm text-gray-700">
+              {t("locations")}:
+            </span>
+            {(serviceRequest.locationData ||
+              activityDefinition?.locations)!.map((location) => {
+              return (
+                <Badge
+                  key={location.id}
+                  variant="outline"
+                  className="bg-gray-50 text-gray-700 border-gray-200"
+                >
+                  {location?.name || location.id}
+                </Badge>
+              );
+            })}
+          </div>
+        )}
     </div>
   );
 
@@ -514,6 +518,7 @@ export function ServiceRequestQuestion({
         },
         activity_definition: selectedActivityDefinition,
         encounter: encounterId,
+        locationData: selectedActivityDefinitionData.locations || [],
       };
 
       setPreviewServiceRequest(newServiceRequest);

--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -57,7 +57,6 @@ interface ServiceRequestApplyActivityDefinitionSpec extends Omit<
   > & {
     requester: UserReadMinimal;
   };
-  activity_definition_data?: ActivityDefinitionReadSpec;
 }
 
 interface ServiceRequestQuestionProps {
@@ -129,6 +128,7 @@ interface ServiceRequestFormProps {
   questionId?: string;
   index?: number;
   isPreview?: boolean;
+  activityDefinition?: ActivityDefinitionReadSpec;
   facilityId?: string;
 }
 
@@ -142,6 +142,7 @@ function ServiceRequestForm({
   questionId,
   index,
   isPreview = false,
+  activityDefinition,
   facilityId = "",
 }: ServiceRequestFormProps) {
   const { t } = useTranslation();
@@ -194,25 +195,24 @@ function ServiceRequestForm({
           </Badge>
         </div>
       )}
-      {serviceRequest.activity_definition_data?.locations &&
-        serviceRequest.activity_definition_data.locations.length > 0 && (
-          <div className="flex items-center gap-2 flex-wrap col-span-1 sm:col-span-2 xl:col-span-4">
-            <span className="font-medium text-sm text-gray-700">
-              {t("locations")}:
-            </span>
-            {serviceRequest.activity_definition_data.locations.map(
-              (location) => (
-                <Badge
-                  key={location.id}
-                  variant="outline"
-                  className="bg-gray-50 text-gray-700 border-gray-200"
-                >
-                  {location.name}
-                </Badge>
-              ),
-            )}
-          </div>
-        )}
+      <div className="flex items-center gap-2 flex-wrap col-span-1 sm:col-span-2 xl:col-span-4">
+        <span className="font-medium text-sm text-gray-700">
+          {t("locations")}:
+        </span>
+        {activityDefinition?.locations &&
+          activityDefinition?.locations.length > 0 &&
+          activityDefinition?.locations.map((location) => {
+            return (
+              <Badge
+                key={location.id}
+                variant="outline"
+                className="bg-gray-50 text-gray-700 border-gray-200"
+              >
+                {location?.name || location.id}
+              </Badge>
+            );
+          })}
+      </div>
     </div>
   );
 
@@ -488,6 +488,10 @@ export function ServiceRequestQuestion({
   });
 
   useEffect(() => {
+    console.log("selectedActivityDefinition", selectedActivityDefinition);
+  }, [selectedActivityDefinition]);
+
+  useEffect(() => {
     if (selectedActivityDefinition && selectedActivityDefinitionData) {
       const newServiceRequest: ServiceRequestApplyActivityDefinitionSpec = {
         service_request: {
@@ -510,7 +514,6 @@ export function ServiceRequestQuestion({
         },
         activity_definition: selectedActivityDefinition,
         encounter: encounterId,
-        activity_definition_data: selectedActivityDefinitionData,
       };
 
       setPreviewServiceRequest(newServiceRequest);
@@ -697,6 +700,7 @@ export function ServiceRequestQuestion({
       {previewServiceRequest && !isLoadingSelectedAD && (
         <ServiceRequestForm
           serviceRequest={previewServiceRequest}
+          activityDefinition={selectedActivityDefinitionData}
           onUpdate={handlePreviewServiceRequestUpdate}
           onRemove={() => {
             setPreviewServiceRequest(null);


### PR DESCRIPTION
## Proposed Changes

Fixes #14626
Tagging: @ohcnetwork/care-fe-code-reviewers

before clicking add
<img width="1182" height="868" alt="image" src="https://github.com/user-attachments/assets/94e8359e-41c9-4c17-85c8-7f7d90a750ea" />

after clicking add
<img width="1182" height="437" alt="image" src="https://github.com/user-attachments/assets/3f1a77b9-d41d-49da-a3d5-f93a654f1dbc" />



## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service requests can now carry their own location data so selections are preserved and shown in previews.

* **Refactor**
  * Internal handling of activity/location details was streamlined to improve data flow between forms and previews.

* **Bug Fix**
  * Preview rendering now reliably shows location badges when locations are present, ensuring consistent display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->