### PR TITLE
fix: remove prescription start-time lock for medication administration

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -5470,7 +5470,6 @@
   "start_new_template_with_item": "Start a new template with this item",
   "start_review": "Start Review",
   "start_time": "Start Time",
-  "start_time_before_authored_error": "Start time cannot be before the medication was prescribed",
   "start_time_future_error": "Start time cannot be in the future",
   "start_time_must_be_before_end_time": "Start time must be before end time",
   "start_time_must_be_in_the_future": "Start time must be a future time",

--- a/public/locale/ml.json
+++ b/public/locale/ml.json
@@ -2594,7 +2594,6 @@
   "start_dose": "ആരംഭ ഡോസ്",
   "start_new_clinical_encounter": "ഒരു പുതിയ ക്ലിനിക്കൽ എൻകൗണ്ടർ ആരംഭിക്കുക",
   "start_time": "ആരംഭ സമയം",
-  "start_time_before_authored_error": "ആരംഭ സമയം മരുന്ന് നിർദ്ദേശിച്ചതിന് മുമ്പാകരുത്",
   "start_time_future_error": "ആരംഭ സമയം ഭാവിയിൽ ആയിരിക്കരുത്",
   "start_time_must_be_before_end_time": "ആരംഭ സമയം അവസാന സമയത്തിനു മുമ്പാകണം",
   "start_time_required": "ആരംഭ സമയം ആവശ്യമാണ്",

--- a/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
+++ b/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
@@ -55,7 +55,6 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
 
   const validateDateTime = (date: Date, isStartTime: boolean): string => {
     const now = startOfMinute(new Date());
-    const authoredOn = startOfMinute(new Date(medication.authored_on));
     const startTime = startOfMinute(
       new Date(administrationRequest.occurrence_period_start),
     );
@@ -65,10 +64,6 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
       return t(
         isStartTime ? "start_time_future_error" : "end_time_future_error",
       );
-    }
-
-    if (isStartTime) {
-      return date < authoredOn ? t("start_time_before_authored_error") : "";
     }
 
     return date < startTime ? t("end_time_before_start_error") : "";


### PR DESCRIPTION
Fixes #15550

<img width="1501" height="756" alt="image" src="https://github.com/user-attachments/assets/b44a9917-3c12-4cba-858d-5d3a27cfa0b6" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed validation that restricted medication start time from being set before the prescription date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->