### PR TITLE
move 'Add Component' to bottom of observation definiton so that users can avoid excessive scrolling when adding multiple component

### DIFF
--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
@@ -724,45 +724,16 @@ function ObservationDefinitionFormContent({
             {/* Components Section */}
             <div className="rounded-lg border border-gray-200 bg-white p-4">
               <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h2 className="text-base font-medium text-gray-900">
-                      {t("components")}{" "}
-                      <span className="text-sm font-normal text-gray-500">
-                        {t("optional")}
-                      </span>
-                    </h2>
-                    <p className="mt-0.5 text-sm text-gray-500">
-                      {t("observation_components_description")}
-                    </p>
-                  </div>
-                  {(form.watch("component") ?? [])?.length > 0 && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        const currentComponents =
-                          form.getValues("component") || [];
-                        form.setValue("component", [
-                          ...currentComponents,
-                          {
-                            code: { code: "", display: "", system: "" },
-                            permitted_data_type: QuestionType.quantity,
-                            permitted_unit: {
-                              code: "",
-                              display: "",
-                              system: "",
-                            },
-                            qualified_ranges: [],
-                          },
-                        ]);
-                      }}
-                    >
-                      <PlusCircle className="mr-2 h-4 w-4" />
-                      {t("add_component")}
-                    </Button>
-                  )}
+                <div>
+                  <h2 className="text-base font-medium text-gray-900">
+                    {t("components")}{" "}
+                    <span className="text-sm font-normal text-gray-500">
+                      {t("optional")}
+                    </span>
+                  </h2>
+                  <p className="mt-0.5 text-sm text-gray-500">
+                    {t("observation_components_description")}
+                  </p>
                 </div>
 
                 {(form.watch("component") ?? [])?.length === 0 ? (
@@ -804,7 +775,7 @@ function ObservationDefinitionFormContent({
                     {(form.watch("component") ?? []).map((_, index) => (
                       <div
                         key={index}
-                        className="relative rounded-lg border border-gray-200 bg-white p-4"
+                        className="relative rounded-lg border border-gray-200 bg-gray-50 p-4"
                       >
                         <div className="absolute right-3 top-3">
                           <Button
@@ -961,6 +932,31 @@ function ObservationDefinitionFormContent({
                         </div>
                       </div>
                     ))}
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-full"
+                      onClick={() => {
+                        const currentComponents =
+                          form.getValues("component") || [];
+                        form.setValue("component", [
+                          ...currentComponents,
+                          {
+                            code: { code: "", display: "", system: "" },
+                            permitted_data_type: QuestionType.quantity,
+                            permitted_unit: {
+                              code: "",
+                              display: "",
+                              system: "",
+                            },
+                            qualified_ranges: [],
+                          },
+                        ]);
+                      }}
+                    >
+                      <PlusCircle className="mr-2 h-4 w-4" />
+                      {t("add_component")}
+                    </Button>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
move 'Add Component' to bottom of observation definiton so that users can avoid excessive scrolling when adding multiple component

fixes #15208

<img width="1166" height="1032" alt="image" src="https://github.com/user-attachments/assets/c6c209f6-27c4-48c6-8d95-ae483129f667" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Component cards now display with a light gray background for improved visual distinction.
  * Simplified the Components section header to a compact stacked layout.

* **Refactor**
  * Relocated the "Add Component" button to appear after the component list.
  * Simplified the empty state display when no components are present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->