### PR TITLE
fix error not shown for missing category in create purchase delivery

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1025,6 +1025,7 @@
   "category_description": "Choose the category  ",
   "category_description_help": "Optional description for this category",
   "category_is_required": "Please select a token category",
+  "category_required_at_row": "Category is required at row {{row}}",
   "category_required_for_item": "Category is required for {{item}}",
   "category_updated_successfully": "Category updated successfully",
   "caution": "Caution",

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -399,6 +399,11 @@ export function AddSupplyDeliveryForm({
               hasErrors = true;
               break;
             }
+            if (!item.charge_item_category) {
+              toast.error(t("category_required_at_row", { row: index + 1 }));
+              hasErrors = true;
+              break;
+            }
           }
           if (item.unit_price === undefined) {
             toast.error(t("unit_price_required_at_row", { row: index + 1 }));


### PR DESCRIPTION
- fixes #15302



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation requiring category selection for external supply delivery items. Users will now receive row-specific error notifications if required category information is missing during order entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->