### PR TITLE
Prevent record payment sheet from opening when invoice is balanced

### DIFF
--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -309,13 +309,7 @@ export function InvoiceShow({
             : invoice?.issue_date,
       };
 
-      updateInvoice(data, {
-        onSuccess: () => {
-          if (status === InvoiceStatus.issued) {
-            setIsPaymentSheetOpen(true);
-          }
-        },
-      });
+      updateInvoice(data);
     }
   };
 

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -50,7 +50,7 @@ import {
   SquareArrowOutUpRight,
 } from "lucide-react";
 import { Link, navigate, useQueryParams } from "raviger";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 import AddChargeItemSheet from "@/components/Billing/Invoice/AddChargeItemSheet";
@@ -136,6 +136,12 @@ export function InvoiceShow({
       pathParams: { facilityId, invoiceId },
     }),
   });
+
+  useEffect(() => {
+    if (invoice?.status === InvoiceStatus.issued) {
+      setIsPaymentSheetOpen(true);
+    }
+  }, [invoice?.status]);
 
   const patient = invoice?.account.patient;
 


### PR DESCRIPTION
## Proposed Changes

When invoice is automatically balanced on issuing (done in plugs), we ideally don't want the record payment sheet to be opened, so this PR prevents record payment sheet from opening when invoice is balanced.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the payment sheet opening behavior for issued invoices through enhanced state management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->