### PR TITLE
fix(ui): make Prefix dropdown placeholder fully visible.

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -147,7 +147,7 @@ export default function Autocomplete({
         placeholder={inputPlaceholder}
         disabled={disabled}
         onValueChange={handleInputChange}
-        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm"
+        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm md:pr-0"
         autoFocus={!isAppleDevice}
       />
       <CommandList className="overflow-y-auto">


### PR DESCRIPTION
## Proposed Changes

Fixes #14746 
- Fixed styling of the Prefix dropdown input so the placeholder text "Select or type" is fully visible.
- Adjusted spacing to prevent the placeholder text from getting cut off.
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

after fixing the issue : 

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/6426bf6e-3e38-4e8c-827f-4de104b09989" />


## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined padding adjustments on the autocomplete component to enhance spacing consistency and visual alignment across different screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->