### PR TITLE
Fix: Update managing_organization field to be nullable in healthcare service specs

### DIFF
--- a/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
+++ b/src/pages/Facility/settings/healthcareService/HealthcareServiceForm.tsx
@@ -202,14 +202,14 @@ function HealthcareServiceFormContent({
         ...data,
         facility: facilityId,
         locations: data.locations.map((loc) => loc.id),
-        managing_organization: data.managing_organization || undefined,
+        managing_organization: data.managing_organization || null,
       } as HealthcareServiceUpdateSpec);
     } else {
       const payload: HealthcareServiceCreateSpec = {
         ...data,
         facility: facilityId,
         locations: data.locations.map((loc) => loc.id),
-        managing_organization: data.managing_organization || undefined,
+        managing_organization: data.managing_organization || null,
       };
       createHealthcareService(payload);
     }

--- a/src/types/healthcareService/healthcareService.ts
+++ b/src/types/healthcareService/healthcareService.ts
@@ -28,13 +28,13 @@ export interface HealthcareServiceCreateSpec extends Omit<
 > {
   facility: string;
   locations: string[];
-  managing_organization?: string;
+  managing_organization: string | null;
 }
 
 export interface HealthcareServiceUpdateSpec extends BaseHealthcareServiceSpec {
   facility: string;
   locations: string[];
-  managing_organization?: string;
+  managing_organization: string | null;
 }
 
 export interface HealthcareServiceReadSpec extends BaseHealthcareServiceSpec {


### PR DESCRIPTION

## Proposed Changes

Fixes #14778 
<img width="2290" height="1056" alt="image" src="https://github.com/user-attachments/assets/160e3e66-b345-41b4-aa35-d2f077974b9a" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling for the managing organization field in healthcare service forms to ensure consistent and reliable form submission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->