### PR TITLE
fix: handle reconciliation type for credit notes

### DIFF
--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -318,9 +318,11 @@ export function PaymentReconciliationSheet({
         ? round(new Decimal(invoice.total_gross).abs())
         : "";
       form.reset({
-        reconciliation_type: invoice
-          ? PaymentReconciliationType.payment
-          : PaymentReconciliationType.advance,
+        reconciliation_type: isCreditNote
+          ? undefined
+          : invoice
+            ? PaymentReconciliationType.payment
+            : PaymentReconciliationType.advance,
         status: PaymentReconciliationStatus.active,
         kind: PaymentReconciliationKind.deposit,
         issuer_type: PaymentReconciliationIssuerType.patient,


### PR DESCRIPTION
Fixes #15465

<img width="494" height="725" alt="image" src="https://github.com/user-attachments/assets/0a2b1bb0-634a-423d-9584-228f8c95bc1b" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Adjusted form initialization for credit note processing to require explicit reconciliation type selection instead of automatically assigning a default value, improving accuracy in billing reconciliation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->