### PR TITLE
fix: disabled create button in Add Location form

### DIFF
--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -201,7 +201,7 @@ export default function LocationForm({
     },
   });
 
-  const { mutate: submitBatch } = useMutation({
+  const { mutate: submitBatch, isPending: isBatchPending } = useMutation({
     mutationFn: mutate(batchApi.batchRequest),
     onSuccess: (data: BatchRequestResponse) => {
       toast.success(
@@ -548,11 +548,12 @@ export default function LocationForm({
           type="submit"
           disabled={
             isPending ||
+            isBatchPending ||
             !form.formState.isValid ||
             (!!location?.id && !form.formState.isDirty)
           }
         >
-          {isPending ? (
+          {isPending || isBatchPending ? (
             <>{isEditMode ? t("updating") : t("creating")}</>
           ) : (
             <>{isEditMode ? t("update") : t("create")}</>


### PR DESCRIPTION
## Proposed Changes

Fixes #14908 
- In Location form, while the request is in progress, create button is disabled so that duplicate locations are not created.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location form submission handling. The submit button now properly synchronizes its disabled state and label with batch operation progress, preventing duplicate submissions while requests are processing and providing clearer feedback to users about operation status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->