### PR TITLE
fix: fixed issue with the value set

### DIFF
--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -305,6 +305,36 @@ export function ValueSetForm({
   isSystemDefined,
 }: ValueSetFormProps) {
   const { t } = useTranslation();
+  const ruleSchema = z
+    .object({
+      system: z.string(),
+      concept: z
+        .array(
+          z.object({
+            code: z.string().min(1, t("field_required")),
+            display: z.string().min(1, t("field_required")),
+          }),
+        )
+        .default([]),
+      filter: z
+        .array(
+          z.object({
+            property: z.string().min(1, t("field_required")),
+            op: z.string().min(1, t("field_required")),
+            value: z.string().min(1, t("field_required")),
+          }),
+        )
+        .default([]),
+    })
+    .refine(
+      (data) =>
+        (data.concept?.length ?? 0) > 0 || (data.filter?.length ?? 0) > 0,
+      {
+        message: t("field_required"),
+        path: ["concept"],
+      },
+    );
+
   const valuesetFormSchema = z.object({
     name: z.string().trim().min(1, t("field_required")),
     slug: z
@@ -322,50 +352,8 @@ export function ValueSetForm({
     ]),
     is_system_defined: z.boolean(),
     compose: z.object({
-      include: z.array(
-        z.object({
-          system: z.string(),
-          concept: z
-            .array(
-              z.object({
-                code: z.string().min(1, t("field_required")),
-                display: z.string().min(1, t("field_required")),
-              }),
-            )
-            .optional(),
-          filter: z
-            .array(
-              z.object({
-                property: z.string().min(1, t("field_required")),
-                op: z.string().min(1, t("field_required")),
-                value: z.string().min(1, t("field_required")),
-              }),
-            )
-            .optional(),
-        }),
-      ),
-      exclude: z.array(
-        z.object({
-          system: z.string(),
-          concept: z
-            .array(
-              z.object({
-                code: z.string().min(1, t("field_required")),
-                display: z.string().min(1, t("field_required")),
-              }),
-            )
-            .optional(),
-          filter: z
-            .array(
-              z.object({
-                property: z.string().min(1, t("field_required")),
-                op: z.string().min(1, t("field_required")),
-                value: z.string().min(1, t("field_required")),
-              }),
-            )
-            .optional(),
-        }),
-      ),
+      include: z.array(ruleSchema),
+      exclude: z.array(ruleSchema),
     }),
   });
 
@@ -389,17 +377,15 @@ export function ValueSetForm({
   return (
     <Form {...form}>
       <div className="flex justify-end">
-        {!initialData?.id && (
-          <ValueSetPreview
-            valueset={form.watch()}
-            trigger={
-              <Button variant="outline_primary">
-                <CareIcon icon={"l-eye"} className="h-4 w-4" />
-                {t("valueset_preview")}
-              </Button>
-            }
-          />
-        )}
+        <ValueSetPreview
+          valueset={form.watch()}
+          trigger={
+            <Button variant="outline_primary">
+              <CareIcon icon={"l-eye"} className="h-4 w-4" />
+              {t("valueset_preview")}
+            </Button>
+          }
+        />
       </div>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         <FormField

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -82,7 +82,7 @@ function makeRuleSchema(fieldRequiredMsg: string) {
 }
 
 function makeValueSetFormSchema(
-  ruleSchema: z.ZodType<any>,
+  ruleSchema: z.ZodTypeAny,
   fieldRequiredMsg: string,
   charCountMsg: string,
   slugFormatMsg: string,

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon, TrashIcon } from "@radix-ui/react-icons";
+import { useMemo } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as z from "zod";
@@ -46,6 +47,67 @@ interface ValueSetFormProps {
   onSubmit: (data: ValueSetBase) => void;
   isSubmitting?: boolean;
   isSystemDefined?: boolean;
+}
+
+function makeRuleSchema(fieldRequiredMsg: string) {
+  return z
+    .object({
+      system: z.string(),
+      concept: z
+        .array(
+          z.object({
+            code: z.string().min(1, fieldRequiredMsg),
+            display: z.string().min(1, fieldRequiredMsg),
+          }),
+        )
+        .default([]),
+      filter: z
+        .array(
+          z.object({
+            property: z.string().min(1, fieldRequiredMsg),
+            op: z.string().min(1, fieldRequiredMsg),
+            value: z.string().min(1, fieldRequiredMsg),
+          }),
+        )
+        .default([]),
+    })
+    .refine(
+      (data) =>
+        (data.concept?.length ?? 0) > 0 || (data.filter?.length ?? 0) > 0,
+      {
+        message: fieldRequiredMsg,
+        path: ["concept"],
+      },
+    );
+}
+
+function makeValueSetFormSchema(
+  ruleSchema: z.ZodType<any>,
+  fieldRequiredMsg: string,
+  charCountMsg: string,
+  slugFormatMsg: string,
+) {
+  return z.object({
+    name: z.string().trim().min(1, fieldRequiredMsg),
+    slug: z
+      .string()
+      .trim()
+      .min(5, charCountMsg)
+      .max(25, charCountMsg)
+      .regex(/^[-\w]+$/, { message: slugFormatMsg }),
+    description: z.string(),
+    status: z.enum([
+      ValueSetStatus.ACTIVE,
+      ValueSetStatus.DRAFT,
+      ValueSetStatus.RETIRED,
+      ValueSetStatus.UNKNOWN,
+    ]),
+    is_system_defined: z.boolean(),
+    compose: z.object({
+      include: z.array(ruleSchema),
+      exclude: z.array(ruleSchema),
+    }),
+  });
 }
 
 function ConceptFields({
@@ -305,57 +367,19 @@ export function ValueSetForm({
   isSystemDefined,
 }: ValueSetFormProps) {
   const { t } = useTranslation();
-  const ruleSchema = z
-    .object({
-      system: z.string(),
-      concept: z
-        .array(
-          z.object({
-            code: z.string().min(1, t("field_required")),
-            display: z.string().min(1, t("field_required")),
-          }),
-        )
-        .default([]),
-      filter: z
-        .array(
-          z.object({
-            property: z.string().min(1, t("field_required")),
-            op: z.string().min(1, t("field_required")),
-            value: z.string().min(1, t("field_required")),
-          }),
-        )
-        .default([]),
-    })
-    .refine(
-      (data) =>
-        (data.concept?.length ?? 0) > 0 || (data.filter?.length ?? 0) > 0,
-      {
-        message: t("field_required"),
-        path: ["concept"],
-      },
-    );
 
-  const valuesetFormSchema = z.object({
-    name: z.string().trim().min(1, t("field_required")),
-    slug: z
-      .string()
-      .trim()
-      .min(5, t("character_count_validation", { min: 5, max: 25 }))
-      .max(25, t("character_count_validation", { min: 5, max: 25 }))
-      .regex(/^[-\w]+$/, { message: t("slug_format_message") }),
-    description: z.string(),
-    status: z.enum([
-      ValueSetStatus.ACTIVE,
-      ValueSetStatus.DRAFT,
-      ValueSetStatus.RETIRED,
-      ValueSetStatus.UNKNOWN,
-    ]),
-    is_system_defined: z.boolean(),
-    compose: z.object({
-      include: z.array(ruleSchema),
-      exclude: z.array(ruleSchema),
-    }),
-  });
+  const ruleSchema = useMemo(() => makeRuleSchema(t("field_required")), [t]);
+
+  const valuesetFormSchema = useMemo(
+    () =>
+      makeValueSetFormSchema(
+        ruleSchema,
+        t("field_required"),
+        t("character_count_validation", { min: 5, max: 25 }),
+        t("slug_format_message"),
+      ),
+    [ruleSchema, t],
+  );
 
   const { goBack } = useAppHistory();
 

--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -27,6 +27,22 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
   const [selected, setSelected] = useState("");
+  const minSearchLength = 3;
+  const isBelowMin = search.length < minSearchLength;
+
+  const compose = valueset.compose?.include?.[0]?.system
+    ? {
+        include: valueset.compose.include ?? [],
+        exclude: valueset.compose.exclude ?? [],
+      }
+    : {
+        include: [{ system: "http://snomed.info/sct" }],
+        exclude: [],
+      };
+
+  const hasValidRules = compose.include?.some(
+    (rule) => (rule.concept?.length ?? 0) > 0 || (rule.filter?.length ?? 0) > 0,
+  );
 
   const { data: searchQuery, isFetching } = useQuery({
     queryKey: ["valueset", "previewSearch", search, valueset.compose],
@@ -36,15 +52,10 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
         ...valueset,
         name: valueset.name || "Preview",
         slug: valueset.slug || "preview-slug",
-        compose: valueset.compose.include[0]?.system
-          ? valueset.compose
-          : {
-              include: [{ system: "http://snomed.info/sct" }],
-              exclude: [],
-            },
+        compose,
       },
     }),
-    enabled: open,
+    enabled: open && !isBelowMin && hasValidRules,
   });
 
   return (
@@ -70,11 +81,18 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
             value={selected}
             onChange={setSelected}
             onSearch={setSearch}
+            isLoading={isFetching}
             placeholder={t("search_concept")}
             noOptionsMessage={
-              searchQuery && !isFetching
-                ? t("no_results_found")
-                : t("searching")
+              !hasValidRules
+                ? t("add_concept")
+                : isBelowMin
+                  ? t("min_char_length_error", {
+                      min_length: minSearchLength,
+                    })
+                  : searchQuery && !isFetching
+                    ? t("no_results_found")
+                    : t("searching")
             }
           />
         </div>

--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -22,6 +22,28 @@ interface ValueSetPreviewProps {
   trigger: React.ReactNode;
 }
 
+function getNoOptionsMessage(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  hasValidRules: boolean,
+  isBelowMin: boolean,
+  searchQuery: unknown,
+  isFetching: boolean,
+  minSearchLength: number,
+): string {
+  if (!hasValidRules) {
+    return t("add_concept");
+  }
+  if (isBelowMin) {
+    return t("min_char_length_error", {
+      min_length: minSearchLength,
+    });
+  }
+  if (searchQuery && !isFetching) {
+    return t("no_results_found");
+  }
+  return t("searching");
+}
+
 export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
@@ -83,17 +105,14 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
             onSearch={setSearch}
             isLoading={isFetching}
             placeholder={t("search_concept")}
-            noOptionsMessage={
-              !hasValidRules
-                ? t("add_concept")
-                : isBelowMin
-                  ? t("min_char_length_error", {
-                      min_length: minSearchLength,
-                    })
-                  : searchQuery && !isFetching
-                    ? t("no_results_found")
-                    : t("searching")
-            }
+            noOptionsMessage={getNoOptionsMessage(
+              t,
+              hasValidRules,
+              isBelowMin,
+              searchQuery,
+              isFetching,
+              minSearchLength,
+            )}
           />
         </div>
       </SheetContent>


### PR DESCRIPTION
## Proposed Changes

Fixes #11846 
-Enable ValueSet preview in edit mode (reuse create preview trigger) and pass live form state.
-Harden compose validation: filter rows require property/op/value, and each include/exclude rule now requires at least one concept or filter.
-Improve preview search UX: min-char guard, loading/no-results messaging, safe compose fallback, and skip API calls until rules exist to avoid 400s

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form validation now uses memoized schemas for more consistent, faster validation.
  * Value set preview always renders; autocomplete enforces a minimum search length and shows contextual states (searching, no results, below-minimum).

* **Bug Fixes**
  * Clearer no-results and validation messages for searches and rule inputs.
  * Preview sheet only activates when input and rules meet minimum criteria, preventing invalid queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->