### PR TITLE
Remove target="_blank" from invoice link in MedicationTable component

### DIFF
--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -251,7 +251,6 @@ function MedicationTable({
                         href={`/facility/${facilityId}/billing/invoices/${medication.charge_item.paid_invoice?.id}`}
                         basePath={`/`}
                         className="hover:text-primary underline underline-offset-2"
-                        target="_blank"
                       >
                         {t("view_invoice")}
                         <CareIcon


### PR DESCRIPTION
## Proposed Changes

I’ve removed the target blank, so the user can choose whether it needs to open in a new tab or not.

Fixes #14675
<img width="3014" height="1068" alt="image" src="https://github.com/user-attachments/assets/70eb0c5b-1f7a-4c4d-80b8-2ee8f8bfca39" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Invoice links in the Pharmacy section now open in the current tab instead of a new tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->