### PR TITLE
allow closing account with pending charge items

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -957,7 +957,7 @@
   "cancel_token_confirmation": "Are you sure you want to cancel the token {{tokenNumber}} for {{patientName}}? This action cannot be undone.",
   "cancelled": "Cancelled",
   "cannot_add_conclusion_without_results": "Cannot add conclusion without results",
-  "cannot_close_account_with_pending_items": "You cannot close an account with pending charge items.",
+  "close_account_with_pending_items_caution_message": "This account has pending charge items. Consider reconciling them before closing the account.",
   "cannot_complete_unpaid_medication": "Cannot complete unpaid medication. Please ensure payment is completed first.",
   "cannot_delete_organization_with_children": "Cannot delete an organization with children",
   "cannot_go_before_prescription_date": "Cannot view slots before the earliest prescription date",

--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -624,15 +624,11 @@ export function AccountShow({
           </Select>
           <ClosedCallout balance={Number(account.total_balance)} />
           {hasBillableItems && (
-            <span className="text-red-500 bg-red-50 text-xs p-2 rounded block -mt-3">
-              {t("cannot_close_account_with_pending_items")}
+            <span className="text-warning-500 bg-warning-50 text-xs p-2 rounded block -mt-3">
+              {t("close_account_with_pending_items_caution_message")}
             </span>
           )}
-          <Button
-            variant="destructive"
-            onClick={handleCloseAccount}
-            disabled={hasBillableItems}
-          >
+          <Button variant="destructive" onClick={handleCloseAccount}>
             {t("close_account")}
           </Button>
         </DialogContent>


### PR DESCRIPTION
## Proposed Changes

- fixes #14798

<img width="2052" height="1172" alt="image" src="https://github.com/user-attachments/assets/436cf819-ba6a-4027-966e-4be8d4a6aafd" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Account closure is now always available, even with pending charge items, accompanied by a caution message.
  * Updated warning message styling from error to informational alert for improved UX clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->