### PR TITLE
Show charges status only for paid charge items in the Appointment Print

### DIFF
--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -136,19 +136,13 @@ export default function AppointmentPrint(props: Props) {
               <div className="p-2 border border-gray-200 bg-gray-100 w-full h-full rounded-md flex flex-col">
                 <div className="flex flex-row items-center  justify-between px-1">
                   <p className="font-semibold text-sm">{t("charges")}</p>
-                  <div className="flex items-center">
-                    <Badge className="text-xs">
-                      {chargeItems?.results?.every(
-                        (item) => item.status === ChargeItemStatus.paid,
-                      )
-                        ? t("paid")
-                        : chargeItems?.results?.some(
-                              (item) => item.status === ChargeItemStatus.billed,
-                            )
-                          ? t("billed")
-                          : t("billable")}
-                    </Badge>
-                  </div>
+                  {chargeItems?.results?.every(
+                    (item) => item.status === ChargeItemStatus.paid,
+                  ) && (
+                    <div className="flex items-center">
+                      <Badge className="text-xs">{t("paid")}</Badge>
+                    </div>
+                  )}
                 </div>
 
                 <div className="bg-white rounded-md p-3 shadow-md mt-2 h-full">

--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -20,6 +20,7 @@ import { usePermissions } from "@/context/PermissionContext";
 import {
   ChargeItemServiceResource,
   ChargeItemStatus,
+  EXCLUDED_CHARGE_ITEM_STATUSES,
 } from "@/types/billing/chargeItem/chargeItem";
 import chargeItemApi from "@/types/billing/chargeItem/chargeItemApi";
 import scheduleApis from "@/types/scheduling/scheduleApi";
@@ -134,14 +135,22 @@ export default function AppointmentPrint(props: Props) {
           {hasChargeItems && (
             <div className="flex justify-center w-2/5">
               <div className="p-2 border border-gray-200 bg-gray-100 w-full h-full rounded-md flex flex-col">
-                <div className="flex flex-row items-center  justify-between px-1">
+                <div className="flex flex-row items-center justify-between px-1">
                   <p className="font-semibold text-sm">{t("charges")}</p>
-                  {chargeItems?.results?.every(
-                    (item) => item.status === ChargeItemStatus.paid,
+                  {!chargeItems.results.some((item) =>
+                    EXCLUDED_CHARGE_ITEM_STATUSES.includes(item.status),
                   ) && (
-                    <div className="flex items-center">
-                      <Badge className="text-xs">{t("paid")}</Badge>
-                    </div>
+                    <Badge className="text-xs">
+                      {chargeItems.results.every(
+                        (item) => item.status === ChargeItemStatus.paid,
+                      )
+                        ? t("paid")
+                        : chargeItems.results.every(
+                              (item) => item.status === ChargeItemStatus.billed,
+                            )
+                          ? t("billed")
+                          : t("billable")}
+                    </Badge>
                   )}
                 </div>
 

--- a/src/types/billing/chargeItem/chargeItem.ts
+++ b/src/types/billing/chargeItem/chargeItem.ts
@@ -17,6 +17,12 @@ export enum ChargeItemStatus {
   entered_in_error = "entered_in_error",
 }
 
+export const EXCLUDED_CHARGE_ITEM_STATUSES = [
+  ChargeItemStatus.not_billable,
+  ChargeItemStatus.entered_in_error,
+  ChargeItemStatus.aborted,
+];
+
 export const CHARGE_ITEM_STATUS_COLORS = {
   // planned: "blue",
   billable: "indigo",


### PR DESCRIPTION
## Proposed Changes
fix #15332

<img width="736" height="527" alt="image" src="https://github.com/user-attachments/assets/cc09a751-00d7-4722-ba35-e92079316e6d" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Charge badge display in Appointments refined: the badge is now hidden if any charge has an excluded status (e.g., not billable or errored), and the "paid" badge appears only when all visible charges are fully paid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->