### PR TITLE
Fix: Back to Services button to redirect to services and not previous location

### DIFF
--- a/src/pages/Facility/services/HealthcareServiceShow.tsx
+++ b/src/pages/Facility/services/HealthcareServiceShow.tsx
@@ -118,7 +118,7 @@ export default function HealthcareServiceShow({
 
   return (
     <div className="container px-4 mx-auto max-w-4xl space-y-6">
-      <BackButton>
+      <BackButton to={`/facility/${facilityId}/services`}>
         <ArrowLeft />
         <span>{t("back_to_services")}</span>
       </BackButton>


### PR DESCRIPTION
## Proposed Changes

Fixes #15408 
-  From `<BackButton>` to `<BackButton to={/facility/${facilityId}/services}>`
- Now when we select any service and then change the location from the sidebar, then the back button correctly points to the services and not the previous location;
Tagging: @ohcnetwork/care-fe-code-reviewers

### Screenshots:
https://github.com/user-attachments/assets/0e202aa7-e0d1-4eab-ae6a-7e3a8107438d

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed back button navigation on the healthcare service detail page to correctly return to the facility services list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->