### PR TITLE
Added keyboard shortcut for diagnostic report print

### DIFF
--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -124,7 +124,8 @@
     { "key": "s", "action": "scan-button", "description": "Scan the QR code", "when": "always" },
     { "key": "c", "action": "collect-specimen", "description": "Collect Specimen", "when": "always" },
     { "key": "m", "action": "mark-as-complete", "description": "Mark as Complete", "when": "always" },
-    { "key": "r", "action": "view-report", "description": "View Report", "when": "always" }
+    { "key": "r", "action": "view-report", "description": "View Report", "when": "always" },
+    { "key": "p", "action": "print-report", "description": "Print Report", "when": "always" }
   ],
 
   "encounter": [

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
@@ -18,10 +18,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import BackButton from "@/components/Common/BackButton";
 import { FileListTable } from "@/components/Files/FileListTable";
 
-import query from "@/Utils/request/query";
-import { PaginatedResponse } from "@/Utils/request/types";
-import { formatName } from "@/Utils/utils";
 import { PatientHeader } from "@/components/Patient/PatientHeader";
+import { useShortcutSubContext } from "@/context/ShortcutContext";
 import { DiagnosticReportResultsTable } from "@/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable";
 import { ObservationHistorySheet } from "@/pages/Facility/services/serviceRequests/components/ObservationHistorySheet";
 import { DIAGNOSTIC_REPORT_STATUS_COLORS } from "@/types/emr/diagnosticReport/diagnosticReport";
@@ -29,6 +27,10 @@ import diagnosticReportApi from "@/types/emr/diagnosticReport/diagnosticReportAp
 import { ObservationStatus } from "@/types/emr/observation/observation";
 import { FileReadMinimal } from "@/types/files/file";
 import fileApi from "@/types/files/fileApi";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+import query from "@/Utils/request/query";
+import { PaginatedResponse } from "@/Utils/request/types";
+import { formatName } from "@/Utils/utils";
 
 export default function DiagnosticReportView({
   facilityId,
@@ -40,6 +42,7 @@ export default function DiagnosticReportView({
   diagnosticReportId: string;
 }) {
   const { t } = useTranslation();
+  useShortcutSubContext("facility:service");
 
   const { data: report, isLoading } = useQuery({
     queryKey: ["diagnosticReport", diagnosticReportId],
@@ -96,6 +99,7 @@ export default function DiagnosticReportView({
         >
           <Printer className="h-4 w-4 mr-2" />
           {t("print")}
+          <ShortcutBadge actionId="print-report" />
         </Button>
       </div>
 


### PR DESCRIPTION
## Proposed Changes
Fix #15338 
Added keyboard shortcut for diagnostic print
<img width="1631" height="817" alt="image" src="https://github.com/user-attachments/assets/9720cbe7-d7ff-49ca-8ae5-dd52a8683bdc" />
<img width="1119" height="782" alt="image" src="https://github.com/user-attachments/assets/3b49db24-bcc7-4dd5-8a5c-de4714529220" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (p) to print diagnostic reports
  * Added visual shortcut indicator on Print button to help users discover available keyboard shortcuts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->