### PR TITLE
account show: fallback to using account's primary encounter id when navigated from outside encounter show

### DIFF
--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -112,7 +112,7 @@ export function AccountShow({
     sheetOpen: boolean;
     reason: AccountBillingStatus;
   }>({ sheetOpen: false, reason: AccountBillingStatus.closed_baddebt });
-  const [{ encounterId }] = useQueryParams();
+  const [qParams] = useQueryParams();
   const { facility } = useCurrentFacility();
   const { hasPermission } = usePermissions();
 
@@ -129,6 +129,8 @@ export function AccountShow({
       pathParams: { facilityId, accountId },
     }),
   });
+
+  const encounterId = qParams.encounterId || account?.primary_encounter.id;
 
   const { data: billableChargeItems } = useQuery({
     queryKey: ["billableChargeItems", accountId],


### PR DESCRIPTION
- fixes #15682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed encounter handling in the billing account section to automatically use the account's primary encounter when not explicitly specified in the URL, ensuring consistent navigation and data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->