### PR TITLE
add resource category filter to print charge items view

### DIFF
--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -10,6 +10,13 @@ import PrintPreview from "@/CAREUI/misc/PrintPreview";
 import Loading from "@/components/Common/Loading";
 import PrintFooter from "@/components/Common/PrintFooter";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
   Table,
@@ -82,6 +89,7 @@ export const PrintChargeItems = (props: {
   const [sortByName, setSortByName] = useState(false);
   const [showCreatedBy, setShowCreatedBy] = useState(false);
   const [groupByParentCategory, setGroupByParentCategory] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
   const hideCategoryLabel = `${t("hide_category_grouping")}`;
   const hidePaymentTypeLabel = `${t("hide_payment_type_grouping")}`;
@@ -254,6 +262,63 @@ export const PrintChargeItems = (props: {
             </div>
           </>
         )}
+
+        {/* Category Filter */}
+        {chargeItems?.results &&
+          chargeItems.results.length > 0 &&
+          (() => {
+            const useParentCategory = groupByParentCategory || summaryMode;
+            const categories = [
+              ...new Set(
+                chargeItems.results
+                  .filter(
+                    (item) => item.status !== ChargeItemStatus.entered_in_error,
+                  )
+                  .map((item) => {
+                    const category = item.charge_item_definition?.category;
+                    return useParentCategory
+                      ? category?.parent?.title ||
+                          category?.title ||
+                          t("uncategorized")
+                      : category?.title || t("uncategorized");
+                  }),
+              ),
+            ].sort();
+
+            return (
+              <div className="gap-2 flex items-center">
+                <label
+                  htmlFor="category-filter"
+                  className="text-sm whitespace-nowrap"
+                >
+                  {t("filter_by_category")}:
+                </label>
+                <Select
+                  value={selectedCategory ?? "__all__"}
+                  onValueChange={(value) =>
+                    setSelectedCategory(value === "__all__" ? null : value)
+                  }
+                >
+                  <SelectTrigger
+                    id="category-filter"
+                    className="w-48 h-8 text-sm"
+                  >
+                    <SelectValue placeholder={t("all_categories")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__all__">
+                      {t("all_categories")}
+                    </SelectItem>
+                    {categories.map((category) => (
+                      <SelectItem key={category} value={category}>
+                        {category}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            );
+          })()}
       </div>
       <PrintPreview
         title={t("charge_items")}
@@ -434,15 +499,30 @@ export const PrintChargeItems = (props: {
                           <TableBody className="[&_tr]:border-0 [&_td]:p-0.5">
                             {(() => {
                               // Group charge items by category, excluding entered_in_error items
-                              const validItems = chargeItems.results.filter(
-                                (item) =>
-                                  item.status !==
-                                  ChargeItemStatus.entered_in_error,
-                              );
+                              const validItemsBeforeFilter =
+                                chargeItems.results.filter(
+                                  (item) =>
+                                    item.status !==
+                                    ChargeItemStatus.entered_in_error,
+                                );
 
                               // In summary mode, default to grouping by parent category
                               const useParentCategory =
                                 groupByParentCategory || summaryMode;
+
+                              // Apply category filter
+                              const validItems = selectedCategory
+                                ? validItemsBeforeFilter.filter((item) => {
+                                    const category =
+                                      item.charge_item_definition?.category;
+                                    const categoryTitle = useParentCategory
+                                      ? category?.parent?.title ||
+                                        category?.title ||
+                                        t("uncategorized")
+                                      : category?.title || t("uncategorized");
+                                    return categoryTitle === selectedCategory;
+                                  })
+                                : validItemsBeforeFilter;
 
                               const groups = validItems.reduce(
                                 (


### PR DESCRIPTION
## Proposed Changes

- fixes #15398



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added category filtering capability to the charge items view. Users can now select a specific category from a dropdown menu to filter items displayed, or choose to show all categories at once. The new filter control integrates seamlessly with existing category grouping and subtotal calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->