### PR TITLE
set dontRestrictExpired default to false in StockLotSelector

### DIFF
--- a/src/pages/Facility/services/inventory/StockLotSelector.tsx
+++ b/src/pages/Facility/services/inventory/StockLotSelector.tsx
@@ -63,7 +63,7 @@ export default function StockLotSelector({
   locationId,
   productKnowledge,
   availableInventories,
-  dontRestrictExpired = true,
+  dontRestrictExpired = false,
   disabled = false,
   showUnitPrice = true,
   net_content_gt = 0,


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced inventory safety controls: Expired inventory items are now restricted by default when selecting stock lots throughout your inventory management system. This prevents accidental selection of expired items during stock operations, strengthening compliance and ensuring your facility maintains proper inventory safety standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->