### PR TITLE
fix: add fallback for plugin encounter encounter tab labels

### DIFF
--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -188,7 +188,9 @@ export const EncounterShow = (props: Props) => {
       entriesOf(pluginTabs).map(([key, Component]) => [
         key,
         {
-          label: t(`ENCOUNTER_TAB__${key}`),
+          label: t(`ENCOUNTER_TAB__${key}`, {
+            defaultValue: key.toUpperCase(),
+          }),
           component: (
             <Component encounter={selectedEncounter!} patient={patient!} />
           ),


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- fix: add fallback for plugin encounter encounter tab labels

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encounter tab label display with enhanced fallback handling for translations, ensuring tab labels render correctly even when translations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->