### PR TITLE
service requests: filter by patient on click

### DIFF
--- a/src/components/ServiceRequest/ServiceRequestTable.tsx
+++ b/src/components/ServiceRequest/ServiceRequestTable.tsx
@@ -19,6 +19,7 @@ import {
 import TagAssignmentSheet from "@/components/Tags/TagAssignmentSheet";
 
 import { LocationNode } from "@/components/Location/LocationTree";
+import { cn } from "@/lib/utils";
 import {
   SERVICE_REQUEST_PRIORITY_COLORS,
   SERVICE_REQUEST_STATUS_COLORS,
@@ -30,6 +31,7 @@ interface ServiceRequestTableProps {
   facilityId: string;
   locationId?: string;
   showPatientInfo?: boolean;
+  onPatientClick?: (request: ServiceRequestReadSpec) => void;
 }
 
 export default function ServiceRequestTable({
@@ -37,6 +39,7 @@ export default function ServiceRequestTable({
   facilityId,
   locationId,
   showPatientInfo = true,
+  onPatientClick,
 }: ServiceRequestTableProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -64,9 +67,18 @@ export default function ServiceRequestTable({
         </TableHeader>
         <TableBody className="bg-white">
           {requests.map((request) => (
-            <TableRow key={request.id} className="divide-x divide-gray-200">
+            <TableRow
+              key={request.id}
+              className="divide-x divide-gray-200 group"
+            >
               {showPatientInfo && (
-                <TableCell className="font-medium">
+                <TableCell
+                  className={cn(
+                    "font-medium",
+                    onPatientClick && "group-hover:underline cursor-pointer",
+                  )}
+                  onClick={() => onPatientClick?.(request)}
+                >
                   <div className="font-semibold text-gray-900">
                     {request.encounter.patient.name}
                   </div>

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestList.tsx
@@ -474,6 +474,12 @@ export default function ServiceRequestList({
                 requests={serviceRequests}
                 facilityId={facilityId}
                 locationId={locationId}
+                onPatientClick={(request) =>
+                  updateQuery({
+                    patient: request.encounter.patient.id,
+                    patient_name: request.encounter.patient.name,
+                  })
+                }
               />
             </div>
           </>


### PR DESCRIPTION
- fixes #15611 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient names in the service request table are now clickable, enabling quick filtering of requests by selecting a patient directly from the table across mobile and desktop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->