### PR TITLE
Fix Add Charge Item sheet close button #15490

### DIFF
--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -136,12 +136,12 @@ export default function AddChargeItemsBillingSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:max-w-3xl p-2">
-        <ScrollArea className="h-full pb-12 pr-6 p-4">
-          <SheetHeader>
-            <SheetTitle>{t("add_charge_items")}</SheetTitle>
-          </SheetHeader>
-          <div className="mt-6 space-y-6">
+      <SheetContent className="w-full sm:max-w-3xl p-0 flex flex-col">
+        <SheetHeader className="px-4 py-4">
+          <SheetTitle>{t("add_charge_items")}</SheetTitle>
+        </SheetHeader>
+        <ScrollArea className="flex-1 pb-12 px-4 pt-0">
+          <div className="mt-4 space-y-4">
             {selectedItems.length > 0 && (
               <div className="space-y-2">
                 <h3 className="text-base font-medium">{t("selected_items")}</h3>


### PR DESCRIPTION
## Proposed Changes

Fixes #15490

Moved SheetHeader outside of ScrollArea to prevent the scroll container from overlaying and blocking the sheet close (X) button.

Refactored sheet layout to use a flex column structure for proper header and body separation.

Normalized padding and margins to ensure consistent spacing between the sheet title and content.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

https://github.com/user-attachments/assets/95c5b22b-729d-4ae6-8374-f80cb56866bf




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual layout and spacing of the billing sheet interface for improved visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->