### PR TITLE
Fix: Add missing Radix UI and Workbox dependencies to prevent dev crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@radix-ui/react-switch": "^1.1.4",
     "@radix-ui/react-tabs": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.2.0",
+    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@sentry/browser": "^9.0.0",
     "@tailwindcss/vite": "^4.0.17",
     "@tanstack/query-async-storage-persister": "^5.83.0",
@@ -136,6 +137,11 @@
     "tailwind-merge": "^3.2.0",
     "use-keyboard-shortcut": "^1.1.6",
     "vaul": "^1.1.2",
+    "workbox-core": "^7.4.0",
+    "workbox-precaching": "^7.4.0",
+    "workbox-routing": "^7.4.0",
+    "workbox-strategies": "^7.4.0",
+    "workbox-window": "^7.4.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Proposed Changes

Fixes development server crash on fresh install.

- Added missing dependency `@radix-ui/react-visually-hidden` to `package.json`.
- Added missing Workbox (PWA) dependencies (`workbox-window`, `workbox-core`, etc.) to `package.json`.
- Verified that the application now starts successfully with `pnpm dev`.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->