### PR TITLE
Swap payment_datetime and reference_number fields in PaymentReconciliationSheet

### DIFF
--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -520,27 +520,6 @@ export function PaymentReconciliationSheet({
 
               <FormField
                 control={form.control}
-                name="payment_datetime"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-gray-950">
-                      {t("payment_date")}
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        type="datetime-local"
-                        {...field}
-                        value={field.value ? field.value : ""}
-                        max={format(new Date(), "yyyy-MM-dd'T'HH:mm")}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
                 name="reference_number"
                 render={({ field }) => (
                   <FormItem>
@@ -556,6 +535,27 @@ export function PaymentReconciliationSheet({
                     <FormDescription className="text-gray-700 italic -mt-1.5">
                       {!isCashPayment && t("reference_number_description")}
                     </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="payment_datetime"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-gray-950">
+                      {t("payment_date")}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="datetime-local"
+                        {...field}
+                        value={field.value ? field.value : ""}
+                        max={format(new Date(), "yyyy-MM-dd'T'HH:mm")}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}


### PR DESCRIPTION
## Proposed Changes

Fixes #14931
<img width="1317" height="812" alt="image" src="https://github.com/user-attachments/assets/842e9300-5fbc-4855-9e7d-7ea3252bbdb5" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected form field order and input types in the payment reconciliation form, ensuring reference number accepts text input and payment date enforces a maximum date constraint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->