### PR TITLE
fix: quantity field in medication billing

### DIFF
--- a/src/pages/Facility/services/pharmacy/AllMedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/AllMedicationBillForm.tsx
@@ -118,6 +118,7 @@ import {
 } from "@/types/emr/medicationDispense/medicationDispense";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import {
+  computeMedicationDispenseQuantity,
   DoseRange,
   MedicationRequestDispenseStatus,
   MedicationRequestDosageInstruction,
@@ -130,15 +131,7 @@ import prescriptionApi from "@/types/emr/prescription/prescriptionApi";
 import { InventoryRead } from "@/types/inventory/product/inventory";
 import inventoryApi from "@/types/inventory/product/inventoryApi";
 import { ProductKnowledgeBase } from "@/types/inventory/productKnowledge/productKnowledge";
-import {
-  add,
-  divide,
-  isGreaterThan,
-  isZero,
-  multiply,
-  round,
-  zodDecimal,
-} from "@/Utils/decimal";
+import { isGreaterThan, isZero, round, zodDecimal } from "@/Utils/decimal";
 import { isLotAllowedForDispensing } from "@/Utils/inventory";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
@@ -830,7 +823,7 @@ export default function AllMedicationBillForm({ patientId }: Props) {
             {
               selectedInventoryId: validLot.id,
               quantity: medication
-                ? computeInitialQuantity(medication)
+                ? computeMedicationDispenseQuantity(medication)
                 : currentLots[0]?.quantity || "1",
             },
           ]);
@@ -925,7 +918,7 @@ export default function AllMedicationBillForm({ patientId }: Props) {
                 selectedInventoryId:
                   (medication.inventory_items_internal?.[0]?.id as string) ||
                   "",
-                quantity: computeInitialQuantity(medication),
+                quantity: computeMedicationDispenseQuantity(medication),
               },
             ],
             prescriptionId,
@@ -934,81 +927,6 @@ export default function AllMedicationBillForm({ patientId }: Props) {
       },
     );
   }, [medications.length, append, form, groupedMedications]);
