### PR TITLE
fix: refine validation for supplied item quantity in delivery form + add remove button

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { PlusCircle } from "lucide-react";
+import { PlusCircle, Trash2 } from "lucide-react";
 import { useQueryParams } from "raviger";
 import { useCallback, useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
@@ -636,6 +636,9 @@ export function AddSupplyDeliveryForm({
                                 </TableHead>
                               </>
                             )}
+                            <TableHead className="text-xs font-semibold">
+                              {t("actions")}
+                            </TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -740,6 +743,17 @@ export function AddSupplyDeliveryForm({
                                     )}
                                   />
                                 </TableCell>
+                                <TableCell className="align-top p-2">
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => remove(index)}
+                                    aria-label={t("remove")}
+                                  >
+                                    <Trash2 className="size-4" />
+                                  </Button>
+                                </TableCell>
                               </TableRow>
                             ) : (
                               <SmartExternalDeliveryRow
@@ -753,6 +767,7 @@ export function AddSupplyDeliveryForm({
                                 onProductSelectOpened={() =>
                                   setNewlyAddedRowIndex(null)
                                 }
+                                onRemove={() => remove(index)}
                               />
                             ),
                           )}

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -79,7 +79,12 @@ import query from "@/Utils/request/query";
 
 const supplyDeliveryItemSchema = z.object({
   supplied_inventory_item: z.string().optional(),
-  supplied_item_quantity: z.number().min(1, "Quantity must be at least 1"),
+  supplied_item_quantity: z
+    .number()
+    .or(z.nan())
+    .refine((val) => !isNaN(val) && val > 0, {
+      message: "Quantity must be at least 1",
+    }),
   product_knowledge: z
     .custom<ProductKnowledgeBase>()
     .refine((data) => data?.slug, {
@@ -725,7 +730,7 @@ export function AddSupplyDeliveryForm({
                                             {...field}
                                             onChange={(e) =>
                                               field.onChange(
-                                                parseInt(e.target.value) || 1,
+                                                parseInt(e.target.value),
                                               )
                                             }
                                           />

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Command,
@@ -50,6 +51,7 @@ interface Props {
   informationalCodes: Code[];
   autoOpenProductSelect?: boolean;
   onProductSelectOpened?: () => void;
+  onRemove?: () => void;
 }
 
 export function SmartExternalDeliveryRow({
@@ -58,6 +60,7 @@ export function SmartExternalDeliveryRow({
   informationalCodes,
   autoOpenProductSelect = false,
   onProductSelectOpened,
+  onRemove,
 }: Props) {
   const { facilityId } = useCurrentFacility();
   const { t } = useTranslation();
@@ -412,6 +415,17 @@ export function SmartExternalDeliveryRow({
             displayMode="short"
           />
         </span>
+      </TableCell>
+      <TableCell>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onRemove}
+          aria-label={t("remove")}
+        >
+          <Trash2 className="size-4" />
+        </Button>
       </TableCell>
     </TableRow>
   );


### PR DESCRIPTION
## Proposed Changes

Fixes #14843



https://github.com/user-attachments/assets/e75d8fb4-8653-48a0-8a6b-e0d4c48bca43

<img width="1037" height="745" alt="image" src="https://github.com/user-attachments/assets/9cbe108f-1a88-4966-8800-908c18dbadea" />

<img width="1037" height="745" alt="image" src="https://github.com/user-attachments/assets/7d186d71-d983-4727-b0a2-f6f9e49e0107" />




Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantity field validation in supply delivery forms to properly detect and report invalid input entries instead of silently converting them to default values, ensuring more transparent validation feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->