### PR TITLE
hide a/c column in accounts > payments; show invoice number in view invoice

### DIFF
--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -264,7 +264,13 @@ export function AccountShow({
     },
     payments: {
       label: t("payments"),
-      component: <PaymentsData facilityId={facilityId} accountId={accountId} />,
+      component: (
+        <PaymentsData
+          facilityId={facilityId}
+          accountId={accountId}
+          hideAccountColumn
+        />
+      ),
       shortcutId: "switch-to-payments-tab",
     },
     reports: {

--- a/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
@@ -77,9 +77,11 @@ const SORT_OPTIONS = {
 export default function PaymentsData({
   facilityId,
   accountId,
+  hideAccountColumn = false,
 }: {
   facilityId: string;
   accountId?: string;
+  hideAccountColumn?: boolean;
 }) {
   const { t } = useTranslation();
   const [createdBy, setCreatedBy] = useState<UserReadMinimal | undefined>(
@@ -281,7 +283,7 @@ export default function PaymentsData({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t("account")}</TableHead>
+                {!hideAccountColumn && <TableHead>{t("account")}</TableHead>}
                 <TableHead>{t("date")}</TableHead>
                 <TableHead>{t("invoice")}</TableHead>
                 <TableHead>{t("type")}</TableHead>
@@ -295,24 +297,26 @@ export default function PaymentsData({
             <TableBody>
               {payments.map((payment) => (
                 <TableRow key={payment.id}>
-                  <TableCell>
-                    <Button variant="link" asChild>
-                      <Link
-                        href={`/facility/${facilityId}/billing/account/${payment.account?.id}`}
-                        className="hover:text-primary "
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <div className="text-base flex items-center gap-1 underline underline-offset-2">
-                          {payment.account?.name}
-                          <CareIcon
-                            icon="l-external-link-alt"
-                            className="size-3"
-                          />
-                        </div>
-                      </Link>
-                    </Button>
-                  </TableCell>
+                  {!hideAccountColumn && (
+                    <TableCell>
+                      <Button variant="link" asChild>
+                        <Link
+                          href={`/facility/${facilityId}/billing/account/${payment.account?.id}`}
+                          className="hover:text-primary "
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <div className="text-base flex items-center gap-1 underline underline-offset-2">
+                            {payment.account?.name}
+                            <CareIcon
+                              icon="l-external-link-alt"
+                              className="size-3"
+                            />
+                          </div>
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  )}
                   <TableCell>
                     {payment.payment_datetime
                       ? format(
@@ -330,7 +334,7 @@ export default function PaymentsData({
                           target="_blank"
                           rel="noopener noreferrer"
                         >
-                          {t("view_invoice")}
+                          {payment.target_invoice.number || t("view_invoice")}
                           <CareIcon
                             icon="l-external-link-alt"
                             className="size-3"


### PR DESCRIPTION

- fixes #15613
- hide account column in payments list inside account show
- show invoice number in payments data instead of view invoice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The account column in the Payments section can now be conditionally hidden, allowing for a more streamlined view of payment data when needed.
  * Invoice links within payment records now display the actual invoice number rather than a generic label, making it easier to identify and access specific invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->