### PR TITLE
Keep bed hold as false for default behavior

### DIFF
--- a/src/components/Location/LocationCard.tsx
+++ b/src/components/Location/LocationCard.tsx
@@ -50,7 +50,7 @@ const LocationBreadcrumb = ({ location }: { location: LocationRead }) => {
 export function LocationCard({
   locationHistory,
   status,
-  keepBedActive = true,
+  keepBedActive = false,
   onKeepBedActiveChange,
 }: LocationCardProps) {
   const { t } = useTranslation();

--- a/src/components/Location/hooks/useLocationAssignment.ts
+++ b/src/components/Location/hooks/useLocationAssignment.ts
@@ -28,12 +28,12 @@ export function useLocationAssignment() {
     useState<LocationSheetState>(initialState);
   const [editingState, setEditingState] =
     useState<EditingState>(initialEditingState);
-  const [keepBedActive, setKeepBedActive] = useState(true);
+  const [keepBedActive, setKeepBedActive] = useState(false);
 
   const resetToInitial = () => {
     setSheetState(initialState);
     setEditingState(initialEditingState);
-    setKeepBedActive(true);
+    setKeepBedActive(false);
   };
 
   const resetEditingState = () => {


### PR DESCRIPTION
## Proposed Changes

- Fixes #14916 
- Keep bed hold as false for default behavior so user doesn't unknowingly link beds

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default state of the "keep bed active" option to be inactive, ensuring consistent default behavior across location management features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->