### PR TITLE
feat: add expiry month offset configuration and restrict expired products in inventory selection

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -136,6 +136,12 @@ REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE=false
 # Default state for tax inclusive pricing in inventory, When true, base price is calculated from MRP by removing tax
 REACT_INVENTORY_DEFAULT_TAX_INCLUSIVE=false
 
+# Number of months offset for expiry restriction
+# 0 = restrict products expiring by end of current month
+# 1 = restrict products expiring by end of next month
+# If not set, expiry restriction is disabled (only restrict already expired products)
+REACT_INVENTORY_EXPIRY_MONTH_OFFSET=
+
 # Auto refresh interval in seconds
 REACT_AUTO_REFRESH_INTERVAL=10
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -255,6 +255,15 @@ const careConfig = {
       env.REACT_INVENTORY_DEFAULT_TAX_INCLUSIVE,
       false,
     ),
+    /**
+     * Number of months offset for expiry restriction.
+     * 0 = current month, 1 = next month, etc.
+     * Products expiring before the end of (current month + offset) will be restricted.
+     * Set to null (default) to disable expiry restriction entirely.
+     */
+    expiryMonthOffset: env.REACT_INVENTORY_EXPIRY_MONTH_OFFSET
+      ? parseInt(env.REACT_INVENTORY_EXPIRY_MONTH_OFFSET, 10)
+      : null,
   },
 
   /**

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2241,6 +2241,7 @@
   "expiration_date_description": "The date after which this product should not be used",
   "expiration_date_must_be_after_manufacture_date": "Expiration date must be after manufacture date",
   "expired": "Expired",
+  "expired_product_cannot_be_dispensed": "Expired products cannot be dispensed",
   "expires": "Expires",
   "expires_on": "Expires On",
   "expiry": "Expiry",

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -122,6 +122,7 @@ const envSchema = z
     REACT_ENCOUNTER_DEFAULT_DATE_FILTER: numberAsString.optional(),
     REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE: booleanAsStringSchema.optional(),
     REACT_INVENTORY_DEFAULT_TAX_INCLUSIVE: booleanAsStringSchema.optional(),
+    REACT_INVENTORY_EXPIRY_MONTH_OFFSET: numberAsString.optional(),
     REACT_OBSERVATION_PLOTS_CONFIG_URL: z.string().url().optional(),
     REACT_DEFAULT_COUNTRY: z.string().optional(),
     REACT_DEFAULT_COUNTRY_NAME: z.string().optional(),

--- a/src/pages/Facility/services/inventory/StockLotSelector.tsx
+++ b/src/pages/Facility/services/inventory/StockLotSelector.tsx
@@ -1,5 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { formatDate } from "date-fns";
+import {
+  addMonths,
+  endOfMonth,
+  formatDate,
+  isBefore,
+  startOfMonth,
+} from "date-fns";
 import { ChevronDownIcon, SearchIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -22,6 +28,7 @@ import inventoryApi from "@/types/inventory/product/inventoryApi";
 import { ProductKnowledgeBase } from "@/types/inventory/productKnowledge/productKnowledge";
 import { isPositive, round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
+import careConfig from "@careConfig";
 
 export interface SelectedLot {
   selectedInventoryId: string;
@@ -40,6 +47,7 @@ interface StockLotSelectorProps {
   locationId?: string;
   productKnowledge?: ProductKnowledgeBase;
   availableInventories?: InventoryRead[];
+  dontRestrictExpired?: boolean;
 }
 
 export default function StockLotSelector({
@@ -54,9 +62,45 @@ export default function StockLotSelector({
   locationId,
   productKnowledge,
   availableInventories,
+  dontRestrictExpired = false,
 }: StockLotSelectorProps) {
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState("");
+  const expiryMonthOffset = careConfig.inventory.expiryMonthOffset;
+
+  const isExpired = (expirationDate: string | undefined): boolean => {
+    if (!expirationDate) return false;
+    const expiryDate = new Date(expirationDate);
+    const currentMonthStart = startOfMonth(new Date());
+    return isBefore(expiryDate, currentMonthStart);
+  };
+
+  const isProductRestricted = (expirationDate: string | undefined): boolean => {
+    if (!expirationDate) return false;
+    if (isExpired(expirationDate)) return true;
+    if (expiryMonthOffset === null) return false;
+    const expiryDate = new Date(expirationDate);
+    const referenceMonthEnd = endOfMonth(
+      addMonths(new Date(), expiryMonthOffset),
+    );
+    return isBefore(expiryDate, referenceMonthEnd);
+  };
+
+  const getExpiryBadgeVariant = (
+    expirationDate: string | undefined,
+  ): "destructive" | "yellow" | "primary" => {
+    if (!expirationDate) return "primary";
+    const expiryDate = new Date(expirationDate);
+    const currentMonthStart = startOfMonth(new Date());
+    if (isBefore(expiryDate, currentMonthStart)) return "destructive";
+    if (expiryMonthOffset !== null) {
+      const referenceMonthEnd = endOfMonth(
+        addMonths(new Date(), expiryMonthOffset),
+      );
+      if (isBefore(expiryDate, referenceMonthEnd)) return "yellow";
+    }
+    return "primary";
+  };
 
   const { data: queryInventories } = useQuery({
     queryKey: ["inventoryItems", facilityId, locationId, productKnowledge?.id],
@@ -86,7 +130,11 @@ export default function StockLotSelector({
         )
       : inventories;
 
-  const toggleLotSelection = (inventoryId: string) => {
+  const toggleLotSelection = (inventoryId: string, isRestricted: boolean) => {
+    if (!dontRestrictExpired && isRestricted) {
+      return;
+    }
+
     const isSelected = selectedLots.some(
       (lot) => lot.selectedInventoryId === inventoryId,
     );
@@ -116,7 +164,7 @@ export default function StockLotSelector({
   };
 
   return (
-    <Popover>
+    <Popover modal>
       <PopoverTrigger>
         <Button
           variant="outline"
@@ -183,14 +231,9 @@ export default function StockLotSelector({
                       {showexpiry &&
                         selectedInventory?.product.expiration_date && (
                           <Badge
-                            variant={
-                              selectedInventory.status === "active" &&
-                              new Date(
-                                selectedInventory.product.expiration_date,
-                              ) >= new Date()
-                                ? "primary"
-                                : "destructive"
-                            }
+                            variant={getExpiryBadgeVariant(
+                              selectedInventory.product.expiration_date,
+                            )}
                             className="border-none rounded-sm"
                           >
                             {t("expiry")}:{" "}
@@ -211,7 +254,7 @@ export default function StockLotSelector({
           <ChevronDownIcon className="size-4 shrink-0" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
+      <PopoverContent className="w-auto max-w-[90vw] p-0">
         {enableSearch && (
           <div className="p-2 border-b">
             <div className="relative">
@@ -226,19 +269,37 @@ export default function StockLotSelector({
           </div>
         )}
         <div className="max-h-60 overflow-auto">
+          {!dontRestrictExpired &&
+            filteredInventories?.some((inv) =>
+              isProductRestricted(inv.product.expiration_date),
+            ) && (
+              <div className="px-2 py-1 bg-red-50 border-b border-red-100">
+                <span className="text-xs text-red-600">
+                  {t("expired_product_cannot_be_dispensed")}
+                </span>
+              </div>
+            )}
           {filteredInventories?.length ? (
             filteredInventories.map((inv) => {
               const isSelected = selectedLots.some(
                 (lot) => lot.selectedInventoryId === inv.id,
               );
+              const isRestricted = isProductRestricted(
+                inv.product.expiration_date,
+              );
+              const isDisabled = !dontRestrictExpired && isRestricted;
 
               return (
                 <div
                   key={inv.id}
-                  className="flex items-center space-x-2 cursor-pointer p-2 hover:bg-accent"
-                  onClick={() => toggleLotSelection(inv.id)}
+                  className={`flex items-center space-x-2 p-2 ${
+                    isDisabled
+                      ? "cursor-not-allowed opacity-50 bg-gray-50"
+                      : "cursor-pointer hover:bg-accent"
+                  }`}
+                  onClick={() => toggleLotSelection(inv.id, isRestricted)}
                 >
-                  <Checkbox checked={isSelected} />
+                  <Checkbox checked={isSelected} disabled={isDisabled} />
                   <div className="flex-1 flex items-center justify-between gap-2">
                     <span
                       className={cn(
@@ -272,12 +333,9 @@ export default function StockLotSelector({
                       </Badge>
                       {inv.product?.expiration_date && (
                         <Badge
-                          variant={
-                            inv.status === "active" &&
-                            new Date(inv.product.expiration_date) >= new Date()
-                              ? "primary"
-                              : "destructive"
-                          }
+                          variant={getExpiryBadgeVariant(
+                            inv.product.expiration_date,
+                          )}
                         >
                           {t("expiry")}:{" "}
                           {inv.product.expiration_date

--- a/src/pages/Facility/services/inventory/StockLotSelector.tsx
+++ b/src/pages/Facility/services/inventory/StockLotSelector.tsx
@@ -68,37 +68,35 @@ export default function StockLotSelector({
   const [searchQuery, setSearchQuery] = useState("");
   const expiryMonthOffset = careConfig.inventory.expiryMonthOffset;
 
-  const isExpired = (expirationDate: string | undefined): boolean => {
-    if (!expirationDate) return false;
+  type ExpiryStatus = "expired" | "expiring_soon" | "valid";
+
+  const getExpiryStatus = (
+    expirationDate: string | undefined,
+  ): ExpiryStatus => {
+    if (!expirationDate) return "valid";
     const expiryDate = new Date(expirationDate);
     const currentMonthStart = startOfMonth(new Date());
-    return isBefore(expiryDate, currentMonthStart);
+    if (isBefore(expiryDate, currentMonthStart)) return "expired";
+    if (expiryMonthOffset !== null) {
+      const referenceMonthEnd = endOfMonth(
+        addMonths(new Date(), expiryMonthOffset),
+      );
+      if (isBefore(expiryDate, referenceMonthEnd)) return "expiring_soon";
+    }
+    return "valid";
   };
 
   const isProductRestricted = (expirationDate: string | undefined): boolean => {
-    if (!expirationDate) return false;
-    if (isExpired(expirationDate)) return true;
-    if (expiryMonthOffset === null) return false;
-    const expiryDate = new Date(expirationDate);
-    const referenceMonthEnd = endOfMonth(
-      addMonths(new Date(), expiryMonthOffset),
-    );
-    return isBefore(expiryDate, referenceMonthEnd);
+    const status = getExpiryStatus(expirationDate);
+    return status === "expired" || status === "expiring_soon";
   };
 
   const getExpiryBadgeVariant = (
     expirationDate: string | undefined,
   ): "destructive" | "yellow" | "primary" => {
-    if (!expirationDate) return "primary";
-    const expiryDate = new Date(expirationDate);
-    const currentMonthStart = startOfMonth(new Date());
-    if (isBefore(expiryDate, currentMonthStart)) return "destructive";
-    if (expiryMonthOffset !== null) {
-      const referenceMonthEnd = endOfMonth(
-        addMonths(new Date(), expiryMonthOffset),
-      );
-      if (isBefore(expiryDate, referenceMonthEnd)) return "yellow";
-    }
+    const status = getExpiryStatus(expirationDate);
+    if (status === "expired") return "destructive";
+    if (status === "expiring_soon") return "yellow";
     return "primary";
   };
 

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -762,6 +762,7 @@ export function AddSupplyDeliveryForm({
                                             enableSearch={true}
                                             multiSelect={false}
                                             className="w-full h-9"
+                                            dontRestrictExpired
                                           />
                                         </FormControl>
                                         <FormMessage />


### PR DESCRIPTION
fixes #15188

keep `REACT_INVENTORY_EXPIRY_MONTH_OFFSET=0` in env to make this possible 

<img width="805" height="433" alt="image" src="https://github.com/user-attachments/assets/c1f8f76c-d6b0-4461-931c-b9078ddbc935" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable inventory expiry month offset to control when items are considered expired.
  * Stock selection now visibly marks and disables expired/soon-to-expire items and shows a warning banner when restrictions apply.
  * Added an option to bypass expiry restrictions for selection where appropriate.

* **Localization**
  * Added message informing that expired products cannot be dispensed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->