### PR TITLE
feat: add ChargeItemDefinitionStatus to query parameters for active definitions

### DIFF
--- a/src/components/Common/ChargeItemDefinitionPicker.tsx
+++ b/src/components/Common/ChargeItemDefinitionPicker.tsx
@@ -24,6 +24,7 @@ import {
 import {
   ChargeItemDefinitionBase,
   ChargeItemDefinitionRead,
+  ChargeItemDefinitionStatus,
 } from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
 import chargeItemDefinitionApi from "@/types/billing/chargeItemDefinition/chargeItemDefinitionApi";
 import query from "@/Utils/request/query";
@@ -170,6 +171,9 @@ export function ChargeItemDefinitionPicker({
           listDefinitions={{
             queryFn: chargeItemDefinitionApi.listChargeItemDefinition,
             pathParams: { facilityId },
+            queryParams: {
+              status: ChargeItemDefinitionStatus.active,
+            },
           }}
           resourceSubType={resourceSubType}
           translationBaseKey="charge_item_definition"

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -43,7 +43,10 @@ import chargeItemDefinitionApi from "@/types/billing/chargeItemDefinition/charge
 import ObservationDefinitionForm from "@/pages/Facility/settings/observationDefinition/ObservationDefinitionForm";
 import { CreateSpecimenDefinition } from "@/pages/Facility/settings/specimen-definitions/CreateSpecimenDefinition";
 import { ResourceCategoryResourceType } from "@/types/base/resourceCategory/resourceCategory";
-import { ChargeItemDefinitionBase } from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
+import {
+  ChargeItemDefinitionBase,
+  ChargeItemDefinitionStatus,
+} from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
 import {
   type ActivityDefinitionCreateSpec,
   type ActivityDefinitionReadSpec,
@@ -888,6 +891,9 @@ function ActivityDefinitionFormContent({
                           queryFn:
                             chargeItemDefinitionApi.listChargeItemDefinition,
                           pathParams: { facilityId },
+                          queryParams: {
+                            status: ChargeItemDefinitionStatus.active,
+                          },
                         }}
                         translationBaseKey="charge_item_definition"
                         mapper={(item) => ({


### PR DESCRIPTION


fixes #15170



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated charge item definition selectors to display exclusively active charge item definitions, preventing inactive items from appearing in the picker and activity definition form. This ensures users only interact with valid, current charge item options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->