### PR TITLE
Fix the logo size in print

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -355,8 +355,8 @@
     #section-to-print img[alt*="logo" i],
     #section-to-print .logo img,
     #section-to-print img.logo {
-      max-width: 200px !important;
-      max-height: 200px !important;
+      max-width: 100px !important;
+      max-height: 100px !important;
       width: auto !important;
       height: auto !important;
       object-fit: contain !important;


### PR DESCRIPTION
## Proposed Changes
Fix : #14852 
- Reduce the logo size 

Screenshot :
<img width="1497" height="948" alt="image" src="https://github.com/user-attachments/assets/0480f84b-f810-496d-83e2-83a93827868b" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
