### PR TITLE
feat: integrate DispenseButton into DispenseHistory

### DIFF
--- a/src/components/Consumable/DispenseButton.tsx
+++ b/src/components/Consumable/DispenseButton.tsx
@@ -24,10 +24,12 @@ export const DispenseButton = ({
   open,
   setOpen,
   facilityId,
+  onSuccess,
 }: {
   open: boolean;
   setOpen: (open: boolean) => void;
   facilityId: string;
+  onSuccess?: () => void;
 }) => {
   const [location, setLocation] = useState<LocationRead | undefined>(undefined);
   const [showDrawer, setShowDrawer] = useState(false);
@@ -105,6 +107,7 @@ export const DispenseButton = ({
           }}
           onDispenseComplete={async (chargeItems: ChargeItemRead[]) => {
             setShowDrawer(false);
+            onSuccess?.();
 
             if (!careConfig.enableAutoInvoiceAfterDispense) {
               return;

--- a/src/components/Consumable/DispenseButton.tsx
+++ b/src/components/Consumable/DispenseButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import careConfig from "@careConfig";
 
@@ -24,12 +24,10 @@ export const DispenseButton = ({
   open,
   setOpen,
   facilityId,
-  onSuccess,
 }: {
   open: boolean;
   setOpen: (open: boolean) => void;
   facilityId: string;
-  onSuccess?: () => void;
 }) => {
   const [location, setLocation] = useState<LocationRead | undefined>(undefined);
   const [showDrawer, setShowDrawer] = useState(false);
@@ -39,6 +37,7 @@ export const DispenseButton = ({
   >([]);
   const [accountId, setAccountId] = useState<string | undefined>(undefined);
   const { selectedEncounter } = useEncounter();
+  const queryClient = useQueryClient();
 
   const { refetch: refetchAccount } = useQuery({
     queryKey: ["accounts", selectedEncounter?.patient.id],
@@ -107,18 +106,27 @@ export const DispenseButton = ({
           }}
           onDispenseComplete={async (chargeItems: ChargeItemRead[]) => {
             setShowDrawer(false);
-            onSuccess?.();
 
-            if (!careConfig.enableAutoInvoiceAfterDispense) {
-              return;
-            }
-            setExtractedChargeItems(chargeItems);
-            const result = await refetchAccount();
-            const fetchedAccountId = result.data?.results?.[0]?.id;
+            queryClient.invalidateQueries({
+              queryKey: [
+                "medication_dispense",
+                selectedEncounter.patient.id,
+                selectedEncounter.id,
+              ],
+            });
 
-            if (fetchedAccountId) {
-              setAccountId(fetchedAccountId);
-              setIsInvoiceSheetOpen(true);
+            if (
+              careConfig.enableAutoInvoiceAfterDispense &&
+              chargeItems.length > 0
+            ) {
+              setExtractedChargeItems(chargeItems);
+              const result = await refetchAccount();
+              const fetchedAccountId = result.data?.results?.[0]?.id;
+
+              if (fetchedAccountId) {
+                setAccountId(fetchedAccountId);
+                setIsInvoiceSheetOpen(true);
+              }
             }
           }}
         />

--- a/src/components/Consumable/DispenseDrawer.tsx
+++ b/src/components/Consumable/DispenseDrawer.tsx
@@ -250,7 +250,7 @@ export default function DispenseDrawer({
         response as ChargeItemBatchResponse,
       );
 
-      if (chargeItems.length > 0 && onDispenseComplete) {
+      if (onDispenseComplete) {
         onDispenseComplete(chargeItems);
       } else {
         onOpenChange(false);

--- a/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
+++ b/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "raviger";
+import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Badge } from "@/components/ui/badge";
@@ -14,7 +15,8 @@ import {
 } from "@/components/ui/table";
 
 import Loading from "@/components/Common/Loading";
-import { EmptyState } from "@/components/Medicine/MedicationRequestTable";
+import { DispenseButton } from "@/components/Consumable/DispenseButton";
+import { EmptyState } from "@/components/ui/empty-state";
 
 import query from "@/Utils/request/query";
 import { formatDateTime } from "@/Utils/utils";
@@ -25,11 +27,56 @@ import {
   MedicationDispenseStatus,
 } from "@/types/emr/medicationDispense/medicationDispense";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
+import { Plus, TabletsIcon } from "lucide-react";
+
+interface DispenseButtonSectionProps {
+  canWrite: boolean;
+  facilityId?: string;
+  isDispenseOpen: boolean;
+  setIsDispenseOpen: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+function DispenseButtonSection({
+  canWrite,
+  facilityId,
+  isDispenseOpen,
+  setIsDispenseOpen,
+  onSuccess,
+}: DispenseButtonSectionProps) {
+  const { t } = useTranslation();
+
+  if (!canWrite) return null;
+
+  return (
+    <>
+      <div className="mb-4 flex justify-end">
+        <Button
+          variant="outline"
+          onClick={() => setIsDispenseOpen(true)}
+          disabled={!facilityId}
+        >
+          <Plus className="mr-2" />
+          {t("dispense")}
+        </Button>
+      </div>
+      {facilityId && (
+        <DispenseButton
+          open={isDispenseOpen}
+          setOpen={setIsDispenseOpen}
+          facilityId={facilityId}
+          onSuccess={onSuccess}
+        />
+      )}
+    </>
+  );
+}
 
 interface Props {
   patientId: string;
   encounterId: string;
   canAccess: boolean;
+  canWrite: boolean;
   facilityId?: string;
 }
 
@@ -38,11 +85,14 @@ export function DispenseHistory({
   encounterId,
   facilityId,
   canAccess,
+  canWrite,
 }: Props) {
   const { t } = useTranslation();
+  const [isDispenseOpen, setIsDispenseOpen] = useState(false);
+  const queryClient = useQueryClient();
 
   const { data: response, isLoading } = useQuery({
-    queryKey: ["medication_dispense", patientId],
+    queryKey: ["medication_dispense", patientId, encounterId],
     queryFn: query(medicationDispenseApi.list, {
       queryParams: {
         encounter: encounterId,
@@ -55,6 +105,13 @@ export function DispenseHistory({
 
   const medications = response?.results || [];
 
+  const handleDispenseComplete = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: ["medication_dispense", patientId, encounterId],
+    });
+    setIsDispenseOpen(false);
+  }, [queryClient, patientId, encounterId]);
+
   if (isLoading) {
     return (
       <div className="min-h-[200px] flex items-center justify-center">
@@ -64,94 +121,120 @@ export function DispenseHistory({
   }
 
   if (!medications.length) {
-    return <EmptyState message={t("no_dispense_history")} />;
+    return (
+      <EmptyState
+        icon={<TabletsIcon className="text-gray-500" />}
+        title={t("no_dispense_history")}
+        action={
+          <DispenseButtonSection
+            canWrite={canWrite}
+            facilityId={facilityId}
+            isDispenseOpen={isDispenseOpen}
+            setIsDispenseOpen={setIsDispenseOpen}
+            onSuccess={handleDispenseComplete}
+          />
+        }
+        className="h-full"
+      />
+    );
   }
 
   return (
-    <div className="overflow-hidden rounded-md border-2 border-white shadow-md">
-      <Table>
-        <TableHeader className="bg-gray-100 text-gray-700">
-          <TableRow className="divide-x">
-            <TableHead className="text-gray-700">{t("medicine")}</TableHead>
-            <TableHead className="text-gray-700">{t("dosage")}</TableHead>
-            <TableHead className="text-gray-700">{t("frequency")}</TableHead>
-            <TableHead className="text-gray-700">{t("quantity")}</TableHead>
-            <TableHead className="text-gray-700">{t("location")}</TableHead>
-            <TableHead className="text-gray-700">{t("status")}</TableHead>
-            <TableHead className="text-gray-700">{t("bill_time")}</TableHead>
-            <TableHead className="text-gray-700">{t("actions")}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="bg-white">
-          {medications.map((medication: MedicationDispenseRead) => {
-            const instruction = medication.dosage_instruction[0] ?? {};
-            const frequency = instruction?.timing?.code;
-            const dosage = instruction?.dose_and_rate?.dose_quantity;
+    <>
+      <DispenseButtonSection
+        canWrite={canWrite}
+        facilityId={facilityId}
+        isDispenseOpen={isDispenseOpen}
+        setIsDispenseOpen={setIsDispenseOpen}
+        onSuccess={handleDispenseComplete}
+      />
 
-            return (
-              <TableRow
-                key={medication.id}
-                className="hover:bg-gray-50 divide-x"
-              >
-                <TableCell className="text-gray-950 font-semibold">
-                  {medication.item.product.product_knowledge.name}
-                </TableCell>
-                <TableCell className="text-gray-950">
-                  {dosage ? `${dosage.value} ${dosage.unit.display}` : "-"}
-                </TableCell>
-                <TableCell className="text-gray-950">
-                  {instruction?.as_needed_boolean
-                    ? `${t("as_needed_prn")} ${
-                        instruction?.as_needed_for?.display
-                          ? `(${instruction.as_needed_for.display})`
-                          : ""
-                      }`
-                    : frequency?.display || "-"}
-                </TableCell>
-                <TableCell className="text-gray-950 font-medium">
-                  {medication.quantity || "-"}
-                </TableCell>
-                <TableCell className="text-gray-950 font-medium">
-                  {medication.location.name}
-                  {medication.location.id !== medication.item.location.id &&
-                    ` (${medication.item.location.name})`}
-                </TableCell>
-                <TableCell className="text-gray-950">
-                  <Badge
-                    variant={
-                      MEDICATION_DISPENSE_STATUS_COLORS[medication.status]
-                    }
-                  >
-                    {t(medication.status)}
-                  </Badge>
-                </TableCell>
-                <TableCell className="text-gray-950">
-                  {formatDateTime(
-                    medication.when_prepared.toString(),
-                    "hh:mm A, DD/MM/YYYY",
-                  )}
-                </TableCell>
-                <TableCell>
-                  {medication.status !== MedicationDispenseStatus.completed && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      asChild
-                      disabled={!facilityId}
+      <div className="overflow-hidden rounded-md border-2 border-white shadow-md">
+        <Table>
+          <TableHeader className="bg-gray-100 text-gray-700">
+            <TableRow className="divide-x">
+              <TableHead className="text-gray-700">{t("medicine")}</TableHead>
+              <TableHead className="text-gray-700">{t("dosage")}</TableHead>
+              <TableHead className="text-gray-700">{t("frequency")}</TableHead>
+              <TableHead className="text-gray-700">{t("quantity")}</TableHead>
+              <TableHead className="text-gray-700">{t("location")}</TableHead>
+              <TableHead className="text-gray-700">{t("status")}</TableHead>
+              <TableHead className="text-gray-700">{t("bill_time")}</TableHead>
+              <TableHead className="text-gray-700">{t("actions")}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody className="bg-white">
+            {medications.map((medication: MedicationDispenseRead) => {
+              const instruction = medication.dosage_instruction[0] ?? {};
+              const frequency = instruction?.timing?.code;
+              const dosage = instruction?.dose_and_rate?.dose_quantity;
+
+              return (
+                <TableRow
+                  key={medication.id}
+                  className="hover:bg-gray-50 divide-x"
+                >
+                  <TableCell className="text-gray-950 font-semibold">
+                    {medication.item.product.product_knowledge.name}
+                  </TableCell>
+                  <TableCell className="text-gray-950">
+                    {dosage ? `${dosage.value} ${dosage.unit.display}` : "-"}
+                  </TableCell>
+                  <TableCell className="text-gray-950">
+                    {instruction?.as_needed_boolean
+                      ? `${t("as_needed_prn")} ${
+                          instruction?.as_needed_for?.display
+                            ? `(${instruction.as_needed_for.display})`
+                            : ""
+                        }`
+                      : frequency?.display || "-"}
+                  </TableCell>
+                  <TableCell className="text-gray-950 font-medium">
+                    {medication.quantity || "-"}
+                  </TableCell>
+                  <TableCell className="text-gray-950 font-medium">
+                    {medication.location.name}
+                    {medication.location.id !== medication.item.location.id &&
+                      ` (${medication.item.location.name})`}
+                  </TableCell>
+                  <TableCell className="text-gray-950">
+                    <Badge
+                      variant={
+                        MEDICATION_DISPENSE_STATUS_COLORS[medication.status]
+                      }
                     >
-                      <Link
-                        href={`/facility/${facilityId}/locations/${medication.location.id}/medication_dispense/patient/${patientId}/${medication.status}?payment_status=${medication.charge_item?.paid_invoice?.status === InvoiceStatus.balanced ? "paid" : "unpaid"}`}
+                      {t(medication.status)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-gray-950">
+                    {formatDateTime(
+                      medication.when_prepared.toString(),
+                      "hh:mm A, DD/MM/YYYY",
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {medication.status !==
+                      MedicationDispenseStatus.completed && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        asChild
+                        disabled={!facilityId}
                       >
-                        {t("dispense")}
-                      </Link>
-                    </Button>
-                  )}
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                        <Link
+                          href={`/facility/${facilityId}/locations/${medication.location.id}/medication_dispense/patient/${patientId}/${medication.status}?payment_status=${medication.charge_item?.paid_invoice?.status === InvoiceStatus.balanced ? "paid" : "unpaid"}`}
+                        >
+                          {t("dispense")}
+                        </Link>
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   );
 }

--- a/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
+++ b/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
@@ -1,6 +1,6 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "raviger";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Badge } from "@/components/ui/badge";
@@ -34,7 +34,6 @@ interface DispenseButtonSectionProps {
   facilityId?: string;
   isDispenseOpen: boolean;
   setIsDispenseOpen: (open: boolean) => void;
-  onSuccess: () => void;
 }
 
 function DispenseButtonSection({
@@ -42,7 +41,6 @@ function DispenseButtonSection({
   facilityId,
   isDispenseOpen,
   setIsDispenseOpen,
-  onSuccess,
 }: DispenseButtonSectionProps) {
   const { t } = useTranslation();
 
@@ -65,7 +63,6 @@ function DispenseButtonSection({
           open={isDispenseOpen}
           setOpen={setIsDispenseOpen}
           facilityId={facilityId}
-          onSuccess={onSuccess}
         />
       )}
     </>
@@ -89,7 +86,6 @@ export function DispenseHistory({
 }: Props) {
   const { t } = useTranslation();
   const [isDispenseOpen, setIsDispenseOpen] = useState(false);
-  const queryClient = useQueryClient();
 
   const { data: response, isLoading } = useQuery({
     queryKey: ["medication_dispense", patientId, encounterId],
@@ -104,13 +100,6 @@ export function DispenseHistory({
   });
 
   const medications = response?.results || [];
-
-  const handleDispenseComplete = useCallback(() => {
-    queryClient.invalidateQueries({
-      queryKey: ["medication_dispense", patientId, encounterId],
-    });
-    setIsDispenseOpen(false);
-  }, [queryClient, patientId, encounterId]);
 
   if (isLoading) {
     return (
@@ -131,7 +120,6 @@ export function DispenseHistory({
             facilityId={facilityId}
             isDispenseOpen={isDispenseOpen}
             setIsDispenseOpen={setIsDispenseOpen}
-            onSuccess={handleDispenseComplete}
           />
         }
         className="h-full"
@@ -146,7 +134,6 @@ export function DispenseHistory({
         facilityId={facilityId}
         isDispenseOpen={isDispenseOpen}
         setIsDispenseOpen={setIsDispenseOpen}
-        onSuccess={handleDispenseComplete}
       />
 
       <div className="overflow-hidden rounded-md border-2 border-white shadow-md">

--- a/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
+++ b/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
@@ -206,7 +206,7 @@ export function DispenseHistory({
                         variant="outline"
                         size="sm"
                         asChild
-                        disabled={!facilityId}
+                        hidden={!facilityId}
                       >
                         <Link
                           href={`/facility/${facilityId}/locations/${medication.location.id}/medication_dispense/patient/${patientId}/${medication.status}?payment_status=${medication.charge_item?.paid_invoice?.status === InvoiceStatus.balanced ? "paid" : "unpaid"}`}

--- a/src/components/Medicine/MedicationRequestTable/index.tsx
+++ b/src/components/Medicine/MedicationRequestTable/index.tsx
@@ -170,6 +170,7 @@ export default function MedicationRequestTable() {
             encounterId={encounterId}
             canAccess={canAccess}
             facilityId={facilityId}
+            canWrite={canWrite}
           />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Proposed Changes

- integrate DispenseButton into DispenseHistory
- invalidate Queries

Fixes #14969 
<img width="1245" height="571" alt="image" src="https://github.com/user-attachments/assets/50485edf-8858-4217-8514-1611440bba5e" />
<img width="1245" height="571" alt="image" src="https://github.com/user-attachments/assets/40a51952-4038-48de-9fdf-128d1ca175cc" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permission-based access control for dispensing actions.
  * Dedicated dispense UI section and explicit dispense action in empty state.
  * Facility-aware dispense navigation preserved.

* **Bug Fixes / Behavior Changes**
  * Dispense history now refreshes and is scoped by encounter.
  * History refresh uses query invalidation for more reliable updates.
  * Auto-invoice flow tightened to require valid invoice conditions.
  * Completion callback may now be invoked even when no charge items are present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->