### PR TITLE
medication return: load data from dispense order Id

### DIFF
--- a/src/pages/Facility/services/pharmacy/DispensesView.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensesView.tsx
@@ -173,7 +173,7 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
               onSuccess={(deliveryOrder) => {
                 // Navigate to the medication return detail page
                 navigate(
-                  `/facility/${facilityId}/locations/${locationId}/medication_return/order/${deliveryOrder.id}`,
+                  `/facility/${facilityId}/locations/${locationId}/medication_return/order/${deliveryOrder.id}/?dispenseOrderId=${dispenseOrderId}`,
                 );
               }}
               trigger={

--- a/src/pages/Facility/services/pharmacy/MedicationReturnShow.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationReturnShow.tsx
@@ -8,7 +8,7 @@ import {
   Printer,
   Truck,
 } from "lucide-react";
-import { Link, navigate } from "raviger";
+import { Link, navigate, useQueryParams } from "raviger";
 import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -40,6 +40,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
 import { AddMedicationReturnItemForm } from "@/pages/Facility/services/pharmacy/components/AddMedicationReturnItemForm";
 import { MedicationReturnItemsTable } from "@/pages/Facility/services/pharmacy/components/MedicationReturnItemsTable";
+import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import {
   DELIVERY_ORDER_STATUS_COLORS,
   DeliveryOrderRetrieve,
@@ -82,6 +83,7 @@ export default function MedicationReturnShow({
     open: false,
     status: null,
   });
+  const [{ dispenseOrderId }] = useQueryParams<{ dispenseOrderId?: string }>();
 
   const { data: deliveryOrder, isLoading } = useQuery({
     queryKey: ["medicationReturns", deliveryOrderId],
@@ -143,6 +145,18 @@ export default function MedicationReturnShow({
             }),
       );
     },
+  });
+
+  const { data: medicationDispensesResponse } = useQuery({
+    queryKey: ["medication_dispense", dispenseOrderId, locationId],
+    queryFn: query(medicationDispenseApi.list, {
+      queryParams: {
+        location: locationId,
+        limit: 100,
+        order: dispenseOrderId,
+      },
+    }),
+    enabled: !!dispenseOrderId && !!locationId,
   });
 
   function handleSupplyDeliverySuccess() {
@@ -220,6 +234,9 @@ export default function MedicationReturnShow({
 
     const selectedSupplyDeliveries = supplyDeliveries.results
       .filter((delivery) => selectedDeliveries.includes(delivery.id))
+      .filter(
+        (delivery) => delivery.status === SupplyDeliveryStatus.in_progress,
+      )
       .map((delivery) => ({
         id: delivery.id,
         status: confirmDialog.status,
@@ -617,6 +634,11 @@ export default function MedicationReturnShow({
                     facilityId={facilityId}
                     locationId={locationId}
                     onSuccess={handleSupplyDeliverySuccess}
+                    medicationDispenses={
+                      dispenseOrderId && medicationDispensesResponse?.results
+                        ? medicationDispensesResponse.results
+                        : []
+                    }
                   />
                 )}
               </div>

--- a/src/pages/Facility/services/pharmacy/components/AddMedicationReturnItemForm.tsx
+++ b/src/pages/Facility/services/pharmacy/components/AddMedicationReturnItemForm.tsx
@@ -10,6 +10,14 @@ import { z } from "zod";
 import { DisablingCover } from "@/components/Common/DisablingCover";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Form,
   FormControl,
@@ -29,6 +37,7 @@ import {
 
 import { ProductKnowledgeSelect } from "@/pages/Facility/services/inventory/ProductKnowledgeSelect";
 import StockLotSelector from "@/pages/Facility/services/inventory/StockLotSelector";
+import { MedicationDispenseRead } from "@/types/emr/medicationDispense/medicationDispense";
 import { ProductKnowledgeBase } from "@/types/inventory/productKnowledge/productKnowledge";
 import {
   SupplyDeliveryCondition,
@@ -36,7 +45,7 @@ import {
   SupplyDeliveryType,
 } from "@/types/inventory/supplyDelivery/supplyDelivery";
 import supplyDeliveryApi from "@/types/inventory/supplyDelivery/supplyDeliveryApi";
-import { zodDecimal } from "@/Utils/decimal";
+import { round, zodDecimal } from "@/Utils/decimal";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 
@@ -63,6 +72,7 @@ interface Props {
   facilityId: string;
   locationId: string;
   onSuccess: () => void;
+  medicationDispenses?: MedicationDispenseRead[];
 }
 
 export function AddMedicationReturnItemForm({
@@ -70,6 +80,7 @@ export function AddMedicationReturnItemForm({
   facilityId,
   locationId,
   onSuccess,
+  medicationDispenses = [],
 }: Props) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -77,6 +88,8 @@ export function AddMedicationReturnItemForm({
   const [newlyAddedRowIndex, setNewlyAddedRowIndex] = useState<number | null>(
     null,
   );
+  const [isSelectDialogOpen, setIsSelectDialogOpen] = useState(false);
+  const [selectedDispenses, setSelectedDispenses] = useState<string[]>([]);
 
   const createEmptyItem = useCallback(
     (): ReturnItemValues => ({
@@ -104,6 +117,44 @@ export function AddMedicationReturnItemForm({
     const newIndex = fields.length;
     append(createEmptyItem());
     setNewlyAddedRowIndex(newIndex);
+  };
+
+  const loadFromMedicationDispenses = () => {
+    setIsSelectDialogOpen(true);
+    handleSelectAll(true);
+  };
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedDispenses(medicationDispenses.map((dispense) => dispense.id));
+    } else {
+      setSelectedDispenses([]);
+    }
+  };
+
+  const handleSelectDispense = (id: string, checked: boolean) => {
+    if (checked) {
+      setSelectedDispenses((prev) => [...prev, id]);
+    } else {
+      setSelectedDispenses((prev) =>
+        prev.filter((dispenseId) => dispenseId !== id),
+      );
+    }
+  };
+
+  const handleSelectDispenses = () => {
+    const selectedMedicationDispenses = medicationDispenses.filter((dispense) =>
+      selectedDispenses.includes(dispense.id),
+    );
+    const itemsFromDispenses = selectedMedicationDispenses.map((dispense) => ({
+      supplied_inventory_item: dispense.item.id,
+      supplied_item: dispense.item.product.id,
+      supplied_item_quantity: dispense.quantity,
+      product_knowledge: dispense.item.product.product_knowledge,
+    }));
+    form.setValue("items", itemsFromDispenses);
+    setIsSelectDialogOpen(false);
+    setSelectedDispenses([]);
   };
 
   const { mutateAsync: createSupplyDelivery } = useMutation({
@@ -358,6 +409,17 @@ export function AddMedicationReturnItemForm({
                     <PlusCircle className="mr-2 size-4" />
                     {t("add_another")}
                   </Button>
+                  {medicationDispenses.length > 0 && (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={loadFromMedicationDispenses}
+                    >
+                      {t("load_from_order")} ({medicationDispenses.length}{" "}
+                      {t("items")})
+                      <ShortcutBadge actionId="load-from-order" />
+                    </Button>
+                  )}
                 </div>
 
                 <div className="flex justify-between">
@@ -384,19 +446,111 @@ export function AddMedicationReturnItemForm({
               <p className="text-sm text-gray-500">
                 {t("select_items_from_stock_to_return")}
               </p>
-              <Button
-                type="button"
-                variant="outline_primary"
-                onClick={() => handleAddAnotherItem()}
-              >
-                <PlusCircle className="mr-2 size-4" />
-                {t("add_item")}
-                <ShortcutBadge actionId="add-item" />
-              </Button>
+              <div className="flex flex-row gap-2 items-center mt-2">
+                {medicationDispenses.length > 0 && (
+                  <>
+                    <Button
+                      type="button"
+                      variant="outline_primary"
+                      onClick={loadFromMedicationDispenses}
+                    >
+                      {t("load_from_order")} ({medicationDispenses.length}{" "}
+                      {t("items")})
+                      <ShortcutBadge actionId="load-from-order" />
+                    </Button>
+                    <p>- {t("or")} -</p>
+                  </>
+                )}
+                <Button
+                  type="button"
+                  variant="outline_primary"
+                  onClick={() => handleAddAnotherItem()}
+                >
+                  <PlusCircle className="mr-2 size-4" />
+                  {t("add_item")}
+                  <ShortcutBadge actionId="add-item" />
+                </Button>
+              </div>
             </div>
           )}
         </CardContent>
       </Card>
+      {medicationDispenses.length > 0 && (
+        <Dialog open={isSelectDialogOpen} onOpenChange={setIsSelectDialogOpen}>
+          <DialogContent className="sm:max-w-xl">
+            <DialogHeader>
+              <DialogTitle>{t("select_items_to_add")}</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="select-all"
+                  checked={
+                    selectedDispenses.length === medicationDispenses.length
+                  }
+                  onCheckedChange={(checked) =>
+                    handleSelectAll(checked as boolean)
+                  }
+                  data-shortcut-id="select-all"
+                />
+                <label
+                  htmlFor="select-all"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  {t("select_all")}
+                </label>
+              </div>
+              <div className="border rounded-md divide-y">
+                {medicationDispenses.map((dispense) => (
+                  <div
+                    key={dispense.id}
+                    className="flex items-center space-x-4 p-2 hover:bg-gray-50"
+                  >
+                    <Checkbox
+                      id={dispense.id}
+                      checked={selectedDispenses.includes(dispense.id)}
+                      onCheckedChange={(checked) =>
+                        handleSelectDispense(dispense.id, checked as boolean)
+                      }
+                    />
+                    <div className="flex-1">
+                      <label
+                        htmlFor={dispense.id}
+                        className="text-sm font-medium leading-none"
+                      >
+                        {dispense.item.product.product_knowledge.name}
+                      </label>
+                      {dispense.item.product.batch?.lot_number && (
+                        <p className="text-xs text-gray-500 mt-1">
+                          {t("batch")}: {dispense.item.product.batch.lot_number}
+                        </p>
+                      )}
+                    </div>
+                    <div className="text-sm font-medium">
+                      {round(dispense.quantity)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setIsSelectDialogOpen(false)}
+              >
+                {t("cancel")}
+              </Button>
+              <Button
+                onClick={handleSelectDispenses}
+                disabled={selectedDispenses.length === 0}
+              >
+                {t("done")}
+                <ShortcutBadge actionId="enter-action" />
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </DisablingCover>
   );
 }


### PR DESCRIPTION
## Proposed Changes

- Allow for loading data from dispenses for medication return


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk import feature: select and load multiple medication dispenses from an order into medication return forms via a selection dialog.
  * Improved workflow navigation to maintain order context throughout medication return processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->