### PR TITLE
feat: add report date and requester fields to diagnostic report

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -4300,6 +4300,7 @@
   "report_builder_title": "Report Template Builder",
   "report_builder_will_be_generated": "Report for template: {{reportSlug}} will be generated shortly.",
   "report_created_by": "Report created by",
+  "report_date": "Report Date",
   "report_details": "Report Details",
   "report_generation_failed": "Failed to generate report",
   "report_generation_started": "Report generation started successfully",

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
@@ -10,10 +10,11 @@ import PrintPreview from "@/CAREUI/misc/PrintPreview";
 
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
-import { formatName } from "@/Utils/utils";
+import { formatName, formatPatientAge } from "@/Utils/utils";
 import diagnosticReportApi from "@/types/emr/diagnosticReport/diagnosticReportApi";
 import { FileReadMinimal } from "@/types/files/file";
 import fileApi from "@/types/files/fileApi";
+import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 
 import { ObservationStatus } from "@/types/emr/observation/observation";
 import { DiagnosticReportResultsTable } from "./components/DiagnosticReportResultsTable";
@@ -175,45 +176,67 @@ export default function DiagnosticReportPrint({
           </div>
 
           {/* Patient Details */}
-          <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
-            <div className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center">
+          <div className="mt-6 grid md:grid-cols-2 print:grid-cols-2 gap-x-6 gap-y-1">
+            <div className="grid grid-cols-[6rem_auto_1fr] items-center">
               <span className="text-gray-600">{t("patient")}</span>
               <span className="text-gray-600">:</span>
-              <span className="font-semibold break-words">
+              <span className="font-semibold ml-2 wrap-break-word">
                 {report.encounter?.patient?.name}
               </span>
             </div>
-            <div className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center">
+            {report.encounter?.patient &&
+              "instance_identifiers" in report.encounter.patient &&
+              report.encounter.patient.instance_identifiers
+                .filter(
+                  ({ config }) =>
+                    config.config.use === PatientIdentifierUse.official,
+                )
+                .map((identifier) => (
+                  <div
+                    key={identifier.config.id}
+                    className="grid grid-cols-[6rem_auto_1fr] items-center"
+                  >
+                    <span className="text-gray-600">
+                      {identifier.config.config.display}
+                    </span>
+                    <span className="text-gray-600">:</span>
+                    <span className="font-semibold ml-2">
+                      {identifier.value}
+                    </span>
+                  </div>
+                ))}
+            <div className="grid grid-cols-[6rem_auto_1fr] items-center">
+              <span className="text-gray-600">
+                {t("age")} / {t("sex")}
+              </span>
+              <span className="text-gray-600">:</span>
+              <span className="font-semibold ml-2">
+                {formatPatientAge(report.encounter.patient, true)} /
+                <span className="capitalize ml-1">
+                  {t(`GENDER__${report.encounter.patient.gender}`)}
+                </span>
+              </span>
+            </div>
+            <div className="grid grid-cols-[6rem_auto_1fr] items-center">
               <span className="text-gray-600">{t("category")}</span>
               <span className="text-gray-600">:</span>
-              <span className="font-semibold break-words">
+              <span className="font-semibold ml-2 wrap-break-word">
                 {report.category?.display || "-"}
               </span>
             </div>
-            <div className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center">
-              <span className="text-gray-600">{t("status")}</span>
+            <div className="grid grid-cols-[6rem_auto_1fr] items-center">
+              <span className="text-gray-600">{t("report_date")}</span>
               <span className="text-gray-600">:</span>
-              <span className="font-semibold capitalize">
-                {t(report.status)}
+              <span className="font-semibold ml-2">
+                {report.created_date &&
+                  format(new Date(report.created_date), "dd-MM-yyyy")}
               </span>
             </div>
-
-            <div className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center">
-              <span className="text-gray-600">{t("date")}</span>
+            <div className="grid grid-cols-[6rem_auto_1fr] items-center">
+              <span className="text-gray-600">{t("requested_by")}</span>
               <span className="text-gray-600">:</span>
-              <span className="font-semibold">
-                {report.encounter?.created_date &&
-                  format(
-                    new Date(report.encounter.created_date),
-                    "dd MMM yyyy, EEEE",
-                  )}
-              </span>
-            </div>
-            <div className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center">
-              <span className="text-gray-600">{t("report_created_by")}</span>
-              <span className="text-gray-600">:</span>
-              <span className="font-semibold">
-                {formatName(report.created_by)}
+              <span className="font-semibold ml-2">
+                {formatName(report.requester)}
               </span>
             </div>
           </div>

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
 import { ArrowLeft, MoreVertical, Printer } from "lucide-react";
 import { navigate } from "raviger";
 import { useTranslation } from "react-i18next";
@@ -19,6 +20,7 @@ import { FileListTable } from "@/components/Files/FileListTable";
 
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
+import { formatName } from "@/Utils/utils";
 import { PatientHeader } from "@/components/Patient/PatientHeader";
 import { DiagnosticReportResultsTable } from "@/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable";
 import { ObservationHistorySheet } from "@/pages/Facility/services/serviceRequests/components/ObservationHistorySheet";
@@ -139,6 +141,18 @@ export default function DiagnosticReportView({
                     {t(report.status)}
                   </Badge>
                 </div>
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-500">
+                  {t("report_date")}
+                </div>
+                <div>{format(new Date(report.created_date), "dd-MM-yyyy")}</div>
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-500">
+                  {t("requested_by")}
+                </div>
+                <div>{formatName(report.requester)}</div>
               </div>
               {report.note && (
                 <div className="col-span-full">

--- a/src/types/emr/diagnosticReport/diagnosticReport.ts
+++ b/src/types/emr/diagnosticReport/diagnosticReport.ts
@@ -50,4 +50,5 @@ export interface DiagnosticReportRead extends Omit<DiagnosticReportBase, "id"> {
   created_date: string;
   modified_date: string;
   updated_by: UserReadMinimal;
+  requester: UserReadMinimal;
 }


### PR DESCRIPTION
## Proposed Changes

BE: https://github.com/ohcnetwork/care/pull/3411, https://github.com/ohcnetwork/care/pull/3443

Fixes #15018
<img width="777" height="764" alt="image" src="https://github.com/user-attachments/assets/a126f9a2-8ae2-4fda-9148-e7980cbc3dfa" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official patient identifiers are now shown in diagnostic report prints.
  * Request originator is now displayed as the report requester.

* **Improvements**
  * Patient info now shows age and sex together for clarity.
  * Report date label updated and date formatting standardized (dd-MM-yyyy).
  * Patient details layout refined for improved readability.
* **Documentation**
  * Added localized label for "Report Date."

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->