### PR TITLE
Fix: Fetch full diagnostic report details in Encounter tab

### DIFF
--- a/src/pages/Encounters/tabs/diagnostic-reports.tsx
+++ b/src/pages/Encounters/tabs/diagnostic-reports.tsx
@@ -271,9 +271,7 @@ function DiagnosticReportDetailCard({
               {t("test_results")}
             </h4>
             <DiagnosticReportResultsTable
-              observations={report.observations.filter(
-                (obs) => obs.status !== ObservationStatus.ENTERED_IN_ERROR,
-              )}
+              observations={filteredObservations}
             />
           </div>
         )}

--- a/src/pages/Encounters/tabs/diagnostic-reports.tsx
+++ b/src/pages/Encounters/tabs/diagnostic-reports.tsx
@@ -270,9 +270,7 @@ function DiagnosticReportDetailCard({
             <h4 className="text-sm font-semibold text-gray-700">
               {t("test_results")}
             </h4>
-            <DiagnosticReportResultsTable
-              observations={filteredObservations}
-            />
+            <DiagnosticReportResultsTable observations={filteredObservations} />
           </div>
         )}
 
@@ -288,27 +286,6 @@ function DiagnosticReportDetailCard({
               canEdit={false}
               showHeader={false}
             />
-          </div>
-        )}
-
-        {files.length < 0 && (
-          <div className="flex justify-end pt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                navigate(
-                  buildEncounterUrl(
-                    patientId,
-                    `/diagnostic_reports/${report.id}`,
-                    facilityId,
-                  ),
-                )
-              }
-              hidden={files.length > 0}
-            >
-              {t("view_details")}
-            </Button>
           </div>
         )}
       </CardContent>

--- a/src/pages/Encounters/tabs/diagnostic-reports.tsx
+++ b/src/pages/Encounters/tabs/diagnostic-reports.tsx
@@ -95,33 +95,52 @@ function LeftCard({ report, isActive, onClick }: LeftCardProps) {
 }
 
 interface DiagnosticReportDetailCardProps {
-  report: DiagnosticReportRead;
+  reportId: string;
   patientId: string;
   facilityId?: string;
 }
 
 function DiagnosticReportDetailCard({
-  report,
+  reportId,
   patientId,
   facilityId,
 }: DiagnosticReportDetailCardProps) {
   const { t } = useTranslation();
 
+  const { data: report, isLoading: isReportLoading } = useQuery({
+    queryKey: ["diagnosticReport", reportId],
+    queryFn: query(diagnosticReportApi.retrieveDiagnosticReport, {
+      pathParams: {
+        patient_external_id: patientId,
+        external_id: reportId,
+      },
+    }),
+    enabled: !!reportId && !!patientId,
+  });
+
   // Query to fetch files for the diagnostic report
   const { data: filesData } = useQuery<PaginatedResponse<FileReadMinimal>>({
-    queryKey: ["files", "diagnostic_report", report.id],
+    queryKey: ["files", "diagnostic_report", report?.id],
     queryFn: query(fileApi.list, {
       queryParams: {
         file_type: "diagnostic_report",
-        associating_id: report.id,
+        associating_id: report?.id,
         limit: 100,
         offset: 0,
       },
     }),
-    enabled: !!report.id,
+    enabled: !!report?.id,
   });
 
   const files = filesData?.results || [];
+
+  if (isReportLoading) {
+    return <CardListSkeleton count={1} />;
+  }
+
+  if (!report) {
+    return null;
+  }
 
   const filteredObservations = report.observations?.filter(
     (obs) => obs.status !== ObservationStatus.ENTERED_IN_ERROR,
@@ -155,6 +174,7 @@ function DiagnosticReportDetailCard({
                       ),
                     )
                   }
+                  data-shortcut-id="print-button"
                 >
                   <Printer className="size-4" />
                 </Button>
@@ -245,6 +265,19 @@ function DiagnosticReportDetailCard({
           )}
         </div>
 
+        {filteredObservations && filteredObservations.length > 0 && (
+          <div className="space-y-2">
+            <h4 className="text-sm font-semibold text-gray-700">
+              {t("test_results")}
+            </h4>
+            <DiagnosticReportResultsTable
+              observations={report.observations.filter(
+                (obs) => obs.status !== ObservationStatus.ENTERED_IN_ERROR,
+              )}
+            />
+          </div>
+        )}
+
         {files.length > 0 && (
           <div className="space-y-2">
             <h4 className="text-sm font-semibold text-gray-700">
@@ -257,15 +290,6 @@ function DiagnosticReportDetailCard({
               canEdit={false}
               showHeader={false}
             />
-          </div>
-        )}
-
-        {filteredObservations && filteredObservations.length > 0 && (
-          <div className="space-y-2">
-            <h4 className="text-sm font-semibold text-gray-700">
-              {t("test_results")}
-            </h4>
-            <DiagnosticReportResultsTable observations={filteredObservations} />
           </div>
         )}
 
@@ -543,7 +567,7 @@ export const EncounterDiagnosticReportsTab = () => {
             ) : (
               selectedReport && (
                 <DiagnosticReportDetailCard
-                  report={selectedReport}
+                  reportId={selectedReport.id}
                   patientId={patientId}
                   facilityId={facilityId}
                 />


### PR DESCRIPTION
Fetch complete report details using the retrieve API so all observations and test results are visible in the Encounter tab.

<img width="1467" height="822" alt="image" src="https://github.com/user-attachments/assets/2e656a08-0bcf-4abe-9b5d-e8329a968a43" />


Fixes #15346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual loading state with skeleton UI while fetching diagnostic reports
  * Print functionality with keyboard shortcut support for diagnostic report details

* **Bug Fixes**
  * Improved test results rendering to filter out invalid observations
  * Consolidated duplicate test results into a single display
  * Graceful handling when a diagnostic report is unavailable

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->