### PR TITLE
Made the resource name resetting  when generating a token

### DIFF
--- a/src/components/Tokens/CreateTokenForm.tsx
+++ b/src/components/Tokens/CreateTokenForm.tsx
@@ -165,15 +165,15 @@ export default function CreateTokenForm({
   }
 
   const handleOpenChange = (open: boolean) => {
-    setIsOpen(open);
-    if (!open) {
-      // Reset all state when closing
+    if (open) {
+      // Reset BEFORE opening for clean slate
+      form.reset();
       setSelectedResource({
         resource: null,
         resource_type: SchedulableResourceType.Practitioner,
       });
-      form.reset();
     }
+    setIsOpen(open);
   };
 
   return (

--- a/src/components/Tokens/CreateTokenForm.tsx
+++ b/src/components/Tokens/CreateTokenForm.tsx
@@ -166,7 +166,6 @@ export default function CreateTokenForm({
 
   const handleOpenChange = (open: boolean) => {
     if (open) {
-      // Reset BEFORE opening for clean slate
       form.reset();
       setSelectedResource({
         resource: null,


### PR DESCRIPTION
## Proposed Changes

Fixes #14737 
- made form resets when opening
- changed the condition to if open


https://github.com/user-attachments/assets/662ce040-4188-4fad-a4f4-874fe689aec1



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the token creation form reset behavior. The form now resets when opened instead of when closed, ensuring you always start with a clean form state. The default resource type is automatically set to Practitioner upon opening.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->