### PR TITLE
Service req list: add AD and created date filters

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3489,6 +3489,7 @@
   "no_matching_discount_codes": "No discount codes matches this search",
   "no_matching_discount_components": "No discount components matches this search",
   "no_matching_informational_codes": "No matching informational codes",
+  "no_matching_items_found": "No matching items found",
   "no_matching_permissions": "No permissions match your search",
   "no_matching_tax_codes": "No matching tax codes found",
   "no_matching_tax_components": "No matching tax components found",

--- a/src/components/ui/multi-filter/activityDefinitionFilter.tsx
+++ b/src/components/ui/multi-filter/activityDefinitionFilter.tsx
@@ -1,0 +1,496 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  ChevronRight,
+  Folder,
+  FolderOpen,
+  Home,
+  MoreHorizontal,
+  Search,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import useKeyboardShortcut from "use-keyboard-shortcut";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+import query from "@/Utils/request/query";
+import {
+  ResourceCategoryParent,
+  ResourceCategoryResourceType,
+} from "@/types/base/resourceCategory/resourceCategory";
+import resourceCategoryApi from "@/types/base/resourceCategory/resourceCategoryApi";
+import {
+  ActivityDefinitionReadSpec,
+  Status,
+} from "@/types/emr/activityDefinition/activityDefinition";
+import activityDefinitionApi from "@/types/emr/activityDefinition/activityDefinitionApi";
+
+import FilterHeader from "./filterHeader";
+import { FilterConfig, FilterMode, FilterValues } from "./utils/Utils";
+
+interface CategoryBreadcrumb {
+  slug: string;
+  title: string;
+}
+
+export interface ActivityDefinitionFilterMeta {
+  facilityId: string;
+}
+
+export interface ActivityDefinitionFilterValue {
+  id: string;
+  slug: string;
+  title: string;
+  category?: ResourceCategoryParent;
+}
+
+function ActivityDefinitionFilterDropdown({
+  selectedDefinitions,
+  onDefinitionsChange,
+  facilityId,
+  handleBack,
+  mode = "single",
+}: {
+  selectedDefinitions: ActivityDefinitionFilterValue[];
+  onDefinitionsChange: (definitions: ActivityDefinitionFilterValue[]) => void;
+  facilityId: string;
+  handleBack?: () => void;
+  mode?: FilterMode;
+}) {
+  const { t } = useTranslation();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [breadcrumbs, setBreadcrumbs] = useState<CategoryBreadcrumb[]>([]);
+  const [currentParent, setCurrentParent] = useState<string | undefined>(
+    undefined,
+  );
+  const [breadcrumbsExpanded, setBreadcrumbsExpanded] = useState(false);
+
+  // Fetch categories for current level
+  const { data: categoriesResponse, isLoading: isLoadingCategories } = useQuery(
+    {
+      queryKey: [
+        "resourceCategories",
+        facilityId,
+        ResourceCategoryResourceType.activity_definition,
+        currentParent,
+      ],
+      queryFn: query(resourceCategoryApi.list, {
+        pathParams: { facilityId },
+        queryParams: {
+          resource_type: ResourceCategoryResourceType.activity_definition,
+          parent: currentParent || "",
+          limit: 100,
+        },
+      }),
+    },
+  );
+
+  // Fetch definitions for current category or search
+  const { data: definitionsResponse, isLoading: isLoadingDefinitions } =
+    useQuery({
+      queryKey: [
+        "activityDefinitions",
+        facilityId,
+        currentParent,
+        searchQuery,
+        "filter",
+      ],
+      queryFn: query.debounced(activityDefinitionApi.listActivityDefinition, {
+        pathParams: { facilityId },
+        queryParams: {
+          category: currentParent || "",
+          ...(searchQuery ? { title: searchQuery } : {}),
+          limit: 100,
+          status: Status.active,
+        },
+      }),
+    });
+
+  const categories = useMemo(
+    () => categoriesResponse?.results || [],
+    [categoriesResponse?.results],
+  );
+
+  const definitions = useMemo(
+    () => definitionsResponse?.results || [],
+    [definitionsResponse?.results],
+  );
+
+  const isLoading = isLoadingCategories || isLoadingDefinitions;
+
+  const handleCategorySelect = (
+    categorySlug: string,
+    categoryTitle: string,
+  ) => {
+    setBreadcrumbs((prev) => [
+      ...prev,
+      { slug: categorySlug, title: categoryTitle },
+    ]);
+    setCurrentParent(categorySlug);
+    setBreadcrumbsExpanded(false);
+    setSearchQuery("");
+  };
+
+  const handleBreadcrumbClick = (index: number) => {
+    const newBreadcrumbs = breadcrumbs.slice(0, index + 1);
+    setBreadcrumbs(newBreadcrumbs);
+
+    if (index === -1) {
+      setCurrentParent(undefined);
+    } else {
+      setCurrentParent(newBreadcrumbs[index].slug);
+    }
+    setBreadcrumbsExpanded(false);
+    setSearchQuery("");
+  };
+
+  const handleBackToRoot = () => {
+    setBreadcrumbs([]);
+    setCurrentParent(undefined);
+    setBreadcrumbsExpanded(false);
+    setSearchQuery("");
+  };
+
+  const handleDefinitionToggle = (definition: ActivityDefinitionReadSpec) => {
+    const isSelected = selectedDefinitions.some((d) => d.id === definition.id);
+
+    if (mode === "single") {
+      // Single-select: replace selection
+      if (isSelected) {
+        onDefinitionsChange([]);
+      } else {
+        onDefinitionsChange([
+          {
+            id: definition.id,
+            slug: definition.slug,
+            title: definition.title,
+            category: definition.category,
+          },
+        ]);
+      }
+    } else {
+      // Multi-select: toggle
+      if (isSelected) {
+        onDefinitionsChange(
+          selectedDefinitions.filter((d) => d.id !== definition.id),
+        );
+      } else {
+        onDefinitionsChange([
+          ...selectedDefinitions,
+          {
+            id: definition.id,
+            slug: definition.slug,
+            title: definition.title,
+            category: definition.category,
+          },
+        ]);
+      }
+    }
+  };
+
+  const getDisplayPath = (definition: ActivityDefinitionReadSpec) => {
+    const pathParts: string[] = [];
+    if (definition.category) {
+      let current: ResourceCategoryParent | undefined = definition.category;
+      while (current) {
+        if (current.title) {
+          pathParts.unshift(current.title);
+        }
+        current = current.parent;
+      }
+    }
+
+    if (pathParts.length === 0) return null;
+    if (pathParts.length > 2) {
+      return `${pathParts[0]} > ... > ${pathParts[pathParts.length - 1]}`;
+    }
+    return pathParts.join(" > ");
+  };
+
+  useKeyboardShortcut(
+    ["ArrowLeft"],
+    () => {
+      if (breadcrumbs.length > 0) {
+        handleBreadcrumbClick(breadcrumbs.length - 2);
+      } else {
+        handleBack?.();
+      }
+    },
+    {
+      overrideSystem: true,
+    },
+  );
+
+  return (
+    <div className="max-h-[40vh] overflow-y-auto">
+      {/* Search Input */}
+      <div className="p-3 border-b">
+        <Input
+          placeholder={t("search_activity_definition")}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      {/* Breadcrumbs */}
+      {breadcrumbs.length > 0 && (
+        <div className="px-3 py-2 border-b bg-gray-50">
+          <div className="flex items-center gap-1 text-xs overflow-auto">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleBackToRoot}
+              className="h-6 px-2 text-xs hover:bg-white"
+            >
+              <Home className="size-3 mr-1" />
+              {t("root")}
+            </Button>
+            {breadcrumbs.length <= 2 || breadcrumbsExpanded ? (
+              breadcrumbs.map((breadcrumb, index) => (
+                <div key={breadcrumb.slug} className="flex items-center">
+                  <ChevronRight className="size-3 mx-1 text-gray-500" />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleBreadcrumbClick(index)}
+                    className="h-6 px-2 text-xs hover:bg-white"
+                  >
+                    {breadcrumb.title}
+                  </Button>
+                </div>
+              ))
+            ) : (
+              <>
+                <ChevronRight className="size-3 mx-1 text-gray-500" />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setBreadcrumbsExpanded(true)}
+                  className="h-6 px-2 text-xs hover:bg-white"
+                >
+                  <MoreHorizontal className="size-3" />
+                </Button>
+                <ChevronRight className="size-3 mx-1 text-gray-500" />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleBreadcrumbClick(breadcrumbs.length - 1)}
+                  className="h-6 px-2 text-xs hover:bg-white"
+                >
+                  {breadcrumbs[breadcrumbs.length - 1].title}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="p-2">
+        {/* Selected Definitions */}
+        {selectedDefinitions.length > 0 && (
+          <>
+            <div className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+              {t("selected")}
+            </div>
+            {selectedDefinitions.map((def) => (
+              <DropdownMenuItem
+                key={def.id}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  onDefinitionsChange(
+                    selectedDefinitions.filter((d) => d.id !== def.id),
+                  );
+                }}
+                className="flex items-center gap-2 px-2 py-1 cursor-pointer"
+              >
+                <Checkbox
+                  checked={true}
+                  className="data-[state=checked]:border-primary-700 text-white"
+                />
+                <div className="flex flex-col min-w-0 flex-1">
+                  <span className="text-sm truncate">{def.title}</span>
+                  {def.category && (
+                    <span className="text-xs text-gray-500 flex items-center gap-1">
+                      <Folder className="size-2.5" />
+                      {def.category.title}
+                    </span>
+                  )}
+                </div>
+              </DropdownMenuItem>
+            ))}
+            <div className="border-b my-2" />
+          </>
+        )}
+
+        {/* Loading State */}
+        {isLoading && (
+          <div className="p-3 space-y-2">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-3/4" />
+          </div>
+        )}
+
+        {/* Categories (only show when not searching) */}
+        {!isLoading && !searchQuery && categories.length > 0 && (
+          <>
+            <div className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+              {currentParent ? t("subcategories") : t("categories")}
+            </div>
+            {categories.map((category) => (
+              <DropdownMenuItem
+                key={category.id}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  handleCategorySelect(category.slug, category.title);
+                }}
+                className="flex items-center justify-between px-2 py-2 cursor-pointer"
+              >
+                <div className="flex items-center gap-2">
+                  <FolderOpen className="size-4 text-amber-500" />
+                  <span className="text-sm">{category.title}</span>
+                </div>
+                <ChevronRight className="size-4 text-gray-400" />
+              </DropdownMenuItem>
+            ))}
+            {definitions.length > 0 && <div className="border-b my-2" />}
+          </>
+        )}
+
+        {/* Definitions */}
+        {!isLoading && (searchQuery || currentParent) && (
+          <>
+            {definitions.length > 0 && (
+              <div className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+                {t("activity_definitions")}
+              </div>
+            )}
+            {definitions
+              .filter(
+                (def) => !selectedDefinitions.some((s) => s.id === def.id),
+              )
+              .map((definition) => {
+                const displayPath = getDisplayPath(definition);
+                return (
+                  <DropdownMenuItem
+                    key={definition.id}
+                    onSelect={(e) => {
+                      e.preventDefault();
+                      handleDefinitionToggle(definition);
+                    }}
+                    className="flex items-center gap-2 px-2 py-1.5 cursor-pointer"
+                  >
+                    <Checkbox checked={false} className="h-4 w-4" />
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="text-sm truncate">
+                        {definition.title}
+                      </span>
+                      {searchQuery && displayPath && (
+                        <span className="text-xs text-gray-500 flex items-center gap-1">
+                          <Folder className="size-2.5" />
+                          {displayPath}
+                        </span>
+                      )}
+                    </div>
+                  </DropdownMenuItem>
+                );
+              })}
+          </>
+        )}
+
+        {/* Empty States */}
+        {!isLoading &&
+          !searchQuery &&
+          !currentParent &&
+          definitions.length === 0 &&
+          categories.length === 0 && (
+            <div className="p-4 text-center text-gray-500">
+              <Folder className="size-8 mx-auto mb-2 opacity-50" />
+              <div className="text-sm">{t("no_items_found")}</div>
+            </div>
+          )}
+
+        {!isLoading && searchQuery && definitions.length === 0 && (
+          <div className="p-4 text-center text-gray-500">
+            <Search className="size-8 mx-auto mb-2 opacity-50" />
+            <div className="text-sm">{t("no_matching_items_found")}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function RenderActivityDefinitionFilter({
+  filter,
+  selectedDefinitions,
+  onFilterChange,
+  handleBack,
+  facilityId,
+}: {
+  filter: FilterConfig;
+  selectedDefinitions: ActivityDefinitionFilterValue[];
+  onFilterChange: (filterKey: string, values: FilterValues) => void;
+  handleBack?: () => void;
+  facilityId: string;
+}) {
+  return (
+    <div className="p-0">
+      {handleBack && <FilterHeader label={filter.label} onBack={handleBack} />}
+      <ActivityDefinitionFilterDropdown
+        selectedDefinitions={selectedDefinitions}
+        onDefinitionsChange={(definitions) => {
+          onFilterChange(filter.key, definitions);
+        }}
+        facilityId={facilityId}
+        handleBack={handleBack}
+        mode={filter.mode}
+      />
+    </div>
+  );
+}
+
+export function SelectedActivityDefinitionBadge({
+  selected,
+}: {
+  selected: ActivityDefinitionFilterValue[];
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2 min-w-0 flex-shrink-0">
+      {selected.length === 1 ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="text-sm whitespace-nowrap truncate max-w-[150px]">
+              {selected[0].title}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{selected[0].title}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger>
+            <span className="text-sm whitespace-nowrap">
+              {selected.length} {t("activity_definitions")}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {selected.map((def) => (
+              <div key={def.id}>{def.title}</div>
+            ))}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/multi-filter/filterConfigs.tsx
+++ b/src/components/ui/multi-filter/filterConfigs.tsx
@@ -7,9 +7,19 @@ import {
 } from "@/types/emr/encounter/encounter";
 import { TagConfig, TagResource } from "@/types/emr/tagConfig/tagConfig";
 import { FacilityOrganizationRead } from "@/types/facilityOrganization/facilityOrganization";
-import { Building, CalendarFold, CircleDashed, Tag } from "lucide-react";
+import {
+  Beaker,
+  Building,
+  CalendarFold,
+  CircleDashed,
+  Tag,
+} from "lucide-react";
 
 import { t } from "i18next";
+import {
+  ActivityDefinitionFilterValue,
+  SelectedActivityDefinitionBadge,
+} from "./activityDefinitionFilter";
 import { SelectedDateBadge, getDateOperations } from "./dateFilter";
 import { SelectedDepartmentBadge } from "./departmentFilter";
 import { GenericSelectedBadge } from "./genericFilter";
@@ -455,5 +465,29 @@ export const paymentMethodFilter = (
       mode,
       icon: <CircleDashed className="size-4" />,
       showColorIndicators: false,
+    },
+  );
+
+export const activityDefinitionFilter = (
+  key: string = "activity_definition",
+  mode: FilterMode = "single",
+  label?: string,
+) =>
+  createFilterConfig(
+    key,
+    label ? t(label) : t("activity_definition"),
+    "activity_definition",
+    [],
+    {
+      renderSelected: (selected: FilterValues) => {
+        return (
+          <SelectedActivityDefinitionBadge
+            selected={selected as ActivityDefinitionFilterValue[]}
+          />
+        );
+      },
+      getOperations: () => [{ label: "is" }],
+      mode,
+      icon: <Beaker className="size-4" />,
     },
   );

--- a/src/components/ui/multi-filter/filterRenderer.tsx
+++ b/src/components/ui/multi-filter/filterRenderer.tsx
@@ -1,6 +1,9 @@
 import { TagConfig } from "@/types/emr/tagConfig/tagConfig";
 import { FacilityOrganizationRead } from "@/types/facilityOrganization/facilityOrganization";
 
+import RenderActivityDefinitionFilter, {
+  ActivityDefinitionFilterValue,
+} from "./activityDefinitionFilter";
 import RenderDateFilter from "./dateFilter";
 import RenderDepartmentFilter from "./departmentFilter";
 import GenericFilter from "./genericFilter";
@@ -57,6 +60,17 @@ export default function FilterRenderer({
           <RenderDepartmentFilter
             {...commonProps}
             selectedOrgs={selected as FacilityOrganizationRead[]}
+          />
+          <NavigationHelper isActiveFilter={true} />
+        </>
+      );
+    case "activity_definition":
+      return (
+        <>
+          <RenderActivityDefinitionFilter
+            {...commonProps}
+            facilityId={facilityId || ""}
+            selectedDefinitions={selected as ActivityDefinitionFilterValue[]}
           />
           <NavigationHelper isActiveFilter={true} />
         </>

--- a/src/components/ui/multi-filter/utils/Utils.tsx
+++ b/src/components/ui/multi-filter/utils/Utils.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { addDays, subDays, subMonths, subWeeks, subYears } from "date-fns";
 
+import { ActivityDefinitionFilterValue } from "@/components/ui/multi-filter/activityDefinitionFilter";
 import { GenericSelectedBadge } from "@/components/ui/multi-filter/genericFilter";
 
 import { TagConfig, TagResource } from "@/types/emr/tagConfig/tagConfig";
@@ -37,7 +38,8 @@ export type FilterValues =
   | string[]
   | TagConfig[]
   | FilterDateRange
-  | FacilityOrganizationRead[];
+  | FacilityOrganizationRead[]
+  | ActivityDefinitionFilterValue[];
 
 export type FilterMode = "single" | "multi";
 
@@ -48,6 +50,10 @@ export type TagFilterMeta = {
   resource: TagResource;
 };
 export type DepartmentFilterMeta = {
+  facilityId?: string;
+};
+
+export type ActivityDefinitionFilterMeta = {
   facilityId?: string;
 };
 
@@ -89,11 +95,17 @@ export interface DepartmentFilterConfig extends BaseFilterConfig {
   meta: DepartmentFilterMeta;
 }
 
+export interface ActivityDefinitionFilterConfig extends BaseFilterConfig {
+  type: "activity_definition";
+  meta: ActivityDefinitionFilterMeta;
+}
+
 export type FilterConfig =
   | CommandFilterConfig
   | TagFilterConfig
   | DateFilterConfig
-  | DepartmentFilterConfig;
+  | DepartmentFilterConfig
+  | ActivityDefinitionFilterConfig;
 
 export interface OperationConfig {
   selectedOperation: Operation | null;
@@ -143,7 +155,7 @@ function defaultGetOperations(_selected: FilterValues) {
 export function createFilterConfig(
   key: string,
   label: string,
-  type: "command" | "tag" | "date" | "department",
+  type: "command" | "tag" | "date" | "department" | "activity_definition",
   options: FilterOption[],
   meta?: {
     resource?: TagResource;
@@ -159,6 +171,7 @@ export function createFilterConfig(
     operationKey?: string;
     disableClear?: boolean;
     showColorIndicators?: boolean;
+    facilityId?: string;
   },
 ): FilterConfig {
   const {
@@ -171,6 +184,7 @@ export function createFilterConfig(
     operationKey,
     disableClear,
     showColorIndicators,
+    facilityId,
   } = meta || {};
   const baseConfig: BaseFilterConfig = {
     key,
@@ -206,6 +220,12 @@ export function createFilterConfig(
         type: "department",
         meta: {},
       } as DepartmentFilterConfig;
+    case "activity_definition":
+      return {
+        ...baseConfig,
+        type: "activity_definition",
+        meta: { facilityId },
+      } as ActivityDefinitionFilterConfig;
     case "command":
       return {
         ...baseConfig,

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
@@ -262,7 +262,7 @@ export default function ServiceRequestList({
         "single",
         "activity_definition",
       ),
-      dateFilter("created_date", t("date"), longDateRangeOptions, true),
+      dateFilter("created_date", t("date"), longDateRangeOptions),
     ],
     [],
   );

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Hash, ScanQrCode } from "lucide-react";
 import { navigate } from "raviger";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -23,7 +23,10 @@ import useFilters from "@/hooks/useFilters";
 
 import PatientIdentifierFilter from "@/components/Patient/PatientIdentifierFilter";
 import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
+import { ActivityDefinitionFilterValue } from "@/components/ui/multi-filter/activityDefinitionFilter";
 import {
+  activityDefinitionFilter,
+  dateFilter,
   encounterClassFilter,
   tagFilter,
 } from "@/components/ui/multi-filter/filterConfigs";
@@ -31,9 +34,12 @@ import MultiFilter from "@/components/ui/multi-filter/MultiFilter";
 import useMultiFilterState from "@/components/ui/multi-filter/utils/useMultiFilterState";
 import {
   createFilterConfig,
+  FilterDateRange,
   getVariantColorClasses,
+  longDateRangeOptions,
 } from "@/components/ui/multi-filter/utils/Utils";
 import { useShortcutSubContext } from "@/context/ShortcutContext";
+import activityDefinitionApi from "@/types/emr/activityDefinition/activityDefinitionApi";
 import {
   Priority,
   SERVICE_REQUEST_PRIORITY_COLORS,
@@ -47,6 +53,7 @@ import useTagConfigs from "@/types/emr/tagConfig/useTagConfig";
 import locationApi from "@/types/location/locationApi";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import query from "@/Utils/request/query";
+import { dateQueryString, dateTimeQueryString } from "@/Utils/utils";
 
 function EmptyState() {
   const { t } = useTranslation();
@@ -203,6 +210,38 @@ export default function ServiceRequestList({
     .map((query) => query.data)
     .filter(Boolean) as TagConfig[];
 
+  const [selectedActivityDefinition, setSelectedActivityDefinition] = useState<
+    ActivityDefinitionFilterValue | undefined
+  >(undefined);
+
+  const { data: activityDefinitionData } = useQuery({
+    queryKey: ["activityDefinition", facilityId, qParams.activity_definition],
+    queryFn: query(activityDefinitionApi.retrieveActivityDefinition, {
+      pathParams: {
+        facilityId,
+        activityDefinitionSlug: qParams.activity_definition,
+      },
+    }),
+    enabled: !!qParams.activity_definition && !selectedActivityDefinition,
+  });
+
+  useEffect(() => {
+    if (activityDefinitionData && !selectedActivityDefinition) {
+      setSelectedActivityDefinition({
+        id: activityDefinitionData.id,
+        slug: activityDefinitionData.slug,
+        title: activityDefinitionData.title,
+        category: activityDefinitionData.category,
+      });
+    } else if (!qParams.activity_definition && selectedActivityDefinition) {
+      setSelectedActivityDefinition(undefined);
+    }
+  }, [
+    activityDefinitionData,
+    qParams.activity_definition,
+    selectedActivityDefinition,
+  ]);
+
   // Create filter configurations
   const filters = useMemo(
     () => [
@@ -218,20 +257,52 @@ export default function ServiceRequestList({
         })),
       ),
       encounterClassFilter(),
+      activityDefinitionFilter(
+        "activity_definition",
+        "single",
+        "activity_definition",
+      ),
+      dateFilter("created_date", t("date"), longDateRangeOptions, true),
     ],
     [],
   );
 
   // Handle filter updates
-  const onFilterUpdate = (query: Record<string, unknown>) => {
-    for (const [key, value] of Object.entries(query)) {
+  const onFilterUpdate = (updates: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(updates)) {
       switch (key) {
         case "tags":
-          query.tags = (value as TagConfig[])?.map((tag) => tag.id);
+          updates.tags = (value as TagConfig[])?.map((tag) => tag.id);
+          break;
+        case "activity_definition": {
+          const adValue = Array.isArray(value)
+            ? (value as ActivityDefinitionFilterValue[])[0]
+            : (value as ActivityDefinitionFilterValue | undefined);
+
+          setSelectedActivityDefinition(adValue);
+
+          if (adValue) {
+            updates.activity_definition = adValue.slug;
+          } else {
+            updates.activity_definition = undefined;
+          }
+          break;
+        }
+        case "created_date":
+          {
+            const dateRange = value as FilterDateRange;
+            updates.created_date = undefined;
+            updates.created_date_after = dateRange?.from
+              ? dateQueryString(dateRange.from)
+              : undefined;
+            updates.created_date_before = dateRange?.to
+              ? dateQueryString(dateRange.to)
+              : undefined;
+          }
           break;
       }
     }
-    updateQuery(query);
+    updateQuery(updates);
   };
 
   // Use the multi-filter state hook
@@ -244,6 +315,20 @@ export default function ServiceRequestList({
   } = useMultiFilterState(filters, onFilterUpdate, {
     ...qParams,
     tags: selectedTags,
+    activity_definition: selectedActivityDefinition
+      ? [selectedActivityDefinition]
+      : [],
+    created_date:
+      qParams.created_date_after || qParams.created_date_before
+        ? {
+            from: qParams.created_date_after
+              ? new Date(qParams.created_date_after)
+              : undefined,
+            to: qParams.created_date_before
+              ? new Date(qParams.created_date_before)
+              : undefined,
+          }
+        : undefined,
   });
 
   const { data: location } = useQuery({
@@ -268,6 +353,13 @@ export default function ServiceRequestList({
         patient: qParams.patient,
         tags_behavior: qParams.tags_behavior,
         encounter_class: qParams.encounter_class,
+        activity_definition: qParams.activity_definition,
+        created_date_after: qParams.created_date_after
+          ? dateTimeQueryString(new Date(qParams.created_date_after))
+          : undefined,
+        created_date_before: qParams.created_date_before
+          ? dateTimeQueryString(new Date(qParams.created_date_before))
+          : undefined,
       },
     }),
   });


### PR DESCRIPTION
## Proposed Changes

- allow filtering service req list w/ AD and created date

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Activity Definition filter with hierarchical category navigation, search functionality, and multi/single-select modes.
  * Filter includes breadcrumb navigation, category browsing, and visual indicators for selections.
  * Integrated Activity Definition filtering into service request lists.

* **Documentation**
  * Added localization support for "no matching items found" message display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->