### PR TITLE
Disable Charge items print when invoice locked

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -3544,6 +3544,7 @@
   "no_payments": "No payments",
   "no_payments_description": "No payments found",
   "no_payments_recorded": "No payments recorded",
+  "no_permission_to_print_charge_items": "You do not have access to print the charge items",
   "no_permission_to_view_clinical_data": "You do not have permission to view clinical data for this encounter",
   "no_permission_to_view_clinical_data_description": "Contact your administrator to grant you access.",
   "no_permission_to_view_page": "You do not have permissions to view this page",

--- a/src/common/Permissions.tsx
+++ b/src/common/Permissions.tsx
@@ -114,6 +114,10 @@ export const PERMISSION_CREATE_ACCOUNT = "can_create_account";
 export const PERMISSION_UPDATE_ACCOUNT = "can_update_account";
 export const PERMISSION_READ_ACCOUNT = "can_read_account";
 
+// Invoice Permissions
+export const PERMISSION_MANAGE_LOCKED_INVOICE =
+  "can_manage_locked_invoice_in_facility";
+
 export interface Permissions {
   // Patient Permissions
   /** Permission slug: "can_create_patient" */
@@ -272,6 +276,9 @@ export interface Permissions {
   canUpdateAccount: boolean;
   /** Permission slug: "can_read_account" */
   canReadAccount: boolean;
+
+  /** Permission slug: "can_manage_locked_invoice_in_facility" */
+  canManageLockedInvoice: boolean;
 }
 
 export type HasPermissionFn = (
@@ -495,5 +502,11 @@ export function getPermissions(
     canCreateAccount: hasPermission(PERMISSION_CREATE_ACCOUNT, permissions),
     canUpdateAccount: hasPermission(PERMISSION_UPDATE_ACCOUNT, permissions),
     canReadAccount: hasPermission(PERMISSION_READ_ACCOUNT, permissions),
+
+    // Invoice
+    canManageLockedInvoice: hasPermission(
+      PERMISSION_MANAGE_LOCKED_INVOICE,
+      permissions,
+    ),
   };
 }

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -7,8 +7,12 @@ import { formatPhoneNumberIntl } from "react-phone-number-input";
 
 import PrintPreview from "@/CAREUI/misc/PrintPreview";
 
+import { getPermissions } from "@/common/Permissions";
+import { usePermissions } from "@/context/PermissionContext";
+
 import Loading from "@/components/Common/Loading";
 import PrintFooter from "@/components/Common/PrintFooter";
+import { Button } from "@/components/ui/button";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
   Select,
@@ -26,6 +30,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+
+import useAppHistory from "@/hooks/useAppHistory";
 
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import { PAYMENT_RECONCILIATION_METHOD_MAP } from "@/types/billing/paymentReconciliation/paymentReconciliation";
@@ -81,6 +87,12 @@ export const PrintChargeItems = (props: {
   const { facilityId, accountId } = props;
   const { facility } = useCurrentFacility();
   const { t } = useTranslation();
+  const { goBack } = useAppHistory();
+  const { hasPermission } = usePermissions();
+  const { canManageLockedInvoice } = getPermissions(
+    hasPermission,
+    facility?.permissions ?? [],
+  );
   const [hideCategories, setHideCategories] = useState(false);
   const [hidePaymentTypeGrouping, setHidePaymentTypeGrouping] = useState(false);
   const [summaryMode, setSummaryMode] = useState(false);
@@ -145,6 +157,23 @@ export const PrintChargeItems = (props: {
     return (
       <div className="flex h-[200px] items-center justify-center  border-2 border-dashed p-4 text-gray-500 border-gray-200">
         {t("no_charge_items_found_for_this_account")}
+      </div>
+    );
+  }
+
+  const hasLockedInvoice = chargeItems.results.some(
+    (item) => item.paid_invoice?.locked,
+  );
+
+  if (hasLockedInvoice && !canManageLockedInvoice) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[200px] gap-4">
+        <p className="text-gray-500">
+          {t("no_permission_to_print_charge_items")}
+        </p>
+        <Button variant="outline" onClick={() => goBack()}>
+          {t("go_back")}
+        </Button>
       </div>
     );
   }


### PR DESCRIPTION
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added permission-based access control for printing charge items linked to locked invoices. Users lacking the necessary permission will encounter an access restriction message instead of the standard print interface, with a navigation option to return.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->