### PR TITLE
Wrapped text in DiagnosticReportTable

### DIFF
--- a/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
+++ b/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
@@ -104,27 +104,27 @@ export function DiagnosticReportResultsTable({
           component.interpretation && "font-semibold",
         )}
       >
-        <TableCell className="pl-4 border-r border-b border-gray-300">
+        <TableCell className="pl-4 border-r border-b border-gray-300 whitespace-normal wrap-break-word">
           <div className="flex items-center gap-1">
             <div className="w-2 h-px bg-gray-400" />
             {component.code?.display}
           </div>
         </TableCell>
-        <TableCell className="border-r border-b border-gray-300">
-          <div className="flex items-center gap-2">
+        <TableCell className="border-r border-b border-gray-300 whitespace-normal wrap-break-word">
+          <div className="whitespace-normal">
             <span>{component.value.value}</span>
             {component.value.unit && (
-              <span className="text-gray-500">
+              <span className="text-gray-500 ml-1">
                 {component.value.unit.display}
               </span>
             )}
           </div>
         </TableCell>
-        <TableCell className="border-r border-b border-gray-300">
+        <TableCell className="border-r border-b border-gray-300 whitespace-normal wrap-break-word">
           {component.reference_range &&
             renderReferenceRange(component.reference_range, component.value)}
         </TableCell>
-        <TableCell className="border-b border-gray-300">
+        <TableCell className="border-b border-gray-300 whitespace-normal wrap-break-word">
           {renderInterpretation(component.interpretation || "")}
         </TableCell>
       </TableRow>
@@ -145,30 +145,30 @@ export function DiagnosticReportResultsTable({
             observation.interpretation && "font-semibold",
           )}
         >
-          <TableCell>
+          <TableCell className="whitespace-normal wrap-break-word">
             {observation.observation_definition?.title ||
               observation.observation_definition?.code?.display}
           </TableCell>
-          <TableCell>
+          <TableCell className="whitespace-normal wrap-break-word">
             {!hasComponents && (
-              <div className="flex items-center gap-2">
+              <div className="whitespace-normal">
                 <span>{observation.value.value}</span>
                 {observation.value.unit && (
-                  <span className="text-gray-500">
+                  <span className="text-gray-500 ml-1">
                     {observation.value.unit.display}
                   </span>
                 )}
               </div>
             )}
           </TableCell>
-          <TableCell>
+          <TableCell className="whitespace-normal wrap-break-word">
             {!hasComponents &&
               renderReferenceRange(
                 observation.reference_range || [],
                 observation.value,
               )}
           </TableCell>
-          <TableCell>
+          <TableCell className="whitespace-normal wrap-break-word">
             {!hasComponents &&
               observation.interpretation &&
               renderInterpretation(observation.interpretation)}
@@ -186,20 +186,20 @@ export function DiagnosticReportResultsTable({
   }
 
   return (
-    <div className="rounded-md border">
-      <Table className="border-collapse bg-white shadow-sm cursor-default">
+    <div className="rounded-md border overflow-hidden">
+      <Table className="border-collapse bg-white shadow-sm cursor-default table-fixed w-full">
         <TableHeader className="bg-gray-100">
           <TableRow className="divide-x-1 divide-gray-300">
             <TableHead className="font-medium text-sm text-gray-700">
               {t("test")}
             </TableHead>
-            <TableHead className="font-medium text-sm text-gray-700">
+            <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
               {t("result")}
             </TableHead>
-            <TableHead className="font-medium text-sm text-gray-700">
+            <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
               {t("reference_range")}
             </TableHead>
-            <TableHead className="font-medium text-sm text-gray-700">
+            <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
               {t("interpretation")}
             </TableHead>
           </TableRow>

--- a/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
+++ b/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
@@ -105,10 +105,8 @@ export function DiagnosticReportResultsTable({
         )}
       >
         <TableCell className="pl-4 border-r border-b border-gray-300 whitespace-normal wrap-break-word">
-          <div className="flex items-center gap-1">
-            <div className="w-2 h-px bg-gray-400" />
-            {component.code?.display}
-          </div>
+          <div className="w-2 h-px bg-gray-400" />
+          {component.code?.display}
         </TableCell>
         <TableCell className="border-r border-b border-gray-300 whitespace-normal wrap-break-word">
           <div className="whitespace-normal">
@@ -190,16 +188,16 @@ export function DiagnosticReportResultsTable({
       <Table className="border-collapse bg-white shadow-sm cursor-default table-fixed w-full">
         <TableHeader className="bg-gray-100">
           <TableRow className="divide-x-1 divide-gray-300">
-            <TableHead className="font-medium text-sm text-gray-700">
+            <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
               {t("test")}
             </TableHead>
             <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
               {t("result")}
             </TableHead>
-            <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
+            <TableHead className="font-medium text-sm text-gray-700 w-[25%] whitespace-normal wrap-break-word">
               {t("reference_range")}
             </TableHead>
-            <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
+            <TableHead className="font-medium text-sm text-gray-700 w-[25%] whitespace-normal wrap-break-word">
               {t("interpretation")}
             </TableHead>
           </TableRow>


### PR DESCRIPTION
## Proposed Changes

Fixes #15220 
- Added text-wrap classes to table cells to wrap text instead of showing scrollbar

<img width="2024" height="1732" alt="Screenshot 2026-01-19 at 11 17 19 AM" src="https://github.com/user-attachments/assets/7d1786ec-35f8-4f3e-bb14-07ce3c9a9db6" />
<img width="2030" height="1482" alt="Screenshot 2026-01-19 at 11 18 48 AM" src="https://github.com/user-attachments/assets/7ce7b024-ef76-4f51-8a20-8ac0e835911f" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping and layout in the Diagnostic Report Results Table for better readability of test results, values, units, and reference ranges.
  * Enhanced spacing and alignment between values and units.
  * Optimized table column width distribution for more consistent display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->