### PR TITLE
Add status filter to PrintChargeItems and improve loading state handling

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2664,6 +2664,7 @@
   "in_transit": "In Transit",
   "inactive": "Inactive",
   "include": "Include",
+  "include_cancelled": "Include Cancelled",
   "include_rules": "Include rules",
   "includes_all_taxes": "Includes all applicable taxes",
   "incoming": "Incoming",

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -14,7 +14,6 @@ import { usePermissions } from "@/context/PermissionContext";
 import { DisablingCover } from "@/components/Common/DisablingCover";
 import PrintFooter from "@/components/Common/PrintFooter";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
   Select,
@@ -55,7 +54,7 @@ import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/pa
 
 import { add, multiply, round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
-import { formatDateTime, formatPatientAge } from "@/Utils/utils";
+import { formatDateTime, formatName, formatPatientAge } from "@/Utils/utils";
 
 interface DetailRowProps {
   label: string;
@@ -106,11 +105,21 @@ export const PrintChargeItems = (props: {
   const [showStatus, setShowStatus] = useState(false);
   const [groupByParentCategory, setGroupByParentCategory] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [selectedStatuses, setSelectedStatuses] = useState<ChargeItemStatus[]>([
-    ChargeItemStatus.billable,
-    ChargeItemStatus.billed,
-    ChargeItemStatus.paid,
-  ]);
+  const [showAllStatuses, setShowAllStatuses] = useState(false);
+  const selectedStatuses = showAllStatuses
+    ? [
+        ChargeItemStatus.billable,
+        ChargeItemStatus.billed,
+        ChargeItemStatus.paid,
+        ChargeItemStatus.entered_in_error,
+        ChargeItemStatus.not_billable,
+        ChargeItemStatus.aborted,
+      ]
+    : [
+        ChargeItemStatus.billable,
+        ChargeItemStatus.billed,
+        ChargeItemStatus.paid,
+      ];
 
   const hideCategoryLabel = `${t("hide_category_grouping")}`;
   const hidePaymentTypeLabel = `${t("hide_payment_type_grouping")}`;
@@ -308,6 +317,20 @@ export const PrintChargeItems = (props: {
                 {showStatusLabel}
               </label>
             </div>
+
+            <div className="gap-2 flex items-center">
+              <Switch
+                id="show-all-statuses"
+                checked={showAllStatuses}
+                onCheckedChange={setShowAllStatuses}
+              />
+              <label
+                htmlFor="show-all-statuses"
+                className="cursor-pointer text-sm"
+              >
+                {t("include_cancelled")}
+              </label>
+            </div>
           </>
         )}
 
@@ -318,18 +341,14 @@ export const PrintChargeItems = (props: {
             const useParentCategory = groupByParentCategory || summaryMode;
             const categories = [
               ...new Set(
-                chargeItems.results
-                  .filter(
-                    (item) => item.status !== ChargeItemStatus.entered_in_error,
-                  )
-                  .map((item) => {
-                    const category = item.charge_item_definition?.category;
-                    return useParentCategory
-                      ? category?.parent?.title ||
-                          category?.title ||
-                          t("uncategorized")
-                      : category?.title || t("uncategorized");
-                  }),
+                chargeItems.results.map((item) => {
+                  const category = item.charge_item_definition?.category;
+                  return useParentCategory
+                    ? category?.parent?.title ||
+                        category?.title ||
+                        t("uncategorized")
+                    : category?.title || t("uncategorized");
+                }),
               ),
             ].sort();
 
@@ -367,35 +386,6 @@ export const PrintChargeItems = (props: {
               </div>
             );
           })()}
-
-        <div className="gap-4 flex items-center flex-wrap">
-          <label className="text-sm whitespace-nowrap">
-            {t("filter_by_status")}:
-          </label>
-          {Object.values(ChargeItemStatus).map((status) => (
-            <div key={status} className="flex items-center gap-1">
-              <Checkbox
-                id={`status-${status}`}
-                checked={selectedStatuses.includes(status)}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    setSelectedStatuses([...selectedStatuses, status]);
-                  } else {
-                    setSelectedStatuses(
-                      selectedStatuses.filter((s) => s !== status),
-                    );
-                  }
-                }}
-              />
-              <label
-                htmlFor={`status-${status}`}
-                className="text-xs cursor-pointer uppercase"
-              >
-                {t(status)}
-              </label>
-            </div>
-          ))}
-        </div>
       </div>
       <PrintPreview
         title={t("charge_items")}
@@ -523,6 +513,15 @@ export const PrintChargeItems = (props: {
                               }
                               width="w-24"
                             />
+                            {account?.primary_encounter?.care_team?.[0] && (
+                              <DetailRow
+                                label={t("doctor")}
+                                value={formatName(
+                                  account.primary_encounter.care_team[0].member,
+                                )}
+                                width="w-24"
+                              />
+                            )}
                           </>
                         )}
                       </div>
