### PR TITLE
charge item display: prevent discounts being included for totals if they are conditional

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1286,6 +1286,8 @@
   "condition_operation__equality": "Equals to",
   "condition_operation__has_tag": "Has tag",
   "condition_operation__in_range": "In range",
+  "conditional": "Conditional",
+  "conditional_discounts_not_applied": "Conditional discounts not applied to total",
   "conditions": "Conditions",
   "configuration": "Configuration",
   "configure": "Configure",

--- a/src/components/Billing/ChargeItem/ChargeItemPriceDisplay.tsx
+++ b/src/components/Billing/ChargeItem/ChargeItemPriceDisplay.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 
+import { Separator } from "@/components/ui/separator";
 import {
   MonetaryComponent,
   MonetaryComponentType,
@@ -51,6 +52,8 @@ export default function ChargeItemPriceDisplay({
   const baseAmount = baseComponents[0]?.amount || "0";
   const mrpAmount = mrpComponents[0]?.amount;
   const purchasePriceAmount = purchasePriceComponents[0]?.amount;
+  const showAsterisk =
+    discountComponents.some((c) => c.conditions?.length) || false;
 
   const renderComponentValue = (
     component: MonetaryComponent,
@@ -101,6 +104,11 @@ export default function ChargeItemPriceDisplay({
           >
             <span className="max-w-40">
               {component.code?.display || t("discount")}
+              {component.conditions?.length ? (
+                <span className="ml-1 text-xs text-gray-400">
+                  ({t("conditional")})*
+                </span>
+              ) : null}
             </span>
             {renderComponentValue(component, "-")}
           </div>
@@ -130,6 +138,15 @@ export default function ChargeItemPriceDisplay({
             <span>{t("purchase_price")}</span>
             <MonetaryDisplay amount={purchasePriceAmount} />
           </div>
+        )}
+
+        {showAsterisk && (
+          <>
+            <Separator />
+            <p className="text-xs text-gray-400 mt-2">
+              *{t("conditional_discounts_not_applied")}
+            </p>
+          </>
         )}
       </div>
     </div>

--- a/src/types/base/monetaryComponent/monetaryComponent.ts
+++ b/src/types/base/monetaryComponent/monetaryComponent.ts
@@ -167,7 +167,9 @@ export function getDiscountAmount(
 ): Decimal {
   const base = baseAmount ?? getBasePrice(priceComponents);
   const discounts = priceComponents.filter(
-    (c) => c.monetary_component_type === MonetaryComponentType.discount,
+    (c) =>
+      c.monetary_component_type === MonetaryComponentType.discount &&
+      c.conditions?.length === 0,
   );
 
   return discounts.reduce(


### PR DESCRIPTION
## Proposed Changes

- Prevent conditional discounts from being included in totals

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Conditional discounts are now visually distinguished with a special label in the discount list
* Added a clarifying note indicating that conditional discounts do not apply to the total amount
* Updated total calculations to explicitly exclude conditional discounts from the final sum

<!-- end of auto-generated comment: release notes by coderabbit.ai -->