### PR TITLE
Added print button in request order detail page

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -4653,6 +4653,7 @@
   "request_for": "Request for",
   "request_id": "Request ID",
   "request_letter": "Request Letter",
+  "request_order": "Request Order",
   "request_order_details": "Request Order Details",
   "request_order_not_found": "Request order not found",
   "request_orders": "Request Orders",

--- a/src/pages/Facility/locations/LocationLayout.tsx
+++ b/src/pages/Facility/locations/LocationLayout.tsx
@@ -36,6 +36,7 @@ import { PrintDispenseOrder } from "@/pages/Facility/services/pharmacy/PrintDisp
 import { PrintMedicationReturn } from "@/pages/Facility/services/pharmacy/PrintMedicationReturn";
 import ServiceRequestList from "@/pages/Facility/services/serviceRequests/ServiceRequestList";
 import ServiceRequestShow from "@/pages/Facility/services/serviceRequests/ServiceRequestShow";
+import { PrintRequestOrder } from "@/src/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder";
 import { SchedulableResourceType } from "@/types/scheduling/schedule";
 
 interface LocationLayoutProps {
@@ -179,6 +180,15 @@ const getRoutes = (facilityId: string, locationId: string) => ({
   // Edit Internal Order
   "/inventory/internal/:type/orders/:id/edit": ({ id }: { id: string }) => (
     <RequestOrderForm
+      facilityId={facilityId}
+      locationId={locationId}
+      requestOrderId={id}
+      internal={true}
+    />
+  ),
+  //Print Internal Order
+  "/inventory/internal/:type/orders/:id/print": ({ id }: { id: string }) => (
+    <PrintRequestOrder
       facilityId={facilityId}
       locationId={locationId}
       requestOrderId={id}

--- a/src/pages/Facility/locations/LocationLayout.tsx
+++ b/src/pages/Facility/locations/LocationLayout.tsx
@@ -20,6 +20,7 @@ import DeliveryOrderForm from "@/pages/Facility/services/inventory/externalSuppl
 import { DeliveryOrderList } from "@/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderList";
 import { DeliveryOrderShow } from "@/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow";
 import { PrintDeliveryOrder } from "@/pages/Facility/services/inventory/externalSupply/deliveryOrder/PrintDeliveryOrder";
+import { PrintRequestOrder } from "@/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder";
 import { ToDispatch } from "@/pages/Facility/services/inventory/ToDispatch";
 import { ToReceive } from "@/pages/Facility/services/inventory/ToReceive";
 import AllMedicationBillForm from "@/pages/Facility/services/pharmacy/AllMedicationBillForm";
@@ -36,7 +37,6 @@ import { PrintDispenseOrder } from "@/pages/Facility/services/pharmacy/PrintDisp
 import { PrintMedicationReturn } from "@/pages/Facility/services/pharmacy/PrintMedicationReturn";
 import ServiceRequestList from "@/pages/Facility/services/serviceRequests/ServiceRequestList";
 import ServiceRequestShow from "@/pages/Facility/services/serviceRequests/ServiceRequestShow";
-import { PrintRequestOrder } from "@/src/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder";
 import { SchedulableResourceType } from "@/types/scheduling/schedule";
 
 interface LocationLayoutProps {
@@ -192,7 +192,6 @@ const getRoutes = (facilityId: string, locationId: string) => ({
       facilityId={facilityId}
       locationId={locationId}
       requestOrderId={id}
-      internal={true}
     />
   ),
   // Create Delivery

--- a/src/pages/Facility/locations/LocationLayout.tsx
+++ b/src/pages/Facility/locations/LocationLayout.tsx
@@ -20,7 +20,7 @@ import DeliveryOrderForm from "@/pages/Facility/services/inventory/externalSuppl
 import { DeliveryOrderList } from "@/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderList";
 import { DeliveryOrderShow } from "@/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow";
 import { PrintDeliveryOrder } from "@/pages/Facility/services/inventory/externalSupply/deliveryOrder/PrintDeliveryOrder";
-import { PrintRequestOrder } from "@/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder";
+import { PrintRequestOrder } from "@/pages/Facility/services/inventory/externalSupply/requestOrder/PrintRequestOrder";
 import { ToDispatch } from "@/pages/Facility/services/inventory/ToDispatch";
 import { ToReceive } from "@/pages/Facility/services/inventory/ToReceive";
 import AllMedicationBillForm from "@/pages/Facility/services/pharmacy/AllMedicationBillForm";
@@ -192,6 +192,7 @@ const getRoutes = (facilityId: string, locationId: string) => ({
       facilityId={facilityId}
       locationId={locationId}
       requestOrderId={id}
+      internal={true}
     />
   ),
   // Create Delivery
@@ -293,6 +294,15 @@ const getRoutes = (facilityId: string, locationId: string) => ({
   // Edit External Order
   "/inventory/external/orders/:tab/:id/edit": ({ id }: { id: string }) => (
     <RequestOrderForm
+      facilityId={facilityId}
+      locationId={locationId}
+      requestOrderId={id}
+      internal={false}
+    />
+  ),
+  // Print External Order
+  "/inventory/external/orders/:tab/:id/print": ({ id }: { id: string }) => (
+    <PrintRequestOrder
       facilityId={facilityId}
       locationId={locationId}
       requestOrderId={id}

--- a/src/pages/Facility/services/inventory/externalSupply/requestOrder/PrintRequestOrder.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/requestOrder/PrintRequestOrder.tsx
@@ -204,12 +204,14 @@ interface PrintRequestOrderProps {
   facilityId: string;
   requestOrderId: string;
   locationId?: string;
+  internal: boolean;
 }
 
 export const PrintRequestOrder = ({
   facilityId,
   requestOrderId,
   locationId,
+  internal,
 }: PrintRequestOrderProps) => {
   const { t } = useTranslation();
 
@@ -250,8 +252,9 @@ export const PrintRequestOrder = ({
   const dispatchedQuantities =
     allSupplyDeliveries?.results?.reduce(
       (acc, delivery) => {
-        const productId =
-          delivery.supplied_inventory_item?.product?.product_knowledge?.id;
+        const productId = internal
+          ? delivery.supplied_inventory_item?.product?.product_knowledge?.id
+          : delivery.supplied_item?.product_knowledge?.id;
         if (productId) {
           acc[productId] = add(
             acc[productId] || 0,

--- a/src/pages/Facility/services/inventory/externalSupply/requestOrder/RequestOrderShow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/requestOrder/RequestOrderShow.tsx
@@ -4,7 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { Box, ChevronLeft, Edit, Hash, Truck } from "lucide-react";
+import { Box, ChevronLeft, Edit, Hash, Printer, Truck } from "lucide-react";
 import { Link } from "raviger";
 import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -358,6 +358,12 @@ export function RequestOrderShow({
             </div>
           </div>
           <div className="flex items-center justify-end gap-2">
+            <Button variant="outline" asChild>
+              <Link href={`${requestOrderId}/print`}>
+                <Printer className="size-4" /> {t("print")}
+                <ShortcutBadge actionId="print-button" />
+              </Link>
+            </Button>
             {isRequester && (
               <Button variant="outline" asChild>
                 <Link href={`${requestOrderId}/edit`}>

--- a/src/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder.tsx
@@ -1,0 +1,291 @@
+import careConfig from "@careConfig";
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { useTranslation } from "react-i18next";
+
+import PrintPreview from "@/CAREUI/misc/PrintPreview";
+
+import Loading from "@/components/Common/Loading";
+import PrintFooter from "@/components/Common/PrintFooter";
+import PrintTable from "@/components/Common/PrintTable";
+
+import { Badge } from "@/components/ui/badge";
+import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
+import {
+  REQUEST_ORDER_STATUS_COLORS,
+  RequestOrderRetrieve,
+} from "@/types/inventory/requestOrder/requestOrder";
+import requestOrderApi from "@/types/inventory/requestOrder/requestOrderApi";
+import supplyDeliveryApi from "@/types/inventory/supplyDelivery/supplyDeliveryApi";
+import { SupplyRequestRead } from "@/types/inventory/supplyRequest/supplyRequest";
+import supplyRequestApi from "@/types/inventory/supplyRequest/supplyRequestApi";
+import { add, round, subtract } from "@/Utils/decimal";
+import query from "@/Utils/request/query";
+import Decimal from "decimal.js";
+
+interface DetailRowProps {
+  label: string;
+  value?: string | null;
+  isStrong?: boolean;
+}
+
+const DetailRow = ({ label, value, isStrong = false }: DetailRowProps) => {
+  return (
+    <div className="flex">
+      <span className="text-gray-600 w-32">{label}</span>
+      <span className="text-gray-600">: </span>
+      <span className={`ml-1 ${isStrong ? "font-semibold" : ""}`}>
+        {value || "-"}
+      </span>
+    </div>
+  );
+};
+
+interface RequestOrderContentProps {
+  requestOrder: RequestOrderRetrieve;
+  supplyRequests: SupplyRequestRead[];
+  dispatchedQuantities: Record<string, Decimal>;
+}
+
+const RequestOrderContent = ({
+  requestOrder,
+  supplyRequests,
+  dispatchedQuantities,
+}: RequestOrderContentProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      {/* Request Order Header */}
+      <div className="mb-4">
+        <div className="text-2xl font-semibold mb-2 flex items-end gap-4">
+          <p>{requestOrder.name}</p>
+        </div>
+        {requestOrder.note && (
+          <p className="text-sm text-gray-600">{requestOrder.note}</p>
+        )}
+      </div>
+
+      {/* Supply Requests Table */}
+      {supplyRequests && supplyRequests.length > 0 && (
+        <div className="mt-4">
+          <p className="text-base font-semibold mb-2">{t("requested_items")}</p>
+          <PrintTable
+            headers={[
+              { key: "product" },
+              { key: "quantity" },
+              { key: "dispatched_quantity" },
+              { key: "remaining_quantity" },
+              { key: "status" },
+            ]}
+            rows={supplyRequests.map((request) => {
+              const dispatched =
+                dispatchedQuantities[request.item.id] || new Decimal(0);
+              const remaining = subtract(request.quantity, dispatched);
+
+              return {
+                product: request.item.name || "-",
+                quantity: String(round(request.quantity)),
+                dispatched_quantity: String(round(dispatched)),
+                remaining_quantity: String(round(remaining)),
+                status: t(request.status),
+              };
+            })}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface RequestOrderPreviewProps {
+  requestOrder: RequestOrderRetrieve;
+  supplyRequests: SupplyRequestRead[];
+  dispatchedQuantities: Record<string, Decimal>;
+}
+
+const RequestOrderPreview = ({
+  requestOrder,
+  supplyRequests,
+  dispatchedQuantities,
+}: RequestOrderPreviewProps) => {
+  const { t } = useTranslation();
+  const { facility } = useCurrentFacility();
+
+  return (
+    <PrintPreview
+      title={`${t("request_order")} - ${requestOrder.name}`}
+      disabled={!supplyRequests?.length}
+    >
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-start mb-2 pb-2 border-b border-gray-200">
+          <div className="flex items-start gap-4">
+            <div className="text-left">
+              <h1 className="text-2xl font-medium">{facility?.name}</h1>
+              {facility?.address && (
+                <div className="text-gray-500 whitespace-pre-wrap wrap-break-word text-sm">
+                  {facility.address}
+                  {facility.phone_number && (
+                    <p className="text-gray-500 text-sm">
+                      {t("phone")}: {facility.phone_number}
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+          <img
+            src={careConfig.mainLogo?.dark}
+            alt="Logo"
+            className="h-10 w-auto object-contain mb-2 sm:mb-0 text-end"
+          />
+        </div>
+
+        <h2 className="text-gray-500 uppercase text-sm tracking-wide font-semibold my-2">
+          {t("request_order")}
+        </h2>
+
+        {/* Request Order Details */}
+        <div className="grid md:grid-cols-2 print:grid-cols-2 gap-6 border-t border-gray-200 pt-2">
+          <div className="space-y-2">
+            <DetailRow
+              label={t("deliver_to")}
+              value={requestOrder.destination?.name}
+              isStrong
+            />
+            {requestOrder.origin && (
+              <DetailRow
+                label={t("origin")}
+                value={requestOrder.origin.name}
+                isStrong
+              />
+            )}
+            {requestOrder.supplier && (
+              <DetailRow
+                label={t("supplier")}
+                value={requestOrder.supplier.name}
+                isStrong
+              />
+            )}
+          </div>
+          <div className="space-y-2">
+            <DetailRow
+              label={t("date")}
+              value={format(new Date(), "dd MMM yyyy, EEEE")}
+              isStrong
+            />
+            <div className="flex">
+              <span className="text-gray-600 w-32">{t("status")}</span>
+              <span className="text-gray-600">: </span>
+              <Badge
+                className="rounded-sm ml-1"
+                variant={REQUEST_ORDER_STATUS_COLORS[requestOrder.status]}
+              >
+                {t(requestOrder.status)}
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        <RequestOrderContent
+          requestOrder={requestOrder}
+          supplyRequests={supplyRequests}
+          dispatchedQuantities={dispatchedQuantities}
+        />
+
+        {/* Footer */}
+        <PrintFooter leftContent={t("computer_generated_document")} />
+      </div>
+    </PrintPreview>
+  );
+};
+
+interface PrintRequestOrderProps {
+  facilityId: string;
+  requestOrderId: string;
+}
+
+export const PrintRequestOrder = ({
+  facilityId,
+  requestOrderId,
+}: PrintRequestOrderProps) => {
+  const { t } = useTranslation();
+
+  const { data: requestOrder, isLoading: isLoadingOrder } = useQuery({
+    queryKey: ["requestOrders", requestOrderId],
+    queryFn: query(requestOrderApi.retrieveRequestOrder, {
+      pathParams: {
+        facilityId,
+        requestOrderId,
+      },
+    }),
+    enabled: !!requestOrderId,
+  });
+
+  const { data: supplyRequests, isLoading: isLoadingRequests } = useQuery({
+    queryKey: ["supplyRequests", requestOrderId],
+    queryFn: query.paginated(supplyRequestApi.listSupplyRequest, {
+      queryParams: {
+        order: requestOrderId,
+      },
+    }),
+    enabled: !!requestOrderId,
+  });
+
+  const { data: allSupplyDeliveries, isLoading: isLoadingDeliveries } =
+    useQuery({
+      queryKey: ["allSupplyDeliveries", requestOrderId],
+      queryFn: query.paginated(supplyDeliveryApi.listSupplyDelivery, {
+        queryParams: {
+          facility: facilityId,
+          request_order: requestOrderId,
+        },
+      }),
+      enabled: !!requestOrderId,
+    });
+
+  // Calculate dispatched quantities per product
+  const dispatchedQuantities =
+    allSupplyDeliveries?.results?.reduce(
+      (acc, delivery) => {
+        const productId =
+          delivery.supplied_inventory_item?.product?.product_knowledge?.id;
+        if (productId) {
+          acc[productId] = add(
+            acc[productId] || 0,
+            delivery.supplied_item_quantity,
+          );
+        }
+        return acc;
+      },
+      {} as Record<string, Decimal>,
+    ) || {};
+
+  if (isLoadingOrder || isLoadingRequests || isLoadingDeliveries) {
+    return <Loading />;
+  }
+
+  if (!requestOrder) {
+    return (
+      <div className="flex h-[200px] items-center justify-center rounded-lg border-2 border-dashed p-4 text-gray-500 border-gray-200">
+        {t("request_order_not_found")}
+      </div>
+    );
+  }
+
+  if (!supplyRequests?.results?.length) {
+    return (
+      <div className="flex h-[200px] items-center justify-center rounded-lg border-2 border-dashed p-4 text-gray-500 border-gray-200">
+        {t("no_supply_requests_found")}
+      </div>
+    );
+  }
+
+  return (
+    <RequestOrderPreview
+      requestOrder={requestOrder}
+      supplyRequests={supplyRequests.results}
+      dispatchedQuantities={dispatchedQuantities}
+    />
+  );
+};

--- a/src/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/requestOrder/printRequestOrder.tsx
@@ -203,11 +203,13 @@ const RequestOrderPreview = ({
 interface PrintRequestOrderProps {
   facilityId: string;
   requestOrderId: string;
+  locationId?: string;
 }
 
 export const PrintRequestOrder = ({
   facilityId,
   requestOrderId,
+  locationId,
 }: PrintRequestOrderProps) => {
   const { t } = useTranslation();
 
@@ -241,7 +243,7 @@ export const PrintRequestOrder = ({
           request_order: requestOrderId,
         },
       }),
-      enabled: !!requestOrderId,
+      enabled: !!requestOrderId && !!locationId,
     });
 
   // Calculate dispatched quantities per product


### PR DESCRIPTION
## Proposed Changes

Fixes #15694 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added print functionality for request orders, enabling users to generate and preview printable views of both internal and external orders with full order details, quantities, dispatch status, and related information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->