### PR TITLE
fix: Remove 'intersects_any' from 'ConditionOperation' type enum

### DIFF
--- a/src/types/base/condition/condition.ts
+++ b/src/types/base/condition/condition.ts
@@ -8,7 +8,6 @@ import { z } from "zod";
 export enum ConditionOperation {
   equality = "equality",
   in_range = "in_range",
-  intersects_any = "intersects_any",
   has_tag = "has_tag",
 }
 


### PR DESCRIPTION
## Proposed Changes

### Fixes #14408 
- Remove intersects_any from ConditionOperation type enum as it has been replaced by has_tag.
- Confirmed that intersects_any is no longer used in the codebase.
Tagging: @ohcnetwork/care-fe-code-reviewers

@Jacobjeevan @yash-learner 
## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Add or update Playwright tests for related changes

### Checks:

1. Backend Alignment: Since the backend has already removed this operation, the API will never send `intersects_any` in the `allowed_operations` list. Therefore, the UI dropdowns (which rely on this list) will never display it.
2. Type Safety (Zod): The conditionSchema in `condition.ts` (used for form validation) already excluded `intersects_any`, only allowing `equality`, `in_range`, and `has_tag`.
3. UI Logic: The **CompactConditionEditor** component explicitly handles `equality, in_range, and has_tag`. It does not have logic for `intersects_any`, so removing it from the type definition cleans up dead code that would never be reachable.
4. No Textual Matches: `grep -r "intersects_any" .` confirms the string "intersects_any" does not exist anywhere else in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a legacy condition option from the platform, simplifying the list of available condition choices.
  * Configuration clarified by eliminating an unsupported selection; existing conditions continue to function but that option is no longer available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->