### PR TITLE
Remove default ordering from list charge item definitions API

### DIFF
--- a/src/types/billing/chargeItemDefinition/chargeItemDefinitionApi.ts
+++ b/src/types/billing/chargeItemDefinition/chargeItemDefinitionApi.ts
@@ -12,9 +12,6 @@ export default {
     path: "/api/v1/facility/{facilityId}/charge_item_definition/",
     method: HttpMethod.GET,
     TRes: Type<PaginatedResponse<ChargeItemDefinitionBase>>(),
-    defaultQueryParams: {
-      ordering: "-created_date",
-    },
   },
   retrieveChargeItemDefinition: {
     path: "/api/v1/facility/{facilityId}/charge_item_definition/{slug}/",


### PR DESCRIPTION
Removes `defaultQueryParams` (ordering: "-created_date") from the list charge item definitions API in `chargeItemDefinitionApi.ts`.

Callers can pass ordering explicitly when needed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic sort order from charge item definition results. Items will now display in their natural retrieval order rather than sorted by creation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->