### PR TITLE
feat: add encounter link to tokens in ManageQueueFinishedTab

### DIFF
--- a/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
@@ -1,5 +1,6 @@
 import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -73,6 +74,7 @@ export function ManageQueueFinishedTab({
             <TableRow>
               <TableHead>{t("token_number")}</TableHead>
               <TableHead>{t("patient_name")}</TableHead>
+              <TableHead>{t("encounter")}</TableHead>
               <TableHead>{t("service_points")}</TableHead>
               <TableHead>{t("status")}</TableHead>
               <TableHead className="w-[100px]">{t("actions")}</TableHead>
@@ -110,6 +112,16 @@ export function ManageQueueFinishedTab({
                   ) : (
                     <span className="text-gray-500">-</span>
                   )}
+                </TableCell>
+                <TableCell>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link
+                      href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
+                    >
+                      {t("encounter")}
+                      <ExternalLink />
+                    </Link>
+                  </Button>
                 </TableCell>
                 <TableCell>
                   {token.sub_queue?.name || (

--- a/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
@@ -1,6 +1,5 @@
 import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -114,14 +113,13 @@ export function ManageQueueFinishedTab({
                   )}
                 </TableCell>
                 <TableCell>
-                  <Button variant="outline" size="sm" asChild>
-                    <Link
-                      href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
-                    >
-                      {t("encounter")}
-                      <ExternalLink />
-                    </Link>
-                  </Button>
+                  <Link
+                    href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
+                    className="hover:underline transition-colors flex items-center gap-1"
+                  >
+                    {t("encounter")}
+                    <ExternalLink className="size-3" />
+                  </Link>
                 </TableCell>
                 <TableCell>
                   {token.sub_queue?.name || (


### PR DESCRIPTION
Fixes  #15594

<img width="1444" height="612" alt="image" src="https://github.com/user-attachments/assets/bd93dc8c-67d1-4bcf-bfb1-0fbc23d449ff" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "encounter" column to the finished queue management table. Each row now includes a quick-access link labeled "encounter" (with an external-link indicator) that opens the corresponding encounter page for that queue item, streamlining navigation directly from the queue view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->