### PR TITLE
Expose plugin config meta in global browser window

### DIFF
--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -96,9 +96,7 @@ export default function PluginEngine({
   }, [pluginsQuery]);
 
   useEffect(() => {
-    window.__CARE_PLUGIN_RUNTIME__ = deepFreeze({
-      getMetaSnapshot: (slug: string) => pluginMeta[slug],
-    });
+    window.__CARE_PLUGIN_RUNTIME__ = deepFreeze({ meta: pluginMeta });
   }, [pluginMeta]);
 
   return (

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -10,14 +10,15 @@ import {
   __federation_method_setRemote as setFederationRemote,
   __federation_method_unwrapDefault as unwrapModule,
 } from "__federation__";
-import React, { Suspense } from "react";
+import React, { Suspense, useEffect, useMemo } from "react";
 
 import ErrorBoundary from "@/components/Common/ErrorBoundary";
 import Loading from "@/components/Common/Loading";
 import { PluginErrorBoundary } from "@/components/Common/PluginErrorBoundary";
-import { PlugConfig } from "@/types/plugConfig";
+import { PlugConfig, PlugConfigMeta } from "@/types/plugConfig";
 import plugConfigApi from "@/types/plugConfig/plugConfigApi";
 import query from "@/Utils/request/query";
+import { deepFreeze } from "@/Utils/utils";
 import { t } from "i18next";
 import { Loader2Icon } from "lucide-react";
 import { z } from "zod";
@@ -81,6 +82,24 @@ export default function PluginEngine({
         return { ...config, isLoading: false as const, ...data! };
       }),
   });
+
+  const pluginMeta = useMemo(() => {
+    return pluginsQuery.reduce(
+      (acc, plugin) => {
+        if (!plugin.isLoading && plugin.meta) {
+          acc[plugin.slug] = deepFreeze({ ...plugin.meta });
+        }
+        return acc;
+      },
+      {} as Record<string, PlugConfigMeta>,
+    );
+  }, [pluginsQuery]);
+
+  useEffect(() => {
+    window.__CARE_PLUGIN_RUNTIME__ = deepFreeze({
+      getMetaSnapshot: (slug: string) => pluginMeta[slug],
+    });
+  }, [pluginMeta]);
 
   return (
     <Suspense fallback={<Loading />}>

--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -430,3 +430,12 @@ export function formatTruncatedList<T>(
 
   return `${displayedItems.map(getDisplayValue).join(", ")} ... +${remainingCount} ${t("more") || moreText}`;
 }
+
+export function deepFreeze<T>(obj: T): T {
+  if (!obj || typeof obj !== "object") return obj;
+
+  Object.freeze(obj);
+  Object.values(obj).forEach(deepFreeze);
+
+  return obj;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import * as Sentry from "@sentry/browser";
 import App from "@/App";
 import { AuthContextType, AuthUserContext } from "@/hooks/useAuthUser";
 import { initI18n } from "@/i18n";
+import { PlugConfigMeta } from "@/types/plugConfig";
 import careConfig from "@careConfig";
 import React, { Context } from "react";
 import { createRoot } from "react-dom/client";
@@ -16,6 +17,9 @@ declare global {
   interface Window {
     CARE_API_URL: string;
     __CORE_ENV__: typeof careConfig;
+    __CARE_PLUGIN_RUNTIME__: {
+      getMetaSnapshot: (slug: string) => PlugConfigMeta;
+    };
     AuthUserContext: Context<AuthContextType | null>;
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,9 +17,7 @@ declare global {
   interface Window {
     CARE_API_URL: string;
     __CORE_ENV__: typeof careConfig;
-    __CARE_PLUGIN_RUNTIME__: {
-      getMetaSnapshot: (slug: string) => PlugConfigMeta;
-    };
+    __CARE_PLUGIN_RUNTIME__: { meta: PlugConfigMeta };
     AuthUserContext: Context<AuthContextType | null>;
   }
 }


### PR DESCRIPTION
## Proposed Changes

Exposed plugin config meta in global windows through __CARE_PLUGIN_RUNTIME__. This can be used by the plugs to access the meta. The previous implementation exposes the meta through props which is accessed by atomic components but not pages. The current implementation is universal which works both for pages and pluggable components.

To access meta within a plug:
```ts
const PLUGIN_SLUG = "care_abdm_fe"; // This may vary for each plug, this should be exactly same as the plugin config slug.
const meta = window.__CARE_PLUGIN_RUNTIME__?.meta[PLUGIN_SLUG]
```

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can now read an immutable snapshot of plugin metadata at runtime.
  * Plugin metadata is exposed as read-only to guard against accidental modification during execution.

* **Chores**
  * Added internal utilities to create and freeze runtime metadata snapshots to support the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->