### PR TITLE
feat: display patient address in patient list when available

### DIFF
--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -304,13 +304,9 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
                                 <TableCell className="font-medium">
                                   {patient.name}
                                   {!patientList?.partial && (
-                                    <div>
-                                      <p className="text-xs text-gray-500 text-wrap line-clamp-2">
-                                        {"address" in patient
-                                          ? patient.address
-                                          : ""}
-                                      </p>
-                                    </div>
+                                    <p className="text-xs text-gray-500 text-wrap line-clamp-2">
+                                      {"address" in patient && patient.address}
+                                    </p>
                                   )}
                                 </TableCell>
                                 <TableCell>

--- a/src/components/Patient/PatientIndex.tsx
+++ b/src/components/Patient/PatientIndex.tsx
@@ -303,6 +303,15 @@ export default function PatientIndex({ facilityId }: { facilityId: string }) {
                               >
                                 <TableCell className="font-medium">
                                   {patient.name}
+                                  {!patientList?.partial && (
+                                    <div>
+                                      <p className="text-xs text-gray-500 text-wrap line-clamp-2">
+                                        {"address" in patient
+                                          ? patient.address
+                                          : ""}
+                                      </p>
+                                    </div>
+                                  )}
                                 </TableCell>
                                 <TableCell>
                                   {formatPhoneNumberIntl(patient.phone_number)}


### PR DESCRIPTION
Fixes #15570

<img width="1449" height="641" alt="image" src="https://github.com/user-attachments/assets/658f5a05-9898-4d8e-8681-d7db539d08a8" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Patient addresses now appear beneath patient names in the patient list when viewing in standard (non-partial) mode, displaying the stored address if available; list interactions and other fields remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->