### PR TITLE
skip including medication requests that have been untouched

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3140,6 +3140,7 @@
   "medication_dispenses": "Medication Dispenses",
   "medication_history": "Medication History",
   "medication_list": "Medication List",
+  "medication_list_truncated_warning": "Showing {{shown}} of {{total}} medications. Some older medications may not be displayed due to the large number of records.",
   "medication_request_prescription": "Medication Request Prescription",
   "medication_request_status_updated_successfully": "Medication request status updated successfully",
   "medication_requests": "Medication Requests",

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -277,6 +277,7 @@ export function MedicationRequestQuestion({
               requested_product_internal: medication.requested_product,
               requested_product: medication.requested_product?.id,
               requester: medication.requester || currentUser,
+              dirty: false, // Existing medications are not dirty
             })),
           },
         ],
@@ -556,7 +557,7 @@ export function MedicationRequestQuestion({
   const addNewMedication = (medication: MedicationRequestCreate) => {
     const newMedications: MedicationRequestCreate[] = [
       ...medications,
-      medication,
+      { ...medication, dirty: true }, // Mark new medication as dirty
     ];
 
     updateQuestionnaireResponseCB(
@@ -592,6 +593,7 @@ export function MedicationRequestQuestion({
           requested_product_internal: requested_product,
           requester: currentUser,
           medication: requested_product?.id ? null : request.medication,
+          dirty: true, // Mark as dirty since it's being added as new
         } as MedicationRequestCreate;
       } else {
         const statement = record as MedicationStatementRead;
@@ -600,6 +602,7 @@ export function MedicationRequestQuestion({
           authored_on: new Date().toISOString(),
           note: statement.note,
           requester: currentUser,
+          dirty: true, // Mark as dirty since it's being added as new
         } as MedicationRequestCreate;
       }
     });
@@ -631,7 +634,7 @@ export function MedicationRequestQuestion({
       // For existing records, update status to entered_in_error
       const newMedications = medications.map((med, i) =>
         i === medicationToDelete
-          ? { ...med, status: "entered_in_error" as const }
+          ? { ...med, status: "entered_in_error" as const, dirty: true }
           : med,
       );
       updateQuestionnaireResponseCB(
@@ -656,7 +659,7 @@ export function MedicationRequestQuestion({
     updates: Partial<MedicationRequestCreate>,
   ) => {
     const newMedications = medications.map((medication, i) =>
-      i === index ? { ...medication, ...updates } : medication,
+      i === index ? { ...medication, ...updates, dirty: true } : medication,
     );
 
     updateQuestionnaireResponseCB(
@@ -703,6 +706,7 @@ export function MedicationRequestQuestion({
       requester: currentUser,
       requested_product: productId, // Use UUID
       requested_product_internal: productKnowledge,
+      dirty: true, // Mark as dirty since it's being added as new
     };
 
     const newMedications: MedicationRequestCreate[] = [
@@ -775,6 +779,7 @@ export function MedicationRequestQuestion({
             requester: currentUser,
             requested_product: productId, // Use UUID
             requested_product_internal: productKnowledge,
+            dirty: true, // Mark as dirty since it's being added as new
           };
         }),
       );

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -2,6 +2,7 @@ import { MinusCircledIcon } from "@radix-ui/react-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { t } from "i18next";
 import {
+  AlertTriangle,
   ChevronsDownUp,
   ChevronsUpDown,
   FileTextIcon,
@@ -17,6 +18,7 @@ import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -259,6 +261,7 @@ export function MedicationRequestQuestion({
       pathParams: { patientId },
       queryParams: {
         encounter: encounterId,
+        ordering: "-modified_date",
         limit: 100,
         facility: facilityId,
       },
@@ -1278,6 +1281,17 @@ export function MedicationRequestQuestion({
           />
         )}
       </div>
+      {patientMedications?.count && patientMedications.count > 100 && (
+        <Alert className="bg-yellow-50 border-yellow-200">
+          <AlertTriangle className="h-4 w-4 text-yellow-600" />
+          <AlertDescription className="text-yellow-800">
+            {t("medication_list_truncated_warning", {
+              shown: 100,
+              total: patientMedications.count,
+            })}
+          </AlertDescription>
+        </Alert>
+      )}
       {medications.length > 0 && (
         <div className="md:overflow-x-auto w-auto">
           <div className="min-w-fit">

--- a/src/components/Questionnaire/structured/handlers.ts
+++ b/src/components/Questionnaire/structured/handlers.ts
@@ -58,7 +58,10 @@ export const structuredHandlers: {
   },
   medication_request: {
     getRequests: async (medications, { patientId, encounterId }) => {
-      if (medications.length === 0) {
+      // Only submit medications that have been modified (dirty)
+      const dirtyMedications = medications.filter((m) => m.dirty);
+
+      if (dirtyMedications.length === 0) {
         return [];
       }
 
@@ -69,7 +72,7 @@ export const structuredHandlers: {
           url: `/api/v1/patient/${patientId}/medication/request/upsert/`,
           method: "POST",
           body: {
-            datapoints: medications.map((medication) => ({
+            datapoints: dirtyMedications.map((medication) => ({
               ...medication,
               ...(!medication.id && {
                 create_prescription: {

--- a/src/types/emr/medicationRequest/medicationRequest.ts
+++ b/src/types/emr/medicationRequest/medicationRequest.ts
@@ -222,6 +222,7 @@ export interface MedicationRequest {
 
 export interface MedicationRequestCreate extends MedicationRequest {
   create_prescription?: PrescriptionCreate;
+  dirty?: boolean;
 }
 
 export interface MedicationRequestRequest extends Omit<


### PR DESCRIPTION
- fixes #15288

<img width="1150" height="572" alt="image" src="https://github.com/user-attachments/assets/d0f2f3d4-742a-4c16-9302-cca9706fff69" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Medication handling now tracks and submits only medications the user has added or modified, reducing unnecessary updates.
* **New Features**
  * Shows a warning when a patient has more than 100 medications and indicates only a subset is displayed.
  * Medication lists are ordered by most-recently modified items.
* **Localization**
  * Added copy for the medication-list truncation warning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->