### PR TITLE
allow selecting nested facility even if it is already selected

### DIFF
--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
@@ -101,8 +101,6 @@ export default function FacilityOrganizationSelector(
     if (isAlreadySelected) {
       setAlreadySelected(true);
       setCurrentSelection(org);
-      setFacilityOrgSearch("");
-      return;
     }
     if (org.has_children) {
       setNavigationLevels([...navigationLevels, org]);


### PR DESCRIPTION
## Proposed Changes

Fixes https://github.com/ohcnetwork/care_fe/issues/14732
- allow selecting nested facility even if it is already selected

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed organization selection behavior to properly handle re-selecting an already-selected organization, allowing the selection workflow to continue correctly instead of prematurely exiting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->