### PR TITLE
Fixed Max level org required * not displaying

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -823,7 +823,7 @@ const AdditionalDetailsContent = ({
               <FormControl>
                 <GovtOrganizationSelector
                   {...field}
-                  required={minGeoOrganizationLevelsRequired == null}
+                  required={minGeoOrganizationLevelsRequired != null}
                   requiredDepth={minGeoOrganizationLevelsRequired}
                   selected={form.watch("_selected_levels")}
                   value={form.watch("geo_organization")}

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -823,8 +823,7 @@ const AdditionalDetailsContent = ({
               <FormControl>
                 <GovtOrganizationSelector
                   {...field}
-                  required={minGeoOrganizationLevelsRequired != null}
-                  requiredDepth={minGeoOrganizationLevelsRequired}
+                  requiredDepth={minGeoOrganizationLevelsRequired ?? 1}
                   selected={form.watch("_selected_levels")}
                   value={form.watch("geo_organization")}
                   onChange={field.onChange}

--- a/src/pages/Organization/components/GovtOrganizationSelector.tsx
+++ b/src/pages/Organization/components/GovtOrganizationSelector.tsx
@@ -183,7 +183,7 @@ export default function GovtOrganizationSelector({
           currentLevel={selectedLevels[index]}
           previousLevel={selectedLevels[index - 1]}
           onChange={handleFilterChange}
-          required={required}
+          required={requiredDepth != null ? index < requiredDepth : required}
           authToken={authToken}
         />
       ))}


### PR DESCRIPTION
## Proposed Changes

Fixes #15052 
- Changed required to be false when min level is not set
- Setting required to be true based on depth for OrganizationLevelSelect

<img width="686" height="498" alt="Screenshot 2026-01-08 at 3 24 34 PM" src="https://github.com/user-attachments/assets/e589734c-8b72-4002-a45d-11ae90ad7e39" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the validation logic for government organization selection during patient registration to dynamically determine required fields based on organizational hierarchy depth, improving form validation handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->