### PR TITLE
Locations: reset data after mutate

### DIFF
--- a/src/components/Location/hooks/useLocationNavigation.ts
+++ b/src/components/Location/hooks/useLocationNavigation.ts
@@ -92,7 +92,7 @@ export function useLocationNavigation({
   });
 
   useEffect(() => {
-    if (locationsData && open) {
+    if (locationsData) {
       if (locationsPage === 1) {
         setAllLocations(locationsData.results);
       } else {
@@ -100,7 +100,7 @@ export function useLocationNavigation({
       }
       setHasMoreLocations(locationsData.count > locationsPage * ITEMS_PER_PAGE);
     }
-  }, [locationsData, locationsPage, open]);
+  }, [locationsData, locationsPage]);
 
   useEffect(() => {
     if (bedsData) {
@@ -193,6 +193,9 @@ export function useLocationNavigation({
     setAllBeds([]);
     setHasMoreLocations(true);
     setHasMoreBeds(true);
+    if (locationsData?.results) {
+      setAllLocations(locationsData.results);
+    }
   };
 
   return {


### PR DESCRIPTION
## Proposed Changes

- Minor change to set data on refresh (called after a mutate).
- To test: compare behavior on assigning (list locations) screens after updating time on an existing bed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location data updates to occur reliably independent of UI state toggles.
  * Enhanced location data restoration during navigation resets to ensure data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->