### PR TITLE
Fix: Memory leak in AudioPlayer due to incorrect event listener cleanup

### DIFF
--- a/src/components/Common/AudioPlayer.tsx
+++ b/src/components/Common/AudioPlayer.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { cn } from "@/lib/utils";
-
 import CareIcon from "@/CAREUI/icons/CareIcon";
-
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 
 interface AudioPlayerProps {
   src: string;
@@ -48,25 +46,26 @@ function AudioPlayer({ src, className }: AudioPlayerProps) {
   }, []);
 
   useEffect(() => {
-    // Create the audio element
     const audio = new Audio(src);
     audio.preload = "metadata";
 
-    // Add event listeners
+    // ✅ FIX: stable function reference
+    const handleEnded = () => {
+      setIsPlaying(false);
+    };
+
     audio.addEventListener("loadedmetadata", handleLoadedMetadata);
     audio.addEventListener("durationchange", handleDurationChange);
     audio.addEventListener("timeupdate", handleTimeUpdate);
-    audio.addEventListener("ended", () => setIsPlaying(false));
+    audio.addEventListener("ended", handleEnded);
 
-    // Set the ref
     audioRef.current = audio;
 
-    // Cleanup
     return () => {
       audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
       audio.removeEventListener("durationchange", handleDurationChange);
       audio.removeEventListener("timeupdate", handleTimeUpdate);
-      audio.removeEventListener("ended", () => setIsPlaying(false));
+      audio.removeEventListener("ended", handleEnded);
       audio.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Proposed Changes

Fixes #14827
- Replaced inline arrow function for the `ended` event listener with a stable `handleEnded` callback.
- Used the same function reference in both `addEventListener` and `removeEventListener` to ensure proper cleanup.
- Prevents memory leak on repeated mounts/unmounts of the `AudioPlayer` component.

Additional context:
This fix addresses a common JavaScript mistake where inline functions cannot be removed by `removeEventListener`.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code stability and organization of the audio player component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->