-
-  function computeInitialQuantity(medication: MedicationRequestRead) {
-    const instruction = medication.dosage_instruction[0];
-    if (!instruction) {
-      return "0";
-    }
-
-    if (instruction.as_needed_boolean) {
-      return "0";
-    }
-
-    const doseValue = instruction.dose_and_rate?.dose_quantity?.value;
-    if (!doseValue) {
-      return "0";
-    }
-
-    const repeat = instruction.timing?.repeat;
-    if (!repeat?.bounds_duration || !repeat.period_unit) {
-      return doseValue;
-    }
-
-    const convertToHours = (value: string, unit: string) => {
-      switch (unit) {
-        case "h":
-          return new Decimal(value);
-        case "d":
-          return multiply(value, 24);
-        case "wk":
-          return multiply(value, 24 * 7);
-        case "mo":
-          return multiply(value, 24 * 30);
-        case "a":
-          return multiply(value, 24 * 365);
-        default:
-          return 0;
-      }
-    };
-
-    const {
-      frequency = 1,
-      period = "1",
-      period_unit,
-      bounds_duration,
-    } = repeat;
-
-    const totalDurationInHours = convertToHours(
-      bounds_duration.value,
-      bounds_duration.unit,
-    );
-    const periodInHours = convertToHours(period, period_unit);
-
-    if (periodInHours === 0) {
-      return doseValue;
-    }
-
-    const doseIntervalInHours = divide(periodInHours, frequency);
-
-    if (isZero(doseIntervalInHours)) {
-      return doseValue;
-    }
-
-    const numberOfDoses = divide(
-      totalDurationInHours,
-      doseIntervalInHours,
-    ).ceil();
-
-    if (instruction.dose_and_rate?.dose_range) {
-      const lowDose = instruction.dose_and_rate.dose_range.low.value || "0";
-      const highDose = instruction.dose_and_rate.dose_range.high.value || "0";
-      const avgDose = divide(add(lowDose, highDose), 2);
-      return round(multiply(avgDose, numberOfDoses));
-    }
-
-    return round(multiply(doseValue, numberOfDoses));
-  }
 
   // Mutation to create invoice automatically after dispensing
   const { mutate: createInvoice, isPending: isCreatingInvoice } = useMutation({
@@ -1893,7 +1811,7 @@ export default function AllMedicationBillForm({ patientId }: Props) {
                                                 return {
                                                   ...lot,
                                                   quantity: medication
-                                                    ? computeInitialQuantity(
+                                                    ? computeMedicationDispenseQuantity(
                                                         medication,
                                                       )
                                                     : lot.quantity,
@@ -2250,7 +2168,7 @@ export default function AllMedicationBillForm({ patientId }: Props) {
                         dosageInstructions;
                     }
 
-                    const newQuantity = computeInitialQuantity(
+                    const newQuantity = computeMedicationDispenseQuantity(
                       medicationDataForQuantity,
                     );
 
@@ -2274,7 +2192,7 @@ export default function AllMedicationBillForm({ patientId }: Props) {
               : undefined
           }
           onAdd={(product, dosageInstructions) => {
-            const newQuantity = computeInitialQuantity({
+            const newQuantity = computeMedicationDispenseQuantity({
               dosage_instruction: dosageInstructions,
             } as MedicationRequestRead);
 
@@ -2351,7 +2269,7 @@ export default function AllMedicationBillForm({ patientId }: Props) {
                   | MedicationRequestRead
                   | undefined;
                 const initialQuantity = originalMedication
-                  ? computeInitialQuantity(originalMedication)
+                  ? computeMedicationDispenseQuantity(originalMedication)
                   : "0";
                 form.setValue(
                   `items.${substitutingItemIndex}.lots`,

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -125,7 +125,7 @@ import {
 } from "@/types/emr/medicationDispense/medicationDispense";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import {
-  computeInitialQuantity,
+  computeMedicationDispenseQuantity,
   DoseRange,
   MedicationRequestDispenseStatus,
   MedicationRequestDosageInstruction,
@@ -846,7 +846,7 @@ export default function MedicationBillForm({
             {
               selectedInventoryId: validLot.id,
               quantity: medication
-                ? computeInitialQuantity(medication)
+                ? computeMedicationDispenseQuantity(medication)
                 : currentLots[0]?.quantity || "1",
             },
           ]);
@@ -920,7 +920,7 @@ export default function MedicationBillForm({
           {
             selectedInventoryId:
               (medication.inventory_items_internal?.[0]?.id as string) || "",
-            quantity: computeInitialQuantity(medication),
+            quantity: computeMedicationDispenseQuantity(medication),
           },
         ],
         prescriptionId,
@@ -1751,7 +1751,9 @@ export default function MedicationBillForm({
                                       return {
                                         ...lot,
                                         quantity: medication
-                                          ? computeInitialQuantity(medication)
+                                          ? computeMedicationDispenseQuantity(
+                                              medication,
+                                            )
                                           : lot.quantity,
                                       };
                                     }
@@ -2092,7 +2094,7 @@ export default function MedicationBillForm({
                         dosageInstructions;
                     }
 
-                    const newQuantity = computeInitialQuantity(
+                    const newQuantity = computeMedicationDispenseQuantity(
                       medicationDataForQuantity,
                     );
 
@@ -2116,7 +2118,7 @@ export default function MedicationBillForm({
               : undefined
           }
           onAdd={(product, dosageInstructions) => {
-            const newQuantity = computeInitialQuantity({
+            const newQuantity = computeMedicationDispenseQuantity({
               dosage_instruction: dosageInstructions,
             } as MedicationRequestRead);
 
@@ -2193,7 +2195,7 @@ export default function MedicationBillForm({
                   | MedicationRequestRead
                   | undefined;
                 const initialQuantity = originalMedication
-                  ? computeInitialQuantity(originalMedication)
+                  ? computeMedicationDispenseQuantity(originalMedication)
                   : "0";
                 form.setValue(
                   `items.${substitutingItemIndex}.lots`,

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -941,6 +941,13 @@ export default function MedicationBillForm({
       return "0";
     }
 
+    const unitCode = instruction.dose_and_rate?.dose_quantity?.unit?.code;
+    const volumetricUnitCodes = ["g", "mg", "ug", "mL", "[drp]"];
+
+    if (unitCode && volumetricUnitCodes.includes(unitCode)) {
+      return "";
+    }
+
     if (instruction.as_needed_boolean) {
       return round(doseValue);
     }

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -942,9 +942,9 @@ export default function MedicationBillForm({
     }
 
     const unitCode = instruction.dose_and_rate?.dose_quantity?.unit?.code;
-    const volumetricUnitCodes = ["g", "mg", "ug", "mL", "[drp]"];
+    const nonVolumetric = ["{tbl}", "{count}"];
 
-    if (unitCode && volumetricUnitCodes.includes(unitCode)) {
+    if (unitCode && !nonVolumetric.includes(unitCode)) {
       return "";
     }
 

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -125,6 +125,7 @@ import {
 } from "@/types/emr/medicationDispense/medicationDispense";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import {
+  computeInitialQuantity,
   DoseRange,
   MedicationRequestDispenseStatus,
   MedicationRequestDosageInstruction,
@@ -137,11 +138,8 @@ import { InventoryRead } from "@/types/inventory/product/inventory";
 import inventoryApi from "@/types/inventory/product/inventoryApi";
 import { ProductKnowledgeBase } from "@/types/inventory/productKnowledge/productKnowledge";
 import {
-  add,
-  divide,
   isGreaterThan,
   isZero,
-  multiply,
   round,
   roundWhole,
   zodDecimal,
@@ -929,88 +927,6 @@ export default function MedicationBillForm({
       });
     });
   }, [medications.length, append, form, prescriptionId]);
-
-  function computeInitialQuantity(medication: MedicationRequestRead) {
-    const instruction = medication.dosage_instruction[0];
-    if (!instruction) {
-      return "0";
-    }
-
-    const doseValue = instruction.dose_and_rate?.dose_quantity?.value;
-    if (!doseValue) {
-      return "0";
-    }
-
-    const unitCode = instruction.dose_and_rate?.dose_quantity?.unit?.code;
-    const nonVolumetric = ["{tbl}", "{count}"];
-
-    if (unitCode && !nonVolumetric.includes(unitCode)) {
-      return "";
-    }
-
-    if (instruction.as_needed_boolean) {
-      return round(doseValue);
-    }
-
-    const repeat = instruction.timing?.repeat;
-    if (!repeat?.bounds_duration || !repeat.period_unit) {
-      return doseValue;
-    }
-
-    const convertToHours = (value: string, unit: string) => {
-      switch (unit) {
-        case "h":
-          return new Decimal(value);
-        case "d":
-          return multiply(value, 24);
-        case "wk":
-          return multiply(value, 24 * 7);
-        case "mo":
-          return multiply(value, 24 * 30);
-        case "a":
-          return multiply(value, 24 * 365);
-        default:
-          return 0;
-      }
-    };
-
-    const {
-      frequency = 1,
-      period = "1",
-      period_unit,
-      bounds_duration,
-    } = repeat;
-
-    const totalDurationInHours = convertToHours(
-      bounds_duration.value,
-      bounds_duration.unit,
-    );
-    const periodInHours = convertToHours(period, period_unit);
-
-    if (periodInHours === 0) {
-      return doseValue;
-    }
-
-    const doseIntervalInHours = divide(periodInHours, frequency);
-
-    if (isZero(doseIntervalInHours)) {
-      return doseValue;
-    }
-
-    const numberOfDoses = divide(
-      totalDurationInHours,
-      doseIntervalInHours,
-    ).ceil();
-
-    if (instruction.dose_and_rate?.dose_range) {
-      const lowDose = instruction.dose_and_rate.dose_range.low.value || "0";
-      const highDose = instruction.dose_and_rate.dose_range.high.value || "0";
-      const avgDose = divide(add(lowDose, highDose), 2);
-      return round(multiply(avgDose, numberOfDoses));
-    }
-
-    return round(multiply(doseValue, numberOfDoses));
-  }
 
   // Mutation to create invoice automatically after dispensing
   const { mutate: createInvoice, isPending: isCreatingInvoice } = useMutation({

--- a/src/types/emr/medicationRequest/medicationRequest.ts
+++ b/src/types/emr/medicationRequest/medicationRequest.ts
@@ -845,7 +845,7 @@ export function displayMedicationName(
   );
 }
 
-export function computeInitialQuantity(
+export function computeMedicationDispenseQuantity(
   medication: MedicationRequestRead,
 ): string {
   const instruction = medication.dosage_instruction[0];

--- a/src/types/emr/medicationRequest/medicationRequest.ts
+++ b/src/types/emr/medicationRequest/medicationRequest.ts
@@ -6,6 +6,8 @@ import {
 import { InventoryRead } from "@/types/inventory/product/inventory";
 import { ProductKnowledgeBase } from "@/types/inventory/productKnowledge/productKnowledge";
 import { UserReadMinimal } from "@/types/user/user";
+import { add, divide, isZero, multiply, round } from "@/Utils/decimal";
+import Decimal from "decimal.js";
 
 export const MEDICATION_REQUEST_STATUS_COLORS = {
   active: "primary",
@@ -841,4 +843,83 @@ export function displayMedicationName(
       : "") ||
     ""
   );
+}
+
+export function computeInitialQuantity(
+  medication: MedicationRequestRead,
+): string {
+  const instruction = medication.dosage_instruction[0];
+  if (!instruction) {
+    return "0";
+  }
+
+  const doseValue = instruction.dose_and_rate?.dose_quantity?.value;
+  if (!doseValue) {
+    return "0";
+  }
+
+  const unitCode = instruction.dose_and_rate?.dose_quantity?.unit?.code;
+  const nonVolumetric = ["{tbl}", "{count}"];
+
+  if (unitCode && !nonVolumetric.includes(unitCode)) {
+    return "";
+  }
+
+  if (instruction.as_needed_boolean) {
+    return round(doseValue);
+  }
+
+  const repeat = instruction.timing?.repeat;
+  if (!repeat?.bounds_duration || !repeat.period_unit) {
+    return doseValue;
+  }
+
+  const convertToHours = (value: string, unit: string) => {
+    switch (unit) {
+      case "h":
+        return new Decimal(value);
+      case "d":
+        return multiply(value, 24);
+      case "wk":
+        return multiply(value, 24 * 7);
+      case "mo":
+        return multiply(value, 24 * 30);
+      case "a":
+        return multiply(value, 24 * 365);
+      default:
+        return 0;
+    }
+  };
+
+  const { frequency = 1, period = "1", period_unit, bounds_duration } = repeat;
+
+  const totalDurationInHours = convertToHours(
+    bounds_duration.value,
+    bounds_duration.unit,
+  );
+  const periodInHours = convertToHours(period, period_unit);
+
+  if (periodInHours === 0) {
+    return doseValue;
+  }
+
+  const doseIntervalInHours = divide(periodInHours, frequency);
+
+  if (isZero(doseIntervalInHours)) {
+    return doseValue;
+  }
+
+  const numberOfDoses = divide(
+    totalDurationInHours,
+    doseIntervalInHours,
+  ).ceil();
+
+  if (instruction.dose_and_rate?.dose_range) {
+    const lowDose = instruction.dose_and_rate.dose_range.low.value || "0";
+    const highDose = instruction.dose_and_rate.dose_range.high.value || "0";
+    const avgDose = divide(add(lowDose, highDose), 2);
+    return round(multiply(avgDose, numberOfDoses));
+  }
+
+  return round(multiply(doseValue, numberOfDoses));
 }


### PR DESCRIPTION
## Proposed Changes

Fixes #15432
- Quantity field of medications with volumetric units is not auto calculated.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Medication quantity calculations were standardized across pharmacy forms: totals now account for timing/duration, frequency, and dose ranges (with proper rounding). PRN doses use the single-dose value. Non‑volumetric unit medications prompt empty quantity for manual entry. Missing dose data defaults to zero.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->