### PR TITLE
feat: Appointments should have only healthcare service of type schedule

### DIFF
--- a/src/components/Schedule/ResourceSelector.tsx
+++ b/src/components/Schedule/ResourceSelector.tsx
@@ -1,7 +1,10 @@
 import { LocationSearch } from "@/components/Location/LocationSearch";
 import { PractitionerSelector } from "@/pages/Appointments/components/PractitionerSelector";
 import { HealthcareServiceSelector } from "@/pages/Facility/services/HealthcareServiceSelector";
-import { HealthcareServiceReadSpec } from "@/types/healthcareService/healthcareService";
+import {
+  HealthcareServiceReadSpec,
+  InternalType,
+} from "@/types/healthcareService/healthcareService";
 import { LocationRead } from "@/types/location/location";
 import { SchedulableResourceType } from "@/types/scheduling/schedule";
 import { UserReadMinimal } from "@/types/user/user";
@@ -75,6 +78,7 @@ export const ScheduleResourceSelector = ({
               resource_type: selectedResource.resource_type,
             });
           }}
+          internalType={InternalType.scheduling}
         />
       );
 

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -44,6 +44,7 @@ interface HealthcareServiceSelectorProps {
   onSelect: (service: HealthcareServiceReadSpec | null) => void;
   facilityId: string;
   clearSelection?: boolean;
+  internalType?: InternalType;
 }
 
 export const HealthcareServiceSelector = ({
@@ -51,6 +52,7 @@ export const HealthcareServiceSelector = ({
   selected,
   onSelect,
   clearSelection = false,
+  internalType,
 }: HealthcareServiceSelectorProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -62,12 +64,12 @@ export const HealthcareServiceSelector = ({
     isLoading,
     isFetching,
   } = useQuery({
-    queryKey: ["healthcareServices", facilityId, searchValue],
+    queryKey: ["healthcareServices", facilityId, searchValue, internalType],
     queryFn: query.debounced(healthcareServiceApi.listHealthcareService, {
       pathParams: { facilityId },
       queryParams: {
         limit: 50,
-        internal_type: InternalType.scheduling,
+        ...(internalType && { internal_type: internalType }),
         ...(searchValue && { name: searchValue }),
       },
     }),
@@ -209,7 +211,7 @@ export const HealthcareServiceSelector = ({
         {triggerButton}
       </PopoverTrigger>
       <PopoverContent
-        className="p-0 w-[var(--radix-popover-trigger-width)]"
+        className="p-0 w-(--radix-popover-trigger-width)"
         align="start"
       >
         {commandContent}

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -31,7 +31,10 @@ import {
 
 import query from "@/Utils/request/query";
 import useBreakpoints from "@/hooks/useBreakpoints";
-import { HealthcareServiceReadSpec } from "@/types/healthcareService/healthcareService";
+import {
+  HealthcareServiceReadSpec,
+  InternalType,
+} from "@/types/healthcareService/healthcareService";
 import healthcareServiceApi from "@/types/healthcareService/healthcareServiceApi";
 
 type DuoToneIconName = keyof typeof duoToneIcons;
@@ -64,6 +67,7 @@ export const HealthcareServiceSelector = ({
       pathParams: { facilityId },
       queryParams: {
         limit: 50,
+        internal_type: InternalType.scheduling,
         ...(searchValue && { name: searchValue }),
       },
     }),


### PR DESCRIPTION
Fixes #15630
<img width="480" height="316" alt="image" src="https://github.com/user-attachments/assets/c97b5df1-27c3-4bb8-b05b-65b394ebbac8" />


## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Healthcare service selector can now be limited by internal service type, enabling targeted lists (e.g., scheduling services).

* **Bug Fixes**
  * Improved filtering so only relevant scheduling-related services are shown, reducing clutter and improving selection accuracy.
  * Adjusted popover sizing for more consistent display of the selector UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->