### PR TITLE
Clinical history: set responses as first

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -841,6 +841,7 @@
   "awaiting_recall": "Awaiting Re-Call",
   "b/w": "b/w",
   "back": "Back",
+  "back_to_patient": "Back to Patient",
   "back_dated_encounter_date_caution": "You are creating an encounter for",
   "back_to_account": "Back to Account",
   "back_to_accounts": "Back to accounts",

--- a/src/components/Patient/PatientDetailsTab/ClinicalHistory.tsx
+++ b/src/components/Patient/PatientDetailsTab/ClinicalHistory.tsx
@@ -12,8 +12,8 @@ export function ClinicalHistory({
 }: ClinicalHistoryProps) {
   useEffect(() => {
     const historyUrl = facilityId
-      ? `/facility/${facilityId}/patient/${patientId}/history/symptoms`
-      : `/patient/${patientId}/history/symptoms`;
+      ? `/facility/${facilityId}/patient/${patientId}/history/responses`
+      : `/patient/${patientId}/history/responses`;
 
     navigate(historyUrl);
   }, [patientId, facilityId]);

--- a/src/hooks/useEncounterShortcuts.ts
+++ b/src/hooks/useEncounterShortcuts.ts
@@ -100,7 +100,7 @@ export function useEncounterShortcuts() {
         navigate(buildEncounterUrl("/diagnostic_reports")),
       "clinical-history": () =>
         navigate(
-          `/facility/${encounter.facility.id}/patient/${encounter.patient.id}/history/symptoms?sourceUrl=${encodeURIComponent(
+          `/facility/${encounter.facility.id}/patient/${encounter.patient.id}/history/responses?sourceUrl=${encodeURIComponent(
             buildEncounterUrl("/updates"),
           )}`,
         ),

--- a/src/pages/Encounters/tabs/overview/clinical-history-overview.tsx
+++ b/src/pages/Encounters/tabs/overview/clinical-history-overview.tsx
@@ -85,8 +85,8 @@ export const ClinicalHistoryOverview = (props: React.ComponentProps<"div">) => {
           <Link
             href={
               facilityId
-                ? `/facility/${facilityId}/patient/${patientId}/history/symptoms?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
-                : `/patient/${patientId}/history/symptoms?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+                ? `/facility/${facilityId}/patient/${patientId}/history/responses?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
+                : `/patient/${patientId}/history/responses?sourceUrl=${encodeURIComponent(sourceUrl ?? "")}`
             }
           >
             <img

--- a/src/pages/Patient/History/index.tsx
+++ b/src/pages/Patient/History/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { X } from "lucide-react";
+import { ArrowLeftIcon, X } from "lucide-react";
 import { navigate, useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
 
@@ -19,6 +19,7 @@ import { AllergyHistory } from "./AllergyHistory";
 import { DiagnosesHistory } from "./DiagnosesHistory";
 import { ResponsesHistory } from "./ResponsesHistory";
 import { SymptomsHistory } from "./SymptomsHistory";
+import { Separator } from "@radix-ui/react-separator";
 
 export function ClinicalHistoryPage({
   patientId,
@@ -58,6 +59,10 @@ export function ClinicalHistoryPage({
   });
 
   const tabs = {
+    responses: {
+      label: t("responses"),
+      component: <ResponsesHistory patientId={patientId} />,
+    },
     symptoms: {
       label: t("past_symptoms"),
       component: <SymptomsHistory patientId={patientId} />,
@@ -74,10 +79,6 @@ export function ClinicalHistoryPage({
       label: t("past_medications"),
       component: <MedicationHistory patientId={patientId} />,
     },
-    responses: {
-      label: t("responses"),
-      component: <ResponsesHistory patientId={patientId} />,
-    },
   } as const;
 
   return (
@@ -90,16 +91,27 @@ export function ClinicalHistoryPage({
       hideTitleOnPage
     >
       <div className="flex justify-between items-center bg-gray-100 -mx-3 -mt-8 md:-mt-8 md:-mx-9 px-3 md:px-6 pb-3 pt-2 md:rounded-t-lg">
-        <div>
-          {patient ? (
-            <h5 className="text-lg font-semibold">
-              {t("patient_clinical_history_page_title", { name: patient.name })}
-            </h5>
-          ) : (
-            <Skeleton className="w-20 h-4" />
-          )}
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <div className="flex items-center gap-2 shrink-0">
+            <Button variant="outline" onClick={handleClose} size="icon">
+              <ArrowLeftIcon />
+            </Button>
+            <span className="text-sm text-gray-700">
+              {sourceUrl ? t("back_to_encounter") : t("back_to_patient")}
+            </span>
+          </div>
+          <Separator orientation="vertical" />
+          <div className="min-w-0">
+            {patient ? (
+              <h5 className="text-lg font-semibold whitespace-nowrap overflow-hidden text-ellipsis">
+                {t("patient_clinical_history_page_title", { name: patient.name })}
+              </h5>
+            ) : (
+              <Skeleton className="w-20 h-4" />
+            )}
+          </div>
         </div>
-        <div>
+        <div className="shrink-0">
           <Button variant="outline" onClick={handleClose} size="icon">
             <X className="size-4" />
           </Button>


### PR DESCRIPTION
## Proposed Changes

- Clinical history: set responses as first view

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Responses" tab in the patient history view.
  * Enhanced back navigation with context-aware labels ("Back to Encounter" or "Back to Patient").

* **Refactor**
  * Updated clinical history navigation to use responses endpoint.
  * Improved patient history header layout with visual separator for better organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->