### PR TITLE
fix: handle optional tendered and amount fields in payment reconciliation schema

### DIFF
--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -149,10 +149,18 @@ const createFormSchema = () =>
         ? z.string().min(1)
         : z.string().optional(),
     })
-    .refine((data) => isGreaterThanOrEqual(data.tendered_amount, data.amount), {
-      message: t("tender_amount_cannot_be_less_than_payment_amount"),
-      path: ["tendered_amount"],
-    });
+    .refine(
+      (data) => {
+        if (!data.tendered_amount || !data.amount) {
+          return true;
+        }
+        return isGreaterThanOrEqual(data.tendered_amount, data.amount);
+      },
+      {
+        message: t("tender_amount_cannot_be_less_than_payment_amount"),
+        path: ["tendered_amount"],
+      },
+    );
 
 export function PaymentReconciliationSheet({
   open,
@@ -253,7 +261,9 @@ export function PaymentReconciliationSheet({
 
   useEffect(() => {
     if (open) {
-      const initialAmount = round(invoice?.total_gross || "0");
+      const initialAmount = invoice?.total_gross
+        ? round(invoice.total_gross)
+        : "";
       form.reset({
         reconciliation_type: invoice
           ? PaymentReconciliationType.payment


### PR DESCRIPTION
Fixes #15196

<img width="493" height="565" alt="image" src="https://github.com/user-attachments/assets/d293e2a8-0f21-4640-af46-8a63bec0164d" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation for payment amount fields to only check for mismatches when both values are provided.

* **Refactor**
  * Updated initial form state handling for payment records when invoice totals are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->