### PR TITLE
Resolved Edit resource category form and charge item definition edit form bug

### DIFF
--- a/src/components/Common/ResourceCategoryForm.tsx
+++ b/src/components/Common/ResourceCategoryForm.tsx
@@ -96,20 +96,20 @@ export function ResourceCategoryForm({
     enabled: isEditing && !!categorySlug,
   });
 
-  // Update form when category data loads
+  // Update form when sheet opens - handles both create and edit modes
   useEffect(() => {
-    if (categoryData) {
+    if (!isOpen) return;
+
+    if (isEditing && categoryData) {
+      // Edit mode: populate form with existing data
       form.reset({
         title: categoryData.title,
         slug_value: categoryData.slug_config.slug_value,
         description: categoryData.description || "",
         resource_sub_type: categoryData.resource_sub_type,
       });
-    }
-  }, [categoryData, form]);
-
-  useEffect(() => {
-    if (!isOpen) {
+    } else if (!isEditing) {
+      // Create mode: reset to empty defaults
       form.reset({
         title: "",
         slug_value: "",
@@ -117,7 +117,7 @@ export function ResourceCategoryForm({
         resource_sub_type: ResourceCategorySubType.other,
       });
     }
-  }, [isOpen, form]);
+  }, [isOpen, isEditing, categoryData, form]);
 
   // Auto-generate slug from name when creating new category
   useEffect(() => {
@@ -259,6 +259,7 @@ export function ResourceCategoryForm({
                           .replace(/[^a-z0-9_-]/g, "");
                         form.setValue("slug_value", sanitizedValue, {
                           shouldValidate: true,
+                          shouldDirty: true,
                         });
                       }}
                     />

--- a/src/components/Common/ResourceCategoryForm.tsx
+++ b/src/components/Common/ResourceCategoryForm.tsx
@@ -100,23 +100,21 @@ export function ResourceCategoryForm({
   useEffect(() => {
     if (!isOpen) return;
 
-    if (isEditing && categoryData) {
-      // Edit mode: populate form with existing data
-      form.reset({
-        title: categoryData.title,
-        slug_value: categoryData.slug_config.slug_value,
-        description: categoryData.description || "",
-        resource_sub_type: categoryData.resource_sub_type,
-      });
-    } else if (!isEditing) {
-      // Create mode: reset to empty defaults
-      form.reset({
-        title: "",
-        slug_value: "",
-        description: "",
-        resource_sub_type: ResourceCategorySubType.other,
-      });
-    }
+    form.reset(
+      isEditing && categoryData
+        ? {
+            title: categoryData.title,
+            slug_value: categoryData.slug_config.slug_value,
+            description: categoryData.description || "",
+            resource_sub_type: categoryData.resource_sub_type,
+          }
+        : {
+            title: "",
+            slug_value: "",
+            description: "",
+            resource_sub_type: ResourceCategorySubType.other,
+          },
+    );
   }, [isOpen, isEditing, categoryData, form]);
 
   // Auto-generate slug from name when creating new category

--- a/src/components/Common/ResourceCategoryForm.tsx
+++ b/src/components/Common/ResourceCategoryForm.tsx
@@ -115,7 +115,7 @@ export function ResourceCategoryForm({
             resource_sub_type: ResourceCategorySubType.other,
           },
     );
-  }, [isOpen, isEditing, categoryData, form]);
+  }, [isOpen, isEditing, categoryData]);
 
   // Auto-generate slug from name when creating new category
   useEffect(() => {

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -522,6 +522,7 @@ export function ChargeItemDefinitionForm({
                         .replace(/[^a-z0-9_-]/g, "");
                       form.setValue("slug_value", sanitizedValue, {
                         shouldValidate: true,
+                        shouldDirty: true,
                       });
                     }}
                   />

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeForm.tsx
@@ -394,6 +394,7 @@ function ProductKnowledgeFormContent({
                                 .replace(/[^a-z0-9_-]/g, "");
                               form.setValue("slug_value", sanitizedValue, {
                                 shouldValidate: true,
+                                shouldDirty: true,
                               });
                             }}
                           />


### PR DESCRIPTION
## Proposed Changes

Fixes #15068 
- Consolidated the two useEffects that handles both create and edit modes based on isOpen state, eliminating the race condition that caused form reset on second open.
- Added shouldDirty: true flag so the form properly tracks changes in slug values, enabling the Update button in ChargeItemDefinitionForm.
- Find and fixed similar issue in ProductKnowledgeForm and ResourceCategoryForm


https://github.com/user-attachments/assets/630b30cd-da0b-48de-bf71-93983b7cdacf


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated form initialization for create/edit sheets so fields reliably reset or populate when a sheet opens, preventing stale or incorrect values.
  * Slug input handling now marks manual/sanitized changes as “dirty,” ensuring validation and change tracking run consistently during edits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->