### PR TITLE
fix: remove debug console logs and fix strict equality in LocationImport

### DIFF
--- a/src/pages/Facility/settings/locations/LocationImport.tsx
+++ b/src/pages/Facility/settings/locations/LocationImport.tsx
@@ -170,9 +170,7 @@ export default function LocationImport({ facilityId }: LocationImportProps) {
         setProcessedLocations(processRowLocations(data));
         setCurrentStep("review");
       } catch (error) {
-        console.error("=== CSV PROCESSING ERROR ===");
-        console.error("Error details:", error);
-        console.error("=== END ERROR LOG ===");
+        console.error("CSV processing failed:", error);
         setUploadError("Error processing CSV file");
       }
     };

--- a/src/pages/Facility/settings/locations/LocationImport.tsx
+++ b/src/pages/Facility/settings/locations/LocationImport.tsx
@@ -58,7 +58,6 @@ const LocationFormLabels = {
 
 const mapLabelToForm = (label: string): LocationForm | undefined => {
   const formKey = LocationFormLabels[label as keyof typeof LocationFormLabels];
-  console.log("Mapping label", label, "to form", formKey);
   return formKey as LocationForm | undefined;
 };
 
@@ -68,14 +67,12 @@ const processRowLocations = (data: string[][]) => {
     locationData: string[],
     locations: LocationImportT[],
   ): LocationImportT[] => {
-    console.log("Processing location:", locationData);
     const [location, location_type, description] = locationData.slice(0, 3);
     const tail = locationData.slice(3);
 
     const existingLocation = locations.find((l) => l.name === location);
 
     if (existingLocation && tail.length > 0 && tail[0] !== "") {
-      console.log("Processing new children for location:", location);
       return [
         ...locations.filter((l) => l.name !== location),
         {
@@ -95,9 +92,7 @@ const processRowLocations = (data: string[][]) => {
         children: [],
       };
       let children: LocationImportT[] = [];
-      console.log("Adding new location:", newLocation);
-      if (tail.length > 0 && tail[0] != "") {
-        console.log("Processing children for location:", location);
+      if (tail.length > 0 && tail[0] !== "") {
         children = processAtLocation(tail, newLocation.children);
       }
       return [
@@ -114,7 +109,6 @@ const processRowLocations = (data: string[][]) => {
     locations = processAtLocation(locationRow, locations);
   }
 
-  console.log(locations);
   return locations;
 };
 
@@ -519,7 +513,6 @@ export function useSaveLocations(facilityId: string) {
 
   // Effect: process the next batch whenever the queue changes
   useEffect(() => {
-    console.log("Processing queue:", queue);
     if (queue.length === 0) return;
 
     const { parentId, nodes: allNodes } = queue[0];
@@ -550,8 +543,6 @@ export function useSaveLocations(facilityId: string) {
         mode: n.mode,
       }));
 
-    console.log("Saving locations:", toSave);
-
     if (toSave.length === 0) {
       // dequeue empty and let effect run again
       setQueue((prev) => prev.slice(1));
@@ -575,7 +566,6 @@ export function useSaveLocations(facilityId: string) {
 
   // Entry point: start the saving process
   const saveLocations = useCallback((roots: LocationImportT[]) => {
-    console.log("Saving locations:", roots);
     setQueue([{ parentId: undefined, nodes: roots }]);
   }, []);
 


### PR DESCRIPTION
Summary
Fixes #15686 

This PR cleans up the `LocationImport.tsx` file by removing leftover debug console logs and fixing an inconsistent equality operator.

Changes Made
- Removed 9 `console.log()` statements that were left from development
- Fixed strict equality operator on line 99: changed `!=` to `!==` for consistency

 Details
 Console Logs Removed:
The following debug statements have been removed:
- Label mapping logging (line 61)
- Location processing logs (lines 71, 78, 98, 100, 117)
- Queue processing logs (lines 522, 553, 578)

Strict Equality Fix:
Previously on line 99 we had:
```typescript
if (tail.length > 0 && tail[0] != "") {
```

Changed to be consistent with line 77:
```typescript
if (tail.length > 0 && tail[0] !== "") {


- Testing
-  Linting passes (npm run lint)
-  The code still compiles without errors
-  No functional changes - just code cleanup

- Why This Matters
- Keeps the browser console clean for developers and users
- Eliminates minor performance overhead from unnecessary logging
- Using `!==` prevents potential type coercion bugs
- Aligns with TypeScript/JavaScript best practices

Let me know if there's anything else that should be addressed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed internal debug and verbose logging throughout the location import and save workflow to reduce noise.
  * Consolidated and simplified CSV error reporting to a single, clearer failure message.
  * Improved conditional checks and minor formatting to tighten import flow behavior and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->