### PR TITLE
add fluid intake and output measurements to nutrition group in plots.

### DIFF
--- a/public/config/plots.json
+++ b/public/config/plots.json
@@ -272,6 +272,46 @@
         "name": "Nutrition",
         "groups": [
             {
+                "title": "Fluid intake intravascular Measured",
+                "codes": [
+                    {
+                        "code": "8975-5",
+                        "system": "http://loinc.org",
+                        "display": "Fluid intake IV Measured"
+                    }
+                ]
+            },
+            {
+                "title": "Fluid intake oral Measured",
+                "codes": [
+                    {
+                        "code": "9000-1",
+                        "system": "http://loinc.org",
+                        "display": "Fluid intake oral Measured"
+                    }
+                ]
+            },
+             {
+                "title": "Fluid output wound drain",
+                "codes": [
+                    {
+                        "code": "9203-1",
+                        "system": "http://loinc.org",
+                        "display": "Fluid output wound drain"
+                    }
+                ]
+            },
+            {
+                "title": "Urine output",
+                "codes": [
+                    {
+                        "code": "9187-6",
+                        "system": "http://loinc.org",
+                        "display": "Urine output"
+                    }
+                ]
+            },
+            {
                 "title": "Fluid intake total Measured",
                 "codes": [
                     {


### PR DESCRIPTION


Fixes #15404

<img width="1041" height="515" alt="Image" src="https://github.com/user-attachments/assets/ede57ab5-48c5-4e78-a27e-f8a84160ad9d" />

                        "code": "8975-5",
                        "system": "http://loinc.org",
                        "display": "Fluid intake IV Measured"

                        "code": "9000-1",
                        "system": "http://loinc.org",
                        "display": "Fluid intake oral Measured"

                        "system": "http://loinc.org",
                        "display": "Fluid output wound drain"

                        "code": "9187-6",
                        "system": "http://loinc.org",
                        "display": "Urine output"


## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded fluid and output tracking with four new measurement categories: intravascular fluid intake, oral fluid intake, wound drain output, and urine output. These additions enhance the available Nutrition measurements in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->