### PR TITLE
Fixes: Redirect logged-in users from /login to home to prevent page not found

### DIFF
--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -22,6 +22,8 @@ import authApi from "@/types/auth/authApi";
 import { TokenData } from "@/types/otp/otp";
 import userApi from "@/types/user/userApi";
 
+// import Login from "@/components/Auth/Login";
+
 interface Props {
   children: React.ReactNode;
   unauthorized: React.ReactNode;
@@ -194,16 +196,14 @@ export default function AuthUserProvider({
     };
   }, [signOut]);
 
+  useEffect(() => {
+    if (user && (path?.startsWith("/login") || path?.startsWith("/patient"))) {
+      navigate("/", { replace: true });
+    }
+  }, [user, path]);
+
   if (isLoading) {
     return <Loading />;
-  }
-
-  if (accessToken) {
-    if (path?.startsWith("/login")) {
-      navigate("/", {
-        replace: true,
-      });
-    }
   }
 
   return (

--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -22,8 +22,6 @@ import authApi from "@/types/auth/authApi";
 import { TokenData } from "@/types/otp/otp";
 import userApi from "@/types/user/userApi";
 
-// import Login from "@/components/Auth/Login";
-
 interface Props {
   children: React.ReactNode;
   unauthorized: React.ReactNode;
@@ -197,7 +195,10 @@ export default function AuthUserProvider({
   }, [signOut]);
 
   useEffect(() => {
-    if (user && (path?.startsWith("/login") || path?.startsWith("/patient"))) {
+    if (
+      user &&
+      (path?.startsWith("/login") || path?.startsWith("/patient/home"))
+    ) {
       navigate("/", { replace: true });
     }
   }, [user, path]);

--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -198,6 +198,14 @@ export default function AuthUserProvider({
     return <Loading />;
   }
 
+  if (accessToken) {
+    if (path?.startsWith("/login")) {
+      navigate("/", {
+        replace: true,
+      });
+    }
+  }
+
   return (
     <AuthUserContext.Provider
       value={{

--- a/src/Providers/PatientUserProvider.tsx
+++ b/src/Providers/PatientUserProvider.tsx
@@ -48,6 +48,12 @@ export default function PatientUserProvider({ children }: Props) {
     }
   }, [userData]);
 
+  if (tokenData) {
+    navigate("/patient/home", {
+      replace: true,
+    });
+  }
+
   if (!tokenData) {
     navigate("/");
     return null;

--- a/src/Providers/PatientUserProvider.tsx
+++ b/src/Providers/PatientUserProvider.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { navigate } from "raviger";
+import { navigate, usePath } from "raviger";
 import { createContext, useEffect, useState } from "react";
 
 import { useAuthContext } from "@/hooks/useAuthUser";
@@ -31,6 +31,8 @@ export default function PatientUserProvider({ children }: Props) {
 
   const { patientToken: tokenData } = useAuthContext();
 
+  const path = usePath();
+
   const { data: userData } = useQuery({
     queryKey: ["patients", tokenData],
     queryFn: query(publicPatientApi.list, {
@@ -48,11 +50,11 @@ export default function PatientUserProvider({ children }: Props) {
     }
   }, [userData]);
 
-  if (tokenData) {
-    navigate("/patient/home", {
-      replace: true,
-    });
-  }
+  useEffect(() => {
+    if (tokenData?.token && path === "/login") {
+      navigate("/patient/home", { replace: true });
+    }
+  }, [tokenData?.token, path]);
 
   if (!tokenData) {
     navigate("/");

--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -93,8 +93,6 @@ export default function AppRouter() {
 
   useRedirect("/user", "/users");
 
-  useRedirect("/login", "/");
-
   // Merge in Plugin Routes
   routes = {
     ...pluginRoutes,

--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -93,6 +93,8 @@ export default function AppRouter() {
 
   useRedirect("/user", "/users");
 
+  useRedirect("/login", "/");
+
   // Merge in Plugin Routes
   routes = {
     ...pluginRoutes,


### PR DESCRIPTION
## Proposed Changes
In the **AppRouter** this line is added for the redirection of users logged in to the `/` route and not to *Page not found* page as earlier behaviour.
```tsx
useRedirect("/login", "/");
```

Fixes #14734
- Added `useRedirect("/login", "/");` this line to the **AppRouter** function in the *AppRouter.tsx* file. 

Demo:

https://github.com/user-attachments/assets/11e66690-fa49-4dad-9b3c-f07a55934498



Tagging: @ohcnetwork/care-fe-code-reviewers @rithviknishad @Jacobjeevan 

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated users are now automatically redirected away from login and patient entry pages to the main dashboard, removing redundant navigation steps.
  * Patient users with a valid session are immediately taken to their patient home page after authentication, ensuring faster access to their workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->