### PR TITLE
fix: remove @ts-expect-error and fix facility_type display in FacilityCard

### DIFF
--- a/src/pages/Facility/components/FacilityCard.tsx
+++ b/src/pages/Facility/components/FacilityCard.tsx
@@ -35,11 +35,9 @@ export function FacilityCard({ facility, className }: Props) {
               <h3 className="truncate text-xl font-semibold">
                 {facility.name}
               </h3>
-              {facility.facility_type && (
-                <p className="text-sm text-gray-600 mt-1">
-                  {facility.facility_type}
-                </p>
-              )}
+              <p className="text-sm text-gray-600 mt-1">
+                {facility.facility_type}
+              </p>
               <p className="text-sm text-gray-500 truncate">
                 {[facility.address].filter(Boolean).join(", ")}
                 {facility.latitude && facility.longitude && (

--- a/src/pages/Facility/components/FacilityCard.tsx
+++ b/src/pages/Facility/components/FacilityCard.tsx
@@ -35,8 +35,11 @@ export function FacilityCard({ facility, className }: Props) {
               <h3 className="truncate text-xl font-semibold">
                 {facility.name}
               </h3>
-              {/* @ts-expect-error Type is not defined properly */}
-              {facility.facility_type?.name}
+              {facility.facility_type && (
+                <p className="text-sm text-gray-600 mt-1">
+                  {facility.facility_type}
+                </p>
+              )}
               <p className="text-sm text-gray-500 truncate">
                 {[facility.address].filter(Boolean).join(", ")}
                 {facility.latitude && facility.longitude && (


### PR DESCRIPTION
## Proposed Changes

Fixes #14717 

Fixed a TypeScript error in `FacilityCard.tsx` where `facility_type` was being accessed incorrectly. The code was trying to access `facility.facility_type?.name`, but `facility_type` is actually a string, not an object with a `name` property.

**Changes:**
- Removed the `@ts-expect-error` comment that was suppressing the TypeScript error
- Fixed the property access: changed from `facility.facility_type?.name` to `facility.facility_type` (direct string access)
- Added proper conditional rendering with styling to display the facility type below the facility name

This fix ensures the facility type is displayed correctly on facility cards and removes the need for TypeScript error suppression.

## Screenshots

**Before (Bug):**
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/63a879b6-a663-4c5a-91c9-a8f7b4d9dc28" />


**After (Fixed):**
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/43eafe03-ccf1-4e53-a50c-1184c8900737" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network). _(N/A - internal bug fix)_
- [x] Ensure that UI text is placed in I18n files. _(N/A - no new UI text)_
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed facility type display in facility cards so the type text renders reliably without errors.

* **Style**
  * Adjusted facility type appearance to a smaller, subdued gray paragraph for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->