### PR TITLE
auto apply tax components when category is changed in purchase delivery page

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
@@ -40,7 +40,10 @@ import { ProcessedExtension } from "@/hooks/useExtensions";
 import { ProductKnowledgeSelect } from "@/pages/Facility/services/inventory/ProductKnowledgeSelect";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import { Code } from "@/types/base/code/code";
-import { MonetaryComponentType } from "@/types/base/monetaryComponent/monetaryComponent";
+import {
+  MonetaryComponent,
+  MonetaryComponentType,
+} from "@/types/base/monetaryComponent/monetaryComponent";
 import { ResourceCategoryResourceType } from "@/types/base/resourceCategory/resourceCategory";
 import { ProductRead } from "@/types/inventory/product/product";
 
@@ -300,6 +303,19 @@ export function SmartExternalDeliveryRow({
             value={chargeItemCategory}
             onValueChange={(category) => {
               setField("charge_item_category", category?.slug || "");
+
+              // Auto-apply configured monetary components from category
+              if (category?.configured_monetary_components) {
+                const taxes = category.configured_monetary_components.filter(
+                  (c): c is MonetaryComponent =>
+                    c.monetary_component_type === MonetaryComponentType.tax,
+                );
+                setField("tax_components", taxes);
+              } else {
+                // Clear components when category is cleared
+                setField("tax_components", []);
+              }
+              markAsEdited();
             }}
             placeholder={t("select_category")}
             className="w-full min-w-[140px]"

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
@@ -160,18 +160,14 @@ export function useDeliveryRowItem({ form, index }: UseDeliveryRowItemProps) {
           setField("informational_components", informational);
         }
 
-        // Get taxes from charge item, fallback to category's configured_monetary_components
         const taxes = getComponentsFromChargeItem(
           chargeItemDef,
           MonetaryComponentType.tax,
         );
-        const categoryTaxes =
-          chargeItemDef.category?.configured_monetary_components?.filter(
-            (c) => c.monetary_component_type === MonetaryComponentType.tax,
-          ) || [];
-        setField("tax_components", taxes.length ? taxes : categoryTaxes);
+        if (taxes.length) {
+          setField("tax_components", taxes);
+        }
 
-        // Get discounts from charge item, fallback to category's configured_monetary_components
         const discounts = getComponentsFromChargeItem(
           chargeItemDef,
           MonetaryComponentType.discount,

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
@@ -160,14 +160,18 @@ export function useDeliveryRowItem({ form, index }: UseDeliveryRowItemProps) {
           setField("informational_components", informational);
         }
 
+        // Get taxes from charge item, fallback to category's configured_monetary_components
         const taxes = getComponentsFromChargeItem(
           chargeItemDef,
           MonetaryComponentType.tax,
         );
-        if (taxes.length) {
-          setField("tax_components", taxes);
-        }
+        const categoryTaxes =
+          chargeItemDef.category?.configured_monetary_components?.filter(
+            (c) => c.monetary_component_type === MonetaryComponentType.tax,
+          ) || [];
+        setField("tax_components", taxes.length ? taxes : categoryTaxes);
 
+        // Get discounts from charge item, fallback to category's configured_monetary_components
         const discounts = getComponentsFromChargeItem(
           chargeItemDef,
           MonetaryComponentType.discount,


### PR DESCRIPTION


## Proposed Changes

- Fixes #15319



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tax components are now automatically applied when selecting charge item categories in delivery orders. The system intelligently derives taxes from the selected category's configuration, with fallback logic to handle edge cases. This ensures consistent tax assignment across delivery orders.

* **Bug Fixes**
  * Fixed tax component handling to properly clear components when categories lack configured taxes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->