### PR TITLE
add close button to toast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ const App = () => {
                   // For `richColors` to work, pass at-least an empty object.
                   // Refer: https://github.com/shadcn-ui/ui/issues/2234.
                   toastOptions={{}}
+                  closeButton
                 />
                 <AppUpdateNotifier />
               </PluginEngine>


### PR DESCRIPTION
## Proposed Changes

Fixes #15598


<img width="424" height="102" alt="image" src="https://github.com/user-attachments/assets/9b4b5022-86cf-4c91-bd60-c2361614e189" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a close button to toast notifications, enabling users to dismiss messages directly from the toast UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->