### PR TITLE
Removed default filter in the Dispense History

### DIFF
--- a/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseHistory.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { startOfDay } from "date-fns";
 import { ArrowUpRightSquare } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -63,17 +62,6 @@ export default function MedicationDispenseHistory({
     disableCache: true,
   });
   const [selectedDispenses, setSelectedDispenses] = useState<string[]>([]);
-
-  // Set default filters on mount (today's date and current user)
-  useEffect(() => {
-    const today = dateQueryString(startOfDay(new Date()));
-    if (!qParams.created_date_after && !qParams.created_date_before) {
-      updateQuery({
-        created_date_after: today,
-        created_date_before: today,
-      });
-    }
-  }, []);
 
   // Clear selections when patient filter changes
   useEffect(() => {


### PR DESCRIPTION
## Proposed Changes

Fixes #15768
<img width="1758" height="740" alt="image" src="https://github.com/user-attachments/assets/801722bf-040d-4918-84a2-213447cfdbde" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic date filtering from the Medication Dispense History view. Users will no longer see today's date automatically applied as a filter when loading the page, allowing for viewing the complete history of records by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->