### PR TITLE
fix: SR queue prevent input from losing focus for ad filter

### DIFF
--- a/src/components/ui/multi-filter/activityDefinitionFilter.tsx
+++ b/src/components/ui/multi-filter/activityDefinitionFilter.tsx
@@ -238,6 +238,7 @@ function ActivityDefinitionFilterDropdown({
           placeholder={t("search_activity_definition")}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => e.stopPropagation()}
           className="h-8 text-sm"
         />
       </div>


### PR DESCRIPTION
## Proposed Changes

- SR queue's ad filter was losing focus when you remove all characters from input box so preventing event bubbling up.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where keyboard input in the search field could trigger unexpected behavior in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->