### PR TITLE
add charge item status to print charge items

### DIFF
--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -26,7 +26,6 @@ import { PAYMENT_RECONCILIATION_METHOD_MAP } from "@/types/billing/paymentReconc
 import { MonetaryComponentType } from "@/types/base/monetaryComponent/monetaryComponent";
 import accountApi from "@/types/billing/account/accountApi";
 import {
-  CHARGE_ITEM_STATUS_COLORS,
   ChargeItemRead,
   ChargeItemStatus,
 } from "@/types/billing/chargeItem/chargeItem";
@@ -41,7 +40,6 @@ import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/pa
 import { add, round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
 import { formatDateTime, formatPatientAge } from "@/Utils/utils";
-import { Badge } from "@/components/ui/badge";
 
 interface DetailRowProps {
   label: string;
@@ -460,16 +458,9 @@ export const PrintChargeItems = (props: {
                                             </div>
                                           </TableCell>
                                           <TableCell className="text-center w-8">
-                                            <Badge
-                                              variant={
-                                                CHARGE_ITEM_STATUS_COLORS[
-                                                  chargeItem.status
-                                                ]
-                                              }
-                                              className="text-xs py-0 px-1"
-                                            >
+                                            <span className="text-xs">
                                               {t(chargeItem.status)}
-                                            </Badge>
+                                            </span>
                                           </TableCell>
                                           <TableCell className="text-right w-10">
                                             <MonetaryDisplay

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -26,6 +26,7 @@ import { PAYMENT_RECONCILIATION_METHOD_MAP } from "@/types/billing/paymentReconc
 import { MonetaryComponentType } from "@/types/base/monetaryComponent/monetaryComponent";
 import accountApi from "@/types/billing/account/accountApi";
 import {
+  CHARGE_ITEM_STATUS_COLORS,
   ChargeItemRead,
   ChargeItemStatus,
 } from "@/types/billing/chargeItem/chargeItem";
@@ -40,6 +41,7 @@ import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/pa
 import { add, round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
 import { formatDateTime, formatPatientAge } from "@/Utils/utils";
+import { Badge } from "@/components/ui/badge";
 
 interface DetailRowProps {
   label: string;
@@ -328,7 +330,10 @@ export const PrintChargeItems = (props: {
                                   <TableHead className="font-bold w-24">
                                     {t("title")}
                                   </TableHead>
-                                  <TableHead className="font-bold text-right w-10">
+                                  <TableHead className="font-bold text-center w-8">
+                                    {t("status")}
+                                  </TableHead>
+                                  <TableHead className="font-bold w-10">
                                     {t("rate")}
                                   </TableHead>
                                   <TableHead className="font-bold text-right w-10">
@@ -453,6 +458,18 @@ export const PrintChargeItems = (props: {
                                                 {chargeItem.title}
                                               </span>
                                             </div>
+                                          </TableCell>
+                                          <TableCell className="text-center w-8">
+                                            <Badge
+                                              variant={
+                                                CHARGE_ITEM_STATUS_COLORS[
+                                                  chargeItem.status
+                                                ]
+                                              }
+                                              className="text-xs py-0 px-1"
+                                            >
+                                              {t(chargeItem.status)}
+                                            </Badge>
                                           </TableCell>
                                           <TableCell className="text-right w-10">
                                             <MonetaryDisplay


### PR DESCRIPTION
## proposed changes

- fixes #15282

<img width="1069" height="768" alt="image" src="https://github.com/user-attachments/assets/bf980df4-4676-44bb-b019-17a2a0e91d61" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing table includes a new centered Status column between Title and Rate.
  * Each charge row now shows the item status (translated) for clearer at-a-glance state visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->