### PR TITLE
SRs: hide interp/range if no value

### DIFF
--- a/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
+++ b/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
@@ -26,6 +26,29 @@ interface DiagnosticReportResultsTableProps {
 export function DiagnosticReportResultsTable({
   observations,
 }: DiagnosticReportResultsTableProps) {
+  const hasReferenceRange = observations.some(
+    (observation) =>
+      observation.reference_range && observation.reference_range.length > 0,
+  );
+  const hasInterpretation = observations.some(
+    (observation) => observation.interpretation,
+  );
+  const hasComponentReferenceRange = observations.some(
+    (observation) =>
+      observation.component &&
+      observation.component.some(
+        (component) =>
+          component.reference_range && component.reference_range.length > 0,
+      ),
+  );
+  const hasComponentInterpretation = observations.some(
+    (observation) =>
+      observation.component &&
+      observation.component.some((component) => component.interpretation),
+  );
+  const showReferenceRange = hasReferenceRange || hasComponentReferenceRange;
+  const showInterpretation = hasInterpretation || hasComponentInterpretation;
+
   const renderReferenceRange = (
     referenceRange: ObservationReferenceRange[],
     value: QuestionnaireSubmitResultValue,
@@ -124,13 +147,18 @@ export function DiagnosticReportResultsTable({
             )}
           </div>
         </TableCell>
-        <TableCell className="border-r border-b border-gray-300 whitespace-normal wrap-break-word">
-          {component.reference_range &&
-            renderReferenceRange(component.reference_range, component.value)}
-        </TableCell>
-        <TableCell className="border-b border-gray-300 whitespace-normal wrap-break-word">
-          {renderInterpretation(component.interpretation || "")}
-        </TableCell>
+        {showReferenceRange && (
+          <TableCell className="border-r border-b border-gray-300 whitespace-normal wrap-break-word">
+            {component.reference_range &&
+              renderReferenceRange(component.reference_range, component.value)}
+          </TableCell>
+        )}
+        {showInterpretation && (
+          <TableCell className="border-b border-gray-300 whitespace-normal wrap-break-word">
+            {component.interpretation &&
+              renderInterpretation(component.interpretation)}
+          </TableCell>
+        )}
       </TableRow>
     ));
   };
@@ -166,18 +194,23 @@ export function DiagnosticReportResultsTable({
               </div>
             )}
           </TableCell>
