### PR TITLE
pharmacy: show medication note in bill medicines page

### DIFF
--- a/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
+++ b/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
@@ -369,7 +369,7 @@ export function MedicationBillRow({
               </div>
             )}
             {field.medication?.note && (
-              <span className="mt-4 text-xs text-gray-600 wrap-break-word whitespace-pre-wrap">
+              <span className="mt-4 text-xs text-gray-600 break-words whitespace-pre-wrap">
                 {field.medication.note}
               </span>
             )}

--- a/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
+++ b/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
@@ -131,7 +131,7 @@ export function MedicationBillRow({
           )}
         />
       </TableCell>
-      <TableCell className={tableCellClass}>
+      <TableCell className={cn(tableCellClass, "max-w-xs")}>
         <div
           className={cn(
             "flex items-center justify-between gap-2",
@@ -367,6 +367,11 @@ export function MedicationBillRow({
                   return t("click_to_add_dosage_instructions");
                 })()}
               </div>
+            )}
+            {field.medication?.note && (
+              <span className="mt-4 text-xs text-gray-600 wrap-break-word whitespace-pre-wrap">
+                {field.medication.note}
+              </span>
             )}
           </div>
           {field.medication && (


### PR DESCRIPTION
- fixes #15618

<img width="1585" height="882" alt="image" src="https://github.com/user-attachments/assets/d82e24fd-61da-48bd-921b-4056b9db1c34" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Medication notes now appear on billing records when present, providing additional context for each entry.

* **UI Improvements**
  * Medication table columns adjusted to limit overly wide cells, improving readability and layout consistency across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->