### PR TITLE
Shows service point dialog when more than one service point present otherwise auto assign

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2234,6 +2234,7 @@
   "facility_updated_successfully": "Facility updated successfully",
   "factor": "Factor",
   "failed_to_archive_child_tag": "Failed to archive child tag",
+  "failed_to_assign_token_to_service_point": "Failed to assign token to service point",
   "failed_to_cancel_invoice": "Failed to cancel invoice",
   "failed_to_capture_image": "Failed to capture image",
   "failed_to_create_appointment": "Failed to create an appointment",

--- a/src/pages/Facility/queues/AssignToServicePointDialog.tsx
+++ b/src/pages/Facility/queues/AssignToServicePointDialog.tsx
@@ -42,6 +42,10 @@ export function AssignToServicePointDialog({
     facilityId,
   });
 
+  const availableServicePoints = assignedServicePoints.filter(
+    (sp) => sp.id !== token.sub_queue?.id,
+  );
+
   const { mutate: updateToken, isPending } = useMutation({
     mutationFn: mutate(tokenApi.update, {
       pathParams: {
@@ -89,7 +93,7 @@ export function AssignToServicePointDialog({
           value={selectedSubQueueId}
           onValueChange={setSelectedSubQueueId}
         >
-          {assignedServicePoints.map((subQueue) => (
+          {availableServicePoints.map((subQueue) => (
             <div
               key={subQueue.id}
               className={cn(
@@ -110,7 +114,7 @@ export function AssignToServicePointDialog({
               </span>
             </div>
           ))}
-          {assignedServicePoints.length === 0 && (
+          {availableServicePoints.length === 0 && (
             <div className="flex items-center space-x-3 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors">
               <RadioGroupItem value="none" id="none" disabled />
               <label

--- a/src/pages/Facility/queues/AssignToServicePointDialog.tsx
+++ b/src/pages/Facility/queues/AssignToServicePointDialog.tsx
@@ -114,17 +114,6 @@ export function AssignToServicePointDialog({
               </span>
             </div>
           ))}
-          {availableServicePoints.length === 0 && (
-            <div className="flex items-center space-x-3 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors">
-              <RadioGroupItem value="none" id="none" disabled />
-              <label
-                htmlFor="none"
-                className="flex-1 text-sm font-medium cursor-pointer"
-              >
-                {t("no_service_points_available")}
-              </label>
-            </div>
-          )}
         </RadioGroup>
         <div className="flex">
           <Button

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -91,16 +91,12 @@ export function OngoingQueueTokenCard({
     );
 
     if (availableServicePoints.length === 1) {
-      try {
-        await updateTokenAsync({
-          sub_queue: availableServicePoints[0].id,
-          status: TokenStatus.CREATED,
-          note: token.note,
-        });
-        toast.success(t("token_assigned_to_service_point"));
-      } catch (_error) {
-        toast.error(t("failed_to_assign_token_to_service_point"));
-      }
+      await updateTokenAsync({
+        sub_queue: availableServicePoints[0].id,
+        status: TokenStatus.CREATED,
+        note: token.note,
+      });
+      toast.success(t("token_assigned_to_service_point"));
     } else {
       setShowAssignToServicePointDialog(true);
     }

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -56,11 +56,7 @@ export function OngoingQueueTokenCard({
     useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
 
-  const {
-    mutate: updateToken,
-    mutateAsync: updateTokenAsync,
-    isPending,
-  } = useMutation({
+  const { mutate: updateToken, isPending } = useMutation({
     mutationFn: mutate(tokenApi.update, {
       pathParams: {
         facility_id: facilityId,
@@ -91,7 +87,7 @@ export function OngoingQueueTokenCard({
     },
   });
 
-  const handleAssignToServicePoint = async () => {
+  const handleAssignToServicePoint = () => {
     if (!token) return;
 
     const availableServicePoints = assignedServicePoints.filter(
@@ -99,7 +95,7 @@ export function OngoingQueueTokenCard({
     );
 
     if (availableServicePoints.length === 1) {
-      await updateTokenAsync({
+      updateToken({
         sub_queue: availableServicePoints[0].id,
         status: TokenStatus.CREATED,
         note: token.note,

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -80,6 +80,14 @@ export function OngoingQueueTokenCard({
         toast.success(t("token_has_been_completed"));
         return;
       }
+
+      // Show success toast for service point assignment
+      if (data.sub_queue) {
+        toast.success(t("token_assigned_to_service_point"));
+      }
+    },
+    onError: () => {
+      toast.error(t("failed_to_assign_token_to_service_point"));
     },
   });
 
@@ -96,7 +104,6 @@ export function OngoingQueueTokenCard({
         status: TokenStatus.CREATED,
         note: token.note,
       });
-      toast.success(t("token_assigned_to_service_point"));
     } else {
       setShowAssignToServicePointDialog(true);
     }
@@ -251,19 +258,21 @@ export function OngoingQueueTokenCard({
               </ContextMenuItem>
             )}
 
-            <ContextMenuItem onClick={handleAssignToServicePoint}>
-              {token.sub_queue ? (
-                <>
-                  <RedoDot className="size-4 mr-2" />
-                  {t("reassign_service_point")}
-                </>
-              ) : (
-                <>
-                  <TicketCheck className="size-4 mr-2" />
-                  {t("assign_to_service_point")}
-                </>
-              )}
-            </ContextMenuItem>
+            {assignedServicePoints.length > 0 && (
+              <ContextMenuItem onClick={handleAssignToServicePoint}>
+                {token.sub_queue ? (
+                  <>
+                    <RedoDot className="size-4 mr-2" />
+                    {t("reassign_service_point")}
+                  </>
+                ) : (
+                  <>
+                    <TicketCheck className="size-4 mr-2" />
+                    {t("assign_to_service_point")}
+                  </>
+                )}
+              </ContextMenuItem>
+            )}
 
             <ContextMenuSeparator />
             {/* Cancel Token */}

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -56,7 +56,11 @@ export function OngoingQueueTokenCard({
     useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
 
-  const { mutate: updateToken } = useMutation({
+  const {
+    mutate: updateToken,
+    mutateAsync: updateTokenAsync,
+    isPending,
+  } = useMutation({
     mutationFn: mutate(tokenApi.update, {
       pathParams: {
         facility_id: facilityId,
@@ -79,26 +83,7 @@ export function OngoingQueueTokenCard({
     },
   });
 
-  const { mutate: assignToServicePoint, isPending: isAssigning } = useMutation({
-    mutationFn: mutate(tokenApi.update, {
-      pathParams: {
-        facility_id: facilityId,
-        queue_id: token?.queue.id ?? "",
-        id: token?.id ?? "",
-      },
-    }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["infinite-tokens", facilityId, token?.queue.id ?? ""],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["token-queue-summary", facilityId, token?.queue.id ?? ""],
-      });
-      toast.success(t("token_assigned_to_service_point"));
-    },
-  });
-
-  const handleAssignToServicePoint = () => {
+  const handleAssignToServicePoint = async () => {
     if (!token) return;
 
     const availableServicePoints = assignedServicePoints.filter(
@@ -106,11 +91,16 @@ export function OngoingQueueTokenCard({
     );
 
     if (availableServicePoints.length === 1) {
-      assignToServicePoint({
-        sub_queue: availableServicePoints[0].id,
-        status: TokenStatus.CREATED,
-        note: token.note,
-      });
+      try {
+        await updateTokenAsync({
+          sub_queue: availableServicePoints[0].id,
+          status: TokenStatus.CREATED,
+          note: token.note,
+        });
+        toast.success(t("token_assigned_to_service_point"));
+      } catch (_error) {
+        toast.error(t("failed_to_assign_token_to_service_point"));
+      }
     } else {
       setShowAssignToServicePointDialog(true);
     }
@@ -124,7 +114,7 @@ export function OngoingQueueTokenCard({
             "relative flex gap-3 items-center justify-between p-3 bg-gray-50 rounded-lg shadow",
             token?.status === TokenStatus.IN_PROGRESS &&
               "border border-primary-500",
-            isAssigning && "opacity-50 pointer-events-none",
+            isPending && "opacity-50 pointer-events-none",
           )}
         >
           <div className="flex flex-col">

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -35,6 +35,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useInView } from "react-intersection-observer";
 import { toast } from "sonner";
+import { useQueueServicePoints } from "./useQueueServicePoints";
 import { useTokenListInfiniteQuery } from "./utils";
 
 export function OngoingQueueTokenCard({
@@ -49,6 +50,7 @@ export function OngoingQueueTokenCard({
   const { t } = useTranslation();
   const contextMenuTriggerRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
+  const { assignedServicePoints } = useQueueServicePoints();
 
   const [showAssignToServicePointDialog, setShowAssignToServicePointDialog] =
     useState(false);
@@ -77,6 +79,43 @@ export function OngoingQueueTokenCard({
     },
   });
 
+  const { mutate: assignToServicePoint, isPending: isAssigning } = useMutation({
+    mutationFn: mutate(tokenApi.update, {
+      pathParams: {
+        facility_id: facilityId,
+        queue_id: token?.queue.id ?? "",
+        id: token?.id ?? "",
+      },
+    }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["infinite-tokens", facilityId, token?.queue.id ?? ""],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["token-queue-summary", facilityId, token?.queue.id ?? ""],
+      });
+      toast.success(t("token_assigned_to_service_point"));
+    },
+  });
+
+  const handleAssignToServicePoint = () => {
+    if (!token) return;
+
+    const availableServicePoints = assignedServicePoints.filter(
+      (sp) => sp.id !== token.sub_queue?.id,
+    );
+
+    if (availableServicePoints.length === 1) {
+      assignToServicePoint({
+        sub_queue: availableServicePoints[0].id,
+        status: TokenStatus.CREATED,
+        note: token.note,
+      });
+    } else {
+      setShowAssignToServicePointDialog(true);
+    }
+  };
+
   return (
     <ContextMenu>
       <ContextMenuTrigger ref={contextMenuTriggerRef}>
@@ -85,6 +124,7 @@ export function OngoingQueueTokenCard({
             "relative flex gap-3 items-center justify-between p-3 bg-gray-50 rounded-lg shadow",
             token?.status === TokenStatus.IN_PROGRESS &&
               "border border-primary-500",
+            isAssigning && "opacity-50 pointer-events-none",
           )}
         >
           <div className="flex flex-col">
@@ -225,9 +265,7 @@ export function OngoingQueueTokenCard({
               </ContextMenuItem>
             )}
 
-            <ContextMenuItem
-              onClick={() => setShowAssignToServicePointDialog(true)}
-            >
+            <ContextMenuItem onClick={handleAssignToServicePoint}>
               {token.sub_queue ? (
                 <>
                   <RedoDot className="size-4 mr-2" />


### PR DESCRIPTION
## Proposed Changes

Fixes #14771 
- Checks available service points in the parent component and auto-assigns if only one service point
- Shows dialog only for multiple service points
- Additional context if needed


https://github.com/user-attachments/assets/18fbf35b-2005-49c8-95b0-f33d65e5c5dd


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assign queue tokens to service points; auto-assign when only one option exists.
  * Dialog for selection when multiple options are available.
  * Loading/disabled feedback while assignment is in progress.
  * Success and failure toasts for assignment outcomes; added localized failure message.

* **Bug Fixes**
  * Exclude the token's currently assigned sub-queue from selectable service point options and removed the empty-state fallback.
  * Context menu shows assignment option only when service points are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->