### PR TITLE
upscale prescription print's sizes to match other prints

### DIFF
--- a/src/components/Prescription/PrescriptionPreview.tsx
+++ b/src/components/Prescription/PrescriptionPreview.tsx
@@ -75,7 +75,7 @@ const PrescriptionContent = ({
                 instructions: [remarks, notes].filter(Boolean).join("\n"),
               };
             })}
-            className="text-xs font-semibold whitespace-break-spaces text-gray-950"
+            className="text-sm font-semibold whitespace-break-spaces text-gray-950"
             cellConfig={{
               medicine: { className: "text-left" },
             }}
@@ -95,8 +95,8 @@ const PrescriptionContent = ({
       {/* Doctor's Signature */}
       <div className="w-full items-end mt-6 flex flex-row justify-end gap-1">
         <div className="text-right">
-          <p className="text-xs text-gray-400">{t("prescribed_by")}</p>
-          <p className="text-sm text-gray-600 font-semibold">
+          <p className="text-sm text-gray-400">{t("prescribed_by")}</p>
+          <p className="text-base text-gray-600 font-semibold">
             {formatName(prescription.prescribed_by)}
           </p>
         </div>
@@ -140,18 +140,18 @@ export const PrescriptionPreview = ({
       autoPrint={{ enabled: !!prescription.medications?.length }}
       disabled={!prescription.medications?.length}
     >
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-5xl mx-auto">
         <div>
           {/* Header */}
           <div className="flex justify-between items-start mb-4 pb-2 border-b border-gray-200">
             <div className="flex items-start gap-4">
               <div className="text-left">
-                <h1 className="text-xl font-medium">{facility?.name}</h1>
+                <h1 className="text-2xl font-medium">{facility?.name}</h1>
                 {facility?.address && (
-                  <div className="text-gray-500 whitespace-pre-wrap wrap-break-word text-xs">
+                  <div className="text-gray-500 whitespace-pre-wrap wrap-break-word text-sm">
                     {facility.address}
                     {facility.phone_number && (
-                      <p className="text-gray-500 text-xs">
+                      <p className="text-gray-500 text-sm">
                         {t("phone")}: {facility.phone_number}
                       </p>
                     )}
@@ -220,7 +220,7 @@ export const PrescriptionPreview = ({
           {/* Footer */}
           <PrintFooter
             leftContent={t("computer_generated_prescription")}
-            className="text-xs"
+            className="text-sm"
           />
         </div>
       </div>


### PR DESCRIPTION
- fixes #15649

<img width="1536" height="1243" alt="image" src="https://github.com/user-attachments/assets/b18595ab-bd98-4191-b716-6c5feb0750ef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved prescription document readability with larger, clearer text across medicine details, doctor information, and facility sections
  * Enhanced layout spacing with adjusted container width for better overall presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->