### PR TITLE
add negative sign for credit note in print charge items

### DIFF
--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -37,7 +37,7 @@ import {
 import paymentReconciliationApi from "@/types/billing/paymentReconciliation/paymentReconciliationApi";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 
-import { add, round } from "@/Utils/decimal";
+import { add, multiply, round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
 import { formatDateTime, formatPatientAge } from "@/Utils/utils";
 
@@ -743,7 +743,10 @@ export const PrintChargeItems = (props: {
                                           </TableCell>
                                           <TableCell className="text-right">
                                             <MonetaryDisplay
-                                              amount={payment.amount}
+                                              amount={multiply(
+                                                payment.amount,
+                                                payment.is_credit_note ? -1 : 1,
+                                              )}
                                             />
                                           </TableCell>
                                         </TableRow>,


### PR DESCRIPTION
- fixes #15377
<img width="887" height="230" alt="image" src="https://github.com/user-attachments/assets/8868ce2c-08ec-4a67-82fa-5ec415947cca" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the display of credit note amounts in billing account records. Credit notes now correctly show with negative sign values, while regular charges display as positive amounts. This ensures accurate financial reconciliation across charge item listings and payment reconciliation sections for improved billing accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->