### PR TITLE
Added keyboard shortcut in Specimen Collection page

### DIFF
--- a/src/components/ui/sidebar/facility/location/location-switcher.tsx
+++ b/src/components/ui/sidebar/facility/location/location-switcher.tsx
@@ -126,9 +126,9 @@ export function LocationSelectorDialog({
   onLocationSelect?: (location: LocationRead) => void;
 }) {
   const { t } = useTranslation();
-  const shortcuts = useShortcutSubContext(
-    open ? "patient:search:-global" : undefined,
-  );
+  useShortcutSubContext(open ? "patient:search:-global" : undefined, {
+    ignoreInputFields: open,
+  });
   const [locationLevel, setLocationLevel] = useState<LocationRead[]>([]);
   const [searchValue, setSearchValue] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
@@ -136,15 +136,6 @@ export function LocationSelectorDialog({
   const path = usePath();
   const subPath =
     path?.match(/\/facility\/[^/]+\/locations\/[^/]+\/(.*)/)?.[1] || "";
-
-  useEffect(() => {
-    if (open) {
-      shortcuts.setIgnoreInputFields(true);
-    }
-    return () => {
-      shortcuts.setIgnoreInputFields(false);
-    };
-  }, [open, shortcuts]);
 
   const currentParentId = locationLevel.length
     ? locationLevel[locationLevel.length - 1].id

--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -80,8 +80,7 @@
     { "key": "r", "action": "record-payment", "description": "Record Payment", "when": "always" },
     { "key": "p", "action": "print-invoice", "description": "Print Invoice", "when": "always" },
     { "key": "s", "action": "navigate-to-source", "description": "Navigate to Source", "when": "always" },
-    { "key": "v", "action": "view-invoice-payment", "description": "View Invoice", "when": "always" },
-    { "key": "a", "action": "view-account", "description": "View Account", "when": "always" }
+    { "key": "v", "action": "view-invoice-payment", "description": "View Invoice", "when": "always" }
   ],
 
   "facility:account:show": [

--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -115,7 +115,10 @@
     { "key": "l", "action": "load-from-order", "description": "Load from Order", "when": "always" }
   ],
   "facility:service": [
-    { "key": "s", "action": "scan-button", "description": "Scan the QR code", "when": "always" }
+    { "key": "s", "action": "scan-button", "description": "Scan the QR code", "when": "always" },
+    { "key": "c", "action": "collect-specimen", "description": "Collect Specimen", "when": "always" },
+    { "key": "m", "action": "mark-as-complete", "description": "Mark as Complete", "when": "always" },
+    { "key": "r", "action": "view-report", "description": "View Report", "when": "always" }
   ],
 
   "encounter": [

--- a/src/context/ShortcutContext.tsx
+++ b/src/context/ShortcutContext.tsx
@@ -196,8 +196,31 @@ export function useShortcutDisplay() {
  * This is a one-liner alternative to manually managing sub-contexts.
  *
  * @param subContext - The sub-context to set (e.g., "facility:appointment:detail")
+ * @param options - Optional configuration
+ * @param options.ignoreInputFields - Whether shortcuts should run even when input fields are focused
+ *
+ * @example
+ * // Basic usage with just sub-context
+ * useShortcutSubContext("patient:search:-global");
+ *
+ * @example
+ * // With ignoreInputFields for dialogs/modals
+ * const [open, setOpen] = useState(false);
+ * useShortcutSubContext(
+ *   open ? "patient:search:-global" : undefined,
+ *   { ignoreInputFields: open }
+ * );
+ *
+ * @example
+ * // Always ignore input fields (e.g., for search pages)
+ * useShortcutSubContext("patient:search:-global", { ignoreInputFields: true });
  */
-export function useShortcutSubContext(subContext?: string) {
+export function useShortcutSubContext(
+  subContext?: string,
+  options?: {
+    ignoreInputFields?: boolean;
+  },
+) {
   const shortcuts = useShortcuts();
 
   // Set sub-context if provided
@@ -207,6 +230,13 @@ export function useShortcutSubContext(subContext?: string) {
       return () => shortcuts.setSubContext(undefined);
     }
   }, [subContext, shortcuts]);
+
+  useEffect(() => {
+    if (options?.ignoreInputFields !== undefined) {
+      shortcuts.setIgnoreInputFields(options.ignoreInputFields);
+      return () => shortcuts.setIgnoreInputFields(false);
+    }
+  }, [options?.ignoreInputFields, shortcuts]);
 
   return shortcuts;
 }

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
@@ -52,6 +52,7 @@ import {
 import specimenApi from "@/types/emr/specimen/specimenApi";
 import { SpecimenDefinitionRead } from "@/types/emr/specimenDefinition/specimenDefinition";
 
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import { PatientHeader } from "@/components/Patient/PatientHeader";
 import { DiagnosticReportForm } from "./components/DiagnosticReportForm";
 import { DiagnosticReportReview } from "./components/DiagnosticReportReview";
@@ -333,6 +334,7 @@ export default function ServiceRequestShow({
                           className="font-semibold border border-gray-400"
                         >
                           {t("mark_as_complete")}
+                          <ShortcutBadge actionId="mark-as-complete" />
                         </Button>
                       </AlertDialogTrigger>
                       <AlertDialogContent>
@@ -350,6 +352,7 @@ export default function ServiceRequestShow({
                             onClick={() => completeServiceRequest({})}
                           >
                             {t("confirm")}
+                            <ShortcutBadge actionId="enter-action" />
                           </AlertDialogAction>
                         </AlertDialogFooter>
                       </AlertDialogContent>
@@ -367,6 +370,7 @@ export default function ServiceRequestShow({
                       }
                     >
                       {t("view_report")}
+                      <ShortcutBadge actionId="view-report" />
                     </Button>
                   )}
                 </div>

--- a/src/pages/Facility/services/serviceRequests/components/ProcessSpecimen.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/ProcessSpecimen.tsx
@@ -16,13 +16,15 @@ import { Textarea } from "@/components/ui/textarea";
 
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
-import { formatName } from "@/Utils/utils";
+import { useShortcutSubContext } from "@/context/ShortcutContext";
 import { Code } from "@/types/base/code/code";
 import { DiagnosticReportRead } from "@/types/emr/diagnosticReport/diagnosticReport";
 import {
   ProcessingReadSpec,
   ProcessingSpec,
 } from "@/types/emr/specimen/specimen";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+import { formatName } from "@/Utils/utils";
 
 interface ProcessSpecimenProps {
   onAddProcessing: (processing: ProcessingSpec) => void;
@@ -50,6 +52,13 @@ export function ProcessSpecimen({
     description: "",
     method: null,
   });
+
+  useShortcutSubContext(
+    noteDialog.open ? "patient:search:-global" : undefined,
+    {
+      ignoreInputFields: noteDialog.open,
+    },
+  );
 
   const handleSelectStep = (code: Code | null) => {
     if (!code) return;
@@ -246,6 +255,7 @@ export function ProcessSpecimen({
             </Button>
             <Button type="button" onClick={handleUpdateNote}>
               {noteDialog.index === -1 ? t("add") : t("update")}
+              <ShortcutBadge actionId="submit-action" />
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
@@ -21,7 +21,6 @@ import SpecimenIDScanDialog from "@/components/Scan/SpecimenIDScanDialog";
 // Change to default import
 import useAuthUser from "@/hooks/useAuthUser";
 
-import mutate from "@/Utils/request/mutate";
 import { Code } from "@/types/base/code/code";
 import {
   CollectionSpec,
@@ -31,6 +30,8 @@ import {
 } from "@/types/emr/specimen/specimen";
 import specimenApi from "@/types/emr/specimen/specimenApi";
 import type { SpecimenDefinitionRead } from "@/types/emr/specimenDefinition/specimenDefinition";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+import mutate from "@/Utils/request/mutate";
 
 interface SpecimenFormProps {
   specimenDefinition: SpecimenDefinitionRead;
@@ -534,6 +535,7 @@ export function SpecimenForm({
               </Button>
               <Button type="submit" disabled={disableEdit || isPending}>
                 {t("collect")}
+                <ShortcutBadge actionId="submit-action" />
               </Button>
             </div>
           </div>

--- a/src/pages/Facility/services/serviceRequests/components/SpecimenWorkflowCard.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/SpecimenWorkflowCard.tsx
@@ -65,10 +65,9 @@ import {
 import { Avatar } from "@/components/Common/Avatar";
 import { PrintableQRCode } from "@/components/PrintableQRCode";
 
+import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useAuthUser from "@/hooks/useAuthUser";
 
-import mutate from "@/Utils/request/mutate";
-import { formatName } from "@/Utils/utils";
 import { ProcessSpecimen } from "@/pages/Facility/services/serviceRequests/components/ProcessSpecimen";
 import {
   EDITABLE_SERVICE_REQUEST_STATUSES,
@@ -83,6 +82,9 @@ import {
 } from "@/types/emr/specimen/specimen";
 import specimenApi from "@/types/emr/specimen/specimenApi";
 import { SpecimenDefinitionRead } from "@/types/emr/specimenDefinition/specimenDefinition";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+import mutate from "@/Utils/request/mutate";
+import { formatName } from "@/Utils/utils";
 
 // --- Helper function (keep or move to utils) ---
 function formatQuantity(quantity: any): string {
@@ -112,6 +114,8 @@ export function SpecimenWorkflowCard({
   onCollect,
   request,
 }: SpecimenWorkflowCardProps) {
+  useShortcutSubContext("facility:service");
+
   const queryClient = useQueryClient();
   const authUser = useAuthUser();
   const currentUserId = authUser.id;
@@ -452,6 +456,7 @@ export function SpecimenWorkflowCard({
                 >
                   <Plus className="size-4" />
                   {t("collect_specimen")}
+                  <ShortcutBadge actionId="collect-specimen" />
                 </Button>
               </div>
             )}


### PR DESCRIPTION
## Proposed Changes

Fixes #14937
Fixes #14944

<img width="1245" height="571" alt="image" src="https://github.com/user-attachments/assets/f0052c66-52cf-448e-b98f-dde3eb318174" />




Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut indicator badges across specimen and service UI (note dialog, submit buttons, collect/complete/report actions).

* **Updates**
  * Shortcut configuration now respects dialog/modal open state so shortcuts behave correctly when dialogs are open.
  * Removed the "a" shortcut for View Account in facility billing; the "v" shortcut for invoice payment remains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->