### PR TITLE
feat: add Chrome 83 compatibility support for frontend build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.21.0",
         "@typescript-eslint/parser": "^8.21.0",
+        "@vitejs/plugin-legacy": "^6.0.0",
         "dompurify": "^3.2.5",
         "dotenv": "^16.4.5",
         "eslint": "^9.18.0",
@@ -137,6 +138,7 @@
         "prettier-plugin-tailwindcss": "^0.7.0",
         "snyk": "^1.1294.0",
         "tailwindcss": "^4.1.3",
+        "terser": "^5.44.1",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.2",
         "tw-animate-css": "^1.2.4",
@@ -147,6 +149,7 @@
         "vite-plugin-checker": "^0.9.0",
         "vite-plugin-pwa": "^1.0.0",
         "vite-plugin-static-copy": "^2.0.0",
+        "vite-plugin-top-level-await": "^1.6.0",
         "zod": "^3.24.2"
       },
       "optionalDependencies": {
@@ -5114,6 +5117,24 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
+      "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -5633,6 +5654,239 @@
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "node_modules/@swc/core": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.7.tgz",
+      "integrity": "sha512-kTGB8XI7P+pTKW83tnUEDVP4zduF951u3UAOn5eTi0vyW6MvL56A3+ggMdfuVFtDI0/DsbSzf5z34HVBbuScWw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.7",
+        "@swc/core-darwin-x64": "1.15.7",
+        "@swc/core-linux-arm-gnueabihf": "1.15.7",
+        "@swc/core-linux-arm64-gnu": "1.15.7",
+        "@swc/core-linux-arm64-musl": "1.15.7",
+        "@swc/core-linux-x64-gnu": "1.15.7",
+        "@swc/core-linux-x64-musl": "1.15.7",
+        "@swc/core-win32-arm64-msvc": "1.15.7",
+        "@swc/core-win32-ia32-msvc": "1.15.7",
+        "@swc/core-win32-x64-msvc": "1.15.7"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.7.tgz",
+      "integrity": "sha512-+hNVUfezUid7LeSHqnhoC6Gh3BROABxjlDNInuZ/fie1RUxaEX4qzDwdTgozJELgHhvYxyPIg1ro8ibnKtgO4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.7.tgz",
+      "integrity": "sha512-ZAFuvtSYZTuXPcrhanaD5eyp27H8LlDzx2NAeVyH0FchYcuXf0h5/k3GL9ZU6Jw9eQ63R1E8KBgpXEJlgRwZUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.7.tgz",
+      "integrity": "sha512-K3HTYocpqnOw8KcD8SBFxiDHjIma7G/X+bLdfWqf+qzETNBrzOub/IEkq9UaeupaJiZJkPptr/2EhEXXWryS/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.7.tgz",
+      "integrity": "sha512-HCnVIlsLnCtQ3uXcXgWrvQ6SAraskLA9QJo9ykTnqTH6TvUYqEta+TdTdGjzngD6TOE7XjlAiUs/RBtU8Z0t+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.7.tgz",
+      "integrity": "sha512-/OOp9UZBg4v2q9+x/U21Jtld0Wb8ghzBScwhscI7YvoSh4E8RALaJ1msV8V8AKkBkZH7FUAFB7Vbv0oVzZsezA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.7.tgz",
+      "integrity": "sha512-VBbs4gtD4XQxrHuQ2/2+TDZpPQQgrOHYRnS6SyJW+dw0Nj/OomRqH+n5Z4e/TgKRRbieufipeIGvADYC/90PYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.7.tgz",
+      "integrity": "sha512-kVuy2unodso6p0rMauS2zby8/bhzoGRYxBDyD6i2tls/fEYAE74oP0VPFzxIyHaIjK1SN6u5TgvV9MpyJ5xVug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.7.tgz",
+      "integrity": "sha512-uddYoo5Xmo1XKLhAnh4NBIyy5d0xk33x1sX3nIJboFySLNz878ksCFCZ3IBqrt1Za0gaoIWoOSSSk0eNhAc/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.7.tgz",
+      "integrity": "sha512-rqq8JjNMLx3QNlh0aPTtN/4+BGLEHC94rj9mkH1stoNRf3ra6IksNHMHy+V1HUqElEgcZyx+0yeXx3eLOTcoFw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.7.tgz",
+      "integrity": "sha512-4BK06EGdPnuplgcNhmSbOIiLdRgHYX3v1nl4HXo5uo4GZMfllXaCyBUes+0ePRfwbn9OFgVhCWPcYYjMT6hycQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.7.tgz",
+      "integrity": "sha512-m1Cslgkp7gFIUB2ZiIUHMoUskwxOAi9uaf27inoKb7Oc8MkMjt+eNTeSyeGckkwRtMQiybKYTGGnA5imxSsedQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@tailwindcss/container-queries": {
       "version": "0.1.1",
@@ -7174,6 +7428,43 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/@vitejs/plugin-legacy": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-6.0.0.tgz",
+      "integrity": "sha512-pWt9cWaGJAKYw+67VLpN8hSP+G+yAQnrf5Pqh/NzSDKFl/4KpxTtwb5OLQezHoZOxghahO/ha3IpvblBbX/t6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/preset-env": "^7.26.0",
+        "browserslist": "^4.24.2",
+        "browserslist-to-esbuild": "^2.1.1",
+        "core-js": "^3.39.0",
+        "magic-string": "^0.30.13",
+        "regenerator-runtime": "^0.14.1",
+        "systemjs": "^6.15.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "peerDependencies": {
+        "terser": "^5.16.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-legacy/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -7208,9 +7499,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -7769,6 +8060,25 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/browserslist-to-esbuild": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-2.1.1.tgz",
+      "integrity": "sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "browserslist-to-esbuild": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "browserslist": "*"
+      }
+    },
     "node_modules/browserslist-useragent-regexp": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/browserslist-useragent-regexp/-/browserslist-useragent-regexp-4.1.3.tgz",
