### PR TITLE
Improve error message when questionnaire fetch fails

### DIFF
--- a/src/components/Questionnaire/QuestionnaireEditor.tsx
+++ b/src/components/Questionnaire/QuestionnaireEditor.tsx
@@ -411,7 +411,7 @@ export default function QuestionnaireEditor({
   const { mutate: importQuestionnaire, isPending: isImporting } = useMutation({
     mutationFn: async (url: string) => {
       const response = await fetch(url);
-      if (!response.ok) throw new Error("Failed to fetch questionnaire");
+      if (!response.ok) throw new Error("Unable to fetch the questionnaire");
       return response.json();
     },
     onSuccess: (data) => {


### PR DESCRIPTION
## Proposed Changes

Improves the error message shown when importing a questionnaire fails.
The updated message is clearer and more user-friendly.

No existing behavior is changed.

Requesting review from @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs/tests (not required for text-only change)
- [ ] Update documentation (not applicable)
- [x] Ensure that UI text is placed in i18n files
- [ ] Screenshots or demo (not applicable for text change)
- [x] Request peer reviews
- [ ] QA on mobile devices (not required)
- [ ] QA on desktop devices (not required)
- [ ] Add or update Playwright tests (not required)