### PR TITLE
fix: Icon of latest location with completed bed stay

### DIFF
--- a/src/components/Location/LocationTree.tsx
+++ b/src/components/Location/LocationTree.tsx
@@ -105,6 +105,8 @@ export function LocationTree({
   isLatest,
   showTimeline = false,
 }: LocationPathProps) {
+  const completed = isLatest && endTime;
+
   return (
     <div
       className={`relative flex ${showTimeline ? "gap-8 pl-12" : ""}  pt-0.5`}
@@ -115,11 +117,17 @@ export function LocationTree({
             className={`absolute w-px bg-gray-200 h-full ${isLatest ? "top-3" : "-top-3"}`}
           />
           <div
-            className={`size-6 rounded-full ${isLatest ? "bg-green-100" : "bg-gray-100"} flex items-center justify-center z-10`}
+            className={`size-6 rounded-full ${completed ? "bg-gray-100" : isLatest ? "bg-green-100" : "bg-gray-100"} flex items-center justify-center z-10`}
           >
             <CareIcon
-              icon={isLatest ? "l-location-point" : "l-check"}
-              className={`size-4 ${isLatest ? "text-green-600" : "text-gray-600"}`}
+              icon={
+                completed
+                  ? "l-check"
+                  : isLatest
+                    ? "l-location-point"
+                    : "l-check"
+              }
+              className={`size-4 ${completed ? "text-gray-600" : isLatest ? "text-green-600" : "text-gray-600"}`}
             />
           </div>
           {!isLatest && <div className="flex-1 w-px bg-gray-200" />}

--- a/src/components/Location/LocationTree.tsx
+++ b/src/components/Location/LocationTree.tsx
@@ -105,7 +105,7 @@ export function LocationTree({
   isLatest,
   showTimeline = false,
 }: LocationPathProps) {
-  const completed = isLatest && endTime;
+  const isCompleted = !!endTime;
 
   return (
     <div
@@ -117,11 +117,11 @@ export function LocationTree({
             className={`absolute w-px bg-gray-200 h-full ${isLatest ? "top-3" : "-top-3"}`}
           />
           <div
-            className={`size-6 rounded-full ${completed ? "bg-gray-100" : isLatest ? "bg-green-100" : "bg-gray-100"} flex items-center justify-center z-10`}
+            className={`size-6 rounded-full ${isCompleted ? "bg-gray-100" : isLatest ? "bg-green-100" : "bg-gray-100"} flex items-center justify-center z-10`}
           >
             <CareIcon
-              icon={completed || !isLatest ? "l-check" : "l-location-point"}
-              className={`size-4 ${completed ? "text-gray-600" : isLatest ? "text-green-600" : "text-gray-600"}`}
+              icon={isCompleted ? "l-check" : "l-location-point"}
+              className={`size-4 ${isCompleted ? "text-gray-600" : isLatest ? "text-green-600" : "text-gray-600"}`}
             />
           </div>
           {!isLatest && <div className="flex-1 w-px bg-gray-200" />}

--- a/src/components/Location/LocationTree.tsx
+++ b/src/components/Location/LocationTree.tsx
@@ -120,13 +120,7 @@ export function LocationTree({
             className={`size-6 rounded-full ${completed ? "bg-gray-100" : isLatest ? "bg-green-100" : "bg-gray-100"} flex items-center justify-center z-10`}
           >
             <CareIcon
-              icon={
-                completed
-                  ? "l-check"
-                  : isLatest
-                    ? "l-location-point"
-                    : "l-check"
-              }
+              icon={completed || !isLatest ? "l-check" : "l-location-point"}
               className={`size-4 ${completed ? "text-gray-600" : isLatest ? "text-green-600" : "text-gray-600"}`}
             />
           </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #14678
- In location history, the latest location with completed bed stay shows check mark icon instead of map marker.

<img width="745" height="717" alt="image" src="https://github.com/user-attachments/assets/6169fc3f-9db3-4934-b36c-f5b6285cc556" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline visuals for locations: completed entries now show a muted gray background, a check-style icon, and muted text; the most recent active location uses green highlights; earlier entries remain muted. Vertical line alignment and non-latest branch rendering remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->