### PR TITLE
Add conditional rendering for view details button and include instanc…

### DIFF
--- a/src/pages/Facility/settings/product/ProductView.tsx
+++ b/src/pages/Facility/settings/product/ProductView.tsx
@@ -167,18 +167,20 @@ export default function ProductView({ facilityId, productId }: Props) {
                     {product.product_knowledge.slug}
                   </p>
                 </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    navigate(
-                      `/facility/${facilityId}/settings/product_knowledge/${product.product_knowledge.slug}`,
-                    )
-                  }
-                >
-                  <CareIcon icon="l-eye" className="mr-2 size-4" />
-                  {t("view_details")}
-                </Button>
+                {product.product_knowledge.is_instance_level === false && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      navigate(
+                        `/facility/${facilityId}/settings/product_knowledge/${product.product_knowledge.slug}`,
+                      )
+                    }
+                  >
+                    <CareIcon icon="l-eye" className="mr-2 size-4" />
+                    {t("view_details")}
+                  </Button>
+                )}
               </div>
             </div>
           </CardContent>

--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeList.tsx
@@ -52,6 +52,7 @@ export default function ProductKnowledgeList({
             queryParams: {
               facility: facilityId,
               status: ProductKnowledgeStatus.active,
+              include_instance: false,
             },
           },
           searchParamName: "name",

--- a/src/types/inventory/productKnowledge/productKnowledge.ts
+++ b/src/types/inventory/productKnowledge/productKnowledge.ts
@@ -83,6 +83,7 @@ export interface ProductKnowledgeBase {
   base_unit: Code;
   category: ResourceCategoryRead;
   slug_config: SlugConfig;
+  is_instance_level: boolean;
 }
 
 export interface ProductKnowledgeCreate extends Omit<


### PR DESCRIPTION
…e flag in product knowledge

Fixes #15423
wont list
<img width="1168" height="407" alt="image" src="https://github.com/user-attachments/assets/324842a5-e12a-4626-a517-176fc980fb04" />

cant see view button
<img width="851" height="651" alt="image" src="https://github.com/user-attachments/assets/2f977f73-1679-4c67-8576-2fb7ee53ce7e" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Conditional display of "View Details" button for product knowledge items based on classification level.
  * Product knowledge lists refined to exclude instance-level entries from queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->