### PR TITLE
Made the service request form default state as open

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/ServiceRequestQuestion.tsx
@@ -141,7 +141,7 @@ function ServiceRequestForm({
   facilityId = "",
 }: ServiceRequestFormProps) {
   const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION
## Proposed Changes

Made the service request form default state as open
- fixes #15262

<img width="951" height="751" alt="image" src="https://github.com/user-attachments/assets/ae7b768d-0a33-42d4-880d-29b3d09b41ac" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Service request form now displays with all fields expanded by default, allowing users to immediately view and access available options without requiring manual interaction to expand the section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->