### PR TITLE
Fix medicine text overflow in Prescription Queue and upscale prescription print's size to match other prints

### DIFF
--- a/src/components/Prescription/PrescriptionPreview.tsx
+++ b/src/components/Prescription/PrescriptionPreview.tsx
@@ -75,7 +75,7 @@ const PrescriptionContent = ({
                 instructions: [remarks, notes].filter(Boolean).join("\n"),
               };
             })}
-            className="text-xs font-semibold whitespace-break-spaces text-gray-950"
+            className="text-sm font-semibold whitespace-break-spaces text-gray-950"
             cellConfig={{
               medicine: { className: "text-left" },
             }}
@@ -95,8 +95,8 @@ const PrescriptionContent = ({
       {/* Doctor's Signature */}
       <div className="w-full items-end mt-6 flex flex-row justify-end gap-1">
         <div className="text-right">
-          <p className="text-xs text-gray-400">{t("prescribed_by")}</p>
-          <p className="text-sm text-gray-600 font-semibold">
+          <p className="text-sm text-gray-400">{t("prescribed_by")}</p>
+          <p className="text-base text-gray-600 font-semibold">
             {formatName(prescription.prescribed_by)}
           </p>
         </div>
@@ -140,18 +140,18 @@ export const PrescriptionPreview = ({
       autoPrint={{ enabled: !!prescription.medications?.length }}
       disabled={!prescription.medications?.length}
     >
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-5xl mx-auto">
         <div>
           {/* Header */}
           <div className="flex justify-between items-start mb-4 pb-2 border-b border-gray-200">
             <div className="flex items-start gap-4">
               <div className="text-left">
-                <h1 className="text-xl font-medium">{facility?.name}</h1>
+                <h1 className="text-2xl font-medium">{facility?.name}</h1>
                 {facility?.address && (
-                  <div className="text-gray-500 whitespace-pre-wrap wrap-break-word text-xs">
+                  <div className="text-gray-500 whitespace-pre-wrap wrap-break-word text-sm">
                     {facility.address}
                     {facility.phone_number && (
-                      <p className="text-gray-500 text-xs">
+                      <p className="text-gray-500 text-sm">
                         {t("phone")}: {facility.phone_number}
                       </p>
                     )}
@@ -220,7 +220,7 @@ export const PrescriptionPreview = ({
           {/* Footer */}
           <PrintFooter
             leftContent={t("computer_generated_prescription")}
-            className="text-xs"
+            className="text-sm"
           />
         </div>
       </div>

--- a/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
@@ -119,7 +119,7 @@ function MedicationTable({
                     : "bg-gray-200",
                 )}
               >
-                <TableCell className="font-semibold text-gray-950 h-full items-center">
+                <TableCell className="font-semibold text-gray-950 h-full items-center max-w-xs break-words">
                   <span className="flex flex-col gap-2">
                     {displayMedicationName(medication)}
                     {medication?.dispense_status ===


### PR DESCRIPTION
## Proposed Changes

Adds `max-w-xs` and `break-words` to the Medicine column in the prescription queue table to wrap long medication names and prevent horizontal scrolling.

- Closes #15650
- fixes #15649

<img width="1440" height="1098" alt="image" src="https://github.com/user-attachments/assets/dc11301a-71c5-4d33-b8a4-a3d6dace4cdd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved typography sizing across prescription documents for better readability
  * Expanded layout width for enhanced content display
  * Enhanced medication name rendering with improved text wrapping for longer names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->