### PR TITLE
fix: conditional interpretation display/rm auto unit selection for components

### DIFF
--- a/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
+++ b/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
@@ -31,7 +31,7 @@ export function DiagnosticReportResultsTable({
       observation.reference_range && observation.reference_range.length > 0,
   );
   const hasInterpretation = observations.some(
-    (observation) => observation.interpretation,
+    (observation) => observation.interpretation?.display,
   );
   const hasComponentReferenceRange = observations.some(
     (observation) =>
@@ -44,7 +44,9 @@ export function DiagnosticReportResultsTable({
   const hasComponentInterpretation = observations.some(
     (observation) =>
       observation.component &&
-      observation.component.some((component) => component.interpretation),
+      observation.component.some(
+        (component) => component.interpretation?.display,
+      ),
   );
   const showReferenceRange = hasReferenceRange || hasComponentReferenceRange;
   const showInterpretation = hasInterpretation || hasComponentInterpretation;

--- a/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
@@ -724,7 +724,7 @@ export function DiagnosticReportForm({
             component.code.code
           ] || {
             value: "",
-            unit: component.permitted_unit?.code,
+            unit: "",
             interpretation: "",
           };
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #15509
- Change condition to check for display (needed for rendering interpretation)
   - required since type of observation interpretation was changed recently
- Prevent auto unit selection for observation component

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic report interpretation display to ensure complete data is shown before rendering.
  * Adjusted unit field handling in diagnostic forms to display empty values for missing component units instead of applying defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->