### PR TITLE
feat: show mark as complete after approval

### DIFF
--- a/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
@@ -326,54 +326,56 @@ export default function ServiceRequestShow({
                 request?.diagnostic_reports?.[0]?.status ===
                   DiagnosticReportStatus.final) && (
                 <div className="flex items-center gap-2">
-                  {!disableEdit &&
-                    request?.diagnostic_reports?.[0]?.status ===
-                      DiagnosticReportStatus.final && (
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            variant="outline"
-                            className="font-semibold border border-gray-400"
-                          >
-                            {t("mark_as_complete")}
-                            <ShortcutBadge actionId="mark-as-complete" />
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>
-                              {t("confirm_completion")}
-                            </AlertDialogTitle>
-                            <AlertDialogDescription>
-                              {t("service_request_completion_confirmation")}
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={() => completeServiceRequest({})}
-                            >
-                              {t("confirm")}
-                              <ShortcutBadge actionId="enter-action" />
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    )}
                   {request?.diagnostic_reports?.[0]?.status ===
                     DiagnosticReportStatus.final && (
-                    <Button
-                      variant="primary"
-                      className="font-semibold"
-                      onClick={() =>
-                        navigate(
-                          `/facility/${facilityId}/patient/${request.encounter.patient.id}/diagnostic_reports/${request.diagnostic_reports[0].id}`,
-                        )
-                      }
-                    >
-                      {t("view_report")}
-                      <ShortcutBadge actionId="view-report" />
-                    </Button>
+                    <>
+                      {!disableEdit && (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="outline"
+                              className="font-semibold border border-gray-400"
+                            >
+                              {t("mark_as_complete")}
+                              <ShortcutBadge actionId="mark-as-complete" />
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                {t("confirm_completion")}
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                {t("service_request_completion_confirmation")}
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>
+                                {t("cancel")}
+                              </AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => completeServiceRequest({})}
+                              >
+                                {t("confirm")}
+                                <ShortcutBadge actionId="enter-action" />
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      )}
+                      <Button
+                        variant="primary"
+                        className="font-semibold"
+                        onClick={() =>
+                          navigate(
+                            `/facility/${facilityId}/patient/${request.encounter.patient.id}/diagnostic_reports/${request.diagnostic_reports[0].id}`,
+                          )
+                        }
+                      >
+                        {t("view_report")}
+                        <ShortcutBadge actionId="view-report" />
+                      </Button>
+                    </>
                   )}
                 </div>
               )}

--- a/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
+++ b/src/pages/Facility/services/serviceRequests/ServiceRequestShow.tsx
@@ -326,38 +326,40 @@ export default function ServiceRequestShow({
                 request?.diagnostic_reports?.[0]?.status ===
                   DiagnosticReportStatus.final) && (
                 <div className="flex items-center gap-2">
-                  {!disableEdit && (
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          variant="outline"
-                          className="font-semibold border border-gray-400"
-                        >
-                          {t("mark_as_complete")}
-                          <ShortcutBadge actionId="mark-as-complete" />
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>
-                            {t("confirm_completion")}
-                          </AlertDialogTitle>
-                          <AlertDialogDescription>
-                            {t("service_request_completion_confirmation")}
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => completeServiceRequest({})}
+                  {!disableEdit &&
+                    request?.diagnostic_reports?.[0]?.status ===
+                      DiagnosticReportStatus.final && (
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className="font-semibold border border-gray-400"
                           >
-                            {t("confirm")}
-                            <ShortcutBadge actionId="enter-action" />
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  )}
+                            {t("mark_as_complete")}
+                            <ShortcutBadge actionId="mark-as-complete" />
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>
+                              {t("confirm_completion")}
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                              {t("service_request_completion_confirmation")}
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+                            <AlertDialogAction
+                              onClick={() => completeServiceRequest({})}
+                            >
+                              {t("confirm")}
+                              <ShortcutBadge actionId="enter-action" />
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    )}
                   {request?.diagnostic_reports?.[0]?.status ===
                     DiagnosticReportStatus.final && (
                     <Button


### PR DESCRIPTION
## Proposed Changes

Fixes #15776
<img width="1098" height="448" alt="image" src="https://github.com/user-attachments/assets/446e3735-d7ac-42a9-a0e3-8580c780247b" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completion confirmation dialog now renders alongside the "View report" control, preserving its visibility rules so it only appears in final, editable states and preventing accidental completions.
  * "View report" button continues to display correctly when diagnostic status is final, ensuring uninterrupted access to reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->