### PR TITLE
fix order selector disappearing while searching

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -151,11 +151,6 @@ export default function Autocomplete({
         autoFocus={!isAppleDevice}
       />
       <CommandList className="overflow-y-auto">
-        {isLoading ? (
-          <CardListSkeleton count={3} />
-        ) : (
-          <CommandEmpty>{noOptionsMessage}</CommandEmpty>
-        )}
         <CommandGroup>
           {options.map((option) => (
             <CommandItem
@@ -188,6 +183,11 @@ export default function Autocomplete({
             </CommandItem>
           ))}
         </CommandGroup>
+        {isLoading ? (
+          <CardListSkeleton count={3} />
+        ) : (
+          <CommandEmpty>{noOptionsMessage}</CommandEmpty>
+        )}
       </CommandList>
     </>
   );

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -49,6 +49,7 @@ interface AutocompleteProps {
   align?: "start" | "center" | "end";
   className?: string;
   popoverClassName?: string;
+  popoverContentClassName?: string;
   freeInput?: boolean;
   closeOnSelect?: boolean;
   showClearButton?: boolean;
@@ -72,6 +73,7 @@ export default function Autocomplete({
   align = "center",
   className,
   popoverClassName,
+  popoverContentClassName,
   freeInput = false,
   closeOnSelect = true,
   showClearButton = true,
@@ -290,7 +292,10 @@ export default function Autocomplete({
           </Button>
         </PopoverTrigger>
         <PopoverContent
-          className="p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]"
+          className={cn(
+            "p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]",
+            popoverContentClassName,
+          )}
           align={align}
         >
           <Command>{commandContent}</Command>

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -244,6 +244,7 @@ export function AddSupplyDeliveryForm({
       inputPlaceholder={t("search_order")}
       noOptionsMessage={t("no_orders_found")}
       className="px-10"
+      popoverContentClassName="w-auto"
     />
   );
 

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -1,5 +1,10 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { PlusCircle, Trash2 } from "lucide-react";
 import { useQueryParams } from "raviger";
 import { useCallback, useState } from "react";
@@ -175,7 +180,7 @@ export function AddSupplyDeliveryForm({
     enabled: !!qParams.supplyOrder,
   });
 
-  const { data: requestOrders, isLoading: isLoadingRequestOrders } = useQuery({
+  const { data: requestOrders, isFetching: isLoadingRequestOrders } = useQuery({
     queryKey: [
       "requestOrders",
       facilityId,
@@ -192,6 +197,7 @@ export function AddSupplyDeliveryForm({
       },
     }),
     enabled: !qParams.supplyOrder,
+    placeholderData: keepPreviousData,
   });
 
   const form = useForm<SupplyDeliveryFormValues>({


### PR DESCRIPTION
## Proposed Changes

Fixes #14872
- fix order selector disappearing while searching

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow external styling of autocomplete popover content (enables custom width/appearance).
  * Delivery order form now applies the popover styling option to improve suggestion popover width.

* **Bug Fixes**
  * Fixed visual ordering of loading indicators and empty-state messages in search suggestions.
  * Preserve previously fetched delivery-order data during refresh to avoid UI disruption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->