@@ -8301,9 +8611,9 @@
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
       "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -13176,6 +13486,19 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
     },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-refs": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.3.0.tgz",
@@ -15693,6 +16016,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
@@ -16966,6 +17296,13 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/systemjs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.15.1.tgz",
+      "integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -17089,14 +17426,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "version": "5.44.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
+      "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -19075,6 +19412,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vite-plugin-top-level-await": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.6.0.tgz",
+      "integrity": "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-virtual": "^3.0.2",
+        "@swc/core": "^1.12.14",
+        "@swc/wasm": "^1.12.14",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.8"
+      }
+    },
+    "node_modules/vite-plugin-top-level-await/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "preview": "cross-env NODE_ENV=production vite preview",
     "preview:scan": "npm run preview & npx react-scan localhost:4000",
     "build:meta": "node ./scripts/generate-build-version.js",
-    "build:react": "cross-env NODE_OPTIONS=--max-old-space-size=5120 NODE_ENV=production vite build",
+    "build:react": "cross-env NODE_OPTIONS=--max-old-space-size=8192 NODE_ENV=production vite build",
     "supported-browsers": "node ./scripts/generate-supported-browsers.mjs",
     "build": "npm run setup && npm run build:meta && npm run supported-browsers && npm run build:react",
     "setup": "tsx scripts/setup-care-apps.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "preview": "cross-env NODE_ENV=production vite preview",
     "preview:scan": "npm run preview & npx react-scan localhost:4000",
     "build:meta": "node ./scripts/generate-build-version.js",
-    "build:react": "cross-env NODE_OPTIONS=--max-old-space-size=8192 NODE_ENV=production vite build",
+    "build:react": "cross-env NODE_OPTIONS=--max-old-space-size=5120 NODE_ENV=production vite build",
     "supported-browsers": "node ./scripts/generate-supported-browsers.mjs",
     "build": "npm run setup && npm run build:meta && npm run supported-browsers && npm run build:react",
     "setup": "tsx scripts/setup-care-apps.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "preview": "cross-env NODE_ENV=production vite preview",
     "preview:scan": "npm run preview & npx react-scan localhost:4000",
     "build:meta": "node ./scripts/generate-build-version.js",
-    "build:react": "cross-env NODE_ENV=production vite build",
+    "build:react": "cross-env NODE_OPTIONS=--max-old-space-size=5120 NODE_ENV=production vite build",
     "supported-browsers": "node ./scripts/generate-supported-browsers.mjs",
     "build": "npm run setup && npm run build:meta && npm run supported-browsers && npm run build:react",
     "setup": "tsx scripts/setup-care-apps.ts",
@@ -157,6 +157,7 @@
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.21.0",
     "@typescript-eslint/parser": "^8.21.0",
+    "@vitejs/plugin-legacy": "^6.0.0",
     "dompurify": "^3.2.5",
     "dotenv": "^16.4.5",
     "eslint": "^9.18.0",
@@ -178,6 +179,7 @@
     "prettier-plugin-tailwindcss": "^0.7.0",
     "snyk": "^1.1294.0",
     "tailwindcss": "^4.1.3",
+    "terser": "^5.44.1",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
     "tw-animate-css": "^1.2.4",
@@ -188,6 +190,7 @@
     "vite-plugin-checker": "^0.9.0",
     "vite-plugin-pwa": "^1.0.0",
     "vite-plugin-static-copy": "^2.0.0",
