### PR TITLE
fix: unable to select certain discounts in edit invoice items dialog

### DIFF
--- a/src/components/Billing/Invoice/EditInvoiceTable.tsx
+++ b/src/components/Billing/Invoice/EditInvoiceTable.tsx
@@ -373,6 +373,8 @@ export function EditInvoiceTable({
     return <div>{t("no_charge_items_found")}</div>;
   }
 
+  const filteredDiscounts = globalDiscounts.filter(getDiscountComponentKey);
+
   return (
     <Form {...form}>
       <form
@@ -395,7 +397,7 @@ export function EditInvoiceTable({
                 <TableHead>
                   <div className="flex items-center justify-center gap-2">
                     {t("discounts")}
-                    {globalDiscounts.length > 0 && chargeItems.length > 1 && (
+                    {filteredDiscounts.length > 0 && chargeItems.length > 1 && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button
@@ -408,7 +410,7 @@ export function EditInvoiceTable({
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          {globalDiscounts.map((discount) => {
+                          {filteredDiscounts.map((discount) => {
                             const key = getDiscountComponentKey(discount);
                             return (
                               <DropdownMenuItem


### PR DESCRIPTION
## Proposed Changes
- Fixes #15183


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discount filtering logic in the invoice editor to display only applicable discounts in the discounts dropdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->