### PR TITLE
show total and batch wise net content in purchase delivery line item

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm.tsx
@@ -813,6 +813,7 @@ export function AddSupplyDeliveryForm({
                                   setNewlyAddedRowIndex(null)
                                 }
                                 processedExtensions={processedExtensions}
+                                locationId={destination}
                                 onRemove={() => remove(index)}
                               />
                             ),

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
@@ -32,6 +32,7 @@ import { TableCell, TableRow } from "@/components/ui/table";
 
 import { cn } from "@/lib/utils";
 
+import { add, isPositive, round } from "@/Utils/decimal";
 import { MonetaryComponentSelector } from "@/components/Billing/MonetaryComponentSelector";
 import { ResourceCategoryPicker } from "@/components/Common/ResourceCategoryPicker";
 import { SchemaField } from "@/components/Extensions/SchemaField";
@@ -55,6 +56,8 @@ interface Props {
   onProductSelectOpened?: () => void;
   /** All processed extensions with owner and schema info */
   processedExtensions: ProcessedExtension[];
+  /** Location ID for fetching inventory (origin location for internal transfers) */
+  locationId?: string;
   onRemove?: () => void;
 }
 
@@ -65,6 +68,7 @@ export function SmartExternalDeliveryRow({
   autoOpenProductSelect = false,
   onProductSelectOpened,
   processedExtensions,
+  locationId,
   onRemove,
 }: Props) {
   const { facilityId } = useCurrentFacility();
@@ -96,6 +100,7 @@ export function SmartExternalDeliveryRow({
     isCreatingNew,
     isLoadingProducts,
     products,
+    inventoryByProductId,
     availableTaxes,
     availableDiscounts,
     setField,
@@ -103,7 +108,7 @@ export function SmartExternalDeliveryRow({
     markAsEdited,
     fillFromProduct,
     updateInformationalComponent,
-  } = useDeliveryRowItem({ form, index });
+  } = useDeliveryRowItem({ form, index, locationId });
 
   const handleProductSelect = (product: ProductRead) => {
     fillFromProduct(product);
@@ -215,42 +220,97 @@ export function SmartExternalDeliveryRow({
                     <CommandEmpty>{t("type_batch_number")}</CommandEmpty>
                   )
                 ) : (
-                  <CommandGroup heading={t("existing_batches")}>
-                    {products
-                      .filter(
-                        (p) =>
-                          !batchNumber ||
-                          p.batch?.lot_number
-                            ?.toLowerCase()
-                            .includes(batchNumber.toLowerCase()),
-                      )
-                      .map((product) => (
-                        <CommandItem
-                          key={product.id}
-                          value={product.id}
-                          onSelect={() => handleProductSelect(product)}
-                          className="cursor-pointer"
-                        >
-                          <div className="flex w-full items-center justify-between">
-                            <div className="flex flex-col">
-                              <span className="font-medium">
-                                #{product.batch?.lot_number || "N/A"}
-                              </span>
-                              <span className="text-xs text-muted-foreground">
-                                {t("expiry_short")}:{" "}
-                                {getExpirationDisplay(product)}
-                              </span>
-                            </div>
-                            {suppliedItem?.id === product.id && (
-                              <CareIcon
-                                icon="l-check"
-                                className="size-4 text-green-600"
-                              />
+                  (() => {
+                    const filteredProducts = products.filter(
+                      (p) =>
+                        !batchNumber ||
+                        p.batch?.lot_number
+                          ?.toLowerCase()
+                          .includes(batchNumber.toLowerCase()),
+                    );
+                    const totalNetContent =
+                      locationId && filteredProducts.length > 0
+                        ? add(
+                            ...filteredProducts.map(
+                              (p) =>
+                                inventoryByProductId.get(p.id)?.net_content ||
+                                "0",
+                            ),
+                          )
+                        : null;
+                    const unit =
+                      productKnowledge?.base_unit?.display || t("units");
+
+                    return (
+                      <CommandGroup
+                        heading={
+                          <span className="flex items-center justify-between w-full">
+                            <span>{t("existing_batches")}</span>
+                            {totalNetContent !== null && (
+                              <Badge
+                                variant={
+                                  isPositive(totalNetContent)
+                                    ? "primary"
+                                    : "secondary"
+                                }
+                                className="text-xs ml-2"
+                              >
+                                {round(totalNetContent)} {unit}
+                              </Badge>
                             )}
-                          </div>
-                        </CommandItem>
-                      ))}
-                  </CommandGroup>
+                          </span>
+                        }
+                      >
+                        {filteredProducts.map((product) => {
+                          const inventory = inventoryByProductId.get(
+                            product.id,
+                          );
+                          const netContent = inventory?.net_content;
+
+                          return (
+                            <CommandItem
+                              key={product.id}
+                              value={product.id}
+                              onSelect={() => handleProductSelect(product)}
+                              className="cursor-pointer"
+                            >
+                              <div className="flex w-full items-center justify-between">
+                                <div className="flex flex-col">
+                                  <span className="font-medium">
+                                    #{product.batch?.lot_number || "N/A"}
+                                  </span>
+                                  <span className="text-xs text-muted-foreground">
+                                    {t("expiry_short")}:{" "}
+                                    {getExpirationDisplay(product)}
+                                  </span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  {locationId && netContent !== undefined && (
+                                    <Badge
+                                      variant={
+                                        isPositive(netContent)
+                                          ? "primary"
+                                          : "destructive"
+                                      }
+                                      className="text-xs"
+                                    >
+                                      {round(netContent)} {unit}
+                                    </Badge>
+                                  )}
+                                  {suppliedItem?.id === product.id && (
+                                    <CareIcon
+                                      icon="l-check"
+                                      className="size-4 text-green-600"
+                                    />
+                                  )}
+                                </div>
+                              </div>
+                            </CommandItem>
+                          );
+                        })}
+                      </CommandGroup>
+                    );
+                  })()
                 )}
               </CommandList>
             </Command>

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
@@ -14,6 +14,8 @@ import {
   MRP_CODE,
   getComponentsFromChargeItem,
 } from "@/types/billing/chargeItem/chargeItem";
+import { InventoryRead } from "@/types/inventory/product/inventory";
+import inventoryApi from "@/types/inventory/product/inventoryApi";
 import { ProductRead } from "@/types/inventory/product/product";
 import productApi from "@/types/inventory/product/productApi";
 import query from "@/Utils/request/query";
@@ -29,13 +31,19 @@ type ItemPath = `items.${number}.${keyof SupplyDeliveryItemValues}`;
 interface UseDeliveryRowItemProps {
   form: UseFormReturn<SupplyDeliveryFormValues>;
   index: number;
+  /** Location ID for fetching inventory (origin location for internal transfers) */
+  locationId?: string;
 }
 
 /**
  * Custom hook that manages all state and logic for a delivery row item.
  * Consolidates multiple useWatch calls and provides clean APIs for mutations.
  */
-export function useDeliveryRowItem({ form, index }: UseDeliveryRowItemProps) {
+export function useDeliveryRowItem({
+  form,
+  index,
+  locationId,
+}: UseDeliveryRowItemProps) {
   const { facilityId, facility: facilityData } = useCurrentFacility();
   const [isCreatingNew, setIsCreatingNew] = useState(false);
 
@@ -120,6 +128,28 @@ export function useDeliveryRowItem({ form, index }: UseDeliveryRowItemProps) {
     () => productsResponse?.results || [],
     [productsResponse?.results],
   );
+
+  // Fetch inventory for location to get net_content (stock levels)
+  const { data: inventoryResponse, isLoading: isLoadingInventory } = useQuery({
+    queryKey: ["inventory", facilityId, locationId, productKnowledge?.slug],
+    queryFn: query(inventoryApi.list, {
+      pathParams: { facilityId, locationId: locationId! },
+      queryParams: {
+        product_knowledge: productKnowledge?.id,
+        limit: 100,
+      },
+    }),
+    enabled: !!facilityId && !!locationId && !!productKnowledge?.id,
+  });
+
+  // Map product IDs to their inventory net_content
+  const inventoryByProductId = useMemo(() => {
+    const map = new Map<string, InventoryRead>();
+    inventoryResponse?.results?.forEach((inv) => {
+      map.set(inv.product.id, inv);
+    });
+    return map;
+  }, [inventoryResponse?.results]);
 
   // Fill form from existing product
   const fillFromProduct = useCallback(
@@ -306,7 +336,9 @@ export function useDeliveryRowItem({ form, index }: UseDeliveryRowItemProps) {
     needsCategorySelection,
     isCreatingNew,
     isLoadingProducts,
+    isLoadingInventory,
     products,
+    inventoryByProductId,
     availableTaxes,
     availableDiscounts,
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #15326

<img width="1586" height="553" alt="image" src="https://github.com/user-attachments/assets/87d16611-661e-4481-9706-3254b772063d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delivery order forms now display location-aware inventory information, including net content badges for each product and calculated total net content per location.
  * Enhanced batch visualization with checkmarks indicating currently supplied items and unit-adjusted inventory status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->