### PR TITLE
Show ChargeItem Price detail for AD

### DIFF
--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -23,14 +23,22 @@ import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import Page from "@/components/Common/Page";
 import { CardListWithHeaderSkeleton } from "@/components/Common/SkeletonLoading";
 
-import mutate from "@/Utils/request/mutate";
-import query from "@/Utils/request/query";
+import { getCurrencySymbol } from "@/components/ui/monetary-display";
 import { Code } from "@/types/base/code/code";
+import { ConditionOperationSummary } from "@/types/base/condition/condition";
+import {
+  MonetaryComponent,
+  MonetaryComponentOrder,
+} from "@/types/base/monetaryComponent/monetaryComponent";
 import {
   ACTIVITY_DEFINITION_STATUS_COLORS,
   Status,
 } from "@/types/emr/activityDefinition/activityDefinition";
 import activityDefinitionApi from "@/types/emr/activityDefinition/activityDefinitionApi";
+import { round } from "@/Utils/decimal";
+import mutate from "@/Utils/request/mutate";
+import query from "@/Utils/request/query";
+import { TFunction } from "i18next";
 import { ArrowLeft } from "lucide-react";
 
 interface Props {
@@ -48,6 +56,40 @@ function CodeDisplay({ code }: { code: Code | null }) {
     </div>
   );
 }
