### PR TITLE
show batch number in purchase delivery line items

### DIFF
--- a/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
+++ b/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
@@ -161,6 +161,7 @@ export function SupplyDeliveryTable({
             </TableHead>
           )}
           <TableHead>{t("item")}</TableHead>
+          <TableHead>{t("batch")}</TableHead>
           <TableHead>{t("requested_qty")}</TableHead>
           {!internal && <TableHead>{t("pack_size")}</TableHead>}
           {!internal && <TableHead>{t("pack_qty")}</TableHead>}
@@ -211,6 +212,10 @@ export function SupplyDeliveryTable({
                       ?.name
                   : delivery.supplied_item?.product_knowledge?.name}
               </div>
+            </TableCell>
+            <TableCell>
+              {delivery.supplied_inventory_item?.product?.batch?.lot_number ||
+                "-"}
             </TableCell>
             <TableCell>
               {delivery.supply_request


### PR DESCRIPTION
- fixes #15374

<img width="2056" height="696" alt="image" src="https://github.com/user-attachments/assets/77c608ec-f85c-46f2-86a7-34d092c44ba7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch lot number information to the Supply Delivery Table, displayed in a new column alongside existing inventory details for improved visibility and tracking of supply deliveries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->