### PR TITLE
Fix diagnostic_report translation key across components

### DIFF
--- a/src/pages/Encounters/tabs/diagnostic-reports.tsx
+++ b/src/pages/Encounters/tabs/diagnostic-reports.tsx
@@ -69,7 +69,7 @@ function LeftCard({ report, isActive, onClick }: LeftCardProps) {
       <div className="flex items-center justify-between">
         <div className="flex-1 min-w-0">
           <div className="font-medium pb-1 truncate">
-            {report.service_request?.title || t("diagnostic_report")}
+            {report.service_request?.title || t("diagnostic_report_one")}
           </div>
           <div className="text-xs text-gray-600">
             {formatDateTime(report.created_date)}
@@ -152,7 +152,7 @@ function DiagnosticReportDetailCard({
         <CardTitle className="text-base font-medium">
           {report.service_request?.title ||
             report.code?.display ||
-            t("diagnostic_report")}
+            t("diagnostic_report_one")}
         </CardTitle>
         <div className="flex items-center gap-2">
           <Badge variant={DIAGNOSTIC_REPORT_STATUS_COLORS[report.status]}>

--- a/src/pages/Encounters/tabs/diagnostic-reports.tsx
+++ b/src/pages/Encounters/tabs/diagnostic-reports.tsx
@@ -69,7 +69,8 @@ function LeftCard({ report, isActive, onClick }: LeftCardProps) {
       <div className="flex items-center justify-between">
         <div className="flex-1 min-w-0">
           <div className="font-medium pb-1 truncate">
-            {report.service_request?.title || t("diagnostic_report_one")}
+            {report.service_request?.title ||
+              t("diagnostic_report", { count: 1 })}
           </div>
           <div className="text-xs text-gray-600">
             {formatDateTime(report.created_date)}
@@ -152,7 +153,7 @@ function DiagnosticReportDetailCard({
         <CardTitle className="text-base font-medium">
           {report.service_request?.title ||
             report.code?.display ||
-            t("diagnostic_report_one")}
+            t("diagnostic_report", { count: 1 })}
         </CardTitle>
         <div className="flex items-center gap-2">
           <Badge variant={DIAGNOSTIC_REPORT_STATUS_COLORS[report.status]}>

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
@@ -209,7 +209,7 @@ export default function DiagnosticReportPrint({
   return (
     <div className="flex justify-center items-center">
       <PrintPreview
-        title={`${t("diagnostic_report_one")} - ${report.code?.display || report.service_request?.title || t("diagnostic_report_one")}`}
+        title={`${t("diagnostic_report", { count: 1 })} - ${report.code?.display || report.service_request?.title || t("diagnostic_report", { count: 1 })}`}
       >
         <div className="max-w-4xl mx-auto">
           {/* Header with Facility Name and Logo */}
@@ -237,7 +237,8 @@ export default function DiagnosticReportPrint({
           </div>
 
           <h2 className="text-gray-500 uppercase text-sm tracking-wide font-semibold my-2">
-            {report.service_request?.title || t("diagnostic_report_one")}
+            {report.service_request?.title ||
+              t("diagnostic_report", { count: 1 })}
           </h2>
 
           {/* Patient Details */}

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
@@ -209,7 +209,7 @@ export default function DiagnosticReportPrint({
   return (
     <div className="flex justify-center items-center">
       <PrintPreview
-        title={`${t("diagnostic_report")} - ${report.code?.display || report.service_request?.title || t("diagnostic_report")}`}
+        title={`${t("diagnostic_report_one")} - ${report.code?.display || report.service_request?.title || t("diagnostic_report_one")}`}
       >
         <div className="max-w-4xl mx-auto">
           {/* Header with Facility Name and Logo */}
@@ -237,7 +237,7 @@ export default function DiagnosticReportPrint({
           </div>
 
           <h2 className="text-gray-500 uppercase text-sm tracking-wide font-semibold my-2">
-            {report.service_request?.title || t("diagnostic_report")}
+            {report.service_request?.title || t("diagnostic_report_one")}
           </h2>
 
           {/* Patient Details */}

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
@@ -122,7 +122,7 @@ export default function DiagnosticReportView({
                   </span>
                 </p>
               ) : (
-                report.service_request?.title || t("diagnostic_report")
+                report.service_request?.title || t("diagnostic_report_one")
               )}
             </CardTitle>
           </CardHeader>

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportView.tsx
@@ -122,7 +122,8 @@ export default function DiagnosticReportView({
                   </span>
                 </p>
               ) : (
-                report.service_request?.title || t("diagnostic_report_one")
+                report.service_request?.title ||
+                t("diagnostic_report", { count: 1 })
               )}
             </CardTitle>
           </CardHeader>

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -978,7 +978,7 @@ function ActivityDefinitionFormContent({
               <div className="space-y-4">
                 <div>
                   <h2 className="text-base font-medium text-gray-900">
-                    {t("diagnostic_report_one")}
+                    {t("diagnostic_report", { count: 1 })}
                   </h2>
                   <p className="mt-0.5 text-sm text-gray-500">
                     {t("specify_diagnostic_report_codes")}

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionForm.tsx
@@ -978,7 +978,7 @@ function ActivityDefinitionFormContent({
               <div className="space-y-4">
                 <div>
                   <h2 className="text-base font-medium text-gray-900">
-                    {t("diagnostic_report")}
+                    {t("diagnostic_report_one")}
                   </h2>
                   <p className="mt-0.5 text-sm text-gray-500">
                     {t("specify_diagnostic_report_codes")}

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -429,7 +429,7 @@ export default function ActivityDefinitionView({
         {definition.diagnostic_report_codes?.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle>{t("diagnostic_report_one")}</CardTitle>
+              <CardTitle>{t("diagnostic_report", { count: 1 })}</CardTitle>
               <CardDescription>
                 {t("diagnostic_report_codes_description")}
               </CardDescription>

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionView.tsx
@@ -429,7 +429,7 @@ export default function ActivityDefinitionView({
         {definition.diagnostic_report_codes?.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle>{t("diagnostic_report")}</CardTitle>
+              <CardTitle>{t("diagnostic_report_one")}</CardTitle>
               <CardDescription>
                 {t("diagnostic_report_codes_description")}
               </CardDescription>


### PR DESCRIPTION

## Proposed Changes

Fixes https://github.com/ohcnetwork/care_fe/issues/15452


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized diagnostic report labels to use pluralization-aware translations across views, print preview, and settings so fallback titles display consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->