### PR TITLE
Made the select service point dialog's buttons clickable on entire area

### DIFF
--- a/src/pages/Facility/queues/AssignToServicePointDialog.tsx
+++ b/src/pages/Facility/queues/AssignToServicePointDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { cn } from "@/lib/utils";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
@@ -90,25 +91,26 @@ export function AssignToServicePointDialog({
           onValueChange={setSelectedSubQueueId}
         >
           {assignedServicePoints.map((subQueue) => (
-            <label
+            <div
               key={subQueue.id}
-              htmlFor={subQueue.id}
               className={cn(
                 "flex items-center space-x-3 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors cursor-pointer",
-                selectedSubQueueId === subQueue.id &&
-                  subQueue.id === token.sub_queue?.id &&
-                  "hidden",
+                subQueue.id === token.sub_queue?.id && "hidden",
               )}
+              onClick={() => setSelectedSubQueueId(subQueue.id)}
             >
               <RadioGroupItem value={subQueue.id} id={subQueue.id} />
-              <span className="flex-1 text-sm font-medium">
+              <Label
+                htmlFor={subQueue.id}
+                className="flex-1 text-sm font-medium cursor-pointer"
+              >
                 {subQueue.name}
-              </span>
+              </Label>
               <span className="text-sm text-gray-600">
                 {preferredServicePointCategories?.[subQueue.id]?.name ??
                   t("all")}
               </span>
-            </label>
+            </div>
           ))}
           {assignedServicePoints.length === 0 && (
             <div className="flex items-center space-x-3 p-3 rounded-lg border border-gray-200 bg-gray-50">

--- a/src/pages/Facility/queues/AssignToServicePointDialog.tsx
+++ b/src/pages/Facility/queues/AssignToServicePointDialog.tsx
@@ -90,35 +90,32 @@ export function AssignToServicePointDialog({
           onValueChange={setSelectedSubQueueId}
         >
           {assignedServicePoints.map((subQueue) => (
-            <div
+            <label
               key={subQueue.id}
+              htmlFor={subQueue.id}
               className={cn(
-                "flex items-center space-x-3 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors",
-                subQueue.id === token.sub_queue?.id && "hidden",
+                "flex items-center space-x-3 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors cursor-pointer",
+                selectedSubQueueId === subQueue.id &&
+                  subQueue.id === token.sub_queue?.id &&
+                  "hidden",
               )}
             >
               <RadioGroupItem value={subQueue.id} id={subQueue.id} />
-              <label
-                htmlFor={subQueue.id}
-                className="flex-1 text-sm font-medium cursor-pointer"
-              >
+              <span className="flex-1 text-sm font-medium">
                 {subQueue.name}
-              </label>
-              <span className="text-sm">
+              </span>
+              <span className="text-sm text-gray-600">
                 {preferredServicePointCategories?.[subQueue.id]?.name ??
                   t("all")}
               </span>
-            </div>
+            </label>
           ))}
           {assignedServicePoints.length === 0 && (
-            <div className="flex items-center space-x-3 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors">
+            <div className="flex items-center space-x-3 p-3 rounded-lg border border-gray-200 bg-gray-50">
               <RadioGroupItem value="none" id="none" disabled />
-              <label
-                htmlFor="none"
-                className="flex-1 text-sm font-medium cursor-pointer"
-              >
+              <span className="flex-1 text-sm font-medium text-gray-500">
                 {t("no_service_points_available")}
-              </label>
+              </span>
             </div>
           )}
         </RadioGroup>


### PR DESCRIPTION
## Proposed Changes

Fixes #14673 
- Made entire area clickable in service point buttons
- Replaced the outer div to label


https://github.com/user-attachments/assets/677a3d94-29f0-486f-8028-903e89ebae28


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated service point assignment dialog visuals: clickable rows with pointer cursor, clearer hierarchy, separate muted description text, and a muted-row style for "no service points" state.

* **Bug Fixes**
  * Improved accessibility and semantic labeling so item names remain keyboard- and screen reader-friendly while keeping row click behavior intuitive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->