### PR TITLE
Interchange pack size and qty position

### DIFF
--- a/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
+++ b/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
@@ -161,8 +161,8 @@ export function SupplyDeliveryTable({
           )}
           <TableHead>{t("item")}</TableHead>
           <TableHead>{t("requested_qty")}</TableHead>
-          <TableHead>{t("pack_qty")}</TableHead>
           <TableHead>{t("pack_size")}</TableHead>
+          <TableHead>{t("pack_qty")}</TableHead>
           <TableHead>
             {isRequester ? t("received_qty") : t("dispatched_qty")}
           </TableHead>
@@ -212,8 +212,8 @@ export function SupplyDeliveryTable({
               </div>
             </TableCell>
             <TableCell>{delivery.supply_request?.quantity || "-"}</TableCell>
-            <TableCell>{delivery.supplied_item_pack_quantity || "-"}</TableCell>
             <TableCell>{delivery.supplied_item_pack_size || "-"}</TableCell>
+            <TableCell>{delivery.supplied_item_pack_quantity || "-"}</TableCell>
             <TableCell>{delivery.supplied_item_quantity}</TableCell>
             <TableCell>
               {delivery.created_date &&

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -648,11 +648,11 @@ export function AddSupplyDeliveryForm({
                                 <TableHead className="min-w-[140px] text-xs font-semibold text-center">
                                   {t("category")}
                                 </TableHead>
-                                <TableHead className="w-[7rem] text-xs font-semibold">
-                                  {t("pack_qty")}
-                                </TableHead>
                                 <TableHead className="w-[5rem] text-xs font-semibold">
                                   {t("pack_size")}
+                                </TableHead>
+                                <TableHead className="w-[7rem] text-xs font-semibold">
+                                  {t("pack_qty")}
                                 </TableHead>
                                 <TableHead className="w-[8rem] text-xs font-semibold">
                                   {t("qty")}

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
@@ -311,23 +311,6 @@ export function SmartExternalDeliveryRow({
         )}
       </TableCell>
 
-      {/* Pack Quantity */}
-      <TableCell className="align-top p-2">
-        <Input
-          type="number"
-          min={1}
-          value={packQuantity || ""}
-          placeholder="0"
-          onChange={(e) => {
-            const value = parseInt(e.target.value) || undefined;
-            setField("supplied_item_pack_quantity", value);
-            markAsEdited();
-          }}
-          disabled={!productKnowledge}
-          className="w-[7rem]"
-        />
-      </TableCell>
-
       {/* Pack Size */}
       <TableCell className="align-top p-2">
         <Input
@@ -342,6 +325,23 @@ export function SmartExternalDeliveryRow({
           }}
           disabled={!productKnowledge}
           className="w-[5rem]"
+        />
+      </TableCell>
+
+      {/* Pack Quantity */}
+      <TableCell className="align-top p-2">
+        <Input
+          type="number"
+          min={1}
+          value={packQuantity || ""}
+          placeholder="0"
+          onChange={(e) => {
+            const value = parseInt(e.target.value) || undefined;
+            setField("supplied_item_pack_quantity", value);
+            markAsEdited();
+          }}
+          disabled={!productKnowledge}
+          className="w-[7rem]"
         />
       </TableCell>
 


### PR DESCRIPTION
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered columns in supply delivery tables: Pack Size now displays before Pack Quantity across all delivery forms and tables for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->