### PR TITLE
docs: update README credentials to _4_0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ Once you have the local backend running and loaded dummy data, you can use the f
 # Default Local Backend Credentials
 ROLE            USERNAME                PASSWORD
 ----------------------------------------------------------------
-Volunteer       volunteer_2_0           Coronasafe@123
-Doctor          doctor_2_0              Coronasafe@123
-Staff           staff_2_0               Coronasafe@123
-Nurse           nurse_2_0               Coronasafe@123
-Administrator   administrator_2_0       Coronasafe@123
-Facility Admin  facility_admin_2_0      Coronasafe@123
+Volunteer       volunteer_4_0           Coronasafe@123
+Doctor          doctor_4_0              Coronasafe@123
+Staff           staff_4_0               Coronasafe@123
+Nurse           nurse_4_0               Coronasafe@123
+Administrator   administrator_4_0       Coronasafe@123
+Facility Admin  facility_admin_4_0      Coronasafe@123
 ```
 
 #### 📱 Patient Login in Staging


### PR DESCRIPTION
## Proposed Changes

Fixes #14758 
- Updated default local backend credentials in the README from _2_0 to _4_0.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ x] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Default Local Backend Credentials reference table to the latest version. The credentials table now covers all user roles including Volunteer, Doctor, Staff, Nurse, Administrator, and Facility Admin with current information for local backend access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->