### PR TITLE
Fix: Remove console.log statements from production code

### DIFF
--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -75,14 +75,9 @@ export default function PluginEngine({
       );
 
       if (availablePlugins.length === 0) {
-        console.log("No plugins found");
         return;
       }
 
-      console.log(
-        `Loading ${filteredManifests.length} plugins; available plugins`,
-        availablePlugins,
-      );
       setPluginManifests(availablePlugins);
     };
 

--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -488,10 +488,6 @@ export function ServiceRequestQuestion({
   });
 
   useEffect(() => {
-    console.log("selectedActivityDefinition", selectedActivityDefinition);
-  }, [selectedActivityDefinition]);
-
-  useEffect(() => {
     if (selectedActivityDefinition && selectedActivityDefinitionData) {
       const newServiceRequest: ServiceRequestApplyActivityDefinitionSpec = {
         service_request: {

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -526,7 +526,6 @@ export default function AppointmentDetail(props: Props) {
                         />
                       }
                       onSuccess={() => {
-                        console.log("invalidating appointment", appointment.id);
                         queryClient.invalidateQueries({
                           queryKey: ["appointment", appointment.id],
                         });

--- a/src/pages/Facility/services/serviceRequests/components/WorkflowProgress.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/WorkflowProgress.tsx
@@ -84,7 +84,6 @@ function TimelineNode({ event }: { event: TimelineEvent }) {
 
 function WorkflowContent({ events }: { events: TimelineEvent[] }) {
   const { t } = useTranslation();
-  console.log(events);
   return (
     <>
       <div className="flex items-center gap-2 p-4 border-b">


### PR DESCRIPTION
### Proposed Changes
Fixes #14720

- Remove `console.log` statement from `PluginEngine.tsx` (2 occurrences)
- Remove `console.log` statement from `MedicationRequestQuestion.tsx`
- Remove `console.log` statement from `ServiceRequestQuestion.tsx`
- Remove `console.log` statement from `AppointmentDetail.tsx`
- Remove `console.log` statement from `WorkflowProgress.tsx`

Note: `LocationImport.tsx` `console.log` statements are intentionally kept as per the maintainer's request (needed for debugging purposes).

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed debug console logging across several UI components (plugin handling, questionnaire, appointment flows, and workflow progress) to reduce console noise and improve log clarity during normal use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->