### PR TITLE
show official patient identifiers in invoice show/print

### DIFF
--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -72,7 +72,10 @@ import { MonetaryComponentType } from "@/types/base/monetaryComponent/monetaryCo
 import { ACCOUNT_STATUS_COLORS } from "@/types/billing/account/Account";
 import chargeItemApi from "@/types/billing/chargeItem/chargeItemApi";
 import invoiceApi from "@/types/billing/invoice/invoiceApi";
+import { getPartialId } from "@/types/emr/patient/patient";
+import patientApi from "@/types/emr/patient/patientApi";
 import facilityApi from "@/types/facility/facilityApi";
+import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import dayjs from "@/Utils/dayjs";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
@@ -125,6 +128,22 @@ export function InvoiceShow({
     queryFn: query(invoiceApi.retrieveInvoice, {
       pathParams: { facilityId, invoiceId },
     }),
+  });
+
+  const patient = invoice?.account.patient;
+
+  // Fetch patient data for identifiers
+  const { data: verifiedPatient } = useQuery({
+    queryKey: ["patient-verify", patient?.id, patient?.year_of_birth],
+    queryFn: query(patientApi.searchRetrieve, {
+      pathParams: { facilityId },
+      body: {
+        phone_number: patient?.phone_number ?? "",
+        year_of_birth: patient?.year_of_birth?.toString() ?? "",
+        partial_id: patient ? getPartialId(patient) : "",
+      },
+    }),
+    enabled: !!patient,
   });
 
   const { mutate: removeChargeItem, isPending: isRemoving } = useMutation({
@@ -540,6 +559,23 @@ export function InvoiceShow({
                       invoice.account.patient.phone_number,
                     )}
                   </p>
+                  {verifiedPatient &&
+                    "instance_identifiers" in verifiedPatient &&
+                    verifiedPatient.instance_identifiers
+                      .filter(
+                        ({ config }) =>
+                          config.config.use === PatientIdentifierUse.official &&
+                          !config.config.auto_maintained,
+                      )
+                      .map((identifier) => (
+                        <p
+                          key={identifier.config.id}
+                          className="font-medium text-gray-700 text-sm ml-2"
+                        >
+                          <span>{identifier.config.config.display}: </span>
+                          <span>{identifier.value}</span>
+                        </p>
+                      ))}
                 </div>
                 <div className="mt-2">
                   {invoice.note && <p>{invoice.note}</p>}

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -75,7 +75,6 @@ import invoiceApi from "@/types/billing/invoice/invoiceApi";
 import { getPartialId } from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import facilityApi from "@/types/facility/facilityApi";
-import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import dayjs from "@/Utils/dayjs";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
@@ -564,7 +563,7 @@ export function InvoiceShow({
                     verifiedPatient.instance_identifiers
                       .filter(
                         ({ config }) =>
-                          config.config.use === PatientIdentifierUse.official &&
+                          // config.config.use === PatientIdentifierUse.official &&
                           !config.config.auto_maintained,
                       )
                       .map((identifier) => (

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -75,6 +75,7 @@ import invoiceApi from "@/types/billing/invoice/invoiceApi";
 import { getPartialId } from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import facilityApi from "@/types/facility/facilityApi";
+import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import dayjs from "@/Utils/dayjs";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
@@ -563,7 +564,7 @@ export function InvoiceShow({
                     verifiedPatient.instance_identifiers
                       .filter(
                         ({ config }) =>
-                          // config.config.use === PatientIdentifierUse.official &&
+                          config.config.use === PatientIdentifierUse.official &&
                           !config.config.auto_maintained,
                       )
                       .map((identifier) => (

--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -31,6 +31,8 @@ import {
 } from "@/types/billing/chargeItem/chargeItem";
 import { InvoiceRead } from "@/types/billing/invoice/invoice";
 import invoiceApi from "@/types/billing/invoice/invoiceApi";
+import { getPartialId } from "@/types/emr/patient/patient";
+import patientApi from "@/types/emr/patient/patientApi";
 import query from "@/Utils/request/query";
 
 type PrintInvoiceProps = {
@@ -46,6 +48,22 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
     queryFn: query(invoiceApi.retrieveInvoice, {
       pathParams: { facilityId, invoiceId },
     }),
+  });
+
+  const patient = invoice?.account.patient;
+
+  // Fetch patient data for identifiers
+  const { data: verifiedPatient } = useQuery({
+    queryKey: ["patient-verify", patient?.id, patient?.year_of_birth],
+    queryFn: query(patientApi.searchRetrieve, {
+      pathParams: { facilityId },
+      body: {
+        phone_number: patient?.phone_number ?? "",
+        year_of_birth: patient?.year_of_birth?.toString() ?? "",
+        partial_id: patient ? getPartialId(patient) : "",
+      },
+    }),
+    enabled: !!patient,
   });
 
   const { facility, isFacilityLoading } = useCurrentFacility();
@@ -156,15 +174,34 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
                 </p>
               </div>
             </div>
-            <div className="flex gap-1 font-medium text-gray-700 text-sm ml-2">
-              {t("address")}:{" "}
-              <p className="font-medium text-gray-700 text-sm whitespace-pre-wrap ml-2">
-                {formatPatientAddress(invoice.account.patient.address) || (
-                  <span className="text-gray-500">
-                    {t("no_address_provided")}
-                  </span>
-                )}
-              </p>
+            <div>
+              <div className="flex gap-1 font-medium text-gray-700 text-sm ml-2">
+                {t("address")}:{" "}
+                <p className="font-medium text-gray-700 text-sm whitespace-pre-wrap ml-2">
+                  {formatPatientAddress(invoice.account.patient.address) || (
+                    <span className="text-gray-500">
+                      {t("no_address_provided")}
+                    </span>
+                  )}
+                </p>
+              </div>
+              {verifiedPatient &&
+                "instance_identifiers" in verifiedPatient &&
+                verifiedPatient.instance_identifiers
+                  .filter(
+                    ({ config }) =>
+                      // config.config.use === PatientIdentifierUse.official &&
+                      !config.config.auto_maintained,
+                  )
+                  .map((identifier) => (
+                    <p
+                      key={identifier.config.id}
+                      className="font-medium text-gray-700 text-sm ml-2"
+                    >
+                      <span>{identifier.config.config.display}: </span>
+                      <span className="ml-2">{identifier.value}</span>
+                    </p>
+                  ))}
             </div>
           </div>
 

--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -33,6 +33,7 @@ import { InvoiceRead } from "@/types/billing/invoice/invoice";
 import invoiceApi from "@/types/billing/invoice/invoiceApi";
 import { getPartialId } from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
+import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import query from "@/Utils/request/query";
 
 type PrintInvoiceProps = {
@@ -190,7 +191,7 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
                 verifiedPatient.instance_identifiers
                   .filter(
                     ({ config }) =>
-                      // config.config.use === PatientIdentifierUse.official &&
+                      config.config.use === PatientIdentifierUse.official &&
                       !config.config.auto_maintained,
                   )
                   .map((identifier) => (


### PR DESCRIPTION
## Proposed Changes

- fixes #14819
- show official patient identifiers in invoice show/print

<img width="1337" height="899" alt="image" src="https://github.com/user-attachments/assets/cd6c5553-2661-4d71-9903-488804f2cac8" />

<img width="1560" height="965" alt="image" src="https://github.com/user-attachments/assets/e157b6b1-94c8-4626-b439-cec18039c22f" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Official patient identifiers now appear in invoice displays, showing alongside patient information in the patient card, billing sections, and printed invoice layouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->