-          <TableCell className="whitespace-normal wrap-break-word">
-            {!hasComponents &&
-              renderReferenceRange(
-                observation.reference_range || [],
-                observation.value,
-              )}
-          </TableCell>
-          <TableCell className="whitespace-normal wrap-break-word">
-            {!hasComponents &&
-              observation.interpretation &&
-              renderInterpretation(observation.interpretation)}
-          </TableCell>
+          {showReferenceRange && (
+            <TableCell className="whitespace-normal wrap-break-word">
+              {!hasComponents &&
+                observation.reference_range &&
+                renderReferenceRange(
+                  observation.reference_range,
+                  observation.value,
+                )}
+            </TableCell>
+          )}
+          {showInterpretation && (
+            <TableCell className="whitespace-normal wrap-break-word">
+              {!hasComponents &&
+                observation.interpretation &&
+                renderInterpretation(observation.interpretation)}
+            </TableCell>
+          )}
         </TableRow>
         {hasComponents &&
           observation.component &&
@@ -201,12 +234,16 @@ export function DiagnosticReportResultsTable({
             <TableHead className="font-medium text-sm text-gray-700 w-[25%]">
               {t("result")}
             </TableHead>
-            <TableHead className="font-medium text-sm text-gray-700 w-[25%] whitespace-normal wrap-break-word">
-              {t("reference_range")}
-            </TableHead>
-            <TableHead className="font-medium text-sm text-gray-700 w-[25%] whitespace-normal wrap-break-word">
-              {t("interpretation")}
-            </TableHead>
+            {showReferenceRange && (
+              <TableHead className="font-medium text-sm text-gray-700 w-[25%] whitespace-normal wrap-break-word">
+                {t("reference_range")}
+              </TableHead>
+            )}
+            {showInterpretation && (
+              <TableHead className="font-medium text-sm text-gray-700 w-[25%] whitespace-normal wrap-break-word">
+                {t("interpretation")}
+              </TableHead>
+            )}
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
@@ -188,16 +188,16 @@ export function SpecimenForm({
     const quantity = specimenData.specimen.collection?.quantity;
     const newErrors: typeof errors = {};
 
-    if (!quantity?.value) {
-      newErrors.quantityValue = t("field_required");
+    if (quantity?.value && !quantity.unit) {
+      newErrors.quantityUnit = t("field_required");
     }
 
     if (quantity?.value && isNegative(quantity.value)) {
       newErrors.quantityValue = t("invalid_quantity");
     }
 
-    if (!quantity?.unit && !defaultUnit) {
-      newErrors.quantityUnit = t("field_required");
+    if (quantity?.unit && !quantity.value) {
+      newErrors.quantityValue = t("field_required");
     }
 
     if (Object.keys(newErrors).length > 0) {

--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
@@ -154,7 +154,7 @@ function ObservationDefinitionFormContent({
           z.object({
             code: CodeSchema,
             permitted_data_type: z.nativeEnum(QuestionType),
-            permitted_unit: CodeSchema,
+            permitted_unit: CodeSchema.nullable(),
             qualified_ranges: qualifiedRangeSchema.default([]),
           }),
         )
@@ -207,6 +207,7 @@ function ObservationDefinitionFormContent({
             component:
               existingData.component?.map((c) => ({
                 ...c,
+                permitted_unit: c.permitted_unit || null,
                 qualified_ranges:
                   c.qualified_ranges?.map((range, index) => ({
                     ...range,
@@ -329,6 +330,7 @@ function ObservationDefinitionFormContent({
       component: data.component?.map((c) => ({
         ...c,
         qualified_ranges: removeConditionType(c.qualified_ranges || []),
+        permitted_unit: c.permitted_unit || null,
       })),
     };
     if (isEditMode && observationSlug) {
@@ -756,11 +758,7 @@ function ObservationDefinitionFormContent({
                           {
                             code: { code: "", display: "", system: "" },
                             permitted_data_type: QuestionType.quantity,
-                            permitted_unit: {
-                              code: "",
-                              display: "",
-                              system: "",
-                            },
+                            permitted_unit: null,
                             qualified_ranges: [],
                           },
                         ]);
@@ -865,9 +863,7 @@ function ObservationDefinitionFormContent({
                               name={`component.${index}.permitted_unit`}
                               render={({ field }) => (
                                 <FormItem className="flex flex-col gap-1">
-                                  <FormLabel aria-required>
-                                    {t("unit")}
-                                  </FormLabel>
+                                  <FormLabel>{t("unit")}</FormLabel>
                                   <FormControl>
                                     <ValueSetSelect
                                       {...field}
@@ -944,11 +940,7 @@ function ObservationDefinitionFormContent({
                           {
                             code: { code: "", display: "", system: "" },
                             permitted_data_type: QuestionType.quantity,
-                            permitted_unit: {
-                              code: "",
-                              display: "",
-                              system: "",
-                            },
+                            permitted_unit: null,
                             qualified_ranges: [],
                           },
                         ]);

--- a/src/types/emr/observationDefinition/observationDefinition.ts
+++ b/src/types/emr/observationDefinition/observationDefinition.ts
@@ -15,7 +15,7 @@ export enum QuestionType {
 export interface ObservationDefinitionComponentSpec {
   code: Code;
   permitted_data_type: QuestionType;
-  permitted_unit: Code;
+  permitted_unit: Code | null;
   qualified_ranges: QualifiedRange[];
 }
 


### PR DESCRIPTION
## Proposed Changes

- Service Reqs: Hide reference range/interpretation if no applicable values
- Observation component: make permitted unit nullable (not relevant for many codes)

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Results table now displays reference range and interpretation columns only when data exists, reducing empty cells and improving layout.
  * Observation definition form treats absent units as null and updates form behavior/labels for more consistent editing and submission.
  * Specimen form now validates quantity value/unit together, preventing partial quantity submissions.

* **Chores**
  * Types updated to allow permitted unit to be null for component specs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->