### PR TITLE
Fix:  slug validation not clearing when manually edited in ValueSet form

### DIFF
--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -441,15 +441,7 @@ export function ValueSetForm({
                       .toLowerCase()
                       .replace(/[^a-z0-9_-]/g, "");
                     field.onChange(sanitizedValue);
-
-                    if (
-                      sanitizedValue.length >= 5 &&
-                      sanitizedValue.length <= 25
-                    ) {
-                      form.clearErrors("slug");
-                    } else {
-                      form.trigger("slug");
-                    }
+                    form.trigger("slug");
                   }}
                 />
               </FormControl>

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -441,6 +441,15 @@ export function ValueSetForm({
                       .toLowerCase()
                       .replace(/[^a-z0-9_-]/g, "");
                     field.onChange(sanitizedValue);
+
+                    if (
+                      sanitizedValue.length >= 5 &&
+                      sanitizedValue.length <= 25
+                    ) {
+                      form.clearErrors("slug");
+                    } else {
+                      form.trigger("slug");
+                    }
                   }}
                 />
               </FormControl>

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -442,6 +442,7 @@ export function ValueSetForm({
                       .replace(/[^a-z0-9_-]/g, "");
                     form.setValue("slug", sanitizedValue, {
                       shouldValidate: true,
+                      shouldDirty: true,
                     });
                   }}
                 />

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -440,8 +440,9 @@ export function ValueSetForm({
                     const sanitizedValue = e.target.value
                       .toLowerCase()
                       .replace(/[^a-z0-9_-]/g, "");
-                    field.onChange(sanitizedValue);
-                    form.trigger("slug");
+                    form.setValue("slug", sanitizedValue, {
+                      shouldValidate: true,
+                    });
                   }}
                 />
               </FormControl>


### PR DESCRIPTION
## Proposed Changes
Fixes #14642

- Modified slug field onChange handler to explicitly clear validation errors when slug length becomes valid (5-25 characters)
- Previously, validation errors persisted even after manually editing slug to valid length because `form.trigger()` didn't clear existing error state
- Now uses `form.clearErrors("slug")` when slug is valid, ensuring error message disappears immediately

## Video

https://github.com/user-attachments/assets/cb04bca0-b162-4968-8291-447829c1b160

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slug input now updates the form state as you type, triggering validation and marking the form as modified.
  * Sanitized slug changes are immediately reflected and validated in the UI, improving consistency between slug and name inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->