### PR TITLE
Fix: validation bypass when removing items from questionnaire

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
@@ -554,7 +554,7 @@ export function validateAllergyIntoleranceQuestion(
   response: ResponseValue | undefined,
   questionId: string,
   required?: boolean,
-) {
+): QuestionValidationError[] {
   const allergies = (response?.value as AllergyIntoleranceRequest[]) || [];
   const validAllergies = allergies.filter(
     (a) => a.verification_status !== "entered_in_error",
@@ -564,7 +564,7 @@ export function validateAllergyIntoleranceQuestion(
       {
         question_id: questionId,
         error: "field_required",
-        type: "validation_error" as const,
+        type: "validation_error",
       },
     ];
   }

--- a/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
@@ -550,6 +550,27 @@ const AllergyItem = ({
   );
 };
 
+export function validateAllergyIntoleranceQuestion(
+  response: ResponseValue | undefined,
+  questionId: string,
+  required?: boolean,
+) {
+  const allergies = (response?.value as AllergyIntoleranceRequest[]) || [];
+  const validAllergies = allergies.filter(
+    (a) => a.verification_status !== "entered_in_error",
+  );
+  if (required && validAllergies.length === 0) {
+    return [
+      {
+        question_id: questionId,
+        error: "field_required",
+        type: "validation_error" as const,
+      },
+    ];
+  }
+  return [];
+}
+
 export function AllergyQuestion({
   questionnaireResponse,
   updateQuestionnaireResponseCB,

--- a/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/AllergyQuestion.tsx
@@ -62,6 +62,7 @@ import {
   type AllergyVerificationStatus,
 } from "@/types/emr/allergyIntolerance/allergyIntolerance";
 import allergyIntoleranceApi from "@/types/emr/allergyIntolerance/allergyIntoleranceApi";
+import type { QuestionValidationError } from "@/types/questionnaire/batch";
 import type {
   QuestionnaireResponse,
   ResponseValue,

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -344,7 +344,7 @@ export function validateDiagnosisQuestion(
   response: ResponseValue | undefined,
   questionId: string,
   required?: boolean,
-) {
+): QuestionValidationError[] {
   const diagnoses = (response?.value as DiagnosisRequest[]) || [];
   const validDiagnoses = diagnoses.filter(
     (d) => d.verification_status !== "entered_in_error",
@@ -354,7 +354,7 @@ export function validateDiagnosisQuestion(
       {
         question_id: questionId,
         error: "field_required",
-        type: "validation_error" as const,
+        type: "validation_error",
       },
     ];
   }

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -340,6 +340,27 @@ function checkForDuplicateDiagnosis(
   return false;
 }
 
+export function validateDiagnosisQuestion(
+  response: ResponseValue | undefined,
+  questionId: string,
+  required?: boolean,
+) {
+  const diagnoses = (response?.value as DiagnosisRequest[]) || [];
+  const validDiagnoses = diagnoses.filter(
+    (d) => d.verification_status !== "entered_in_error",
+  );
+  if (required && validDiagnoses.length === 0) {
+    return [
+      {
+        question_id: questionId,
+        error: "field_required",
+        type: "validation_error" as const,
+      },
+    ];
+  }
+  return [];
+}
+
 export function DiagnosisQuestion({
   patientId,
   encounterId,

--- a/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DiagnosisQuestion.tsx
@@ -69,6 +69,7 @@ import {
   Onset,
 } from "@/types/emr/diagnosis/diagnosis";
 import diagnosisApi from "@/types/emr/diagnosis/diagnosisApi";
+import type { QuestionValidationError } from "@/types/questionnaire/batch";
 import {
   QuestionnaireResponse,
   ResponseValue,

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -648,7 +648,7 @@ export function validateSymptomQuestion(
   response: ResponseValue | undefined,
   questionId: string,
   required?: boolean,
-) {
+): QuestionValidationError[] {
   const symptoms = (response?.value as SymptomRequest[]) || [];
   const validSymptoms = symptoms.filter(
     (s) => s.verification_status !== "entered_in_error",
@@ -658,7 +658,7 @@ export function validateSymptomQuestion(
       {
         question_id: questionId,
         error: "field_required",
-        type: "validation_error" as const,
+        type: "validation_error",
       },
     ];
   }

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -67,6 +67,7 @@ import {
   SymptomRequest,
 } from "@/types/emr/symptom/symptom";
 import symptomApi from "@/types/emr/symptom/symptomApi";
+import type { QuestionValidationError } from "@/types/questionnaire/batch";
 import {
   QuestionnaireResponse,
   ResponseValue,

--- a/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/SymptomQuestion.tsx
@@ -644,6 +644,27 @@ function checkForDuplicateSymptom(
   return false;
 }
 
+export function validateSymptomQuestion(
+  response: ResponseValue | undefined,
+  questionId: string,
+  required?: boolean,
+) {
+  const symptoms = (response?.value as SymptomRequest[]) || [];
+  const validSymptoms = symptoms.filter(
+    (s) => s.verification_status !== "entered_in_error",
+  );
+  if (required && validSymptoms.length === 0) {
+    return [
+      {
+        question_id: questionId,
+        error: "field_required",
+        type: "validation_error" as const,
+      },
+    ];
+  }
+  return [];
+}
+
 export function SymptomQuestion({
   patientId,
   questionnaireResponse,

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -11,6 +11,7 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 
+import BackButton from "@/components/Common/BackButton";
 import { DebugPreview } from "@/components/Common/DebugPreview";
 import Loading from "@/components/Common/Loading";
 
@@ -41,9 +42,11 @@ import { QuestionnaireRead } from "@/types/questionnaire/questionnaire";
 import questionnaireApi from "@/types/questionnaire/questionnaireApi";
 import { CreateAppointmentQuestion } from "@/types/scheduling/schedule";
 
-import BackButton from "@/components/Common/BackButton";
 import { validateEncounterQuestion } from "@/components/Questionnaire/QuestionTypes/EncounterQuestion";
+import { AllergyIntoleranceRequest } from "@/types/emr/allergyIntolerance/allergyIntolerance";
+import { DiagnosisRequest } from "@/types/emr/diagnosis/diagnosis";
 import { EncounterEdit } from "@/types/emr/encounter/encounter";
+import { SymptomRequest } from "@/types/emr/symptom/symptom";
 import { ArrowLeft } from "lucide-react";
 import { QuestionRenderer } from "./QuestionRenderer";
 import { validateAppointmentQuestion } from "./QuestionTypes/AppointmentQuestion";
@@ -324,6 +327,69 @@ const STRUCTURED_TYPE_VALIDATORS = {
   files: (response: ResponseValue | undefined, quesitonId: string) => {
     const files = (response?.value as FileUploadQuestion[]) || [];
     return validateFileUploadQuestion(files, quesitonId);
+  },
+  allergy_intolerance: (
+    response: ResponseValue | undefined,
+    questionId: string,
+    required?: boolean,
+  ) => {
+    const allergies = (response?.value as AllergyIntoleranceRequest[]) || [];
+    const validAllergies = allergies.filter(
+      (a) => a.verification_status !== "entered_in_error",
+    );
+    if (required && validAllergies.length === 0) {
+      return [
+        {
+          question_id: questionId,
+          error: "field_required",
+          type: "validation_error",
+          msg: "field_required",
+        },
+      ];
+    }
+    return [];
+  },
+  condition: (
+    response: ResponseValue | undefined,
+    questionId: string,
+    required?: boolean,
+  ) => {
+    const diagnoses = (response?.value as DiagnosisRequest[]) || [];
+    const validDiagnoses = diagnoses.filter(
+      (d) => d.verification_status !== "entered_in_error",
+    );
+    if (required && validDiagnoses.length === 0) {
+      return [
+        {
+          question_id: questionId,
+          error: "field_required",
+          type: "validation_error",
+          msg: "field_required",
+        },
+      ];
+    }
+    return [];
+  },
+  symptom: (
+    response: ResponseValue | undefined,
+    questionId: string,
+    required?: boolean,
+  ) => {
+    const symptoms = (response?.value as SymptomRequest[]) || [];
+    const validSymptoms = symptoms.filter(
+      (s) => s.verification_status !== "entered_in_error",
+    );
+    if (required && validSymptoms.length === 0) {
+      return [
+        {
+          question_id: questionId,
+          error: "field_required",
+          type: "validation_error",
+          msg: "field_required",
+        },
+      ];
+    }
+    return [];
   },
 } as const;
 

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -349,7 +349,7 @@ const STRUCTURED_TYPE_VALIDATORS = {
     }
     return [];
   },
-  condition: (
+  diagnosis: (
     response: ResponseValue | undefined,
     questionId: string,
     required?: boolean,

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -864,7 +864,15 @@ export function QuestionnaireForm({
               q.id,
               q.required,
             );
-            errors.push(...validationErrors);
+
+            // Normalize error messages for i18n
+            const normalizedErrors = validationErrors.map((error) => ({
+              ...error,
+              error: error.error ? t(error.error) : t("validation_failed"),
+              msg: error.msg ? t(error.msg) : undefined,
+            }));
+
+            errors.push(...normalizedErrors);
             if (validationErrors.length > 0) {
               firstErrorId = firstErrorId ? firstErrorId : q.id;
             }

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -808,7 +808,7 @@ export function QuestionnaireForm({
             // Normalize error messages for i18n
             const normalizedErrors = validationErrors.map((error) => ({
               ...error,
-              error: t(error.error),
+              error: error.error ? t(error.error) : t("validation_failed"),
             }));
 
             errors.push(...normalizedErrors);

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -798,20 +798,13 @@ export function QuestionnaireForm({
             ];
 
           if (validator) {
-            let validationErrors: QuestionValidationError[] = [];
-            validationErrors = validator(
+            const validationErrors = validator(
               response?.values?.[0],
               q.id,
               q.required,
             );
 
-            // Normalize error messages for i18n
-            const normalizedErrors = validationErrors.map((error) => ({
-              ...error,
-              error: error.error ? t(error.error) : t("validation_failed"),
-            }));
-
-            errors.push(...normalizedErrors);
+            errors.push(...validationErrors);
             if (validationErrors.length > 0) {
               firstErrorId = firstErrorId ? firstErrorId : q.id;
             }

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -43,17 +43,17 @@ import questionnaireApi from "@/types/questionnaire/questionnaireApi";
 import { CreateAppointmentQuestion } from "@/types/scheduling/schedule";
 
 import { validateEncounterQuestion } from "@/components/Questionnaire/QuestionTypes/EncounterQuestion";
-import { AllergyIntoleranceRequest } from "@/types/emr/allergyIntolerance/allergyIntolerance";
-import { DiagnosisRequest } from "@/types/emr/diagnosis/diagnosis";
 import { EncounterEdit } from "@/types/emr/encounter/encounter";
-import { SymptomRequest } from "@/types/emr/symptom/symptom";
 import { ArrowLeft } from "lucide-react";
 import { QuestionRenderer } from "./QuestionRenderer";
+import { validateAllergyIntoleranceQuestion } from "./QuestionTypes/AllergyQuestion";
 import { validateAppointmentQuestion } from "./QuestionTypes/AppointmentQuestion";
+import { validateDiagnosisQuestion } from "./QuestionTypes/DiagnosisQuestion";
 import { validateFileUploadQuestion } from "./QuestionTypes/FileQuestion";
 import { validateMedicationRequestQuestion } from "./QuestionTypes/MedicationRequestQuestion";
 import { validateMedicationStatementQuestion } from "./QuestionTypes/MedicationStatementQuestion";
 import { isQuestionEnabled } from "./QuestionTypes/QuestionGroup";
+import { validateSymptomQuestion } from "./QuestionTypes/SymptomQuestion";
 import { QuestionnaireSearch } from "./QuestionnaireSearch";
 import { FIXED_QUESTIONNAIRES } from "./data/StructuredFormData";
 import { getStructuredRequests } from "./structured/handlers";
@@ -328,69 +328,9 @@ const STRUCTURED_TYPE_VALIDATORS = {
     const files = (response?.value as FileUploadQuestion[]) || [];
     return validateFileUploadQuestion(files, quesitonId);
   },
-  allergy_intolerance: (
-    response: ResponseValue | undefined,
-    questionId: string,
-    required?: boolean,
-  ) => {
-    const allergies = (response?.value as AllergyIntoleranceRequest[]) || [];
-    const validAllergies = allergies.filter(
-      (a) => a.verification_status !== "entered_in_error",
-    );
-    if (required && validAllergies.length === 0) {
-      return [
-        {
-          question_id: questionId,
-          error: "field_required",
-          type: "validation_error",
-          msg: "field_required",
-        },
-      ];
-    }
-    return [];
-  },
-  diagnosis: (
-    response: ResponseValue | undefined,
-    questionId: string,
-    required?: boolean,
-  ) => {
-    const diagnoses = (response?.value as DiagnosisRequest[]) || [];
-    const validDiagnoses = diagnoses.filter(
-      (d) => d.verification_status !== "entered_in_error",
-    );
-    if (required && validDiagnoses.length === 0) {
-      return [
-        {
-          question_id: questionId,
-          error: "field_required",
-          type: "validation_error",
-          msg: "field_required",
-        },
-      ];
-    }
-    return [];
-  },
-  symptom: (
-    response: ResponseValue | undefined,
-    questionId: string,
-    required?: boolean,
-  ) => {
-    const symptoms = (response?.value as SymptomRequest[]) || [];
-    const validSymptoms = symptoms.filter(
-      (s) => s.verification_status !== "entered_in_error",
-    );
-    if (required && validSymptoms.length === 0) {
-      return [
-        {
-          question_id: questionId,
-          error: "field_required",
-          type: "validation_error",
-          msg: "field_required",
-        },
-      ];
-    }
-    return [];
-  },
+  allergy_intolerance: validateAllergyIntoleranceQuestion,
+  diagnosis: validateDiagnosisQuestion,
+  symptom: validateSymptomQuestion,
 } as const;
 
 const initializeResponses = (
@@ -868,8 +808,7 @@ export function QuestionnaireForm({
             // Normalize error messages for i18n
             const normalizedErrors = validationErrors.map((error) => ({
               ...error,
-              error: error.error ? t(error.error) : t("validation_failed"),
-              msg: error.msg ? t(error.msg) : undefined,
+              error: t(error.error),
             }));
 
             errors.push(...normalizedErrors);


### PR DESCRIPTION
## Proposed Changes

Fixes #13349

- Fixed validation bypass when removing allergies/diagnosis/symptoms - now filters out `entered_in_error` items before checking if array is empty

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for required structured data and array-valued answers, improving required-field checks.
  * Improved handling and display filtering of deleted medical records (allergies, diagnoses, symptoms).
  * Updated mobile and desktop interfaces for managing allergies, diagnoses, and symptoms.

* **Tests**
  * Added a test ensuring submission is prevented when an allergy is added then removed before submit.

* **Chores**
  * Removed NotesInput and ResponseTemplateSelect components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->