### PR TITLE
fix: prevent changes in pack qty changes resulting in new batch

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/SmartExternalDeliveryRow.tsx
@@ -414,7 +414,6 @@ export function SmartExternalDeliveryRow({
           onChange={(e) => {
             const value = parseInt(e.target.value) || undefined;
             setField("supplied_item_pack_quantity", value);
-            markAsEdited();
           }}
           disabled={!productKnowledge}
           className="w-[7rem]"


### PR DESCRIPTION
## Proposed Changes

- Fixes #15510
- Prevent changes in pack quantity resulting in a new batch, should stay with the same batch selection

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pack Quantity field no longer incorrectly marking the form as edited when modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->