### PR TITLE
Disable Medication Return Button if dispense is not completed

### DIFF
--- a/src/pages/Facility/services/pharmacy/DispensesView.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensesView.tsx
@@ -12,7 +12,10 @@ import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
 import useFilters from "@/hooks/useFilters";
 import useCurrentLocation from "@/pages/Facility/locations/utils/useCurrentLocation";
-import { DISPENSE_ORDER_STATUS_STYLES } from "@/types/emr/dispenseOrder/dispenseOrder";
+import {
+  DISPENSE_ORDER_STATUS_STYLES,
+  DispenseOrderStatus,
+} from "@/types/emr/dispenseOrder/dispenseOrder";
 import dispenseOrderApi from "@/types/emr/dispenseOrder/dispenseOrderApi";
 import { MedicationDispenseStatus } from "@/types/emr/medicationDispense/medicationDispense";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
@@ -166,26 +169,28 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
               {t("status")}:{" "}
               {t(`dispense_order_status__${dispenseOrder.status}`)}
             </Badge>
-            <MedicationReturnSheet
-              facilityId={facilityId}
-              locationId={locationId}
-              patient={dispenseOrder.patient}
-              onSuccess={(deliveryOrder) => {
-                // Navigate to the medication return detail page
-                navigate(
-                  `/facility/${facilityId}/locations/${locationId}/medication_return/order/${deliveryOrder.id}/?dispenseOrderId=${dispenseOrderId}`,
-                );
-              }}
-              trigger={
-                <Button
-                  variant="outline"
-                  className="border-gray-400 font-semibold"
-                >
-                  <RotateCcw className="size-4" />
-                  Medication Return
-                </Button>
-              }
-            />
+            {dispenseOrder.status === DispenseOrderStatus.completed && (
+              <MedicationReturnSheet
+                facilityId={facilityId}
+                locationId={locationId}
+                patient={dispenseOrder.patient}
+                onSuccess={(deliveryOrder) => {
+                  // Navigate to the medication return detail page
+                  navigate(
+                    `/facility/${facilityId}/locations/${locationId}/medication_return/order/${deliveryOrder.id}/?dispenseOrderId=${dispenseOrderId}`,
+                  );
+                }}
+                trigger={
+                  <Button
+                    variant="outline"
+                    className="border-gray-400 font-semibold"
+                  >
+                    <RotateCcw className="size-4" />
+                    Medication Return
+                  </Button>
+                }
+              />
+            )}
             <Button
               variant="outline"
               className="border-gray-400 font-semibold"

--- a/src/pages/Facility/services/pharmacy/DispensesView.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensesView.tsx
@@ -186,7 +186,7 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
                     className="border-gray-400 font-semibold"
                   >
                     <RotateCcw className="size-4" />
-                    Medication Return
+                    {t("medication_return")}
                   </Button>
                 }
               />


### PR DESCRIPTION
## Proposed Changes

Fixes #15766
- <img width="1520" height="667" alt="image" src="https://github.com/user-attachments/assets/23df0970-2fd7-44a0-935a-7cf195a12c12" />
<img width="1495" height="616" alt="image" src="https://github.com/user-attachments/assets/11385652-5d24-4e31-8659-1e0f02e6026c" />

- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Medication return sheet now displays only for completed dispense orders, avoiding visibility for other order states.

* **Localization**
  * Medication return trigger button now uses the app's translation keys so the label respects configured languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->