### PR TITLE
fix: type error LocationAssociationDetail doesn't exist

### DIFF
--- a/src/types/location/locationApi.ts
+++ b/src/types/location/locationApi.ts
@@ -3,7 +3,7 @@ import { FacilityOrganizationRead } from "@/types/facilityOrganization/facilityO
 
 import {
   LocationAssociation,
-  LocationAssociationDetail,
+  LocationAssociationRead,
   LocationAssociationRequest,
   LocationAssociationUpdate,
 } from "./association";
@@ -71,7 +71,7 @@ export default {
   getAssociation: {
     path: "/api/v1/facility/{facility_external_id}/location/{location_external_id}/association/{external_id}/",
     method: HttpMethod.GET,
-    TRes: Type<LocationAssociationDetail>(),
+    TRes: Type<LocationAssociationRead>(),
   },
   updateAssociation: {
     path: "/api/v1/facility/{facility_external_id}/location/{location_external_id}/association/{external_id}/",


### PR DESCRIPTION
## Proposed Changes

Fixes #15545 
- LocationAssociationDetail is not exported member of ./association by replacing it with LocationAssociationRead

Screenshot:
<img width="685" height="298" alt="image" src="https://github.com/user-attachments/assets/6ba27832-3042-4fd3-b342-1997009f77c0" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type definitions to improve consistency and clarity in the location association module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->