### PR TITLE
fix: implement specimen retrieval by accession identifier

### DIFF
--- a/src/components/Scan/SpecimenIDScanDialog.tsx
+++ b/src/components/Scan/SpecimenIDScanDialog.tsx
@@ -46,9 +46,17 @@ export function QRScanDialog({
     const signal = new AbortController().signal;
 
     try {
-      const result = await query(specimenApi.getSpecimen, {
-        pathParams: { facilityId, specimenId: scannedId },
-      })({ signal });
+      let result;
+      try {
+        result = await query(specimenApi.retrieveByAccessionIdentifier, {
+          pathParams: { facilityId },
+          body: { accession_identifier: scannedId },
+        })({ signal });
+      } catch {
+        result = await query(specimenApi.getSpecimen, {
+          pathParams: { facilityId, specimenId: scannedId },
+        })({ signal });
+      }
 
       setSpecimenData(result);
       setShowSuccess(true);

--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -115,6 +115,9 @@
   "facility:inventory:delivery": [
     { "key": "l", "action": "load-from-order", "description": "Load from Order", "when": "always" }
   ],
+  "facility:service": [
+    { "key": "s", "action": "scan-button", "description": "Scan the QR code", "when": "always" }
+  ],
 
   "encounter": [
     { "key": "a", "action": "add-allergy", "description": "Add Allergy", "when": "canEdit" },

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
@@ -27,6 +27,7 @@ import { tagFilter } from "@/components/ui/multi-filter/filterConfigs";
 import MultiFilter from "@/components/ui/multi-filter/MultiFilter";
 import useMultiFilterState from "@/components/ui/multi-filter/utils/useMultiFilterState";
 import { createFilterConfig } from "@/components/ui/multi-filter/utils/Utils";
+import { useShortcutSubContext } from "@/context/ShortcutContext";
 import {
   Priority,
   SERVICE_REQUEST_PRIORITY_COLORS,
@@ -38,6 +39,7 @@ import serviceRequestApi from "@/types/emr/serviceRequest/serviceRequestApi";
 import { TagConfig, TagResource } from "@/types/emr/tagConfig/tagConfig";
 import useTagConfigs from "@/types/emr/tagConfig/useTagConfig";
 import locationApi from "@/types/location/locationApi";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import query from "@/Utils/request/query";
 
 function EmptyState() {
@@ -187,6 +189,7 @@ export default function ServiceRequestList({
     },
   });
   const [isBarcodeOpen, setBarcodeOpen] = useState(false);
+  useShortcutSubContext("facility:service");
 
   const tagIds = qParams.tags?.split(",") || [];
   const tagQueries = useTagConfigs({ ids: tagIds, facilityId });
@@ -287,6 +290,7 @@ export default function ServiceRequestList({
               >
                 <ScanQrCode className="size-4" />
                 {t("scan_qr")}
+                <ShortcutBadge actionId="scan-button" className="ml-2" />
               </Button>
             </div>
           </div>

--- a/src/types/emr/specimen/specimenApi.ts
+++ b/src/types/emr/specimen/specimenApi.ts
@@ -31,4 +31,10 @@ export default {
     method: HttpMethod.GET,
     TRes: Type<SpecimenRead>(),
   },
+  retrieveByAccessionIdentifier: {
+    path: "/api/v1/facility/{facilityId}/specimen/retrieve_by_accession_identifier/",
+    method: HttpMethod.POST,
+    TRes: Type<SpecimenRead>(),
+    TBody: Type<{ accession_identifier: string }>(),
+  },
 };


### PR DESCRIPTION
feat: add scan-button shortcut and implement specimen retrieval by accession identifier

## Proposed Changes

Fixes #14816 
<img width="1187" height="705" alt="image" src="https://github.com/user-attachments/assets/097ddbd3-555b-4595-b287-9254dc1e0313" />

https://github.com/user-attachments/assets/c5382acc-82aa-41ff-92a1-a93b891f7eed



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut support: press 's' to quickly access QR code scanning in service requests.
  * Enhanced specimen lookup to support accession identifier scanning with automatic fallback capability.
  * Added visual shortcut indicator next to the scan button for improved discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->