### PR TITLE
Add hideAccountColumn prop to InvoicesData component

### DIFF
--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -247,7 +247,13 @@ export function AccountShow({
   const tabs = {
     invoices: {
       label: t("invoices"),
-      component: <InvoicesData facilityId={facilityId} accountId={accountId} />,
+      component: (
+        <InvoicesData
+          facilityId={facilityId}
+          accountId={accountId}
+          hideAccountColumn
+        />
+      ),
 
       shortcutId: "switch-to-invoices-tab",
     },

--- a/src/pages/Facility/billing/invoice/InvoicesData.tsx
+++ b/src/pages/Facility/billing/invoice/InvoicesData.tsx
@@ -45,10 +45,12 @@ export default function InvoicesData({
   facilityId,
   accountId,
   showIdentifierFilter = false,
+  hideAccountColumn = false,
 }: {
   facilityId: string;
   accountId?: string;
   showIdentifierFilter?: boolean;
+  hideAccountColumn?: boolean;
 }) {
   const { t } = useTranslation();
   const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
@@ -169,7 +171,7 @@ export default function InvoicesData({
               <TableRow>
                 <TableHead>{t("invoice_number")}</TableHead>
                 <TableHead>{t("invoice_date")}</TableHead>
-                <TableHead>{t("account")}</TableHead>
+                {!hideAccountColumn && <TableHead>{t("account")}</TableHead>}
                 <TableHead>{t("status")}</TableHead>
                 <TableHead>{t("total")}</TableHead>
                 <TableHead>{t("actions")}</TableHead>
@@ -190,24 +192,26 @@ export default function InvoicesData({
                     </div>
                   </TableCell>
 
-                  <TableCell>
-                    <Button variant="link" asChild>
-                      <Link
-                        href={`/facility/${facilityId}/billing/account/${invoice.account?.id}`}
-                        className="hover:text-primary "
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <div className="text-base flex items-center gap-1 underline underline-offset-2">
-                          {invoice.account?.name}
-                          <CareIcon
-                            icon="l-external-link-alt"
-                            className="size-3"
-                          />
-                        </div>
-                      </Link>
-                    </Button>
-                  </TableCell>
+                  {!hideAccountColumn && (
+                    <TableCell>
+                      <Button variant="link" asChild>
+                        <Link
+                          href={`/facility/${facilityId}/billing/account/${invoice.account?.id}`}
+                          className="hover:text-primary "
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <div className="text-base flex items-center gap-1 underline underline-offset-2">
+                            {invoice.account?.name}
+                            <CareIcon
+                              icon="l-external-link-alt"
+                              className="size-3"
+                            />
+                          </div>
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  )}
 
                   <TableCell>
                     <Badge variant={INVOICE_STATUS_COLORS[invoice.status]}>


### PR DESCRIPTION
## Description

Adds `hideAccountColumn` prop to `InvoicesData` component, similar to the existing implementation in `PaymentsData`. This allows the account column to be conditionally hidden when the component is used in contexts where the account is already known (e.g., `AccountShow` page).

## Changes

- Added `hideAccountColumn?: boolean` prop to `InvoicesData` component with default value `false`
- Conditionally render account table header and cell based on the prop
- Pass `hideAccountColumn` when using `InvoicesData` in `AccountShow`

Closes #15670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional visibility for the Account column in the invoices table. When viewing invoices from the Account section, the Account column is automatically hidden to reduce redundancy and streamline the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->