### PR TITLE
update cf preview deploy workflow to use pages-deployment-alias-url and add QR code for mobile access

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -49,20 +49,23 @@ jobs:
 
       - name: Comment PR with preview URL
         uses: actions/github-script@v7
-        if: steps.deploy.outputs.deployment-url
+        if: steps.deploy.outputs.pages-deployment-alias-url
         with:
           script: |
-            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
+            const deploymentUrl = '${{ steps.deploy.outputs.pages-deployment-alias-url }}';
             const prNumber = context.payload.pull_request.number;
-            const commitSha = context.payload.pull_request.head.sha.substring(0, 7);
+
+            // Generate QR code URL for easy mobile access
+            const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&margin=10&data=${encodeURIComponent(deploymentUrl)}`;
 
             const commentBody = `### 🚀 Preview Deployment Ready!
 
-            | Name | Details |
-            |------|---------|
-            | 🔗 Preview URL | ${deploymentUrl} |
-            | 📝 Commit | \`${commitSha}\` |
-            | 🌐 Environment | \`pr-${prNumber}\` |
+            **🔗 Preview URL:** ${deploymentUrl}
+
+            **📱 Mobile Access:**
+            Scan the QR code below to open the preview on your mobile device.
+
+            ![QR Code](${qrCodeUrl})
 
             ---
             *This preview will be automatically updated when you push new commits to this PR.*`;


### PR DESCRIPTION

## Proposed Changes

- Fixes #15148 
- update cloudflare preview deploy workflow to use `pages-deployment-alias-url` instead so that the URL is easier to type and navigate to if needed (similar to how we had in previous netlify's deploy preview URLs).
- Also added QR code, so that anyone can scan and open it in their mobile devices to test things out easily.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QR code for mobile access to preview deployments in PR comments.

* **Improvements**
  * Enhanced PR comment formatting with improved visual hierarchy and dedicated mobile access section.
  * Streamlined preview deployment information by removing unnecessary details.
  * Improved bot comment handling with update logic for existing comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->