### PR TITLE
medication dispense: fallback to 1 instead of none/0 when qty cannot be determined automatically

### DIFF
--- a/src/components/Consumable/DispenseDrawer.tsx
+++ b/src/components/Consumable/DispenseDrawer.tsx
@@ -760,7 +760,6 @@ export default function DispenseDrawer({
                                                         min={0}
                                                         {...formField}
                                                         className="border-gray-300 border rounded-md w-24"
-                                                        placeholder="0"
                                                         autoFocus
                                                       />
                                                     </FormControl>

--- a/src/pages/Facility/services/pharmacy/AllMedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/AllMedicationBillForm.tsx
@@ -1900,7 +1900,6 @@ export default function AllMedicationBillForm({ patientId }: Props) {
                                                         min={0}
                                                         {...formField}
                                                         className="border-gray-300 border rounded-none w-24"
-                                                        placeholder="0"
                                                       />
                                                     </FormControl>
                                                     <FormMessage />

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -1828,7 +1828,6 @@ export default function MedicationBillForm({
                                               min={0}
                                               {...formField}
                                               className="border-gray-300 border rounded-md w-24"
-                                              placeholder="0"
                                               disabled={!isChecked}
                                               autoFocus
                                             />

--- a/src/types/emr/medicationRequest/medicationRequest.ts
+++ b/src/types/emr/medicationRequest/medicationRequest.ts
@@ -848,21 +848,22 @@ export function displayMedicationName(
 export function computeMedicationDispenseQuantity(
   medication: MedicationRequestRead,
 ): string {
+  const DEFAULT_QTY = "1";
   const instruction = medication.dosage_instruction[0];
   if (!instruction) {
-    return "0";
+    return DEFAULT_QTY;
   }
 
   const doseValue = instruction.dose_and_rate?.dose_quantity?.value;
   if (!doseValue) {
-    return "0";
+    return DEFAULT_QTY;
   }
 
   const unitCode = instruction.dose_and_rate?.dose_quantity?.unit?.code;
   const nonVolumetric = ["{tbl}", "{count}"];
 
   if (unitCode && !nonVolumetric.includes(unitCode)) {
-    return "";
+    return DEFAULT_QTY;
   }
 
   if (instruction.as_needed_boolean) {


### PR DESCRIPTION


- fixes #15516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated medication quantity calculation to default to 1 unit instead of empty or zero values when dosage information is incomplete.

* **Style**
  * Removed placeholder text from quantity input fields across medication management forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->