+
+const renderPriceComponent = (component: MonetaryComponent, t: TFunction) => {
+  const typeLabels: Record<string, string> = {
+    base: t("base_price"),
+    discount: t("discount"),
+    tax: t("tax"),
+    informational: t("informational"),
+  };
+
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div>
+        <p className="font-normal">
+          {typeLabels[component.monetary_component_type]}
+        </p>
+        {component.code && (
+          <p className="text-sm text-gray-500">{component.code.display}</p>
+        )}
+      </div>
+      <div className="text-right">
+        {component.amount ? (
+          <p className="font-medium">
+            {getCurrencySymbol()}
+            {round(component.amount)}
+          </p>
+        ) : component.factor ? (
+          <p className="font-medium">{round(component.factor)}%</p>
+        ) : (
+          <p className="text-sm text-gray-500">{t("not_specified")}</p>
+        )}
+      </div>
+    </div>
+  );
+};
 
 export default function ActivityDefinitionView({
   facilityId,
@@ -326,7 +368,7 @@ export default function ActivityDefinitionView({
                 {definition.charge_item_definitions.map((chargeItem) => (
                   <div
                     key={chargeItem.slug}
-                    className="rounded-lg border bg-gray-50/50 p-4 transition-colors hover:bg-gray-50"
+                    className="rounded-lg border bg-gray-50/50 p-4 transition-colors hover:bg-gray-50 space-y-2"
                   >
                     <div className="space-y-2">
                       <p className="font-medium">{chargeItem.title}</p>
@@ -334,11 +376,75 @@ export default function ActivityDefinitionView({
                         {chargeItem.description}
                       </p>
                       <Separator />
-                      <div className="pt-2">
-                        <p className="text-sm text-gray-500">{t("purpose")}</p>
-                        <p className="text-gray-700">{chargeItem.purpose}</p>
-                      </div>
+                      {chargeItem.purpose && (
+                        <div className="pt-2">
+                          <p className="text-sm text-gray-500">
+                            {t("purpose")}
+                          </p>
+                          <p className="text-gray-700">{chargeItem.purpose}</p>
+                        </div>
+                      )}
                     </div>
+                    <Card className="rounded-sm">
+                      <CardHeader>
+                        <CardTitle className="font-medium">
+                          {t("price_components")}
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        {chargeItem.price_components.length === 0 ? (
+                          <div className="py-4 text-center text-gray-500">
+                            <p>{t("no_price_components")}</p>
+                          </div>
+                        ) : (
+                          <div>
+                            {chargeItem.price_components
+                              .sort(
+                                (a, b) =>
+                                  MonetaryComponentOrder[
+                                    a.monetary_component_type
+                                  ] -
+                                  MonetaryComponentOrder[
+                                    b.monetary_component_type
+                                  ],
+                              )
+                              .map((component, index) => (
+                                <div key={index}>
+                                  {renderPriceComponent(component, t)}
+                                  {index <
+                                    chargeItem.price_components.length - 1 && (
+                                    <Separator className="my-2" />
+                                  )}
+                                  {/* {component.conditions && ( */}
+                                  {component.conditions && (
+                                    <div>
+                                      <p className="text-sm text-gray-500">
+                                        {t("conditions")}
+                                      </p>
+                                      <div className="flex flex-wrap gap-1 mt-1">
+                                        {component.conditions?.map(
+                                          (condition, index) => {
+                                            return (
+                                              <div
+                                                key={index}
+                                                className="flex items-center justify-between text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded border"
+                                              >
+                                                <ConditionOperationSummary
+                                                  condition={condition}
+                                                />
+                                              </div>
+                                            );
+                                          },
+                                        )}
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
                   </div>
                 ))}
               </div>

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -23,22 +23,15 @@ import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import Page from "@/components/Common/Page";
 import { CardListWithHeaderSkeleton } from "@/components/Common/SkeletonLoading";
 
-import { getCurrencySymbol } from "@/components/ui/monetary-display";
+import { PriceComponentCard } from "@/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionDetail";
 import { Code } from "@/types/base/code/code";
-import { ConditionOperationSummary } from "@/types/base/condition/condition";
-import {
-  MonetaryComponent,
-  MonetaryComponentOrder,
-} from "@/types/base/monetaryComponent/monetaryComponent";
 import {
   ACTIVITY_DEFINITION_STATUS_COLORS,
   Status,
 } from "@/types/emr/activityDefinition/activityDefinition";
 import activityDefinitionApi from "@/types/emr/activityDefinition/activityDefinitionApi";
-import { round } from "@/Utils/decimal";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
-import { TFunction } from "i18next";
 import { ArrowLeft } from "lucide-react";
 
 interface Props {
@@ -56,40 +49,6 @@ function CodeDisplay({ code }: { code: Code | null }) {
     </div>
   );
 }
-
-const renderPriceComponent = (component: MonetaryComponent, t: TFunction) => {
-  const typeLabels: Record<string, string> = {
-    base: t("base_price"),
-    discount: t("discount"),
-    tax: t("tax"),
-    informational: t("informational"),
-  };
-
-  return (
-    <div className="flex items-center justify-between py-2">
-      <div>
-        <p className="font-normal">
-          {typeLabels[component.monetary_component_type]}
-        </p>
-        {component.code && (
-          <p className="text-sm text-gray-500">{component.code.display}</p>
-        )}
-      </div>
-      <div className="text-right">
-        {component.amount ? (
-          <p className="font-medium">
-            {getCurrencySymbol()}
-            {round(component.amount)}
-          </p>
-        ) : component.factor ? (
-          <p className="font-medium">{round(component.factor)}%</p>
-        ) : (
-          <p className="text-sm text-gray-500">{t("not_specified")}</p>
-        )}
-      </div>
-    </div>
-  );
-};
 
 export default function ActivityDefinitionView({
   facilityId,
@@ -385,66 +344,7 @@ export default function ActivityDefinitionView({
                         </div>
                       )}
                     </div>
-                    <Card className="rounded-sm">
-                      <CardHeader>
-                        <CardTitle className="font-medium">
-                          {t("price_components")}
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        {chargeItem.price_components.length === 0 ? (
-                          <div className="py-4 text-center text-gray-500">
-                            <p>{t("no_price_components")}</p>
-                          </div>
-                        ) : (
-                          <div>
-                            {chargeItem.price_components
-                              .sort(
-                                (a, b) =>
-                                  MonetaryComponentOrder[
-                                    a.monetary_component_type
-                                  ] -
-                                  MonetaryComponentOrder[
-                                    b.monetary_component_type
-                                  ],
-                              )
-                              .map((component, index) => (
-                                <div key={index}>
-                                  {renderPriceComponent(component, t)}
-                                  {index <
-                                    chargeItem.price_components.length - 1 && (
-                                    <Separator className="my-2" />
-                                  )}
-                                  {/* {component.conditions && ( */}
-                                  {component.conditions && (
-                                    <div>
-                                      <p className="text-sm text-gray-500">
-                                        {t("conditions")}
-                                      </p>
-                                      <div className="flex flex-wrap gap-1 mt-1">
-                                        {component.conditions?.map(
-                                          (condition, index) => {
-                                            return (
-                                              <div
-                                                key={index}
-                                                className="flex items-center justify-between text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded border"
-                                              >
-                                                <ConditionOperationSummary
-                                                  condition={condition}
-                                                />
-                                              </div>
-                                            );
-                                          },
-                                        )}
-                                      </div>
-                                    </div>
-                                  )}
-                                </div>
-                              ))}
-                          </div>
-                        )}
-                      </CardContent>
-                    </Card>
+                    <PriceComponentCard chargeItemDefinition={chargeItem} />
                   </div>
                 ))}
               </div>

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionDetail.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionDetail.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/types/base/monetaryComponent/monetaryComponent";
 import {
   CHARGE_ITEM_DEFINITION_STATUS_COLORS,
+  ChargeItemDefinitionRead,
   ChargeItemDefinitionStatus,
 } from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
 import chargeItemDefinitionApi from "@/types/billing/chargeItemDefinition/chargeItemDefinitionApi";
@@ -36,6 +37,98 @@ import { ArrowLeft } from "lucide-react";
 interface ChargeItemDefinitionDetailProps {
   facilityId: string;
   slug: string;
+}
+
+export function PriceComponentCard({
+  chargeItemDefinition,
+}: {
+  chargeItemDefinition: ChargeItemDefinitionRead;
+}) {
+  const { t } = useTranslation();
+  const renderPriceComponent = (component: MonetaryComponent) => {
+    const typeLabels: Record<string, string> = {
+      base: t("base_price"),
+      discount: t("discount"),
+      tax: t("tax"),
+      informational: t("informational"),
+    };
+
+    return (
+      <div className="flex items-center justify-between py-2">
+        <div>
+          <p className="font-medium">
+            {typeLabels[component.monetary_component_type]}
+          </p>
+          {component.code && (
+            <p className="text-sm text-gray-500">{component.code.display}</p>
+          )}
+        </div>
+        <div className="text-right">
+          {component.amount ? (
+            <p className="font-medium">
+              {getCurrencySymbol()}
+              {round(component.amount)}
+            </p>
+          ) : component.factor ? (
+            <p className="font-medium">{round(component.factor)}%</p>
+          ) : (
+            <p className="text-sm text-gray-500">{t("not_specified")}</p>
+          )}
+        </div>
+      </div>
+    );
+  };
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("price_components")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chargeItemDefinition.price_components.length === 0 ? (
+          <div className="py-4 text-center text-gray-500">
+            <p>{t("no_price_components")}</p>
+          </div>
+        ) : (
+          <div>
+            {chargeItemDefinition.price_components
+              .sort(
+                (a, b) =>
+                  MonetaryComponentOrder[a.monetary_component_type] -
+                  MonetaryComponentOrder[b.monetary_component_type],
+              )
+              .map((component, index) => (
+                <div key={index}>
+                  {renderPriceComponent(component)}
+                  {index < chargeItemDefinition.price_components.length - 1 && (
+                    <Separator className="my-2" />
+                  )}
+                  {/* {component.conditions && ( */}
+                  {component.conditions && (
+                    <div>
+                      <p className="text-sm text-gray-500">{t("conditions")}</p>
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {component.conditions?.map((condition, index) => {
+                          return (
+                            <div
+                              key={index}
+                              className="flex items-center justify-between text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded border"
+                            >
+                              <ConditionOperationSummary
+                                condition={condition}
+                              />
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
 }
 
 export function ChargeItemDefinitionDetail({
@@ -75,40 +168,6 @@ export function ChargeItemDefinitionDetail({
       category: chargeItemDefinition.category.slug,
       slug_value: chargeItemDefinition.slug_config.slug_value,
     });
-  };
-
-  const renderPriceComponent = (component: MonetaryComponent) => {
-    const typeLabels: Record<string, string> = {
-      base: t("base_price"),
-      discount: t("discount"),
-      tax: t("tax"),
-      informational: t("informational"),
-    };
-
-    return (
-      <div className="flex items-center justify-between py-2">
-        <div>
-          <p className="font-medium">
-            {typeLabels[component.monetary_component_type]}
-          </p>
-          {component.code && (
-            <p className="text-sm text-gray-500">{component.code.display}</p>
-          )}
-        </div>
-        <div className="text-right">
-          {component.amount ? (
-            <p className="font-medium">
-              {getCurrencySymbol()}
-              {round(component.amount)}
-            </p>
-          ) : component.factor ? (
-            <p className="font-medium">{round(component.factor)}%</p>
-          ) : (
-            <p className="text-sm text-gray-500">{t("not_specified")}</p>
-          )}
-        </div>
-      </div>
-    );
   };
 
   if (isLoading) {
@@ -265,58 +324,7 @@ export function ChargeItemDefinitionDetail({
             </Card>
           )}
 
-          <Card>
-            <CardHeader>
-              <CardTitle>{t("price_components")}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {chargeItemDefinition.price_components.length === 0 ? (
-                <div className="py-4 text-center text-gray-500">
-                  <p>{t("no_price_components")}</p>
-                </div>
-              ) : (
-                <div>
-                  {chargeItemDefinition.price_components
-                    .sort(
-                      (a, b) =>
-                        MonetaryComponentOrder[a.monetary_component_type] -
-                        MonetaryComponentOrder[b.monetary_component_type],
-                    )
-                    .map((component, index) => (
-                      <div key={index}>
-                        {renderPriceComponent(component)}
-                        {index <
-                          chargeItemDefinition.price_components.length - 1 && (
-                          <Separator className="my-2" />
-                        )}
-                        {/* {component.conditions && ( */}
-                        {component.conditions && (
-                          <div>
-                            <p className="text-sm text-gray-500">
-                              {t("conditions")}
-                            </p>
-                            <div className="flex flex-wrap gap-1 mt-1">
-                              {component.conditions?.map((condition, index) => {
-                                return (
-                                  <div
-                                    key={index}
-                                    className="flex items-center justify-between text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded border"
-                                  >
-                                    <ConditionOperationSummary
-                                      condition={condition}
-                                    />
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <PriceComponentCard chargeItemDefinition={chargeItemDefinition} />
         </div>
       </div>
     </Page>

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionDetail.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionDetail.tsx
@@ -51,6 +51,7 @@ export function PriceComponentCard({
       discount: t("discount"),
       tax: t("tax"),
       informational: t("informational"),
+      surcharge: t("surcharge"),
     };
 
     return (
@@ -102,7 +103,6 @@ export function PriceComponentCard({
                   {index < chargeItemDefinition.price_components.length - 1 && (
                     <Separator className="my-2" />
                   )}
-                  {/* {component.conditions && ( */}
                   {component.conditions && (
                     <div>
                       <p className="text-sm text-gray-500">{t("conditions")}</p>


### PR DESCRIPTION
## Proposed Changes

- Fixes https://github.com/ohcnetwork/care_fe/issues/15224


<img width="763" height="804" alt="Screenshot 2026-01-19 at 3 44 43 PM" src="https://github.com/user-attachments/assets/e6242c9d-017a-4f09-8195-72c6ac1ab748" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated card component for displaying price components in charge item definitions, consolidating price rendering for clearer, reusable UI.

* **Bug Fixes**
  * Purpose information now renders only when present, preventing empty or misleading displays.

* **Style**
  * Improved spacing and layout in charge item containers for better visual hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->