### PR TITLE
fix: attempt to close appointment and token when closing encounter only if already not closed

### DIFF
--- a/src/pages/Encounters/utils/utils.tsx
+++ b/src/pages/Encounters/utils/utils.tsx
@@ -14,11 +14,16 @@ import {
 } from "@/types/emr/encounter/encounter";
 import encounterApi from "@/types/emr/encounter/encounterApi";
 import {
+  AppointmentFinalStatuses,
   AppointmentStatus,
   AppointmentUpdateRequest,
 } from "@/types/scheduling/schedule";
 import scheduleApi from "@/types/scheduling/scheduleApi";
-import { TokenStatus, TokenUpdate } from "@/types/tokens/token/token";
+import {
+  TokenActiveStatuses,
+  TokenStatus,
+  TokenUpdate,
+} from "@/types/tokens/token/token";
 import tokenApi from "@/types/tokens/token/tokenApi";
 import mutate from "@/Utils/request/mutate";
 
@@ -107,7 +112,11 @@ export function useEncounterProgressController() {
       });
     }
 
-    if (appointment && appointment.id) {
+    // Close appointment if it exists and is not already in a final status
+    if (
+      appointment?.id &&
+      !AppointmentFinalStatuses.includes(appointment.status)
+    ) {
       requests.push({
         url: scheduleApi.appointments.update.path
           .replace("{facilityId}", encounter.facility.id)
@@ -120,7 +129,12 @@ export function useEncounterProgressController() {
         },
       });
     }
-    if (appointment?.token) {
+
+    // Close token if it exists and is still active
+    if (
+      appointment?.token &&
+      TokenActiveStatuses.includes(appointment.token.status)
+    ) {
       requests.push({
         url: tokenApi.update.path
           .replace("{facility_id}", encounter.facility.id)

--- a/src/types/tokens/token/token.ts
+++ b/src/types/tokens/token/token.ts
@@ -20,6 +20,18 @@ export enum TokenStatus {
   ENTERED_IN_ERROR = "ENTERED_IN_ERROR",
 }
 
+export const TokenActiveStatuses: TokenStatus[] = [
+  TokenStatus.UNFULFILLED,
+  TokenStatus.CREATED,
+  TokenStatus.IN_PROGRESS,
+];
+
+export const TokenFinalStatuses: TokenStatus[] = [
+  TokenStatus.FULFILLED,
+  TokenStatus.CANCELLED,
+  TokenStatus.ENTERED_IN_ERROR,
+];
+
 export const TOKEN_STATUS_COLORS = {
   UNFULFILLED: "secondary",
   CREATED: "blue",


### PR DESCRIPTION
- fixes #15554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved appointment closing logic to prevent invalid state transitions
  * Enhanced token status management with proper validation checks
  * More reliable appointment and token lifecycle handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->