### PR TITLE
fix: ensure npm run dev always starts vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Open Healthcare Network Contributors",
   "license": "MIT",
   "scripts": {
-    "dev": "test -f src/pluginMap.ts || npm run setup && npm run supported-browsers && vite",
+    "dev": "(test -f src/pluginMap.ts || npm run setup) && npm run supported-browsers && vite",
     "local": "npm run supported-browsers && vite --mode docker",
     "preview": "cross-env NODE_ENV=production vite preview",
     "preview:scan": "npm run preview & npx react-scan localhost:4000",


### PR DESCRIPTION
## Proposed Changes

Fixes #15194
- Fix `npm run dev` script so Vite always starts even when `src/pluginMap.ts` already exists.
- Group setup check using parentheses to avoid short-circuit skipping `vite`.
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## How to Test
1. `npm install`
2. `npm run dev`
3. Confirm Vite dev server starts and prints the local URL.


## Merge Checklist
- [ ] Add specs that demonstrate the bug or test the new feature. *(N/A – package.json script change)*
- [ ] Update product documentation. *(N/A)*
- [ ] Ensure that UI text is placed in I18n files. *(N/A)*
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue. *(N/A)*
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices. *(N/A)*
- [x] Complete QA on desktop devices. *(Verified `npm run dev` starts Vite)*
- [ ] Add or update Playwright tests for related changes. *(N/A)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment initialization to ensure all prerequisite steps execute in the correct sequence before the development server starts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->