### PR TITLE
fix: back button in Template Builder, Generate Report 

### DIFF
--- a/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
+++ b/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
@@ -1,4 +1,3 @@
-import BackButton from "@/components/Common/BackButton";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -30,6 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import useAppHistory from "@/hooks/useAppHistory";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
@@ -102,6 +102,8 @@ export default function TemplateBuilder({
     data: Blob | string | null;
     format: TemplateFormat | null;
   }>({ isActive: false, data: null, format: null });
+
+  const { goBack } = useAppHistory();
 
   const form = useForm({
     resolver: zodResolver(templateBuilderSchema),
@@ -342,15 +344,19 @@ export default function TemplateBuilder({
   return (
     <div className="h-screen flex flex-col">
       <div className="border-b p-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => goBack(`/facility/${facilityId}/template`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span>{t("back")}</span>
+        </Button>
         <div className="flex flex-col sm:flex-row gap-2 items-center justify-between mb-4">
           <div>
-            <div className="flex items-center gap-4">
-              <BackButton size="sm">
-                <ChevronLeft />
-              </BackButton>
-              <h1 className="text-2xl font-bold">{t("template_builder")}</h1>
-            </div>
-            <p className="text-sm mt-2 text-muted-foreground">
+            <h1 className="text-2xl font-bold">{t("template_builder")}</h1>
+            <p className="text-sm text-muted-foreground">
               {t("template_builder_description")}
             </p>
           </div>

--- a/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
+++ b/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm, UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -29,6 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import useAppHistory from "@/hooks/useAppHistory";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
@@ -101,6 +102,8 @@ export default function TemplateBuilder({
     data: Blob | string | null;
     format: TemplateFormat | null;
   }>({ isActive: false, data: null, format: null });
+
+  const { goBack } = useAppHistory();
 
   const form = useForm({
     resolver: zodResolver(templateBuilderSchema),
@@ -341,6 +344,15 @@ export default function TemplateBuilder({
   return (
     <div className="h-screen flex flex-col">
       <div className="border-b p-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => goBack(`/facility/${facilityId}/template`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span>{t("back")}</span>
+        </Button>
         <div className="flex flex-col sm:flex-row gap-2 items-center justify-between mb-4">
           <div>
             <h1 className="text-2xl font-bold">{t("template_builder")}</h1>

--- a/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
+++ b/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
@@ -29,7 +29,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import useAppHistory from "@/hooks/useAppHistory";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
@@ -47,6 +46,7 @@ import templateApi from "@/types/emr/template/templateApi";
 
 import queryClient from "@/Utils/request/queryClient";
 import { generateSlug } from "@/Utils/utils";
+import BackButton from "@/components/Common/BackButton";
 import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import DOMPurify from "dompurify";
@@ -102,8 +102,6 @@ export default function TemplateBuilder({
     data: Blob | string | null;
     format: TemplateFormat | null;
   }>({ isActive: false, data: null, format: null });
-
-  const { goBack } = useAppHistory();
 
   const form = useForm({
     resolver: zodResolver(templateBuilderSchema),
@@ -344,21 +342,21 @@ export default function TemplateBuilder({
   return (
     <div className="h-screen flex flex-col">
       <div className="border-b p-4">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => goBack(`/facility/${facilityId}/template`)}
-          className="mb-4"
-        >
-          <ChevronLeft className="h-4 w-4" />
-          <span>{t("back")}</span>
-        </Button>
         <div className="flex flex-col sm:flex-row gap-2 items-center justify-between mb-4">
-          <div>
-            <h1 className="text-2xl font-bold">{t("template_builder")}</h1>
-            <p className="text-sm text-muted-foreground">
-              {t("template_builder_description")}
-            </p>
+          <div className="flex items-center gap-2">
+            <BackButton
+              size="icon"
+              to={`/facility/${facilityId}/template`}
+              aria-label={t("back")}
+            >
+              <ChevronLeft />
+            </BackButton>
+            <div>
+              <h1 className="text-2xl font-bold">{t("template_builder")}</h1>
+              <p className="text-sm text-muted-foreground">
+                {t("template_builder_description")}
+              </p>
+            </div>
           </div>
           <div className="flex gap-2">
             <Button

--- a/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
+++ b/src/pages/Encounters/TemplateBuilder/TemplateBuilder.tsx
@@ -1,3 +1,4 @@
+import BackButton from "@/components/Common/BackButton";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -29,7 +30,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import useAppHistory from "@/hooks/useAppHistory";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
@@ -102,8 +102,6 @@ export default function TemplateBuilder({
     data: Blob | string | null;
     format: TemplateFormat | null;
   }>({ isActive: false, data: null, format: null });
-
-  const { goBack } = useAppHistory();
 
   const form = useForm({
     resolver: zodResolver(templateBuilderSchema),
@@ -344,19 +342,15 @@ export default function TemplateBuilder({
   return (
     <div className="h-screen flex flex-col">
       <div className="border-b p-4">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => goBack(`/facility/${facilityId}/template`)}
-          className="mb-4"
-        >
-          <ChevronLeft className="h-4 w-4" />
-          <span>{t("back")}</span>
-        </Button>
         <div className="flex flex-col sm:flex-row gap-2 items-center justify-between mb-4">
           <div>
-            <h1 className="text-2xl font-bold">{t("template_builder")}</h1>
-            <p className="text-sm text-muted-foreground">
+            <div className="flex items-center gap-4">
+              <BackButton size="sm">
+                <ChevronLeft />
+              </BackButton>
+              <h1 className="text-2xl font-bold">{t("template_builder")}</h1>
+            </div>
+            <p className="text-sm mt-2 text-muted-foreground">
               {t("template_builder_description")}
             </p>
           </div>

--- a/src/pages/Encounters/TemplateBuilder/TemplateCard.tsx
+++ b/src/pages/Encounters/TemplateBuilder/TemplateCard.tsx
@@ -1,18 +1,59 @@
+import { useMutation } from "@tanstack/react-query";
+import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 
+import CareIcon from "@/CAREUI/icons/CareIcon";
+
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
+import mutate from "@/Utils/request/mutate";
+import reportApi from "@/types/emr/report/reportApi";
 import { TemplateBaseRead } from "@/types/emr/template/template";
+
+import { toast } from "sonner";
+
+interface TemplateCardProps {
+  template: TemplateBaseRead;
+  facilityId: string;
+  canWriteTemplate?: boolean;
+  canGenerate?: boolean;
+  associatingId?: string;
+  onSuccess?: () => void;
+}
 
 export default function TemplateCard({
   template,
-  buttons,
-}: {
-  template: TemplateBaseRead;
-  buttons: React.ReactNode;
-}) {
+  facilityId,
+  canWriteTemplate,
+  canGenerate,
+  associatingId,
+  onSuccess,
+}: TemplateCardProps) {
   const { t } = useTranslation();
+
+  const { mutate: generateReport, isPending } = useMutation({
+    mutationFn: mutate(reportApi.createReport),
+    onSuccess: () => {
+      toast.success(t("report_generation_started"));
+      onSuccess?.();
+    },
+    onError: (error) => {
+      toast.error(error.message || t("report_generation_failed"));
+    },
+  });
+
+  const handleGenerateReport = () => {
+    generateReport({
+      template_id: template.id,
+      associating_id: associatingId ?? "",
+      output_format: template.default_format,
+      options: JSON.stringify({}),
+      force: false,
+    });
+  };
+
   return (
     <Card
       key={template.id}
@@ -39,11 +80,29 @@ export default function TemplateCard({
             {t(template.template_type)}
           </span>
         </div>
-        {buttons && (
-          <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-            {buttons}
-          </div>
-        )}
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+          {canWriteTemplate && (
+            <Button variant="outline" size="sm" className="w-full" asChild>
+              <Link
+                href={`/facility/${facilityId}/template/builder/${template.slug}`}
+              >
+                <CareIcon icon="l-pen" className="mr-1" />
+                <span>{t("edit")}</span>
+              </Link>
+            </Button>
+          )}
+          {canGenerate && associatingId && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={handleGenerateReport}
+              disabled={isPending || template.status !== "active"}
+            >
+              {isPending ? t("generating") : t("generate_report")}
+            </Button>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/src/pages/Encounters/TemplateBuilder/TemplateList.tsx
+++ b/src/pages/Encounters/TemplateBuilder/TemplateList.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 
@@ -22,18 +22,11 @@ import useFilters from "@/hooks/useFilters";
 import query from "@/Utils/request/query";
 import templateApi from "@/types/emr/template/templateApi";
 
-import mutate from "@/Utils/request/mutate";
 import { getPermissions } from "@/common/Permissions";
 import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 import { usePermissions } from "@/context/PermissionContext";
 import { cn } from "@/lib/utils";
-import reportApi from "@/types/emr/report/reportApi";
-import {
-  TemplateBaseRead,
-  TemplateType,
-  TemplateTypes,
-} from "@/types/emr/template/template";
-import { toast } from "sonner";
+import { TemplateType, TemplateTypes } from "@/types/emr/template/template";
 import TemplateCard from "./TemplateCard";
 
 interface TemplateListProps {
@@ -81,27 +74,6 @@ export default function TemplateList({
     }),
     enabled: enabled && canListTemplate,
   });
-
-  const { mutate: generateReport, isPending: isGenerating } = useMutation({
-    mutationFn: mutate(reportApi.createReport),
-    onSuccess: () => {
-      toast.success(t("report_generation_started"));
-      onSuccess?.();
-    },
-    onError: (error) => {
-      toast.error(error.message || t("report_generation_failed"));
-    },
-  });
-
-  const handleGenerateReport = (template: TemplateBaseRead) => {
-    generateReport({
-      template_id: template.id,
-      associating_id: associatingId ?? "",
-      output_format: template.default_format,
-      options: JSON.stringify({}),
-      force: false,
-    });
-  };
 
   return (
     <div className="space-y-4">
@@ -202,36 +174,11 @@ export default function TemplateList({
               <TemplateCard
                 key={template.id}
                 template={template}
-                buttons={
-                  <>
-                    {canWriteTemplate && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full"
-                        asChild
-                      >
-                        <Link
-                          href={`/facility/${facilityId}/template/builder/${template.slug}`}
-                        >
-                          <CareIcon icon="l-pen" className="mr-1" />
-                          <span>{t("edit")}</span>
-                        </Link>
-                      </Button>
-                    )}
-                    {associatingId && canGenerateReportFromTemplate && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full"
-                        onClick={() => handleGenerateReport(template)}
-                        disabled={isGenerating || template.status !== "active"}
-                      >
-                        {isGenerating ? t("generating") : t("generate_report")}
-                      </Button>
-                    )}
-                  </>
-                }
+                facilityId={facilityId}
+                canWriteTemplate={canWriteTemplate}
+                canGenerate={canGenerateReportFromTemplate}
+                associatingId={associatingId}
+                onSuccess={onSuccess}
               />
             ))}
           </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #15053 
- Added back button in Template Builder
- Only the template currently generating report shows 'generating' status.

<img width="1580" height="924" alt="image" src="https://github.com/user-attachments/assets/b4463684-e6bc-48d1-913f-aad85567c6b2" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Back navigation button added to the template builder header.
  * Generate Report action added to template cards with success/error notifications and disabled state while generating.
  * Edit and Generate actions shown or hidden based on per-template permissions.

* **Refactor**
  * Report generation flow moved from the template list into individual template cards for clearer per-template control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->