### PR TITLE
Fixed the swapped icons for Edit Form and Form Preview buttons

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -974,11 +974,11 @@ export default function QuestionnaireEditor({
       >
         <TabsList className="mb-4">
           <TabsTrigger value="edit">
-            <ViewIcon className="size-4" />
+            <SquarePenIcon className="size-4" />
             {t("edit_form")}
           </TabsTrigger>
           <TabsTrigger value="preview">
-            <SquarePenIcon className="size-4" />
+            <ViewIcon className="size-4" />
             {t("form_preview")}
           </TabsTrigger>
         </TabsList>


### PR DESCRIPTION
## Proposed Changes

Fixes #14950 

The icons for "Edit Form" and "Form Preview" buttons in the Questionnaire Editor were swapped. This PR corrects the assignment:

- Edit Form now uses SquarePenIcon (Pen icon).
- Form Preview now uses ViewIcon (Eye icon).

Tagging: @ohcnetwork/care-fe-code-reviewers

## Screenshots:
<img width="882" height="474" alt="Screenshot 2025-12-30 at 7 15 16 PM" src="https://github.com/user-attachments/assets/d7430f03-664a-4e65-a419-9377e39725ae" />

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Swapped the icons used in the questionnaire editor tabs so the edit tab now shows a pen-style icon and the preview tab shows a view-style icon for clearer visual cues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->