### PR TITLE
feat: update PrintFooter to display last updated by information

### DIFF
--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -25,6 +25,7 @@ import chargeItemApi from "@/types/billing/chargeItem/chargeItemApi";
 import scheduleApis from "@/types/scheduling/scheduleApi";
 import { add, round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
+import { formatName } from "@/Utils/utils";
 
 interface Props {
   appointmentId: string;
@@ -217,8 +218,13 @@ export default function AppointmentPrint(props: Props) {
 
         {/* Footer */}
         <PrintFooter
-          leftContent={format(new Date(), "PP 'at' p")}
-          rightContent={facility.name}
+          rightContent={format(new Date(), "PP 'at' p")}
+          leftContent={
+            <>
+              <span className="font-semibold">{t("last_updated_by")}: </span>
+              {formatName(appointment.updated_by)}
+            </>
+          }
           className="text-xs"
         />
       </div>


### PR DESCRIPTION
Fixes #15559

<img width="514" height="119" alt="image" src="https://github.com/user-attachments/assets/af9b27f1-0384-4631-8fd6-4c18d42fff26" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the appointment print footer to display who last modified the appointment alongside the modification timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->