### PR TITLE
disable print button when being auto printed to prevent accidental extra prints

### DIFF
--- a/src/CAREUI/misc/PrintPreview.tsx
+++ b/src/CAREUI/misc/PrintPreview.tsx
@@ -36,10 +36,12 @@ export default function PrintPreview(props: Props) {
   const { goBack } = useAppHistory();
   const { t } = useTranslation();
   useShortcutSubContext();
-  useAutoPrint({
+
+  const { isPrinting } = useAutoPrint({
     ...props.autoPrint,
     enabled: (props.autoPrint?.enabled ?? false) && !props.disabled,
   });
+
   return (
     <div className="flex items-center justify-center">
       <Page
@@ -56,7 +58,11 @@ export default function PrintPreview(props: Props) {
                 {t("back")}
               </Button>
             )}
-            <Button variant="primary" disabled={props.disabled} onClick={print}>
+            <Button
+              variant="primary"
+              disabled={props.disabled || isPrinting}
+              onClick={print}
+            >
               <CareIcon icon="l-print" className="text-lg" />
               {t("print")}
               <ShortcutBadge actionId="print-button" className="bg-white" />

--- a/src/hooks/useAutoPrint.ts
+++ b/src/hooks/useAutoPrint.ts
@@ -1,5 +1,5 @@
 import { sleep } from "@/Utils/utils";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export interface AutoPrintOptions {
   enabled?: boolean;
@@ -20,15 +20,22 @@ export default function useAutoPrint({
   delay = 300,
   window: printWindow = window,
 }: AutoPrintOptions) {
+  const [isProcessing, setIsProcessing] = useState(false);
+
   useEffect(() => {
     if (enabled) {
+      setIsProcessing(true);
       const timer = setTimeout(async () => {
         printWindow.print();
+        // Give some time for the print dialog to appear before navigating back
         await sleep(300);
+        setIsProcessing(false);
         window.history.go(-1);
       }, delay); // Delay to ensure content is rendered
 
       return () => clearTimeout(timer);
     }
   }, [enabled, printWindow]);
+
+  return { isPrinting: isProcessing };
 }


### PR DESCRIPTION

## Proposed Changes

- Fixes #15513


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the print preview interface by properly disabling the primary action button during the active printing process. This prevents users from inadvertently triggering any additional actions while printing is actively in progress, resulting in a more reliable and seamless printing experience with clearer visual feedback on the current printing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->