### PR TITLE
Fix zero-value charge items incorrectly marked as unpaid

### DIFF
--- a/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
+++ b/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
@@ -159,6 +159,9 @@ export function DispenseHistory({
               const instruction = medication.dosage_instruction[0] ?? {};
               const frequency = instruction?.timing?.code;
               const dosage = instruction?.dose_and_rate?.dose_quantity;
+              const totalAmount = Number(
+                medication.charge_item?.total_price || 0,
+              );
 
               return (
                 <TableRow
@@ -215,7 +218,18 @@ export function DispenseHistory({
                         hidden={!facilityId}
                       >
                         <Link
-                          href={`/facility/${facilityId}/locations/${medication.location.id}/medication_dispense/${dispenseOrderId ? `order/${dispenseOrderId}/?status=${medication.status}&payment_status=${medication.charge_item?.paid_invoice?.status === InvoiceStatus.balanced ? "paid" : "unpaid"}` : ""}`}
+                          href={`/facility/${facilityId}/locations/${medication.location.id}/medication_dispense/${
+                            dispenseOrderId
+                              ? `order/${dispenseOrderId}/${medication.status}?payment_status=${
+                                  !medication.charge_item || totalAmount === 0
+                                    ? "paid"
+                                    : medication.charge_item?.paid_invoice
+                                          ?.status === InvoiceStatus.balanced
+                                      ? "paid"
+                                      : "unpaid"
+                                }`
+                              : ""
+                          }`}
                         >
                           {t("dispense")}
                         </Link>

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -62,7 +62,6 @@ import {
 } from "@/types/emr/dispenseOrder/dispenseOrder";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import { PatientListRead } from "@/types/emr/patient/patient";
-import { round } from "@/Utils/decimal";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
@@ -70,6 +69,7 @@ import { PillIcon } from "lucide-react";
 import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { round } from "@/Utils/decimal";
 
 interface MedicationTableProps {
   facilityId: string;
@@ -146,6 +146,9 @@ function MedicationTable({ facilityId, medications }: MedicationTableProps) {
             const instruction = medication.dosage_instruction[0] ?? {};
             const frequency = instruction?.timing?.code;
             const dosage = instruction?.dose_and_rate?.dose_quantity;
+            const totalAmount = Number(
+              medication.charge_item?.total_price || 0,
+            );
             const isPaid =
               medication.charge_item?.paid_invoice?.status ===
               InvoiceStatus.balanced;
@@ -221,8 +224,8 @@ function MedicationTable({ facilityId, medications }: MedicationTableProps) {
                   {new Date(medication.when_prepared).toLocaleDateString()}
                 </TableCell>
                 <TableCell>
-                  {!medication.charge_item ? (
-                    "-"
+                  {!medication.charge_item || totalAmount === 0 ? (
+                    "—"
                   ) : (
                     <Badge variant={isPaid ? "green" : "destructive"}>
                       {isPaid ? t("paid") : t("unpaid")}
@@ -428,14 +431,32 @@ export default function DispensedMedicationList({
   };
 
   const filteredMedications = medications?.filter((med) => {
-    if (paymentFilter === "paid")
+    const totalAmount = Number(med.charge_item?.total_price || 0);
+
+    // Case 1: No charge item at all
+    if (!med.charge_item) {
+      return paymentFilter === "all";
+    }
+
+    // Case 2: Zero-amount charge → treat as paid, but neutral
+    if (totalAmount === 0) {
+      return paymentFilter === "all" || paymentFilter === "paid";
+    }
+
+    // Case 3: Normal paid
+    if (paymentFilter === "paid") {
       return med.charge_item?.paid_invoice?.status === InvoiceStatus.balanced;
-    if (paymentFilter === "unpaid")
+    }
+
+    // Case 4: Normal unpaid
+    if (paymentFilter === "unpaid") {
       return (
         !med.charge_item?.paid_invoice ||
         med.charge_item?.paid_invoice?.status === InvoiceStatus.issued ||
         med.charge_item?.paid_invoice?.status === InvoiceStatus.draft
       );
+    }
+
     return true;
   });
 

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/types/emr/dispenseOrder/dispenseOrder";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import { PatientListRead } from "@/types/emr/patient/patient";
+import { round } from "@/Utils/decimal";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
@@ -69,7 +70,6 @@ import { PillIcon } from "lucide-react";
 import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { round } from "@/Utils/decimal";
 
 interface MedicationTableProps {
   facilityId: string;


### PR DESCRIPTION
## Proposed Changes

Fixes #15105

- Fixed incorrect Unpaid status for dispenses with zero-value (₹0) charge items.
- Updated payment status logic to rely on the total payable amount instead of the existence of a ChargeItem.
- Ensured zero-value dispenses no longer appear in unpaid filters and behave consistently across dispense history views.

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update product documentation.
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes.

Additional context
Zero-value charge items are auto-generated in some flows. These were previously classified as unpaid, which is semantically incorrect and caused confusion in dispense history and filters.

Tagging: @ohcnetwork/care-fe-code-reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment-status logic for dispensed medications to correctly handle missing charge items and zero-amount charges.
  * Updated medication list filtering and payment-status display (shows a dash when no charge applies) so lists and links reflect accurate paid/unpaid states across all edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->