### PR TITLE
fix: replace custom loading spinners with skeleton components

### DIFF
--- a/src/components/Users/UserDepartmentsTab.tsx
+++ b/src/components/Users/UserDepartmentsTab.tsx
@@ -8,6 +8,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
+import { CardGridSkeleton } from "@/components/Common/SkeletonLoading";
+
 import { userChildProps } from "@/components/Common/UserColumns";
 import LinkUserToDepartmentSheet from "@/components/Users/LinkUserToDepartmentSheet";
 
@@ -125,8 +127,19 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
 
   if (isLoading) {
     return (
-      <div className="mt-8 flex justify-center">
-        <CareIcon icon="l-spinner" className="h-8 w-8 animate-spin" />
+      <div className="mt-8 space-y-4">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold text-gray-900">
+            {t("departments")}
+          </h3>
+          <LinkUserToDepartmentSheet
+            userId={userData.id}
+            facilityId={facilityId}
+          />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <CardGridSkeleton count={6} />
+        </div>
       </div>
     );
   }

--- a/src/pages/Facility/FacilityDetailsPage.tsx
+++ b/src/pages/Facility/FacilityDetailsPage.tsx
@@ -10,6 +10,7 @@ import { Markdown } from "@/components/ui/markdown";
 
 import { Avatar } from "@/components/Common/Avatar";
 import { LoginHeader } from "@/components/Common/LoginHeader";
+import { CardGridSkeleton } from "@/components/Common/SkeletonLoading";
 import { FacilityMapsLink } from "@/components/Facility/FacilityMapLink";
 
 import useAppHistory from "@/hooks/useAppHistory";
@@ -58,9 +59,31 @@ export function FacilityDetailsPage({ id }: Props) {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center min-h-screen">
-        <div className="animate-spin">
-          <CareIcon icon="l-spinner" className="size-8" />
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex justify-between items-center pb-4">
+          <Button
+            variant="outline"
+            className="border border-secondary-400"
+            onClick={() => goBack("/facilities")}
+          >
+            <CareIcon icon="l-arrow-left" className="size-4 mr-1" />
+            <span className="text-sm underline">{t("back")}</span>
+          </Button>
+          <LoginHeader />
+        </div>
+        <Card className="overflow-hidden bg-white border border-gray-200">
+          <div className="flex flex-col sm:flex-row m-6">
+            <div className="size-64 shrink-0 overflow-hidden rounded-lg bg-gray-200 animate-pulse" />
+            <div className="px-4 space-y-2 flex-1">
+              <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
+              <div className="h-6 w-64 bg-gray-200 rounded animate-pulse" />
+            </div>
+          </div>
+        </Card>
+        <div className="mt-6">
+          <div className="grid grid-cols-1 gap-4 @xl:grid-cols-3 @4xl:grid-cols-4 @6xl:grid-cols-5 lg:grid-cols-2">
+            <CardGridSkeleton count={6} />
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Proposed Changes

Fixes #14749 

I found two places where custom loading spinners were being used instead of skeleton loaders. This was inconsistent with the rest of the codebase, which uses skeleton components for better UX. I've replaced both spinners with appropriate skeleton components:

- **FacilityDetailsPage**: Replaced the centered spinner with skeleton loaders that show the facility card structure and user cards grid layout
- **UserDepartmentsTab**: Replaced the centered spinner with `CardGridSkeleton` to match the department cards grid layout

The skeleton loaders provide better UX by showing users the content structure while data loads, which is consistent with how other pages in the app handle loading states.

**Screenshots:**
<img width="1451" height="859" alt="image" src="https://github.com/user-attachments/assets/9666f3b9-fbda-4dcf-b553-25196da2216e" />
<img width="1417" height="852" alt="image" src="https://github.com/user-attachments/assets/2da24d79-19df-4f76-a8b5-33b3f0da4c82" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network). (N/A - internal code improvement)
- [x] Ensure that UI text is placed in I18n files. (N/A - no new UI text added)
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue. (Screenshots provided in issue)
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes