### PR TITLE
condition editor: add support for encounter class

### DIFF
--- a/src/components/Billing/CompactConditionEditor.tsx
+++ b/src/components/Billing/CompactConditionEditor.tsx
@@ -34,6 +34,7 @@ import {
   Metrics,
   TagOperationValue,
 } from "@/types/base/condition/condition";
+import { ENCOUNTER_CLASS } from "@/types/emr/encounter/encounter";
 
 interface CompactConditionEditorProps {
   conditions: ConditionForm[];
@@ -254,6 +255,41 @@ function RenderInput({
           </FormControl>
         </FormItem>
       </div>
+    );
+  }
+
+  if (
+    metric === "encounter_class" &&
+    operation === ConditionOperation.equality
+  ) {
+    return (
+      <FormField
+        control={form.control}
+        name="value"
+        render={({ field }) => (
+          <FormItem className="flex-1">
+            <FormControl>
+              <Select
+                value={field.value as string}
+                onValueChange={(value) => {
+                  field.onChange(value);
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t("select_a_value")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {ENCOUNTER_CLASS.map((encounterClass) => (
+                    <SelectItem key={encounterClass} value={encounterClass}>
+                      {t(`encounter_class__${encounterClass}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormControl>
+          </FormItem>
+        )}
+      />
     );
   }
 

--- a/src/pages/Facility/settings/observationDefinition/ObservationInterpretation.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationInterpretation.tsx
@@ -59,6 +59,7 @@ import {
   NumericRange,
   QualifiedRange,
 } from "@/types/base/qualifiedRange/qualifiedRange";
+import { ENCOUNTER_CLASS } from "@/types/emr/encounter/encounter";
 import observationDefinitionApi from "@/types/emr/observationDefinition/observationDefinitionApi";
 import { TagConfig } from "@/types/emr/tagConfig/tagConfig";
 import useTagConfigs from "@/types/emr/tagConfig/useTagConfig";
@@ -912,6 +913,41 @@ export function RenderConditionInput({
             />
             <AgeTypeSelector />
           </div>
+        );
+      }
+      break;
+    }
+    case "encounter_class": {
+      if (operation === ConditionOperation.equality) {
+        return (
+          <FormField
+            control={form.control}
+            name={`${fieldName}.value` as any}
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <Select
+                    value={field.value}
+                    onValueChange={(value) => {
+                      handleSetValue(value, index);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder={t("select_a_value")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ENCOUNTER_CLASS.map((encounterClass) => (
+                        <SelectItem key={encounterClass} value={encounterClass}>
+                          {t(`encounter_class__${encounterClass}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
         );
       }
       break;


### PR DESCRIPTION
## Proposed Changes

- add support for encounter class in condition editor
- observation interpretation: change class selector to select, rather than input

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added encounter class metric support in condition editors. Users can now select and filter by encounter class through new dropdown options in billing configuration and observation definition settings, providing enhanced control over condition-based rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->