### PR TITLE
minor fix in translation

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1818,7 +1818,7 @@
   "duplicate_patient_preparation": "This patient preparation has already been added",
   "duplicate_patient_record_birth_unknown": "Please contact your district care coordinator, the shifting facility or the patient themselves if you are not sure about the patient's year of birth.",
   "duplicate_patient_record_confirmation": "Admit the patient record to your facility by adding the year of birth",
-  "duplicate_patient_record_rejection": "I confirm that the suspect / patient I want to create is not on the list.",
+  "duplicate_patient_record_rejection": "I confirm that the patient I want to create is not on the list.",
   "duration": "Duration",
   "duration_unit": "Duration Unit",
   "duration_unit_placeholder": "Select Duration Unit",


### PR DESCRIPTION
## Proposed Changes

Fixes #15048
- Removed 'suspect' from the translation of `duplicate_patient_record_rejection`

<img width="699" height="703" alt="image" src="https://github.com/user-attachments/assets/fd8171f2-7cf8-4233-be66-5c0362a37804" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated English language text displayed during patient record creation to clarify the confirmation message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->