### PR TITLE
Fix extra header space when printing invoices

### DIFF
--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -132,13 +132,13 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
   };
 
   return (
-    <DisablingCover
-      disabled={isLoadingDispenses}
-      message={t("loading_medication_details")}
+    <PrintPreview
+      title={`${t("invoice")} ${invoice.number}`}
+      watermark={getWatermark()}
     >
-      <PrintPreview
-        title={`${t("invoice")} ${invoice.number}`}
-        watermark={getWatermark()}
+      <DisablingCover
+        disabled={isLoadingDispenses}
+        message={t("loading_medication_details")}
       >
         <div className="max-w-5xl mx-auto">
           {/* Header with Facility Name and Logo */}
@@ -619,8 +619,8 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
             }
           />
         </div>
-      </PrintPreview>
-    </DisablingCover>
+      </DisablingCover>
+    </PrintPreview>
   );
 }
 


### PR DESCRIPTION
Fixes #15365

## Changes
Moved \`DisablingCover\` inside \`PrintPreview\` to prevent the wrapper div from affecting print layout.

## Before
<img width="561" height="312" alt="image" src="https://github.com/user-attachments/assets/2752d9eb-bbab-457c-b8f9-09d6e930d68d" />

## After
<img width="564" height="320" alt="image" src="https://github.com/user-attachments/assets/0b428f3b-0eff-4efe-a8cf-1db25a9b5e57" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized component hierarchy in the invoice print preview module to improve the rendering structure and watermark support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->