### PR TITLE
Update charge item status handling and disable edit button for billed/paid items

### DIFF
--- a/src/pages/Facility/billing/account/components/EditChargeItemSheet.tsx
+++ b/src/pages/Facility/billing/account/components/EditChargeItemSheet.tsx
@@ -261,7 +261,8 @@ export function EditChargeItemSheet({
                               min={1}
                               {...field}
                               disabled={
-                                item.status !== ChargeItemStatus.planned
+                                item.status === ChargeItemStatus.billed ||
+                                item.status === ChargeItemStatus.paid
                               }
                             />
                           </FormControl>
@@ -278,21 +279,22 @@ export function EditChargeItemSheet({
                       <h3 className="text-sm font-medium">
                         {t("pricing_details")}
                       </h3>
-                      {(item.status === ChargeItemStatus.planned ||
-                        item.status === ChargeItemStatus.billable) && (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="border-gray-400 gap-1"
-                          onClick={() => {
-                            setIsEditDialogOpen(true);
-                          }}
-                        >
-                          <CareIcon icon="l-edit" className="size-4" />
-                          {t("edit")}
-                          <ShortcutBadge actionId="edit-account" />
-                        </Button>
-                      )}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="border-gray-400 gap-1"
+                        onClick={() => {
+                          setIsEditDialogOpen(true);
+                        }}
+                        disabled={
+                          item.status === ChargeItemStatus.billed ||
+                          item.status === ChargeItemStatus.paid
+                        }
+                      >
+                        <CareIcon icon="l-edit" className="size-4" />
+                        {t("edit")}
+                        <ShortcutBadge actionId="edit-account" />
+                      </Button>
                     </div>
 
                     <div className="rounded-md border bg-card">

--- a/src/types/billing/chargeItem/chargeItem.ts
+++ b/src/types/billing/chargeItem/chargeItem.ts
@@ -8,7 +8,7 @@ import { InvoiceRead } from "@/types/billing/invoice/invoice";
 import { UserReadMinimal } from "@/types/user/user";
 
 export enum ChargeItemStatus {
-  planned = "planned",
+  // planned = "planned",
   billable = "billable",
   not_billable = "not_billable",
   aborted = "aborted",
@@ -18,7 +18,7 @@ export enum ChargeItemStatus {
 }
 
 export const CHARGE_ITEM_STATUS_COLORS = {
-  planned: "blue",
+  // planned: "blue",
   billable: "indigo",
   not_billable: "yellow",
   aborted: "destructive",


### PR DESCRIPTION


- Fixes #15150


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected charge item edit and quantity input behavior to disable when items reach billed or paid status.

* **Refactor**
  * Removed "planned" status from available charge item statuses.
  * Simplified charge item status handling and definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->