### PR TITLE
Fix: Restrict future date selection in encounter form

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2350,6 +2350,7 @@
   "full_history": "Full History",
   "full_name": "Full Name",
   "full_screen": "Full Screen",
+  "future_date_not_allowed_for_non_planned_status": "Future dates are only allowed for planned encounters",
   "gender": "Gender",
   "gender_is_required": "Gender is required",
   "general": "General",

--- a/src/components/Encounter/CreateEncounterForm.tsx
+++ b/src/components/Encounter/CreateEncounterForm.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Stethoscope } from "lucide-react";
 import { navigate } from "raviger";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -111,6 +111,8 @@ export default function CreateEncounterForm({
     },
   });
 
+  const status = form.watch("status");
+
   const tagIds = form.watch("tags");
   const tagQueries = useTagConfigs({ ids: tagIds, facilityId });
   const selectedTags = tagQueries
@@ -147,6 +149,17 @@ export default function CreateEncounterForm({
 
     createEncounter(encounterRequest);
   }
+
+  const startDate = form.watch("start_date");
+
+  useEffect(() => {
+    if (
+      status !== EncounterStatus.PLANNED &&
+      new Date(startDate) > new Date()
+    ) {
+      form.setValue("start_date", new Date().toISOString());
+    }
+  }, [status, startDate, form]);
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
@@ -199,6 +212,14 @@ export default function CreateEncounterForm({
                             field.onChange(updatedDate.toISOString());
                           }}
                           className="h-9"
+                          disabled={(date) => {
+                            if (status !== EncounterStatus.PLANNED) {
+                              const today = new Date();
+                              today.setHours(23, 59, 59, 999);
+                              return date > today;
+                            }
+                            return false;
+                          }}
                         />
                         <Input
                           type="time"

--- a/src/components/Encounter/CreateEncounterForm.tsx
+++ b/src/components/Encounter/CreateEncounterForm.tsx
@@ -84,23 +84,37 @@ export default function CreateEncounterForm({
   const { t } = useTranslation();
   useShortcutSubContext();
 
-  const encounterFormSchema = z.object({
-    status: z.enum([
-      EncounterStatus.PLANNED,
-      EncounterStatus.IN_PROGRESS,
-      EncounterStatus.ON_HOLD,
-    ] as const),
-    encounter_class: z.enum(careConfig.encounterClasses),
-    priority: z.enum(ENCOUNTER_PRIORITY),
-    organizations: z.array(z.string()).min(1, {
-      message: t("at_least_one_department_is_required"),
-    }),
-    start_date: z.string(),
-    tags: z.array(z.string()),
-  });
+  const encounterFormSchema = z
+    .object({
+      status: z.enum([
+        EncounterStatus.PLANNED,
+        EncounterStatus.IN_PROGRESS,
+        EncounterStatus.ON_HOLD,
+      ] as const),
+      encounter_class: z.enum(careConfig.encounterClasses),
+      priority: z.enum(ENCOUNTER_PRIORITY),
+      organizations: z.array(z.string()).min(1, {
+        message: t("at_least_one_department_is_required"),
+      }),
+      start_date: z.string(),
+      tags: z.array(z.string()),
+    })
+    .refine(
+      (data) => {
+        if (data.status !== EncounterStatus.PLANNED) {
+          return new Date(data.start_date) <= new Date();
+        }
+        return true;
+      },
+      {
+        message: t("future_date_not_allowed_for_non_planned_status"),
+        path: ["start_date"],
+      },
+    );
 
   const form = useForm({
     resolver: zodResolver(encounterFormSchema),
+    mode: "onChange",
     defaultValues: {
       status: defaultStatus,
       encounter_class: careConfig.defaultEncounterType,
@@ -112,6 +126,10 @@ export default function CreateEncounterForm({
   });
 
   const status = form.watch("status");
+
+  useEffect(() => {
+    form.trigger("start_date");
+  }, [status, form]);
 
   const tagIds = form.watch("tags");
   const tagQueries = useTagConfigs({ ids: tagIds, facilityId });
@@ -149,17 +167,6 @@ export default function CreateEncounterForm({
 
     createEncounter(encounterRequest);
   }
-
-  const startDate = form.watch("start_date");
-
-  useEffect(() => {
-    if (
-      status !== EncounterStatus.PLANNED &&
-      new Date(startDate) > new Date()
-    ) {
-      form.setValue("start_date", new Date().toISOString());
-    }
-  }, [status, startDate, form]);
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION
## Proposed Changes

Fixes #13293

- Restricted future date selection in [CreateEncounterForm](cci:1://file:///home/krishna/Contribution/care_fe/src/components/Encounter/CreateEncounterForm.tsx:71:0-410:1) to only be allowed when status is "Planned".
- Added `disabled` logic to [DatePicker](cci:1://file:///home/krishna/Contribution/care_fe/src/components/ui/date-picker.tsx:25:0-83:1) to prevent selection of future dates for "In Progress" and "On Hold" statuses.
- Implemented auto-reset of `start_date` to current time if status changes from "Planned" to others while a future date is selected.

[Screencast from 2025-12-10 18-46-25.webm](https://github.com/user-attachments/assets/5224dff2-ae69-421f-9ef9-2ff48d802252)


Tagging: @ohcnetwork/care-fe-code-reviewers  @Jacobjeevan

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
* Improved encounter form validation with new date restrictions. For non-planned encounters, future start dates are now restricted—users can only select today or past dates. Encounters marked as "Planned" continue to allow future start dates. This change prevents scheduling errors and improves data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->