### PR TITLE
Replace hardcoded "Loading..." text with skeleton loaders

### DIFF
--- a/src/components/Common/ResourceCategoryPicker.tsx
+++ b/src/components/Common/ResourceCategoryPicker.tsx
@@ -192,7 +192,7 @@ export function ResourceCategoryPicker({
       return (
         <div className="flex items-center gap-2">
           <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-gray-500">Loading...</span>
+          <span className="text-gray-500">{t("loading")}</span>
         </div>
       );
     }

--- a/src/components/Common/ResourceCategoryPicker.tsx
+++ b/src/components/Common/ResourceCategoryPicker.tsx
@@ -192,7 +192,7 @@ export function ResourceCategoryPicker({
       return (
         <div className="flex items-center gap-2">
           <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-gray-500">{t("loading")}</span>
+          <Skeleton className="h-4 w-20" />
         </div>
       );
     }

--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -263,7 +263,7 @@ export default function LocationForm({
   ];
 
   if (locationId && isLoading) {
-    return <div className="p-4">Loading...</div>;
+    return <div className="p-4">{t("loading")}</div>;
   }
 
   const showBedOptions = form.watch("form") === "bd" && !isEditMode;

--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
+import { FormSkeleton } from "@/components/Common/SkeletonLoading";
+
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import {
@@ -263,7 +265,11 @@ export default function LocationForm({
   ];
 
   if (locationId && isLoading) {
-    return <div className="p-4">{t("loading")}</div>;
+    return (
+      <div className="p-4">
+        <FormSkeleton rows={6} />
+      </div>
+    );
   }
 
   const showBedOptions = form.watch("form") === "bd" && !isEditMode;

--- a/src/pages/Facility/settings/specimen-definitions/UpdateSpecimenDefinition.tsx
+++ b/src/pages/Facility/settings/specimen-definitions/UpdateSpecimenDefinition.tsx
@@ -45,7 +45,7 @@ export function UpdateSpecimenDefinition({
     });
 
   if (isFetching) {
-    return <div>Loading...</div>;
+    return <div>{t("loading")}</div>;
   }
 
   if (!specimenDefinition) {

--- a/src/pages/Facility/settings/specimen-definitions/UpdateSpecimenDefinition.tsx
+++ b/src/pages/Facility/settings/specimen-definitions/UpdateSpecimenDefinition.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "raviger";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
+import { FormSkeleton } from "@/components/Common/SkeletonLoading";
+
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import specimenDefinitionApi from "@/types/emr/specimenDefinition/specimenDefinitionApi";
@@ -45,7 +47,11 @@ export function UpdateSpecimenDefinition({
     });
 
   if (isFetching) {
-    return <div>{t("loading")}</div>;
+    return (
+      <div className="p-4">
+        <FormSkeleton rows={4} />
+      </div>
+    );
   }
 
   if (!specimenDefinition) {


### PR DESCRIPTION
## Proposed Changes

Fixes #14704

- **Replaced hardcoded "Loading..." text with skeleton loaders** in:
  - `LocationForm.tsx` - Uses `FormSkeleton` component for better visual feedback
  - `ResourceCategoryPicker.tsx` - Uses `Skeleton` component with loading spinner
  - `UpdateSpecimenDefinition.tsx` - Uses `FormSkeleton` component

- **Added accessibility support** to skeleton loaders:
  - Added `role="status"` and `aria-live="polite"` for screen reader announcements
  - Added `aria-label` with loading translation
  - Added visually hidden `sr-only` span for assistive technologies
  - Ensures loading states are properly announced to screen readers

- **Updated Playwright tests** to wait for skeleton loaders to disappear:
  - Added wait conditions in `locationCreation.spec.ts`
  - Added wait conditions in `locationEdit.spec.ts`
  - Added wait conditions in `specimenDefinitionEdit.spec.ts`

**Benefits:**
- Better UX: Skeleton loaders provide visual feedback about content structure while loading
- Improved accessibility: Screen readers can properly announce loading states
- Consistent loading patterns across the application
- Better test reliability with proper wait conditions

**Screenshots:**
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/5f9b5802-aae5-45bd-a548-961d14dddec8" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature. _(N/A - UX improvement, existing functionality works as expected)_
- [ ] Update [product documentation](https://docs.ohc.network). _(N/A - Internal UI improvement, no user-facing feature changes)_
- [x] Ensure that UI text is placed in I18n files. _(Loading text uses t("loading") translation)_
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue. _(Optional - Visual improvement)_
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices. _(N/A - Loading state improvement, no mobile-specific changes)_
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes. _(Updated tests to handle skeleton loaders)_