### PR TITLE
Update DepartmentCard link and invalidate additional queries in EditUserRoleSheet

### DIFF
--- a/src/components/Users/UserDepartmentsTab.tsx
+++ b/src/components/Users/UserDepartmentsTab.tsx
@@ -56,7 +56,7 @@ function DepartmentCard({
       <CardContent className="p-4">
         <div className="flex items-start justify-between">
           <Link
-            href={`/facility/${facilityId}/settings/departments/${department.id}`}
+            href={`/facility/${facilityId}/settings/departments/${department.id}/departments`}
             className="flex-1 min-w-0"
           >
             <h3 className="font-semibold text-gray-900 truncate hover:text-primary-600">

--- a/src/pages/Facility/settings/organizations/components/EditFacilityUserRoleSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/EditFacilityUserRoleSheet.tsx
@@ -79,6 +79,14 @@ export default function EditUserRoleSheet({
       queryClient.invalidateQueries({
         queryKey: ["facilityOrganizationUsers", facilityId, organizationId],
       });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "facilityOrganizations",
+          "byUser",
+          facilityId,
+          userRole.user.id,
+        ],
+      });
       toast.success(t("user_removed_success"));
       setOpen(false);
     },


### PR DESCRIPTION
## Proposed Changes

Fixes #14718
Fixes the issue where clicking on the department title caused the page to break, and it also ensures that when a user is removed from a department, their card is immediately removed from the page without requiring a manual refresh.


https://github.com/user-attachments/assets/f38561b1-f105-463c-8591-584b5006d8c7





Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed department navigation routing within user management to ensure proper link behavior
- Improved data synchronization when removing user roles, ensuring organization information updates correctly and consistently across the system

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->