### PR TITLE
feat: display official patient identifiers in treatment summary

### DIFF
--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -295,27 +295,23 @@ export default function TreatmentSummary({
 
               {/* Right Column */}
               <div className="space-y-3">
-                {encounter?.patient &&
-                  "instance_identifiers" in encounter.patient &&
-                  encounter.patient.instance_identifiers
-                    .filter(
-                      ({ config }) =>
-                        config.config.use === PatientIdentifierUse.official,
-                    )
-                    .map((identifier) => (
-                      <div
-                        key={identifier.config.id}
-                        className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center"
-                      >
-                        <span className="text-gray-600">
-                          {identifier.config.config.display}
-                        </span>
-                        <span className="text-gray-600">:</span>
-                        <span className="font-semibold ml-2">
-                          {identifier.value}
-                        </span>
-                      </div>
-                    ))}
+                {encounter?.patient?.instance_identifiers
+                  ?.filter(
+                    ({ config }) =>
+                      config.config.use === PatientIdentifierUse.official,
+                  )
+                  .map((identifier) => (
+                    <div
+                      key={identifier.config.id}
+                      className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center"
+                    >
+                      <span className="text-gray-600">
+                        {identifier.config.config.display}
+                      </span>
+                      <span className="text-gray-600">:</span>
+                      <span className="font-semibold">{identifier.value}</span>
+                    </div>
+                  ))}
 
                 <div className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center">
                   <span className="text-gray-600">{t("mobile_number")}</span>

--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -19,6 +19,7 @@ import medicationStatementApi from "@/types/emr/medicationStatement/medicationSt
 import patientApi from "@/types/emr/patient/patientApi";
 import serviceRequestApi from "@/types/emr/serviceRequest/serviceRequestApi";
 import symptomApi from "@/types/emr/symptom/symptomApi";
+import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import query from "@/Utils/request/query";
 import careConfig from "@careConfig";
 import { useQuery } from "@tanstack/react-query";
@@ -294,6 +295,28 @@ export default function TreatmentSummary({
 
               {/* Right Column */}
               <div className="space-y-3">
+                {encounter?.patient &&
+                  "instance_identifiers" in encounter.patient &&
+                  encounter.patient.instance_identifiers
+                    .filter(
+                      ({ config }) =>
+                        config.config.use === PatientIdentifierUse.official,
+                    )
+                    .map((identifier) => (
+                      <div
+                        key={identifier.config.id}
+                        className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center"
+                      >
+                        <span className="text-gray-600">
+                          {identifier.config.config.display}
+                        </span>
+                        <span className="text-gray-600">:</span>
+                        <span className="font-semibold ml-2">
+                          {identifier.value}
+                        </span>
+                      </div>
+                    ))}
+
                 <div className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center">
                   <span className="text-gray-600">{t("mobile_number")}</span>
                   <span className="text-gray-600">:</span>


### PR DESCRIPTION
## Proposed Changes

Fixes #15050

<img width="711" height="893" alt="image" src="https://github.com/user-attachments/assets/f55cbf6a-e95d-4fad-8730-937df18d763a" />
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official patient identifiers now appear in the treatment summary header (right column), showing each identifier's label and value in a compact grid. This block only shows when patient identifiers are available, preventing empty or irrelevant display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->