### PR TITLE
feat: add PatientHeaderActions component type and integrate into PatientInfoCard

### DIFF
--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader } from "@/components/ui/card";
 import { PatientHoverCard } from "@/pages/Facility/services/serviceRequests/PatientHoverCard";
+import { PLUGIN_Component } from "@/PluginEngine";
 import { PatientRead } from "@/types/emr/patient/patient";
 import {
   getTagHierarchyDisplay,
@@ -40,6 +41,13 @@ export const PatientInfoCard = ({
             <PatientHoverCard patient={patient} facilityId={facilityId} />
           </div>
           {children}
+
+          <PLUGIN_Component
+            __name="PatientHeaderActions"
+            patient={patient}
+            facilityId={facilityId}
+            variant="link"
+          />
         </CardHeader>
       </Card>
       <Card className="bg-white shadow-sm mx-3 rounded-md rounded-t-none rounded-b-md">

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -43,7 +43,7 @@ export const PatientInfoCard = ({
           {children}
 
           <PLUGIN_Component
-            __name="PatientHeaderActions"
+            __name="PrintIDCardButton"
             patient={patient}
             facilityId={facilityId}
             variant="link"

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -69,7 +69,7 @@ export type PatientSearchActionsComponentType = React.FC<{
   className?: string;
 }>;
 
-export type PatientHeaderActionsComponentType = React.FC<{
+export type PrintIDCardComponentType = React.FC<{
   facilityId: string;
   patient: PatientRead;
   className?: string;
@@ -89,7 +89,7 @@ export type SupportedPluginComponents = {
   PatientDetailsTabDemographyGeneralInfo: PatientDetailsTabDemographyGeneralInfoComponentType;
   InvoiceRecordPaymentOptions: InvoiceRecordPaymentOptionsComponentType;
   PatientSearchActions: PatientSearchActionsComponentType;
-  PatientHeaderActions: PatientHeaderActionsComponentType;
+  PrintIDCardButton: PrintIDCardComponentType;
 };
 
 // Create a type for lazy-loaded components

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -1,3 +1,4 @@
+import { ButtonVariant } from "@/components/ui/button";
 import { NavigationLink } from "@/components/ui/sidebar/nav-main";
 import { PluginEncounterTabProps } from "@/pages/Encounters/EncounterShow";
 import { InvoiceRead } from "@/types/billing/invoice/invoice";
@@ -68,6 +69,13 @@ export type PatientSearchActionsComponentType = React.FC<{
   className?: string;
 }>;
 
+export type PatientHeaderActionsComponentType = React.FC<{
+  facilityId: string;
+  patient: PatientRead;
+  className?: string;
+  variant?: ButtonVariant;
+}>;
+
 // Define supported plugin components
 export type SupportedPluginComponents = {
   DoctorConnectButtons: DoctorConnectButtonComponentType;
@@ -81,6 +89,7 @@ export type SupportedPluginComponents = {
   PatientDetailsTabDemographyGeneralInfo: PatientDetailsTabDemographyGeneralInfoComponentType;
   InvoiceRecordPaymentOptions: InvoiceRecordPaymentOptionsComponentType;
   PatientSearchActions: PatientSearchActionsComponentType;
+  PatientHeaderActions: PatientHeaderActionsComponentType;
 };
 
 // Create a type for lazy-loaded components


### PR DESCRIPTION
## Proposed Changes

This added patient ID card print to the patient home page

<img width="894" height="380" alt="image" src="https://github.com/user-attachments/assets/7253117c-06a6-4af4-99b8-9b61b5c1cc63" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Print ID Card" action to the patient information card header, giving users quick access to print a patient's ID card from the patient view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->