### PR TITLE
show only configured encounter classes in encounter class filter

### DIFF
--- a/src/components/ui/multi-filter/filterConfigs.tsx
+++ b/src/components/ui/multi-filter/filterConfigs.tsx
@@ -1,5 +1,4 @@
 import {
-  ENCOUNTER_CLASS,
   ENCOUNTER_PRIORITY,
   EncounterClass,
   EncounterPriority,
@@ -47,6 +46,7 @@ import {
   ENCOUNTER_PRIORITY_FILTER_COLORS,
   ENCOUNTER_STATUS_FILTER_COLORS,
 } from "@/types/emr/encounter/encounter";
+import careConfig from "@careConfig";
 export const encounterStatusFilter = (
   key: string = "encounter_status",
   mode: FilterMode = "single",
@@ -92,10 +92,10 @@ export const encounterClassFilter = (
     key,
     t("encounter_class"),
     "command",
-    Array.from(ENCOUNTER_CLASS).map((value) => ({
+    careConfig.encounterClasses.map((value) => ({
       value: value,
       label: t(`encounter_class__${value}`),
-      color: ENCOUNTER_CLASS_FILTER_COLORS[value as EncounterClass],
+      color: ENCOUNTER_CLASS_FILTER_COLORS[value],
     })),
     {
       renderSelected: (selected: FilterValues) => {

--- a/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
@@ -42,10 +42,7 @@ import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
 import { tagFilter } from "@/components/ui/multi-filter/filterConfigs";
 import MultiFilter from "@/components/ui/multi-filter/MultiFilter";
 import useMultiFilterState from "@/components/ui/multi-filter/utils/useMultiFilterState";
-import {
-  ENCOUNTER_CLASS,
-  ENCOUNTER_CLASSES_COLORS,
-} from "@/types/emr/encounter/encounter";
+import { ENCOUNTER_CLASSES_COLORS } from "@/types/emr/encounter/encounter";
 import {
   PrescriptionStatus,
   PrescriptionSummary,
@@ -61,6 +58,7 @@ import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { PaginatedResponse } from "@/Utils/request/types";
 import { formatDateTime, formatName } from "@/Utils/utils";
+import careConfig from "@careConfig";
 
 export default function MedicationRequestList({
   facilityId,
@@ -206,7 +204,9 @@ export default function MedicationRequestList({
                 : "",
             })
           }
-          options={[...ENCOUNTER_CLASS].map((ec) => `encounter_class__${ec}`)}
+          options={[...careConfig.encounterClasses].map(
+            (ec) => `encounter_class__${ec}`,
+          )}
           showAllOption={true}
           allOptionLabel="all"
           variant="background"

--- a/src/types/emr/encounter/encounter.ts
+++ b/src/types/emr/encounter/encounter.ts
@@ -41,6 +41,9 @@ export const ENCOUNTER_ADMIT_SOURCE = [
   "other",
 ] as const;
 
+/**
+ * Do not use this constant directly. Use `careConfig.encounterClasses` instead.
+ */
 export const ENCOUNTER_CLASS = [
   "imp",
   "amb",


### PR DESCRIPTION
## Proposed Changes

- Fixes #15362


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Encounter-class filter options are now driven by runtime configuration rather than static mappings, improving flexibility and maintainability while preserving labels and UI behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->