### PR TITLE
fix: questionnaire search in encounter actions

### DIFF
--- a/src/components/Encounter/EncounterCommandDialog.tsx
+++ b/src/components/Encounter/EncounterCommandDialog.tsx
@@ -373,8 +373,8 @@ export function EncounterCommandDialog({
               <CommandGroup heading={group.group} className="px-2">
                 {group.items.map((action) => (
                   <CommandItem
-                    key={action.id}
-                    value={`${action.id} ${action.label}`}
+                    key={`${group.group}-${action.id}`}
+                    value={`${group.group} ${action.id} ${action.label}`}
                     onSelect={() => handleSelect(action.id)}
                     className="rounded-md cursor-pointer hover:bg-gray-100 flex justify-between aria-selected:bg-gray-100"
                     autoFocus={false}

--- a/src/hooks/useEncounterShortcuts.ts
+++ b/src/hooks/useEncounterShortcuts.ts
@@ -156,6 +156,12 @@ export function useEncounterShortcuts() {
       const handler = handlers[actionId];
       if (handler) {
         handler();
+        return;
+      }
+
+      if (actionId.startsWith("questionnaire-") && encounter) {
+        const slug = actionId.replace("questionnaire-", "");
+        navigate(buildEncounterUrl(`/questionnaire/${slug}`));
       }
     },
     [handlers],


### PR DESCRIPTION
## Proposed Changes

Fixes #15008 
Fixes #15011
Fixes https://github.com/ohcnetwork/design/issues/60
- When a questionnaire is selected from the search results, it opens

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Questionnaire shortcuts now properly route to the corresponding questionnaire when used within an encounter context, even if no other handler matches.

* **Refactor**
  * Encounter command list items now include group context to prevent duplicate entries and make selections clearer to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->