### PR TITLE
Enhance regex validation in PatientIdentifierConfigForm and improve error handling

### DIFF
--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -455,11 +455,14 @@ export default function PatientIdentifierConfigForm({
                     value={form.watch("config.default_value") ? "auto" : "user"}
                     onValueChange={(v) => {
                       if (v === "user") {
-                        form.setValue("config.default_value", "");
+                        form.setValue("config.default_value", "", {
+                          shouldDirty: true,
+                        });
                       } else if (v === "auto") {
                         form.setValue(
                           "config.default_value",
                           "f'{patient_count}'",
+                          { shouldDirty: true },
                         );
                       }
                     }}

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -66,7 +66,18 @@ export default function PatientIdentifierConfigForm({
         system: z.string().trim().min(1, t("field_required")),
         required: z.boolean(),
         unique: z.boolean(),
-        regex: z.string(),
+        regex: z.string().refine(
+          (val) => {
+            if (!val) return true;
+            try {
+              new RegExp(val);
+              return true;
+            } catch {
+              return false;
+            }
+          },
+          { message: t("invalid_regex") },
+        ),
         display: z.string().trim().min(1, t("field_required")),
         default_value: z.string().trim().optional().nullable(),
         retrieve_config: z.object({
@@ -156,6 +167,7 @@ export default function PatientIdentifierConfigForm({
   });
 
   function onSubmit(values: z.infer<typeof formSchema>) {
+    console.log("Form submitted with values:", values);
     const newValues = {
       ...values,
       config: {
@@ -279,33 +291,19 @@ export default function PatientIdentifierConfigForm({
                     <FormField
                       control={form.control}
                       name="config.regex"
-                      render={({ field }) => {
-                        let regexError = "";
-                        try {
-                          if (field.value) new RegExp(field.value);
-                        } catch {
-                          regexError = t("invalid_regex");
-                        }
-                        return (
-                          <FormItem>
-                            <FormLabel>{t("regex")}</FormLabel>
-                            <FormControl>
-                              <Input
-                                {...field}
-                                placeholder={t("eg_regex_pattern")}
-                              />
-                            </FormControl>
-                            <FormDescription>{t("regex_help")}</FormDescription>
-                            {(regexError ||
-                              form.formState.errors.config?.regex) && (
-                              <div className="text-xs text-red-500 mt-1">
-                                {regexError ||
-                                  form.formState.errors.config?.regex?.message}
-                              </div>
-                            )}
-                          </FormItem>
-                        );
-                      }}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("regex")}</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              placeholder={t("eg_regex_pattern")}
+                            />
+                          </FormControl>
+                          <FormDescription>{t("regex_help")}</FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
                     />
                   </div>
                 </div>

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigForm.tsx
@@ -167,7 +167,6 @@ export default function PatientIdentifierConfigForm({
   });
 
   function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log("Form submitted with values:", values);
     const newValues = {
       ...values,
       config: {


### PR DESCRIPTION
## Proposed Changes

Fixes #14697

The issue was due to a data mismatch and was fix through CURL, here I'm just moving regex validation to zod

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Regex validation now allows an empty value and shows a clear "invalid_regex" error for malformed patterns.

* **Improvements**
  * Simplified Patient Identifier Configuration form so validation messages are handled consistently via form messaging.
  * Switching serial number mode now correctly marks the default value as modified so changes are tracked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->