### PR TITLE
Medication decimal fix

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -1205,6 +1205,7 @@ const MedicationRequestGridRow: React.FC<MedicationRequestGridRowProps> = ({
               pattern="[0-9]*[.]?[0-9]*"
               min={0}
               value={
+                !dosageInstruction.timing.repeat.bounds_duration.value ||
                 isZero(dosageInstruction.timing.repeat.bounds_duration.value)
                   ? ""
                   : dosageInstruction.timing.repeat.bounds_duration?.value


### PR DESCRIPTION
Fic medication request crash on removing default 0 on duration field while calling isZero check

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Medication duration field now displays as empty when no value is set, rather than showing placeholder values, improving form clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->