@@ -583,13 +582,9 @@ export const PrintChargeItems = (props: {
                               </TableHeader>
                               <TableBody className="[&_tr]:border-0 [&_td]:p-0.5">
                                 {(() => {
-                                  // Group charge items by category, excluding entered_in_error items
+                                  // Group charge items by category
                                   const validItemsBeforeFilter =
-                                    chargeItems.results.filter(
-                                      (item) =>
-                                        item.status !==
-                                        ChargeItemStatus.entered_in_error,
-                                    );
+                                    chargeItems.results;
 
                                   // In summary mode, default to grouping by parent category
                                   const useParentCategory =
@@ -1073,7 +1068,10 @@ export const PrintChargeItems = (props: {
                     )}
 
                     {/* Footer Section */}
-                    <PrintFooter className="mt-4 border-t border-gray-200" />
+                    <PrintFooter
+                      showPreparedBy
+                      className="mt-4 border-t border-gray-200"
+                    />
                   </td>
                 </tr>
               </tbody>

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -11,9 +11,10 @@ import PrintPreview from "@/CAREUI/misc/PrintPreview";
 import { getPermissions } from "@/common/Permissions";
 import { usePermissions } from "@/context/PermissionContext";
 
-import Loading from "@/components/Common/Loading";
+import { DisablingCover } from "@/components/Common/DisablingCover";
 import PrintFooter from "@/components/Common/PrintFooter";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
   Select,
@@ -105,6 +106,11 @@ export const PrintChargeItems = (props: {
   const [showStatus, setShowStatus] = useState(false);
   const [groupByParentCategory, setGroupByParentCategory] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedStatuses, setSelectedStatuses] = useState<ChargeItemStatus[]>([
+    ChargeItemStatus.billable,
+    ChargeItemStatus.billed,
+    ChargeItemStatus.paid,
+  ]);
 
   const hideCategoryLabel = `${t("hide_category_grouping")}`;
   const hidePaymentTypeLabel = `${t("hide_payment_type_grouping")}`;
@@ -124,12 +130,12 @@ export const PrintChargeItems = (props: {
   });
 
   const { data: chargeItems, isLoading } = useQuery({
-    queryKey: ["chargeItems", accountId],
+    queryKey: ["chargeItems", accountId, selectedStatuses],
     queryFn: query.paginated(chargeItemApi.listChargeItem, {
       pathParams: { facilityId },
       queryParams: {
         account: accountId,
-        status: "billable,billed,paid",
+        status: selectedStatuses.join(","),
       },
       pageSize: 100,
     }),
@@ -153,9 +159,7 @@ export const PrintChargeItems = (props: {
   const payments =
     (paymentsResponse?.results as PaymentReconciliationRead[]) || [];
 
-  if (isLoading || isLoadingPayments) return <Loading />;
-
-  if (!chargeItems?.results) {
+  if (!chargeItems?.results && !isLoading) {
     return (
       <div className="flex h-[200px] items-center justify-center  border-2 border-dashed p-4 text-gray-500 border-gray-200">
         {t("no_charge_items_found_for_this_account")}
@@ -163,7 +167,7 @@ export const PrintChargeItems = (props: {
     );
   }
 
-  const hasLockedInvoice = chargeItems.results.some(
+  const hasLockedInvoice = chargeItems?.results?.some(
     (item) => item.paid_invoice?.locked,
   );
 
@@ -363,669 +367,719 @@ export const PrintChargeItems = (props: {
               </div>
             );
           })()}
+
+        <div className="gap-4 flex items-center flex-wrap">
+          <label className="text-sm whitespace-nowrap">
+            {t("filter_by_status")}:
+          </label>
+          {Object.values(ChargeItemStatus).map((status) => (
+            <div key={status} className="flex items-center gap-1">
+              <Checkbox
+                id={`status-${status}`}
+                checked={selectedStatuses.includes(status)}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    setSelectedStatuses([...selectedStatuses, status]);
+                  } else {
+                    setSelectedStatuses(
+                      selectedStatuses.filter((s) => s !== status),
+                    );
+                  }
+                }}
+              />
+              <label
+                htmlFor={`status-${status}`}
+                className="text-xs cursor-pointer uppercase"
+              >
+                {t(status)}
+              </label>
+            </div>
+          ))}
+        </div>
       </div>
       <PrintPreview
         title={t("charge_items")}
         disabled={!chargeItems?.results?.length}
         className="print:pt-0"
       >
-        <div className="md:p-2 max-w-4xl mx-auto bg-white">
-          <table className="w-full border-collapse">
-            <thead>
-              <tr>
-                <th className="p-0 font-normal text-left">
-                  {hideHeader && preserveHeaderSpace ? (
-                    <div className="mb-4 pb-2 border-b border-gray-200 h-20" />
-                  ) : !hideHeader ? (
-                    <div className="flex flex-col sm:flex-row print:flex-row print:items-start justify-between items-center sm:items-start mb-4 pb-2 border-b border-gray-200">
-                      <img
-                        src={careConfig.mainLogo?.dark}
-                        alt="Care Logo"
-                        className="h-10 w-auto object-contain mb-2 sm:mb-0 sm:order-2 print:mb-0 print:order-2"
-                      />
-                      <div className="text-center sm:text-left sm:order-1 print:text-left">
-                        <h1 className="text-3xl font-semibold">
-                          {facility?.name}
-                        </h1>
-                        {facility?.address && (
-                          <div className="text-gray-500 whitespace-pre-wrap wrap-break-word text-sm">
-                            {facility.address}
-                            {facility.phone_number && (
-                              <p className="text-gray-500 text-sm">
-                                {facility.phone_number}
-                              </p>
-                            )}
-                          </div>
-                        )}
+        <DisablingCover disabled={isLoading || isLoadingPayments}>
+          <div className="md:p-2 max-w-4xl mx-auto bg-white">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr>
+                  <th className="p-0 font-normal text-left">
+                    {hideHeader && preserveHeaderSpace ? (
+                      <div className="mb-4 pb-2 border-b border-gray-200 h-20" />
+                    ) : !hideHeader ? (
+                      <div className="flex flex-col sm:flex-row print:flex-row print:items-start justify-between items-center sm:items-start mb-4 pb-2 border-b border-gray-200">
+                        <img
+                          src={careConfig.mainLogo?.dark}
+                          alt="Care Logo"
+                          className="h-10 w-auto object-contain mb-2 sm:mb-0 sm:order-2 print:mb-0 print:order-2"
+                        />
+                        <div className="text-center sm:text-left sm:order-1 print:text-left">
+                          <h1 className="text-3xl font-semibold">
+                            {facility?.name}
+                          </h1>
+                          {facility?.address && (
+                            <div className="text-gray-500 whitespace-pre-wrap wrap-break-word text-sm">
+                              {facility.address}
+                              {facility.phone_number && (
+                                <p className="text-gray-500 text-sm">
+                                  {facility.phone_number}
+                                </p>
+                              )}
+                            </div>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  ) : null}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="p-0 align-top">
-                  <div className="grid md:grid-cols-2 print:grid-cols-2 gap-x-8 gap-y-4 mb-4 text-xs">
-                    <div className="space-y-1">
-                      <DetailRow
-                        label={t("name")}
-                        value={account?.patient?.name}
-                        width="w-16"
-                      />
-                      <DetailRow
-                        label={`${t("age")} / ${t("sex")}`}
-                        value={
-                          account?.patient
-                            ? `${formatPatientAge(account.patient, true)}, ${t(`GENDER__${account.patient.gender}`)}`
-                            : undefined
-                        }
-                        width="w-16"
-                      />
-                      <DetailRow
-                        label={`${t("address")}`}
-                        value={account?.patient?.address}
-                        width="w-16"
-                      />
-                      {account?.primary_encounter?.current_location && (
+                    ) : null}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-0 align-top">
+                    <div className="grid md:grid-cols-2 print:grid-cols-2 gap-x-8 gap-y-4 mb-4 text-xs">
+                      <div className="space-y-1">
                         <DetailRow
-                          label={`${t("location")}`}
+                          label={t("name")}
+                          value={account?.patient?.name}
+                          width="w-16"
+                        />
+                        <DetailRow
+                          label={`${t("age")} / ${t("sex")}`}
                           value={
-                            account?.primary_encounter?.current_location?.name
+                            account?.patient
+                              ? `${formatPatientAge(account.patient, true)}, ${t(`GENDER__${account.patient.gender}`)}`
+                              : undefined
                           }
                           width="w-16"
                         />
-                      )}
-                    </div>
-                    <div className="space-y-1">
-                      <DetailRow
-                        label={`${t("date")}`}
-                        value={formatDateTime(new Date(), "DD-MM-YYYY")}
-                        width="w-24"
-                      />
-                      {account?.patient?.instance_identifiers
-                        ?.filter(
-                          ({ config }) =>
-                            config.config.use === PatientIdentifierUse.official,
-                        )
-                        .map((identifier) => (
+                        <DetailRow
+                          label={`${t("address")}`}
+                          value={account?.patient?.address}
+                          width="w-16"
+                        />
+                        {account?.primary_encounter?.current_location && (
                           <DetailRow
-                            key={identifier.config.id}
-                            label={identifier.config.config.display}
-                            value={identifier.value}
-                            width="w-24"
-                          />
-                        ))}
-                      <DetailRow
-                        label={t("mobile_number")}
-                        value={
-                          account?.patient &&
-                          formatPhoneNumberIntl(account.patient.phone_number)
-                        }
-                        width="w-24"
-                      />
-                      {account?.primary_encounter && (
-                        <>
-                          <DetailRow
-                            label={t("start_date")}
+                            label={`${t("location")}`}
                             value={
-                              account?.primary_encounter &&
-                              account?.primary_encounter.period.start &&
-                              new Date(
-                                account?.primary_encounter.period.start,
-                              ).toLocaleDateString("en-IN")
+                              account?.primary_encounter?.current_location?.name
                             }
-                            width="w-24"
+                            width="w-16"
                           />
-                          <DetailRow
-                            label={t("end_date")}
-                            value={
-                              account?.primary_encounter &&
-                              account?.primary_encounter.period.end &&
-                              new Date(
-                                account?.primary_encounter.period.end,
-                              ).toLocaleDateString("en-IN")
-                            }
-                            width="w-24"
-                          />
-                        </>
-                      )}
+                        )}
+                      </div>
+                      <div className="space-y-1">
+                        <DetailRow
+                          label={`${t("date")}`}
+                          value={formatDateTime(new Date(), "DD-MM-YYYY")}
+                          width="w-24"
+                        />
+                        {account?.patient?.instance_identifiers
+                          ?.filter(
+                            ({ config }) =>
+                              config.config.use ===
+                              PatientIdentifierUse.official,
+                          )
+                          .map((identifier) => (
+                            <DetailRow
+                              key={identifier.config.id}
+                              label={identifier.config.config.display}
+                              value={identifier.value}
+                              width="w-24"
+                            />
+                          ))}
+                        <DetailRow
+                          label={t("mobile_number")}
+                          value={
+                            account?.patient &&
+                            formatPhoneNumberIntl(account.patient.phone_number)
+                          }
+                          width="w-24"
+                        />
+                        {account?.primary_encounter && (
+                          <>
+                            <DetailRow
+                              label={t("start_date")}
+                              value={
+                                account?.primary_encounter &&
+                                account?.primary_encounter.period.start &&
+                                new Date(
+                                  account?.primary_encounter.period.start,
+                                ).toLocaleDateString("en-IN")
+                              }
+                              width="w-24"
+                            />
+                            <DetailRow
+                              label={t("end_date")}
+                              value={
+                                account?.primary_encounter &&
+                                account?.primary_encounter.period.end &&
+                                new Date(
+                                  account?.primary_encounter.period.end,
+                                ).toLocaleDateString("en-IN")
+                              }
+                              width="w-24"
+                            />
+                          </>
+                        )}
+                      </div>
                     </div>
-                  </div>
 
-                  {chargeItems?.results && chargeItems?.results?.length > 0 && (
-                    <div className="text-sm">
-                      <div className="overflow-hidden">
-                        <Table className="w-full [&_th]:text-xs [&_td]:text-xs">
-                          <TableHeader className="[&_tr]:border-y [&_th]:p-0.5 [&_th]:h-auto">
-                            <TableRow className="bg-transparent hover:bg-transparent">
-                              {summaryMode ? (
-                                <>
-                                  <TableHead className="font-bold" colSpan={5}>
-                                    {t("category")}
-                                  </TableHead>
-                                  <TableHead className="font-bold text-right w-32">
-                                    {t("amount")}
-                                  </TableHead>
-                                </>
-                              ) : (
-                                <>
-                                  <TableHead className="font-bold w-10">
-                                    {t("date")}
-                                  </TableHead>
-                                  <TableHead className="font-bold w-10">
-                                    {t("invoice")}
-                                  </TableHead>
-                                  <TableHead className="font-bold w-24">
-                                    {t("title")}
-                                  </TableHead>
-                                  {showStatus && (
-                                    <TableHead className="font-bold text-center w-8">
-                                      {t("status")}
-                                    </TableHead>
+                    {chargeItems?.results &&
+                      chargeItems?.results?.length > 0 && (
+                        <div className="text-sm">
+                          <div className="overflow-hidden">
+                            <Table className="w-full [&_th]:text-xs [&_td]:text-xs">
+                              <TableHeader className="[&_tr]:border-y [&_th]:p-0.5 [&_th]:h-auto">
+                                <TableRow className="bg-transparent hover:bg-transparent">
+                                  {summaryMode ? (
+                                    <>
+                                      <TableHead
+                                        className="font-bold"
+                                        colSpan={5}
+                                      >
+                                        {t("category")}
+                                      </TableHead>
+                                      <TableHead className="font-bold text-right w-32">
+                                        {t("amount")}
+                                      </TableHead>
+                                    </>
+                                  ) : (
+                                    <>
+                                      <TableHead className="font-bold w-10">
+                                        {t("date")}
+                                      </TableHead>
+                                      <TableHead className="font-bold w-10">
+                                        {t("invoice")}
+                                      </TableHead>
+                                      <TableHead className="font-bold w-24">
+                                        {t("title")}
+                                      </TableHead>
+                                      {showStatus && (
+                                        <TableHead className="font-bold text-center w-8">
+                                          {t("status")}
+                                        </TableHead>
+                                      )}
+                                      {showCreatedBy && (
+                                        <TableHead className="font-bold w-16">
+                                          {t("created_by")}
+                                        </TableHead>
+                                      )}
+                                      <TableHead className="font-bold w-10">
+                                        {t("rate")}
+                                      </TableHead>
+                                      <TableHead className="font-bold text-right w-10">
+                                        {t("qty")}
+                                      </TableHead>
+                                      <TableHead className="font-bold text-right w-10">
+                                        {t("amount")}
+                                      </TableHead>
+                                    </>
                                   )}
-                                  {showCreatedBy && (
-                                    <TableHead className="font-bold w-16">
-                                      {t("created_by")}
-                                    </TableHead>
-                                  )}
-                                  <TableHead className="font-bold w-10">
-                                    {t("rate")}
-                                  </TableHead>
-                                  <TableHead className="font-bold text-right w-10">
-                                    {t("qty")}
-                                  </TableHead>
-                                  <TableHead className="font-bold text-right w-10">
-                                    {t("amount")}
-                                  </TableHead>
-                                </>
-                              )}
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody className="[&_tr]:border-0 [&_td]:p-0.5">
-                            {(() => {
-                              // Group charge items by category, excluding entered_in_error items
-                              const validItemsBeforeFilter =
-                                chargeItems.results.filter(
-                                  (item) =>
-                                    item.status !==
-                                    ChargeItemStatus.entered_in_error,
-                                );
+                                </TableRow>
+                              </TableHeader>
+                              <TableBody className="[&_tr]:border-0 [&_td]:p-0.5">
+                                {(() => {
+                                  // Group charge items by category, excluding entered_in_error items
+                                  const validItemsBeforeFilter =
+                                    chargeItems.results.filter(
+                                      (item) =>
+                                        item.status !==
+                                        ChargeItemStatus.entered_in_error,
+                                    );
 
-                              // In summary mode, default to grouping by parent category
-                              const useParentCategory =
-                                groupByParentCategory || summaryMode;
+                                  // In summary mode, default to grouping by parent category
+                                  const useParentCategory =
+                                    groupByParentCategory || summaryMode;
 
-                              // Apply category filter
-                              const validItems = selectedCategory
-                                ? validItemsBeforeFilter.filter((item) => {
-                                    const category =
-                                      item.charge_item_definition?.category;
-                                    const categoryTitle = useParentCategory
-                                      ? category?.parent?.title ||
-                                        category?.title ||
-                                        t("uncategorized")
-                                      : category?.title || t("uncategorized");
-                                    return categoryTitle === selectedCategory;
-                                  })
-                                : validItemsBeforeFilter;
+                                  // Apply category filter
+                                  const validItems = selectedCategory
+                                    ? validItemsBeforeFilter.filter((item) => {
+                                        const category =
+                                          item.charge_item_definition?.category;
+                                        const categoryTitle = useParentCategory
+                                          ? category?.parent?.title ||
+                                            category?.title ||
+                                            t("uncategorized")
+                                          : category?.title ||
+                                            t("uncategorized");
+                                        return (
+                                          categoryTitle === selectedCategory
+                                        );
+                                      })
+                                    : validItemsBeforeFilter;
 
-                              const groups = validItems.reduce(
-                                (
-                                  acc: Record<string, ChargeItemRead[]>,
-                                  item: ChargeItemRead,
-                                ) => {
-                                  const category =
-                                    item.charge_item_definition?.category;
-                                  const categoryTitle = useParentCategory
-                                    ? category?.parent?.title ||
-                                      category?.title ||
-                                      t("uncategorized")
-                                    : category?.title || t("uncategorized");
-                                  const list = acc[categoryTitle] ?? [];
-                                  list.push(item);
-                                  acc[categoryTitle] = list;
-                                  return acc;
-                                },
-                                {} as Record<string, ChargeItemRead[]>,
-                              );
+                                  const groups = validItems.reduce(
+                                    (
+                                      acc: Record<string, ChargeItemRead[]>,
+                                      item: ChargeItemRead,
+                                    ) => {
+                                      const category =
+                                        item.charge_item_definition?.category;
+                                      const categoryTitle = useParentCategory
+                                        ? category?.parent?.title ||
+                                          category?.title ||
+                                          t("uncategorized")
+                                        : category?.title || t("uncategorized");
+                                      const list = acc[categoryTitle] ?? [];
+                                      list.push(item);
+                                      acc[categoryTitle] = list;
+                                      return acc;
+                                    },
+                                    {} as Record<string, ChargeItemRead[]>,
+                                  );
 
-                              // Sort categories alphabetically
-                              const sortedCategories =
-                                Object.keys(groups).sort();
+                                  // Sort categories alphabetically
+                                  const sortedCategories =
+                                    Object.keys(groups).sort();
 
-                              const rows: React.ReactNode[] = [];
+                                  const rows: React.ReactNode[] = [];
 
-                              sortedCategories.forEach((categoryTitle) => {
-                                const baseItems: ChargeItemRead[] =
-                                  groups[categoryTitle] ?? [];
-                                const items = sortByName
-                                  ? baseItems.sort((a, b) =>
-                                      a.title.localeCompare(b.title),
-                                    )
-                                  : baseItems;
+                                  sortedCategories.forEach((categoryTitle) => {
+                                    const baseItems: ChargeItemRead[] =
+                                      groups[categoryTitle] ?? [];
+                                    const items = sortByName
+                                      ? baseItems.sort((a, b) =>
+                                          a.title.localeCompare(b.title),
+                                        )
+                                      : baseItems;
 
-                                const categoryTotal = add(
-                                  ...items.map((i) => i.total_price || 0),
-                                );
+                                    const categoryTotal = add(
+                                      ...items.map((i) => i.total_price || 0),
+                                    );
 
-                                if (summaryMode) {
-                                  // In summary mode, show only category with total
+                                    if (summaryMode) {
+                                      // In summary mode, show only category with total
+                                      rows.push(
+                                        <TableRow
+                                          key={`category-${categoryTitle}`}
+                                          className="bg-transparent hover:bg-transparent"
+                                        >
+                                          <TableCell
+                                            colSpan={5}
+                                            className="font-semibold capitalize"
+                                          >
+                                            {categoryTitle}
+                                          </TableCell>
+                                          <TableCell className="text-right font-semibold">
+                                            <MonetaryDisplay
+                                              amount={categoryTotal}
+                                            />
+                                          </TableCell>
+                                        </TableRow>,
+                                      );
+                                    } else {
+                                      // Normal mode - show header, items, and subtotal
+                                      // Add category header (only if not hiding categories)
+                                      if (!hideCategories) {
+                                        rows.push(
+                                          <TableRow
+                                            key={`category-${categoryTitle}`}
+                                            className="font-bold hover:bg-transparent"
+                                          >
+                                            <TableCell
+                                              colSpan={
+                                                5 +
+                                                (showStatus ? 1 : 0) +
+                                                (showCreatedBy ? 1 : 0)
+                                              }
+                                              className="capitalize"
+                                            >
+                                              {categoryTitle}
+                                            </TableCell>
+                                            <TableCell className="text-right">
+                                              <MonetaryDisplay
+                                                amount={categoryTotal}
+                                              />
+                                            </TableCell>
+                                          </TableRow>,
+                                        );
+                                      }
+
+                                      items.forEach(
+                                        (chargeItem: ChargeItemRead) => {
+                                          const unitPrice =
+                                            chargeItem.unit_price_components.find(
+                                              (c) =>
+                                                c.monetary_component_type ===
+                                                MonetaryComponentType.base,
+                                            )?.amount;
+                                          const hasIssuedOrBalancedInvoice =
+                                            chargeItem.paid_invoice &&
+                                            (chargeItem.paid_invoice.status ===
+                                              InvoiceStatus.issued ||
+                                              chargeItem.paid_invoice.status ===
+                                                InvoiceStatus.balanced);
+                                          rows.push(
+                                            <TableRow
+                                              key={chargeItem.id}
+                                              className={
+                                                hasIssuedOrBalancedInvoice
+                                                  ? "bg-transparent hover:bg-transparent"
+                                                  : "bg-red-50 hover:bg-red-50 text-red-700 print:bg-red-50"
+                                              }
+                                            >
+                                              <TableCell className="w-10 text-left">
+                                                <div className="flex items-center gap-1">
+                                                  {!hasIssuedOrBalancedInvoice && (
+                                                    <AlertTriangle className="h-3 w-3 text-red-600 flex-shrink-0" />
+                                                  )}
+                                                  {formatDateTime(
+                                                    chargeItem.created_date,
+                                                    "DD/MM/YY",
+                                                  )}
+                                                </div>
+                                              </TableCell>
+                                              <TableCell className="w-10 text-left">
+                                                {chargeItem.paid_invoice
+                                                  ?.number || "-"}
+                                              </TableCell>
+                                              <TableCell>
+                                                <div className="flex flex-col">
+                                                  <span className="font-medium">
+                                                    {chargeItem.title}
+                                                  </span>
+                                                </div>
+                                              </TableCell>
+                                              {showStatus && (
+                                                <TableCell className="text-center w-8">
+                                                  <span className="text-xs">
+                                                    {t(chargeItem.status)}
+                                                  </span>
+                                                </TableCell>
+                                              )}
+                                              {showCreatedBy && (
+                                                <TableCell className="w-16">
+                                                  {
+                                                    chargeItem.created_by
+                                                      ?.first_name
+                                                  }
+                                                </TableCell>
+                                              )}
+                                              <TableCell className="text-right w-10">
+                                                <MonetaryDisplay
+                                                  amount={unitPrice}
+                                                />
+                                              </TableCell>
+                                              <TableCell className="text-right w-10">
+                                                {round(chargeItem.quantity)}
+                                              </TableCell>
+                                              <TableCell className="text-right w-10">
+                                                <MonetaryDisplay
+                                                  amount={
+                                                    chargeItem.total_price
+                                                  }
+                                                />
+                                              </TableCell>
+                                            </TableRow>,
+                                          );
+                                        },
+                                      );
+                                    }
+                                  });
+
+                                  // Add grand total
                                   rows.push(
                                     <TableRow
-                                      key={`category-${categoryTitle}`}
-                                      className="bg-transparent hover:bg-transparent"
+                                      key="grand-total"
+                                      className="bg-muted/30 font-semibold"
                                     >
                                       <TableCell
-                                        colSpan={5}
-                                        className="font-semibold capitalize"
+                                        colSpan={
+                                          5 +
+                                          (showStatus ? 1 : 0) +
+                                          (showCreatedBy ? 1 : 0)
+                                        }
+                                        className="text-right pr-2"
                                       >
-                                        {categoryTitle}
+                                        {t("net_total")}
                                       </TableCell>
-                                      <TableCell className="text-right font-semibold">
+                                      <TableCell className="text-right">
                                         <MonetaryDisplay
-                                          amount={categoryTotal}
+                                          amount={add(
+                                            ...validItems.map(
+                                              (i) => i.total_price || 0,
+                                            ),
+                                          )}
                                         />
                                       </TableCell>
                                     </TableRow>,
                                   );
-                                } else {
-                                  // Normal mode - show header, items, and subtotal
-                                  // Add category header (only if not hiding categories)
-                                  if (!hideCategories) {
-                                    rows.push(
-                                      <TableRow
-                                        key={`category-${categoryTitle}`}
-                                        className="font-bold hover:bg-transparent"
-                                      >
-                                        <TableCell
-                                          colSpan={
-                                            5 +
-                                            (showStatus ? 1 : 0) +
-                                            (showCreatedBy ? 1 : 0)
-                                          }
-                                          className="capitalize"
-                                        >
-                                          {categoryTitle}
-                                        </TableCell>
-                                        <TableCell className="text-right">
-                                          <MonetaryDisplay
-                                            amount={categoryTotal}
-                                          />
-                                        </TableCell>
-                                      </TableRow>,
-                                    );
-                                  }
+                                  return rows;
+                                })()}
+                              </TableBody>
+                            </Table>
+                          </div>
+                        </div>
+                      )}
 
-                                  items.forEach(
-                                    (chargeItem: ChargeItemRead) => {
-                                      const unitPrice =
-                                        chargeItem.unit_price_components.find(
-                                          (c) =>
-                                            c.monetary_component_type ===
-                                            MonetaryComponentType.base,
-                                        )?.amount;
-                                      const hasIssuedOrBalancedInvoice =
-                                        chargeItem.paid_invoice &&
-                                        (chargeItem.paid_invoice.status ===
-                                          InvoiceStatus.issued ||
-                                          chargeItem.paid_invoice.status ===
-                                            InvoiceStatus.balanced);
-                                      rows.push(
-                                        <TableRow
-                                          key={chargeItem.id}
-                                          className={
-                                            hasIssuedOrBalancedInvoice
-                                              ? "bg-transparent hover:bg-transparent"
-                                              : "bg-red-50 hover:bg-red-50 text-red-700 print:bg-red-50"
-                                          }
-                                        >
-                                          <TableCell className="w-10 text-left">
-                                            <div className="flex items-center gap-1">
-                                              {!hasIssuedOrBalancedInvoice && (
-                                                <AlertTriangle className="h-3 w-3 text-red-600 flex-shrink-0" />
-                                              )}
-                                              {formatDateTime(
-                                                chargeItem.created_date,
-                                                "DD/MM/YY",
-                                              )}
-                                            </div>
-                                          </TableCell>
-                                          <TableCell className="w-10 text-left">
-                                            {chargeItem.paid_invoice?.number ||
-                                              "-"}
-                                          </TableCell>
-                                          <TableCell>
-                                            <div className="flex flex-col">
-                                              <span className="font-medium">
-                                                {chargeItem.title}
-                                              </span>
-                                            </div>
-                                          </TableCell>
-                                          {showStatus && (
-                                            <TableCell className="text-center w-8">
-                                              <span className="text-xs">
-                                                {t(chargeItem.status)}
-                                              </span>
-                                            </TableCell>
-                                          )}
-                                          {showCreatedBy && (
-                                            <TableCell className="w-16">
-                                              {
-                                                chargeItem.created_by
-                                                  ?.first_name
-                                              }
-                                            </TableCell>
-                                          )}
-                                          <TableCell className="text-right w-10">
-                                            <MonetaryDisplay
-                                              amount={unitPrice}
-                                            />
-                                          </TableCell>
-                                          <TableCell className="text-right w-10">
-                                            {round(chargeItem.quantity)}
-                                          </TableCell>
-                                          <TableCell className="text-right w-10">
-                                            <MonetaryDisplay
-                                              amount={chargeItem.total_price}
-                                            />
-                                          </TableCell>
-                                        </TableRow>,
-                                      );
-                                    },
-                                  );
-                                }
-                              });
-
-                              // Add grand total
-                              rows.push(
-                                <TableRow
-                                  key="grand-total"
-                                  className="bg-muted/30 font-semibold"
-                                >
-                                  <TableCell
-                                    colSpan={
-                                      5 +
-                                      (showStatus ? 1 : 0) +
-                                      (showCreatedBy ? 1 : 0)
-                                    }
-                                    className="text-right pr-2"
-                                  >
-                                    {t("net_total")}
-                                  </TableCell>
-                                  <TableCell className="text-right">
-                                    <MonetaryDisplay
-                                      amount={add(
-                                        ...validItems.map(
-                                          (i) => i.total_price || 0,
-                                        ),
-                                      )}
-                                    />
-                                  </TableCell>
-                                </TableRow>,
-                              );
-                              return rows;
-                            })()}
-                          </TableBody>
-                        </Table>
-                      </div>
-                    </div>
-                  )}
-
-                  {payments.length > 0 && !selectedCategory && (
-                    <div className="mt-4">
-                      <hr className="border-gray-300 py-2" />
-                      <h2 className="text-sm font-semibold mb-1">
-                        {t("payment_details")}
-                      </h2>
-                      <div className="overflow-hidden">
-                        <Table className="w-full [&_th]:text-xs [&_td]:text-xs [&_tr]:text-xs">
-                          <TableHeader className="[&_tr]:border-y [&_th]:p-0.5 [&_th]:h-auto">
-                            <TableRow className="bg-transparent hover:bg-transparent">
-                              {summaryMode ? (
-                                <>
-                                  <TableHead className="font-bold" colSpan={2}>
-                                    {t("type")}
-                                  </TableHead>
-                                  <TableHead className="font-bold text-right w-32">
-                                    {t("amount")}
-                                  </TableHead>
-                                </>
-                              ) : (
-                                <>
-                                  <TableHead className="font-bold w-10">
-                                    {t("date")}
-                                  </TableHead>
-                                  {hidePaymentTypeGrouping && (
-                                    <TableHead className="font-bold w-10">
+                    {payments.length > 0 && !selectedCategory && (
+                      <div className="mt-4">
+                        <hr className="border-gray-300 py-2" />
+                        <h2 className="text-sm font-semibold mb-1">
+                          {t("payment_details")}
+                        </h2>
+                        <div className="overflow-hidden">
+                          <Table className="w-full [&_th]:text-xs [&_td]:text-xs [&_tr]:text-xs">
+                            <TableHeader className="[&_tr]:border-y [&_th]:p-0.5 [&_th]:h-auto">
+                              <TableRow className="bg-transparent hover:bg-transparent">
+                                {summaryMode ? (
+                                  <>
+                                    <TableHead
+                                      className="font-bold"
+                                      colSpan={2}
+                                    >
                                       {t("type")}
                                     </TableHead>
-                                  )}
-                                  <TableHead className="font-bold w-32">
-                                    {t("method")}
-                                  </TableHead>
-                                  <TableHead className="font-bold text-right w-32">
-                                    {t("amount")}
-                                  </TableHead>
-                                </>
-                              )}
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody className="[&_tr]:border-0 [&_td]:p-0.5">
-                            {(() => {
-                              const validPayments = payments.filter(
-                                (payment) =>
-                                  payment.status ===
-                                  PaymentReconciliationStatus.active,
-                              );
+                                    <TableHead className="font-bold text-right w-32">
+                                      {t("amount")}
+                                    </TableHead>
+                                  </>
+                                ) : (
+                                  <>
+                                    <TableHead className="font-bold w-10">
+                                      {t("date")}
+                                    </TableHead>
+                                    {hidePaymentTypeGrouping && (
+                                      <TableHead className="font-bold w-10">
+                                        {t("type")}
+                                      </TableHead>
+                                    )}
+                                    <TableHead className="font-bold w-32">
+                                      {t("method")}
+                                    </TableHead>
+                                    <TableHead className="font-bold text-right w-32">
+                                      {t("amount")}
+                                    </TableHead>
+                                  </>
+                                )}
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody className="[&_tr]:border-0 [&_td]:p-0.5">
+                              {(() => {
+                                const validPayments = payments.filter(
+                                  (payment) =>
+                                    payment.status ===
+                                    PaymentReconciliationStatus.active,
+                                );
 
-                              const paymentGroups = validPayments.reduce(
-                                (
-                                  acc: Record<
+                                const paymentGroups = validPayments.reduce(
+                                  (
+                                    acc: Record<
+                                      string,
+                                      PaymentReconciliationRead[]
+                                    >,
+                                    payment: PaymentReconciliationRead,
+                                  ) => {
+                                    const type = payment.reconciliation_type;
+                                    const list = acc[type] ?? [];
+                                    list.push(payment);
+                                    acc[type] = list;
+                                    return acc;
+                                  },
+                                  {} as Record<
                                     string,
                                     PaymentReconciliationRead[]
                                   >,
-                                  payment: PaymentReconciliationRead,
-                                ) => {
-                                  const type = payment.reconciliation_type;
-                                  const list = acc[type] ?? [];
-                                  list.push(payment);
-                                  acc[type] = list;
-                                  return acc;
-                                },
-                                {} as Record<
-                                  string,
-                                  PaymentReconciliationRead[]
-                                >,
-                              );
-
-                              const sortedTypes =
-                                Object.keys(paymentGroups).sort();
-
-                              const rows: React.ReactNode[] = [];
-
-                              sortedTypes.forEach((paymentType) => {
-                                const paymentsOfType: PaymentReconciliationRead[] =
-                                  paymentGroups[paymentType] ?? [];
-                                const typeTotal = add(
-                                  ...paymentsOfType.map((p) =>
-                                    multiply(
-                                      p.amount || 0,
-                                      p.is_credit_note ? -1 : 1,
-                                    ),
-                                  ),
                                 );
 
-                                if (summaryMode) {
-                                  // In summary mode, show only payment type with total
-                                  rows.push(
-                                    <TableRow
-                                      key={`payment-type-${paymentType}`}
-                                      className="bg-transparent hover:bg-transparent"
-                                    >
-                                      <TableCell
-                                        colSpan={2}
-                                        className="font-semibold capitalize"
-                                      >
-                                        {t(paymentType)}
-                                      </TableCell>
-                                      <TableCell className="text-right font-semibold">
-                                        <MonetaryDisplay amount={typeTotal} />
-                                      </TableCell>
-                                    </TableRow>,
+                                const sortedTypes =
+                                  Object.keys(paymentGroups).sort();
+
+                                const rows: React.ReactNode[] = [];
+
+                                sortedTypes.forEach((paymentType) => {
+                                  const paymentsOfType: PaymentReconciliationRead[] =
+                                    paymentGroups[paymentType] ?? [];
+                                  const typeTotal = add(
+                                    ...paymentsOfType.map((p) =>
+                                      multiply(
+                                        p.amount || 0,
+                                        p.is_credit_note ? -1 : 1,
+                                      ),
+                                    ),
                                   );
-                                } else {
-                                  // Normal mode - show header, items, and subtotal
-                                  // Add payment type header (only if not hiding grouping)
-                                  if (!hidePaymentTypeGrouping) {
+
+                                  if (summaryMode) {
+                                    // In summary mode, show only payment type with total
                                     rows.push(
                                       <TableRow
                                         key={`payment-type-${paymentType}`}
-                                        className="font-semibold hover:bg-transparent"
+                                        className="bg-transparent hover:bg-transparent"
                                       >
                                         <TableCell
                                           colSpan={2}
-                                          className="capitalize"
+                                          className="font-semibold capitalize"
                                         >
                                           {t(paymentType)}
                                         </TableCell>
-                                        <TableCell className="text-right">
+                                        <TableCell className="text-right font-semibold">
                                           <MonetaryDisplay amount={typeTotal} />
                                         </TableCell>
                                       </TableRow>,
                                     );
-                                  }
-
-                                  paymentsOfType.forEach(
-                                    (payment: PaymentReconciliationRead) => {
+                                  } else {
+                                    // Normal mode - show header, items, and subtotal
+                                    // Add payment type header (only if not hiding grouping)
+                                    if (!hidePaymentTypeGrouping) {
                                       rows.push(
                                         <TableRow
-                                          key={payment.id}
-                                          className="bg-transparent hover:bg-transparent"
+                                          key={`payment-type-${paymentType}`}
+                                          className="font-semibold hover:bg-transparent"
                                         >
-                                          <TableCell>
-                                            {payment.payment_datetime
-                                              ? formatDateTime(
-                                                  payment.payment_datetime,
-                                                  "DD-MM-YY",
-                                                )
-                                              : "-"}
-                                          </TableCell>
-                                          {hidePaymentTypeGrouping && (
-                                            <TableCell className="text-left capitalize">
-                                              {t(payment.reconciliation_type)}
-                                            </TableCell>
-                                          )}
-                                          <TableCell>
-                                            {
-                                              PAYMENT_RECONCILIATION_METHOD_MAP[
-                                                payment.method
-                                              ]
-                                            }
+                                          <TableCell
+                                            colSpan={2}
+                                            className="capitalize"
+                                          >
+                                            {t(paymentType)}
                                           </TableCell>
                                           <TableCell className="text-right">
                                             <MonetaryDisplay
-                                              amount={multiply(
-                                                payment.amount,
-                                                payment.is_credit_note ? -1 : 1,
-                                              )}
+                                              amount={typeTotal}
                                             />
                                           </TableCell>
                                         </TableRow>,
                                       );
-                                    },
-                                  );
-                                }
-                              });
-
-                              // Add grand total
-                              rows.push(
-                                <TableRow
-                                  key="grand-total"
-                                  className="bg-muted/30 font-semibold"
-                                >
-                                  <TableCell
-                                    colSpan={
-                                      hidePaymentTypeGrouping && !summaryMode
-                                        ? 3
-                                        : 2
                                     }
-                                    className="text-right pr-2"
-                                  >
-                                    {t("total_paid")}
-                                  </TableCell>
-                                  <TableCell className="text-right">
-                                    <MonetaryDisplay
-                                      amount={add(
-                                        ...validPayments.map((p) =>
-                                          multiply(
-                                            p.amount || 0,
-                                            p.is_credit_note ? -1 : 1,
-                                          ),
-                                        ),
-                                      )}
-                                    />
-                                  </TableCell>
-                                </TableRow>,
-                              );
 
-                              return rows;
-                            })()}
+                                    paymentsOfType.forEach(
+                                      (payment: PaymentReconciliationRead) => {
+                                        rows.push(
+                                          <TableRow
+                                            key={payment.id}
+                                            className="bg-transparent hover:bg-transparent"
+                                          >
+                                            <TableCell>
+                                              {payment.payment_datetime
+                                                ? formatDateTime(
+                                                    payment.payment_datetime,
+                                                    "DD-MM-YY",
+                                                  )
+                                                : "-"}
+                                            </TableCell>
+                                            {hidePaymentTypeGrouping && (
+                                              <TableCell className="text-left capitalize">
+                                                {t(payment.reconciliation_type)}
+                                              </TableCell>
+                                            )}
+                                            <TableCell>
+                                              {
+                                                PAYMENT_RECONCILIATION_METHOD_MAP[
+                                                  payment.method
+                                                ]
+                                              }
+                                            </TableCell>
+                                            <TableCell className="text-right">
+                                              <MonetaryDisplay
+                                                amount={multiply(
+                                                  payment.amount,
+                                                  payment.is_credit_note
+                                                    ? -1
+                                                    : 1,
+                                                )}
+                                              />
+                                            </TableCell>
+                                          </TableRow>,
+                                        );
+                                      },
+                                    );
+                                  }
+                                });
+
+                                // Add grand total
+                                rows.push(
+                                  <TableRow
+                                    key="grand-total"
+                                    className="bg-muted/30 font-semibold"
+                                  >
+                                    <TableCell
+                                      colSpan={
+                                        hidePaymentTypeGrouping && !summaryMode
+                                          ? 3
+                                          : 2
+                                      }
+                                      className="text-right pr-2"
+                                    >
+                                      {t("total_paid")}
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                      <MonetaryDisplay
+                                        amount={add(
+                                          ...validPayments.map((p) =>
+                                            multiply(
+                                              p.amount || 0,
+                                              p.is_credit_note ? -1 : 1,
+                                            ),
+                                          ),
+                                        )}
+                                      />
+                                    </TableCell>
+                                  </TableRow>,
+                                );
+
+                                return rows;
+                              })()}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Account Summary Section */}
+                    {account && (
+                      <div className="overflow-hidden mt-4">
+                        <Table className="w-full border [&_th]:text-xs [&_td]:text-xs">
+                          <TableHeader className="[&_tr]:border [&_th]:p-0.5 [&_th]:h-auto">
+                            <TableRow className="bg-transparent hover:bg-transparent">
+                              <TableHead className="text-center font-bold">
+                                {t("billed_gross")}
+                              </TableHead>
+                              <TableHead className="text-center font-bold">
+                                {t("total_paid")}
+                              </TableHead>
+                              <TableHead className="text-center font-bold">
+                                {t("amount_due")}
+                              </TableHead>
+                              <TableHead className="text-center font-bold">
+                                {t("total_billable")}
+                              </TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody className="[&_tr]:border [&_td]:p-0.5">
+                            <TableRow className="bg-transparent hover:bg-transparent">
+                              <TableCell className="text-center">
+                                <MonetaryDisplay amount={account.total_gross} />
+                              </TableCell>
+                              <TableCell className="text-center">
+                                <MonetaryDisplay amount={account.total_paid} />
+                              </TableCell>
+                              <TableCell className="text-center">
+                                <MonetaryDisplay
+                                  amount={account.total_balance}
+                                />
+                              </TableCell>
+                              <TableCell className="text-center">
+                                <MonetaryDisplay
+                                  amount={account.total_billable_charge_items}
+                                />
+                              </TableCell>
+                            </TableRow>
                           </TableBody>
                         </Table>
                       </div>
-                    </div>
-                  )}
+                    )}
 
-                  {/* Account Summary Section */}
-                  {account && (
-                    <div className="overflow-hidden mt-4">
-                      <Table className="w-full border [&_th]:text-xs [&_td]:text-xs">
-                        <TableHeader className="[&_tr]:border [&_th]:p-0.5 [&_th]:h-auto">
-                          <TableRow className="bg-transparent hover:bg-transparent">
-                            <TableHead className="text-center font-bold">
-                              {t("billed_gross")}
-                            </TableHead>
-                            <TableHead className="text-center font-bold">
-                              {t("total_paid")}
-                            </TableHead>
-                            <TableHead className="text-center font-bold">
-                              {t("amount_due")}
-                            </TableHead>
-                            <TableHead className="text-center font-bold">
-                              {t("total_billable")}
-                            </TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody className="[&_tr]:border [&_td]:p-0.5">
-                          <TableRow className="bg-transparent hover:bg-transparent">
-                            <TableCell className="text-center">
-                              <MonetaryDisplay amount={account.total_gross} />
-                            </TableCell>
-                            <TableCell className="text-center">
-                              <MonetaryDisplay amount={account.total_paid} />
-                            </TableCell>
-                            <TableCell className="text-center">
-                              <MonetaryDisplay amount={account.total_balance} />
-                            </TableCell>
-                            <TableCell className="text-center">
-                              <MonetaryDisplay
-                                amount={account.total_billable_charge_items}
-                              />
-                            </TableCell>
-                          </TableRow>
-                        </TableBody>
-                      </Table>
-                    </div>
-                  )}
-
-                  {/* Footer Section */}
-                  <PrintFooter className="mt-4 border-t border-gray-200" />
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                    {/* Footer Section */}
+                    <PrintFooter className="mt-4 border-t border-gray-200" />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </DisablingCover>
       </PrintPreview>
     </div>
   );


### PR DESCRIPTION
## Proposed Changes

fixes #15419

<img width="934" height="589" alt="image" src="https://github.com/user-attachments/assets/0bfc19eb-8863-49d5-aa60-69412462dad0" />

<img width="1716" height="158" alt="image" src="https://github.com/user-attachments/assets/e083562b-50c3-4518-8446-71f5df92fe04" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added status filter controls (minimal/expanded modes) and an "Include Cancelled" toggle; filters persist via query parameters.
  * Added status-filtering section next to print controls and localized "Include Cancelled" label.

* **Bug Fixes**
  * Better loading and empty-state handling so empty results show a clear message instead of a generic loading state.

* **Improvements**
  * Gated/disabled print preview during data fetch and reorganized charge-item rendering for dynamic grouping, summaries, and totals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->