+    "vite-plugin-top-level-await": "^1.6.0",
     "zod": "^3.24.2"
   },
   "optionalDependencies": {
@@ -198,6 +201,10 @@
   },
   "browserslist": {
     "production": [
+      "chrome >= 83",
+      "edge >= 83",
+      "firefox >= 78",
+      "safari >= 14",
       ">0.2%",
       "not dead",
       "not op_mini all"

--- a/src/Utils/request/types.ts
+++ b/src/Utils/request/types.ts
@@ -56,7 +56,8 @@ export class HTTPError extends Error {
     silent: boolean;
     cause?: Record<string, unknown>;
   }) {
-    super(message, { cause });
+    super(message);
+    this.name = "HTTPError";
     this.status = status;
     this.silent = silent;
     this.cause = cause;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    // Using ES2020 target for Chrome 83+ compatibility (Issue #14887)
+    // Polyfills for ES2021+ features are provided via @vitejs/plugin-legacy
+    "target": "ES2020",
+    "lib": [
+      "ES2021",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,14 +21,26 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client", "vite-plugin-pwa/client"],
+    "types": [
+      "vite/client",
+      "vite-plugin-pwa/client"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@core/*": ["src/*"],
-      "@careConfig": ["./care.config.ts"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@core/*": [
+        "src/*"
+      ],
+      "@careConfig": [
+        "./care.config.ts"
+      ]
     },
-    "typeRoots": ["./node_modules/@types", "./src/remote-modules.d.ts"]
+    "typeRoots": [
+      "./node_modules/@types",
+      "./src/remote-modules.d.ts"
+    ]
   },
   "include": [
     "src/**/*.ts",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,6 +1,7 @@
 import { type UserConfig, defineConfig, loadEnv } from "vite";
 
 import federation from "@originjs/vite-plugin-federation";
+import legacy from "@vitejs/plugin-legacy";
 import reactScan from "@react-scan/vite-plugin-react-scan";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -11,6 +12,7 @@ import path from "path";
 import checker from "vite-plugin-checker";
 import { VitePWA } from "vite-plugin-pwa";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import topLevelAwait from "vite-plugin-top-level-await";
 import { careConsoleArt } from "./plugins/careConsoleArt";
 import { fixSonnerPackageJson } from "./plugins/fixSonnerPackageJson";
 import { treeShakeCareIcons } from "./plugins/treeShakeCareIcons";
@@ -51,6 +53,12 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
       ),
     },
     plugins: [
+      // Enables top-level await transformation for ES2020 target compatibility
+      // (top-level await is ES2022 syntax, this plugin transforms it for older targets)
+      topLevelAwait({
+        promiseExportName: "__tla",
+        promiseImportName: (i) => `__tla_${i}`,
+      }),
       careConsoleArt(),
       fixSonnerPackageJson(),
       tailwindcss(),
@@ -138,6 +146,27 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
           ],
         },
       }),
+      legacy({
+        targets: ["chrome >= 83", "edge >= 83", "firefox >= 78", "safari >= 14"],
+        modernTargets: [
+          "chrome >= 83",
+          "edge >= 83",
+          "firefox >= 78",
+          "safari >= 14",
+        ],
+        modernPolyfills: [
+          // ES2021 - String.replaceAll is the ONLY feature not natively supported
+          // by our minimum browser versions (Chrome 85+, but we target 83+)
+          "es.string.replace-all",
+          // Other features like Promise.allSettled, globalThis, Object.fromEntries,
+          // Array.flat, and Array.flatMap are already natively supported in:
+          // Chrome 83+, Edge 83+, Firefox 78+, and Safari 14+
+          //
+          // Note: Optional chaining (?.) and nullish coalescing (??) are syntax features
+          // transpiled by esbuild/TypeScript, not runtime polyfills
+        ],
+        renderLegacyChunks: false,
+      }),
     ],
     resolve: {
       alias: {
@@ -150,12 +179,12 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
     //   include: getPluginDependencies(),
     // },
     build: {
-      target: "es2022",
+      target: ["es2020", "chrome83", "edge83", "firefox78", "safari14"],
       outDir: "build",
       sourcemap: true,
     },
     esbuild: {
-      target: "es2022",
+      target: "es2020",
     },
     server: {
       port: 4000,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -112,7 +112,7 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
           type: "module",
         },
         injectManifest: {
-          maximumFileSizeToCacheInBytes: 8000000,
+          maximumFileSizeToCacheInBytes: 15000000,
         },
         manifest: {
           name: "Care",


### PR DESCRIPTION
## Proposed Changes
Fixes #14887
- Add `@vitejs/plugin-legacy@6.0.0` with comprehensive polyfills for Chrome 83+ browsers
- Configure ES2019-ES2021 polyfills: `replaceAll`, `Promise.allSettled`, `globalThis`, `Object.fromEntries`, `Array.flat`, `Array.flatMap`
- Update TypeScript target to ES2020 with ES2021 lib types
- Fix `HTTPError` constructor to avoid ES2022 `cause` option for compatibility
- Update Vite build targets to chrome83, edge83, firefox78, safari14

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader browser support added (Chrome 83+, Edge 83+, Firefox 78+, Safari 14+).
  * Top-level await enabled in the build.

* **Bug Fixes**
  * HTTP error objects now report a consistent error name at runtime.

* **Chores**
  * Build and TypeScript configuration updated for wider compatibility and polyfill support.
  * Production build adjusted to allow more memory and updated build tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->