### PR TITLE
proceed to dispense if already filtered; "new dispense" in dispense history page

### DIFF
--- a/src/pages/Facility/services/pharmacy/CreateDispenseSheet.tsx
+++ b/src/pages/Facility/services/pharmacy/CreateDispenseSheet.tsx
@@ -59,11 +59,13 @@ interface CreateDispenseSheetProps {
   facilityId: string;
   locationId: string;
   trigger?: React.ReactNode;
+  patientId?: string;
 }
 
 export function CreateDispenseSheet({
   facilityId,
   trigger,
+  patientId,
 }: CreateDispenseSheetProps) {
   const { t } = useTranslation();
   const { facility } = useCurrentFacility();
@@ -79,6 +81,28 @@ export function CreateDispenseSheet({
   const [yearOfBirth, setYearOfBirth] = useState("");
   const [verificationOpen, setVerificationOpen] = useState(false);
   const [scanDialogOpen, setScanDialogOpen] = useState(false);
+
+  // Fetch patient data when patientId is provided
+  const { data: preselectedPatient } = useQuery({
+    queryKey: ["patient", patientId],
+    queryFn: query(patientApi.get, {
+      pathParams: { id: patientId! },
+    }),
+    enabled: !!patientId,
+  });
+
+  // Direct navigation handler when patient is preselected
+  const handleDirectDispense = () => {
+    if (!preselectedPatient) return;
+    navigate(
+      `/facility/${facilityId}/patients/verify?${new URLSearchParams({
+        phone_number: preselectedPatient.phone_number,
+        year_of_birth: preselectedPatient.year_of_birth?.toString() || "",
+        partial_id: preselectedPatient.id.slice(0, 5),
+        flow: "dispense",
+      }).toString()}`,
+    );
+  };
 
   // Combine instance and facility identifier configs
   const allIdentifierConfigs = useMemo(
@@ -239,6 +263,22 @@ export function CreateDispenseSheet({
 
     return null;
   })();
+
+  // When patientId is provided, render a simple button that navigates directly
+  if (patientId && preselectedPatient) {
+    const triggerElement = trigger || (
+      <Button>
+        <Plus className="size-4 mr-1" />
+        {t("new_dispense")}
+      </Button>
+    );
+
+    return (
+      <span onClick={handleDirectDispense} className="cursor-pointer">
+        {triggerElement}
+      </span>
+    );
+  }
 
   return (
     <>

--- a/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowUpRightSquare } from "lucide-react";
+import { ArrowUpRightSquare, Plus } from "lucide-react";
 import { navigate } from "raviger";
 import { useTranslation } from "react-i18next";
 
@@ -17,6 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/Common/Table";
+import { CreateDispenseSheet } from "@/pages/Facility/services/pharmacy/CreateDispenseSheet";
 
 import useFilters from "@/hooks/useFilters";
 
@@ -91,7 +92,7 @@ export default function MedicationDispenseHistory({
           </TabsList>
         </Tabs>
       </div>
-      <div className="flex items-center gap-4 mb-6">
+      <div className="flex items-center justify-between gap-4 mb-6">
         <PatientIdentifierFilter
           onSelect={(patientId, patientName) =>
             updateQuery({
@@ -103,6 +104,17 @@ export default function MedicationDispenseHistory({
           className="w-full sm:w-auto rounded-md h-9 text-gray-500 shadow-sm"
           patientId={qParams.patientId}
           patientName={qParams.patient_name}
+        />
+        <CreateDispenseSheet
+          facilityId={facilityId}
+          locationId={locationId}
+          patientId={qParams.patientId}
+          trigger={
+            <Button>
+              <Plus className="mr-2 size-4" />
+              {t("new_dispense")}
+            </Button>
+          }
         />
       </div>
       <div className="mt-4">

--- a/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationRequestList.tsx
@@ -210,7 +210,11 @@ export default function MedicationRequestList({
     <Page
       title={t("prescription_queue")}
       options={
-        <CreateDispenseSheet facilityId={facilityId} locationId={locationId} />
+        <CreateDispenseSheet
+          facilityId={facilityId}
+          locationId={locationId}
+          patientId={qParams.patient_external_id}
+        />
       }
     >
       {/* Priority tabs with original styling */}


### PR DESCRIPTION
- fixes #15459 
- fixes #15460

https://github.com/user-attachments/assets/7c75685d-6f72-4328-a46d-532b21b71200



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced streamlined dispense creation for preselected patients, enabling direct navigation to the verification step with patient details pre-filled.
  * Added new action button to the medication dispense history interface for initiating dispense sheet creation.
  * Improved UI layout in medication dispense history to better organize and separate controls from patient filters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->