### PR TITLE
Fix specimen form validation showing error when unit is filled via default

### DIFF
--- a/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
@@ -188,7 +188,7 @@ export function SpecimenForm({
     const quantity = specimenData.specimen.collection?.quantity;
     const newErrors: typeof errors = {};
 
-    if (quantity?.value && !quantity.unit) {
+    if (quantity?.value && !quantity.unit && !defaultUnit) {
       newErrors.quantityUnit = t("field_required");
     }
 
@@ -196,7 +196,7 @@ export function SpecimenForm({
       newErrors.quantityValue = t("invalid_quantity");
     }
 
-    if (quantity?.unit && !quantity.value) {
+    if ((quantity?.unit || defaultUnit) && !quantity?.value) {
       newErrors.quantityValue = t("field_required");
     }
 


### PR DESCRIPTION
## Description

Fixes #15348

The specimen form was incorrectly showing "This field is required" error for the quantity unit even when both a quantity value and unit were properly filled in.



@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved specimen form validation to better handle default units when validating quantities, reducing unnecessary validation errors when default units are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->