### PR TITLE
Fixes auto refresh history pollute on toggling 

### DIFF
--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -164,9 +164,14 @@ export function ManageQueuePage({
               <Switch
                 checked={autoRefresh === "true"}
                 onCheckedChange={(checked) =>
-                  setQueryParams({
-                    autoRefresh: checked ? "true" : "false",
-                  })
+                  setQueryParams(
+                    {
+                      autoRefresh: checked ? "true" : "false",
+                    },
+                    {
+                      replace: true,
+                    },
+                  )
                 }
               />
               <div className="flex items-center gap-1">
@@ -198,9 +203,14 @@ export function ManageQueuePage({
                     <Switch
                       checked={autoRefresh === "true"}
                       onCheckedChange={(checked) =>
-                        setQueryParams({
-                          autoRefresh: checked ? "true" : "false",
-                        })
+                        setQueryParams(
+                          {
+                            autoRefresh: checked ? "true" : "false",
+                          },
+                          {
+                            replace: true,
+                          },
+                        )
                       }
                     />
                   </div>


### PR DESCRIPTION
## Proposed Changes
```tsx
<Switch
  checked={autoRefresh === "true"}
  onCheckedChange={(checked) =>
    setQueryParams(
      {
        autoRefresh: checked ? "true" : "false",
      },
      {
        replace: true,
      },
    )
  }
/>
```
The **replace** attribute is added thus replacing the url in the browser history stack for the *Queues* page and hence improving UX and doesn't pollute the browser history.
- The value also persists for the *auto_refresh* as selected by the user in his last toggle based on value in the URL.

Fixes #14702
- Adds on **replace** parameter in the *setQueryParams*.
- The changes are done in two `<Switch/>` in the same file.

https://github.com/user-attachments/assets/0950b48a-45e3-4ca1-a9b3-bcdb0a980f6d

 Tagging: @rithviknishad @Jacobjeevan @ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network/).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated autoRefresh toggle behavior to properly manage browser history by replacing the current entry instead of creating new history entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->