### PR TITLE
Fix/#15260 empty dropdown should show comment

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3375,6 +3375,7 @@
   "no_tests_taken": "No tests taken",
   "no_text": "No text added",
   "no_token": "No token",
+  "no_token_category_avaialable": "No token category available",
   "no_tokens_awaiting_recall": "No tokens awaiting recall",
   "no_tokens_finished": "No tokens finished",
   "no_tokens_found": "No tokens available",

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3375,7 +3375,7 @@
   "no_tests_taken": "No tests taken",
   "no_text": "No text added",
   "no_token": "No token",
-  "no_token_category_avaialable": "No token category available",
+  "no_token_category_available": "No token category available",
   "no_tokens_awaiting_recall": "No tokens awaiting recall",
   "no_tokens_finished": "No tokens finished",
   "no_tokens_found": "No tokens available",

--- a/src/pages/Appointments/components/TokenGenerationSheet.tsx
+++ b/src/pages/Appointments/components/TokenGenerationSheet.tsx
@@ -150,22 +150,20 @@ export function TokenGenerationSheet({
                     <SelectValue placeholder={t("select_token_category")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectContent>
-                      {tokenCategories?.results?.length ? (
-                        tokenCategories.results.map(
-                          (category: TokenCategoryRead) => (
-                            <SelectItem key={category.id} value={category.id}>
-                              {category.name}
-                              {category.default && ` (${t("default")})`}
-                            </SelectItem>
-                          ),
-                        )
-                      ) : (
-                        <SelectItem disabled value="no-options">
-                          {t("no_token_category_available")}
-                        </SelectItem>
-                      )}
-                    </SelectContent>
+                    {tokenCategories?.results?.length ? (
+                      tokenCategories.results.map(
+                        (category: TokenCategoryRead) => (
+                          <SelectItem key={category.id} value={category.id}>
+                            {category.name}
+                            {category.default && ` (${t("default")})`}
+                          </SelectItem>
+                        ),
+                      )
+                    ) : (
+                      <SelectItem disabled value="no-options">
+                        {t("no_token_category_available")}
+                      </SelectItem>
+                    )}
                   </SelectContent>
                 </Select>
               </div>

--- a/src/pages/Appointments/components/TokenGenerationSheet.tsx
+++ b/src/pages/Appointments/components/TokenGenerationSheet.tsx
@@ -150,14 +150,22 @@ export function TokenGenerationSheet({
                     <SelectValue placeholder={t("select_token_category")} />
                   </SelectTrigger>
                   <SelectContent>
-                    {tokenCategories?.results?.map(
-                      (category: TokenCategoryRead) => (
-                        <SelectItem key={category.id} value={category.id}>
-                          {category.name}
-                          {category.default && ` (${t("default")})`}
+                    <SelectContent>
+                      {tokenCategories?.results?.length ? (
+                        tokenCategories.results.map(
+                          (category: TokenCategoryRead) => (
+                            <SelectItem key={category.id} value={category.id}>
+                              {category.name}
+                              {category.default && ` (${t("default")})`}
+                            </SelectItem>
+                          ),
+                        )
+                      ) : (
+                        <SelectItem disabled value="no-options">
+                          {t("no_token_category_avaialable")}
                         </SelectItem>
-                      ),
-                    )}
+                      )}
+                    </SelectContent>
                   </SelectContent>
                 </Select>
               </div>

--- a/src/pages/Appointments/components/TokenGenerationSheet.tsx
+++ b/src/pages/Appointments/components/TokenGenerationSheet.tsx
@@ -162,7 +162,7 @@ export function TokenGenerationSheet({
                         )
                       ) : (
                         <SelectItem disabled value="no-options">
-                          {t("no_token_category_avaialable")}
+                          {t("no_token_category_available")}
                         </SelectItem>
                       )}
                     </SelectContent>

--- a/src/pages/PublicAppointments/Schedule.tsx
+++ b/src/pages/PublicAppointments/Schedule.tsx
@@ -292,6 +292,7 @@ export function ScheduleAppointment(props: AppointmentsProps) {
                 month={selectedMonth}
                 onMonthChange={setSelectedMonth}
                 renderDay={renderDay}
+                setSelectedDate={setSelectedDate}
                 highlightToday={false}
               />
               <div className="space-y-6">

--- a/src/pages/PublicAppointments/Schedule.tsx
+++ b/src/pages/PublicAppointments/Schedule.tsx
@@ -292,7 +292,6 @@ export function ScheduleAppointment(props: AppointmentsProps) {
                 month={selectedMonth}
                 onMonthChange={setSelectedMonth}
                 renderDay={renderDay}
-                setSelectedDate={setSelectedDate}
                 highlightToday={false}
               />
               <div className="space-y-6">


### PR DESCRIPTION
## Proposed Changes

Fixes #15260 
- Added `"no_token_category_avaialable": "No token category available"` in en.json
- If `tokenCategories.length === 0`, added **no_token_category_available**.
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show an explicit disabled empty-state item when no token categories are available.
  * Ensure calendar interactions update the selected appointment date in the schedule.

* **Chores**
  * Added an English UI string: "No token category available" for empty-state messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->