### PR TITLE
fix: ensure npm run dev always starts vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Open Healthcare Network Contributors",
   "license": "MIT",
   "scripts": {
-    "dev": "test -f src/pluginMap.ts || npm run setup && npm run supported-browsers && vite",
+    "dev": "(node -e \"require('fs').existsSync('src/pluginMap.ts') || process.exit(1)\" || npm run setup) && npm run supported-browsers && vite",
     "local": "npm run supported-browsers && vite --mode docker",
     "preview": "cross-env NODE_ENV=production vite preview",
     "preview:scan": "npm run preview & npx react-scan localhost:4000",


### PR DESCRIPTION
This PR fixes an operator precedence issue in the dev script that prevented Vite from starting when src/pluginMap.ts already existed due to shell operator precedence.

It also replaces the shell `test -f` command with a Node.js file existence check to ensure cross-platform compatibility on Windows.

After this change:
- setup runs only when pluginMap.ts is missing
- Vite always starts
- Behavior is consistent across Windows, macOS, and Linux

Closes #15194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development build process for improved cross-platform compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->