### PR TITLE
show invoice number instead of view invoice in charge items list

### DIFF
--- a/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
@@ -433,6 +433,7 @@ export function ChargeItemsTable({
                             className="flex items-center gap-0.5 underline text-gray-600"
                             title={t("view_invoice")}
                           >
+                            {item.paid_invoice.number}
                             <ExternalLinkIcon className="size-3.5" />
                           </Link>
                         )}


### PR DESCRIPTION
- fixes #15616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice numbers are now displayed alongside invoice links in the billing account table, making it easier to identify and reference specific invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->