### PR TITLE
Fix page shift caused by scrollbar disappearing (#14671)

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -147,6 +147,7 @@
 @layer utilities {
   html {
     @apply size-full scroll-smooth;
+    overflow-y: scroll;
   }
 
   body {

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -146,10 +146,8 @@
 
 @layer utilities {
   html {
-    @apply size-full scroll-smooth;
-    overflow-y: scroll;
+    @apply size-full scroll-smooth overflow-y-scroll;
   }
-
   body {
     font-family: "Figtree", sans-serif;
     color: #453c52;


### PR DESCRIPTION
## Proposed Changes

Fixes #14671
- Added overflow-y: scroll; to ensure the scrollbar remains visible.
- Prevents the layout shift caused when the browser hides the scrollbar as dropdown menus open.
- This keeps the page width stable and avoids the rightward shifting effect seen during selection.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

https://github.com/user-attachments/assets/817ca752-358f-418e-88f5-516c5f5021de


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style
* Ensured consistent vertical scrollbar visibility across the application by making the HTML utility always display a vertical scrollbar.
* Improves layout stability and reduces content shift when pages load or content changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->