### PR TITLE
Add healthcare service icon and charge item price popover in Activity Definition View

### DIFF
--- a/src/components/Billing/ChargeItem/ChargeItemDefinitionPopover.tsx
+++ b/src/components/Billing/ChargeItem/ChargeItemDefinitionPopover.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from "react-i18next";
+
+import { MonetaryDisplay } from "@/components/ui/monetary-display";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+
+import ChargeItemPriceDisplay from "@/components/Billing/ChargeItem/ChargeItemPriceDisplay";
+
+import { cn } from "@/lib/utils";
+import { calculateTotalPrice } from "@/types/base/monetaryComponent/monetaryComponent";
+import { ChargeItemDefinitionRead } from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
+
+interface ChargeItemDefinitionPopoverProps {
+  chargeItemDefinition: ChargeItemDefinitionRead;
+  className?: string;
+}
+
+export default function ChargeItemDefinitionPopover({
+  chargeItemDefinition,
+  className,
+}: ChargeItemDefinitionPopoverProps) {
+  const { t } = useTranslation();
+  const priceComponents = chargeItemDefinition.price_components;
+
+  const hasPriceComponents = priceComponents && priceComponents.length > 0;
+
+  if (!hasPriceComponents) {
+    return (
+      <span className={cn("text-sm text-gray-500", className)}>{t("na")}</span>
+    );
+  }
+
+  const totalPrice = calculateTotalPrice(priceComponents);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            "text-sm font-medium underline decoration-dotted underline-offset-4 cursor-pointer hover:text-primary-700 transition-colors",
+            className,
+          )}
+          aria-label={t("view_details")}
+        >
+          <MonetaryDisplay amount={totalPrice.toString()} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="right"
+        align="start"
+        className="p-0 w-auto max-w-[calc(100vw-2rem)]"
+      >
+        <div className="p-3 space-y-2">
+          <div>
+            <p className="font-medium text-sm">{chargeItemDefinition.title}</p>
+            {chargeItemDefinition.description && (
+              <p className="text-xs text-gray-600 mt-1">
+                {chargeItemDefinition.description}
+              </p>
+            )}
+          </div>
+          {chargeItemDefinition.purpose && (
+            <div>
+              <p className="text-xs text-gray-500">{t("purpose")}</p>
+              <p className="text-xs text-gray-700">
+                {chargeItemDefinition.purpose}
+              </p>
+            </div>
+          )}
+        </div>
+        <Separator />
+        <ChargeItemPriceDisplay priceComponents={priceComponents} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
+import duoToneIcons from "@/CAREUI/icons/DuoTonePaths.json";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -17,6 +18,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+
+import ChargeItemDefinitionPopover from "@/components/Billing/ChargeItem/ChargeItemDefinitionPopover";
 
 import BackButton from "@/components/Common/BackButton";
 import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
@@ -32,6 +35,11 @@ import {
 } from "@/types/emr/activityDefinition/activityDefinition";
 import activityDefinitionApi from "@/types/emr/activityDefinition/activityDefinitionApi";
 import { ArrowLeft } from "lucide-react";
+
+type DuoToneIconName = keyof typeof duoToneIcons;
+
+const getIconName = (name: string): DuoToneIconName =>
+  `d-${name}` as DuoToneIconName;
 
 interface Props {
   facilityId: string;
@@ -329,15 +337,17 @@ export default function ActivityDefinitionView({
                     className="rounded-lg border bg-gray-50/50 p-4 transition-colors hover:bg-gray-50"
                   >
                     <div className="space-y-2">
-                      <p className="font-medium">{chargeItem.title}</p>
-                      <p className="text-sm text-gray-600">
-                        {chargeItem.description}
-                      </p>
-                      <Separator />
-                      <div className="pt-2">
-                        <p className="text-sm text-gray-500">{t("purpose")}</p>
-                        <p className="text-gray-700">{chargeItem.purpose}</p>
+                      <div className="flex items-center justify-between gap-4">
+                        <p className="font-medium">{chargeItem.title}</p>
+                        <ChargeItemDefinitionPopover
+                          chargeItemDefinition={chargeItem}
+                        />
                       </div>
+                      {chargeItem.description && (
+                        <p className="text-sm text-gray-600">
+                          {chargeItem.description}
+                        </p>
+                      )}
                     </div>
                   </div>
                 ))}
@@ -356,15 +366,30 @@ export default function ActivityDefinitionView({
             </CardHeader>
             <CardContent>
               <div className="rounded-lg border bg-gray-50/50 p-4 transition-colors hover:bg-gray-50">
-                <div className="space-y-2">
-                  <p className="font-medium">
-                    {definition.healthcare_service.name}
-                  </p>
-                  {definition.healthcare_service.extra_details && (
-                    <p className="text-sm text-gray-600">
-                      {definition.healthcare_service.extra_details}
+                <div className="flex items-start gap-3">
+                  <div className="shrink-0 flex items-center justify-center size-10 rounded-lg bg-primary-100 text-primary-700">
+                    <CareIcon
+                      icon={
+                        definition.healthcare_service.styling_metadata?.careIcon
+                          ? getIconName(
+                              definition.healthcare_service.styling_metadata
+                                .careIcon,
+                            )
+                          : "d-health-worker"
+                      }
+                      className="size-6"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <p className="font-medium">
+                      {definition.healthcare_service.name}
                     </p>
-                  )}
+                    {definition.healthcare_service.extra_details && (
+                      <p className="text-sm text-gray-600">
+                        {definition.healthcare_service.extra_details}
+                      </p>
+                    )}
+                  </div>
                 </div>
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary

Enhances the Activity Definition View page with visual improvements:

1. **Healthcare Service Icon Display**: Shows the configured icon for linked healthcare services using the \`styling_metadata.careIcon\` field, with a fallback to the default \`d-health-worker\` icon.

2. **Charge Item Definition Price Popover**: Displays total price for linked charge item definitions with a clickable underlined trigger that opens a detailed breakdown popover showing:
   - Title and description
   - Purpose
   - Component-wise price breakdown (base, surcharges, discounts, taxes)

## Changes
- Created reusable \`ChargeItemDefinitionPopover\` component at \`src/components/Billing/ChargeItem/ChargeItemDefinitionPopover.tsx\`
- Updated \`ActivityDefinitionView.tsx\` to display healthcare service icons and integrate the price popover

Fixes #15298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Introduced an interactive popover for charge items that displays detailed pricing information, including component breakdowns, descriptions, and purpose details when users click on the price
* Added visual icons to healthcare services throughout facility settings to improve visual identification and navigation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->