### PR TITLE
hide pack size and quantity for internal flow

### DIFF
--- a/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
+++ b/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
@@ -161,8 +161,8 @@ export function SupplyDeliveryTable({
           )}
           <TableHead>{t("item")}</TableHead>
           <TableHead>{t("requested_qty")}</TableHead>
-          <TableHead>{t("pack_size")}</TableHead>
-          <TableHead>{t("pack_qty")}</TableHead>
+          {!internal && <TableHead>{t("pack_size")}</TableHead>}
+          {!internal && <TableHead>{t("pack_qty")}</TableHead>}
           <TableHead>
             {isRequester ? t("received_qty") : t("dispatched_qty")}
           </TableHead>
@@ -212,8 +212,14 @@ export function SupplyDeliveryTable({
               </div>
             </TableCell>
             <TableCell>{delivery.supply_request?.quantity || "-"}</TableCell>
-            <TableCell>{delivery.supplied_item_pack_size || "-"}</TableCell>
-            <TableCell>{delivery.supplied_item_pack_quantity || "-"}</TableCell>
+            {!internal && (
+              <TableCell>{delivery.supplied_item_pack_size || "-"}</TableCell>
+            )}
+            {!internal && (
+              <TableCell>
+                {delivery.supplied_item_pack_quantity || "-"}
+              </TableCell>
+            )}
             <TableCell>{delivery.supplied_item_quantity}</TableCell>
             <TableCell>
               {delivery.created_date &&

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -179,8 +179,8 @@ export function AddSupplyDeliveryForm({
       product_knowledge: {} as ProductKnowledgeBase,
       supplied_inventory_item: "",
       supplied_item_quantity: 1,
-      supplied_item_pack_quantity: 1,
-      supplied_item_pack_size: 1,
+      supplied_item_pack_quantity: origin ? undefined : 1,
+      supplied_item_pack_size: origin ? undefined : 1,
       supplied_item: undefined,
       supply_request: undefined,
       _is_inward_stock: !origin,
@@ -292,8 +292,8 @@ export function AddSupplyDeliveryForm({
     const itemsFromRequests = selectedRequests?.map((request) => ({
       supplied_inventory_item: undefined,
       supplied_item_quantity: request.quantity,
-      supplied_item_pack_quantity: 1,
-      supplied_item_pack_size: 1,
+      supplied_item_pack_quantity: origin ? undefined : 1,
+      supplied_item_pack_size: origin ? undefined : 1,
       product_knowledge: request.item,
       supplied_item: undefined,
       supply_request: request,
@@ -505,11 +505,13 @@ export function AddSupplyDeliveryForm({
       supplied_item_type: suppliedItemType,
       supplied_item_condition: SupplyDeliveryCondition.normal,
       supplied_item_quantity: item.supplied_item_quantity,
-      supplied_item_pack_quantity: item.supplied_item_pack_quantity,
-      supplied_item_pack_size: item.supplied_item_pack_size,
       ...(origin
         ? { supplied_inventory_item: item.supplied_inventory_item }
-        : { supplied_item: productId }),
+        : {
+            supplied_item: productId,
+            supplied_item_pack_quantity: item.supplied_item_pack_quantity,
+            supplied_item_pack_size: item.supplied_item_pack_size,
+          }),
       supply_request: item.supply_request?.id,
       origin: origin,
       destination: destination,


### PR DESCRIPTION
## Proposed Changes

- Hide pack quantity and pack size for internal flow

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supply delivery table now conditionally displays packaging columns based on supply source type.
  * External supply delivery forms improved to properly handle optional packaging information with consistent payload construction across internal and external inventory sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->