### PR TITLE
Cancel token when Appointment cancel/no-show/entered-in-error

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -828,11 +828,13 @@ const AppointmentActions = ({
       queryClient.invalidateQueries({
         queryKey: ["appointment", appointment.id],
       });
-      updateToken({
-        status: TokenStatus.CANCELLED,
-        sub_queue: appointment.token?.sub_queue?.id || null,
-        note: "",
-      });
+      if (appointment.token) {
+        updateToken({
+          status: TokenStatus.CANCELLED,
+          sub_queue: appointment.token.sub_queue?.id || null,
+          note: "",
+        });
+      }
     },
   });
 
@@ -1121,11 +1123,13 @@ const AppointmentActions = ({
                           status: AppointmentStatus.NO_SHOW,
                           note: note,
                         });
-                        updateToken({
-                          status: TokenStatus.CANCELLED,
-                          sub_queue: appointment.token?.sub_queue?.id || null,
-                          note: "",
-                        });
+                        if (appointment.token) {
+                          updateToken({
+                            status: TokenStatus.CANCELLED,
+                            sub_queue: appointment.token.sub_queue?.id || null,
+                            note: "",
+                          });
+                        }
                       }}
                       className={cn(buttonVariants({ variant: "destructive" }))}
                       disabled={!note.trim()}

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -111,6 +111,8 @@ import { QuickAction } from "@/pages/Encounters/tabs/overview/quick-actions";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import { ChargeItemServiceResource } from "@/types/billing/chargeItem/chargeItem";
 import { FacilityRead } from "@/types/facility/facility";
+import { TokenStatus } from "@/types/tokens/token/token";
+import tokenApi from "@/types/tokens/token/tokenApi";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import { formatPhoneNumberIntl } from "react-phone-number-input";
 import { toast } from "sonner";
@@ -785,7 +787,6 @@ const AppointmentActions = ({
   const [isRescheduleReasonOpen, setIsRescheduleReasonOpen] = useState(false);
   const [newNote, setNewVisitReason] = useState(appointment.note);
   const [oldNote, setRescheduleReason] = useState(appointment.note);
-
   const [selectedSlotId, setSelectedSlotId] = useState<string>();
 
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -800,6 +801,32 @@ const AppointmentActions = ({
       toast.success(t("appointment_cancelled"));
       queryClient.invalidateQueries({
         queryKey: ["appointment", appointment.id],
+      });
+    },
+  });
+
+  const { mutate: updateToken } = useMutation({
+    mutationFn: mutate(tokenApi.update, {
+      pathParams: {
+        facility_id: facilityId,
+        queue_id: appointment.token?.queue.id || "",
+        id: appointment.token?.id || "",
+      },
+    }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          "infinite-tokens",
+          facilityId,
+          appointment.token?.queue.id || "",
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "token-queue-summary",
+          facilityId,
+          appointment.token?.queue.id || "",
+        ],
       });
     },
   });
@@ -1084,12 +1111,17 @@ const AppointmentActions = ({
                   <AlertDialogFooter>
                     <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                     <AlertDialogAction
-                      onClick={() =>
+                      onClick={() => {
                         updateAppointment({
                           status: AppointmentStatus.NO_SHOW,
                           note: note,
-                        })
-                      }
+                        });
+                        updateToken({
+                          status: TokenStatus.CANCELLED,
+                          sub_queue: appointment.token?.sub_queue?.id || null,
+                          note: "",
+                        });
+                      }}
                       className={cn(buttonVariants({ variant: "destructive" }))}
                       disabled={!note.trim()}
                     >
@@ -1135,12 +1167,17 @@ const AppointmentActions = ({
                   <AlertDialogFooter>
                     <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                     <AlertDialogAction
-                      onClick={() =>
+                      onClick={() => {
                         cancelAppointment({
                           reason: "cancelled",
                           note: note,
-                        })
-                      }
+                        });
+                        updateToken({
+                          status: TokenStatus.CANCELLED,
+                          sub_queue: appointment.token?.sub_queue?.id || null,
+                          note: "",
+                        });
+                      }}
                       className={cn(buttonVariants({ variant: "destructive" }))}
                       disabled={!note.trim()}
                     >
@@ -1180,9 +1217,14 @@ const AppointmentActions = ({
                 <AlertDialogFooter>
                   <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                   <AlertDialogAction
-                    onClick={() =>
-                      cancelAppointment({ reason: "entered_in_error" })
-                    }
+                    onClick={() => {
+                      updateToken({
+                        status: TokenStatus.CANCELLED,
+                        sub_queue: appointment.token?.sub_queue?.id || null,
+                        note: "",
+                      });
+                      cancelAppointment({ reason: "entered_in_error" });
+                    }}
                     className={cn(buttonVariants({ variant: "destructive" }))}
                   >
                     {isCancelling ? (

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -793,18 +793,6 @@ const AppointmentActions = ({
 
   const [note, setNote] = useState(appointment.note);
 
-  const { mutate: cancelAppointment, isPending: isCancelling } = useMutation({
-    mutationFn: mutate(scheduleApis.appointments.cancel, {
-      pathParams: { facilityId, id: appointment.id },
-    }),
-    onSuccess: () => {
-      toast.success(t("appointment_cancelled"));
-      queryClient.invalidateQueries({
-        queryKey: ["appointment", appointment.id],
-      });
-    },
-  });
-
   const { mutate: updateToken } = useMutation({
     mutationFn: mutate(tokenApi.update, {
       pathParams: {
@@ -827,6 +815,23 @@ const AppointmentActions = ({
           facilityId,
           appointment.token?.queue.id || "",
         ],
+      });
+    },
+  });
+
+  const { mutate: cancelAppointment, isPending: isCancelling } = useMutation({
+    mutationFn: mutate(scheduleApis.appointments.cancel, {
+      pathParams: { facilityId, id: appointment.id },
+    }),
+    onSuccess: () => {
+      toast.success(t("appointment_cancelled"));
+      queryClient.invalidateQueries({
+        queryKey: ["appointment", appointment.id],
+      });
+      updateToken({
+        status: TokenStatus.CANCELLED,
+        sub_queue: appointment.token?.sub_queue?.id || null,
+        note: "",
       });
     },
   });
@@ -1167,17 +1172,12 @@ const AppointmentActions = ({
                   <AlertDialogFooter>
                     <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                     <AlertDialogAction
-                      onClick={() => {
+                      onClick={() =>
                         cancelAppointment({
                           reason: "cancelled",
                           note: note,
-                        });
-                        updateToken({
-                          status: TokenStatus.CANCELLED,
-                          sub_queue: appointment.token?.sub_queue?.id || null,
-                          note: "",
-                        });
-                      }}
+                        })
+                      }
                       className={cn(buttonVariants({ variant: "destructive" }))}
                       disabled={!note.trim()}
                     >
@@ -1217,14 +1217,9 @@ const AppointmentActions = ({
                 <AlertDialogFooter>
                   <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                   <AlertDialogAction
-                    onClick={() => {
-                      updateToken({
-                        status: TokenStatus.CANCELLED,
-                        sub_queue: appointment.token?.sub_queue?.id || null,
-                        note: "",
-                      });
-                      cancelAppointment({ reason: "entered_in_error" });
-                    }}
+                    onClick={() =>
+                      cancelAppointment({ reason: "entered_in_error" })
+                    }
                     className={cn(buttonVariants({ variant: "destructive" }))}
                   >
                     {isCancelling ? (

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -805,53 +805,53 @@ const AppointmentActions = ({
 
   const [note, setNote] = useState(appointment.note);
 
-  const { mutate: batchRequsetAppointment, isPending: isBatchRequestPending } =
-    useMutation({
-      mutationFn: mutate(batchApi.batchRequest),
-      onSuccess: () => {
-        toast.success(t("appointment_cancelled"));
-        queryClient.invalidateQueries({
-          queryKey: ["appointment", appointment.id],
-        });
-        if (appointment.token) {
-          queryClient.invalidateQueries({
-            queryKey: [
-              "infinite-tokens",
-              facilityId,
-              appointment.token?.queue.id || "",
-            ],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              "token-queue-summary",
-              facilityId,
-              appointment.token?.queue.id || "",
-            ],
-          });
-        }
-      },
-    });
+  type AppointmentBatchInput = {
+    requests: BatchRequestBody<
+      AppointmentCancelRequest | AppointmentRescheduleRequest | TokenUpdate
+    >["requests"];
+    mode: "cancel" | "reschedule";
+  };
 
   const {
-    mutate: batchRequestReschedule,
-    isPending: isBatchRequestRescheduling,
+    mutate: submitAppointmentBatch,
+    isPending: isAppointmentBatchPending,
   } = useMutation({
-    mutationFn: mutate(batchApi.batchRequest),
-    onSuccess: (response) => {
-      toast.success(t("appointment_rescheduled"));
+    mutationFn: (input: AppointmentBatchInput) =>
+      mutate(batchApi.batchRequest)({ requests: input.requests }),
+    onSuccess: (response, input: AppointmentBatchInput) => {
       queryClient.invalidateQueries({
         queryKey: ["appointment", appointment.id],
       });
-
-      setIsRescheduleOpen(false);
-      setSelectedSlotId(undefined);
-      setRescheduleReason("");
-      const newAppointment = extractAppointmentFromBatchResponse(
-        response as AppointmentBatchResponse,
-      );
-      navigate(
-        `/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${newAppointment.id}`,
-      );
+      if (appointment.token) {
+        queryClient.invalidateQueries({
+          queryKey: [
+            "infinite-tokens",
+            facilityId,
+            appointment.token?.queue.id || "",
+          ],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [
+            "token-queue-summary",
+            facilityId,
+            appointment.token?.queue.id || "",
+          ],
+        });
+      }
+      if (input.mode === "reschedule") {
+        toast.success(t("appointment_rescheduled"));
+        setIsRescheduleOpen(false);
+        setSelectedSlotId(undefined);
+        setRescheduleReason("");
+        const newAppointment = extractAppointmentFromBatchResponse(
+          response as unknown as AppointmentBatchResponse,
+        );
+        navigate(
+          `/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${newAppointment.id}`,
+        );
+      } else {
+        toast.success(t("appointment_cancelled"));
+      }
     },
   });
 
@@ -893,12 +893,10 @@ const AppointmentActions = ({
         },
       });
     }
-    batchRequestReschedule({
-      requests: requests,
-    });
+    submitAppointmentBatch({ requests, mode: "reschedule" });
   };
 
-  const handleAppointmentTokenUpdate = ({
+  const handleAppointmentTokenCancel = ({
     reason,
     note,
   }: {
@@ -937,9 +935,7 @@ const AppointmentActions = ({
         },
       });
     }
-    batchRequsetAppointment({
-      requests: requests,
-    });
+    submitAppointmentBatch({ requests, mode: "cancel" });
   };
 
   if (AppointmentFinalStatuses.includes(currentStatus)) {
@@ -1147,11 +1143,11 @@ const AppointmentActions = ({
                           <Button
                             variant="default"
                             disabled={
-                              !selectedSlotId || isBatchRequestRescheduling
+                              !selectedSlotId || isAppointmentBatchPending
                             }
                             onClick={handleRescheduleAppointment}
                           >
-                            {isBatchRequestRescheduling
+                            {isAppointmentBatchPending
                               ? t("rescheduling")
                               : t("reschedule")}
                           </Button>
@@ -1248,7 +1244,7 @@ const AppointmentActions = ({
                     <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                     <AlertDialogAction
                       onClick={() =>
-                        handleAppointmentTokenUpdate({
+                        handleAppointmentTokenCancel({
                           reason: "cancelled",
                           note: note,
                         })
@@ -1256,7 +1252,7 @@ const AppointmentActions = ({
                       className={cn(buttonVariants({ variant: "destructive" }))}
                       disabled={!note.trim()}
                     >
-                      {isBatchRequestPending ? (
+                      {isAppointmentBatchPending ? (
                         <Loader2 className="size-4 animate-spin mr-2" />
                       ) : (
                         t("confirm")
@@ -1293,13 +1289,13 @@ const AppointmentActions = ({
                   <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                   <AlertDialogAction
                     onClick={() =>
-                      handleAppointmentTokenUpdate({
+                      handleAppointmentTokenCancel({
                         reason: "entered_in_error",
                       })
                     }
                     className={cn(buttonVariants({ variant: "destructive" }))}
                   >
-                    {isBatchRequestPending ? (
+                    {isAppointmentBatchPending ? (
                       <Loader2 className="size-4 animate-spin mr-2" />
                     ) : (
                       t("confirm")

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -39,8 +39,10 @@ import {
 import {
   APPOINTMENT_STATUS_COLORS,
   Appointment,
+  AppointmentCancelRequest,
   AppointmentFinalStatuses,
   AppointmentRead,
+  AppointmentRescheduleRequest,
   AppointmentStatus,
   AppointmentUpdateRequest,
   SchedulableResourceType,
@@ -107,11 +109,21 @@ import { AppointmentDateSelection } from "@/pages/Appointments/BookAppointment/A
 import { AppointmentSlotPicker } from "@/pages/Appointments/BookAppointment/AppointmentSlotPicker";
 import { TokenCard } from "@/pages/Appointments/components/AppointmentTokenCard";
 import { TokenGenerationSheet } from "@/pages/Appointments/components/TokenGenerationSheet";
+import {
+  AppointmentBatchResponse,
+  extractAppointmentFromBatchResponse,
+} from "@/pages/Appointments/utils";
 import { QuickAction } from "@/pages/Encounters/tabs/overview/quick-actions";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
+import { BatchRequestBody } from "@/types/base/batch/batch";
+import batchApi from "@/types/base/batch/batchApi";
 import { ChargeItemServiceResource } from "@/types/billing/chargeItem/chargeItem";
 import { FacilityRead } from "@/types/facility/facility";
-import { TokenStatus } from "@/types/tokens/token/token";
+import {
+  TokenActiveStatuses,
+  TokenStatus,
+  TokenUpdate,
+} from "@/types/tokens/token/token";
 import tokenApi from "@/types/tokens/token/tokenApi";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import { formatPhoneNumberIntl } from "react-phone-number-input";
@@ -793,69 +805,142 @@ const AppointmentActions = ({
 
   const [note, setNote] = useState(appointment.note);
 
-  const { mutate: updateToken } = useMutation({
-    mutationFn: mutate(tokenApi.update, {
-      pathParams: {
-        facility_id: facilityId,
-        queue_id: appointment.token?.queue.id || "",
-        id: appointment.token?.id || "",
-      },
-    }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [
-          "infinite-tokens",
-          facilityId,
-          appointment.token?.queue.id || "",
-        ],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [
-          "token-queue-summary",
-          facilityId,
-          appointment.token?.queue.id || "",
-        ],
-      });
-    },
-  });
-
-  const { mutate: cancelAppointment, isPending: isCancelling } = useMutation({
-    mutationFn: mutate(scheduleApis.appointments.cancel, {
-      pathParams: { facilityId, id: appointment.id },
-    }),
-    onSuccess: () => {
-      toast.success(t("appointment_cancelled"));
-      queryClient.invalidateQueries({
-        queryKey: ["appointment", appointment.id],
-      });
-      if (appointment.token) {
-        updateToken({
-          status: TokenStatus.CANCELLED,
-          sub_queue: appointment.token.sub_queue?.id || null,
-          note: "",
-        });
-      }
-    },
-  });
-
-  const { mutate: rescheduleAppointment, isPending: isRescheduling } =
+  const { mutate: batchRequsetAppointment, isPending: isBatchRequestPending } =
     useMutation({
-      mutationFn: mutate(scheduleApis.appointments.reschedule, {
-        pathParams: { facilityId, id: appointment.id },
-      }),
-      onSuccess: (newAppointment: Appointment) => {
-        toast.success(t("appointment_rescheduled"));
+      mutationFn: mutate(batchApi.batchRequest),
+      onSuccess: () => {
+        toast.success(t("appointment_cancelled"));
         queryClient.invalidateQueries({
           queryKey: ["appointment", appointment.id],
         });
-        setIsRescheduleOpen(false);
-        setSelectedSlotId(undefined);
-        setRescheduleReason("");
-        navigate(
-          `/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${newAppointment.id}`,
-        );
+        if (appointment.token) {
+          queryClient.invalidateQueries({
+            queryKey: [
+              "infinite-tokens",
+              facilityId,
+              appointment.token?.queue.id || "",
+            ],
+          });
+          queryClient.invalidateQueries({
+            queryKey: [
+              "token-queue-summary",
+              facilityId,
+              appointment.token?.queue.id || "",
+            ],
+          });
+        }
       },
     });
+
+  const {
+    mutate: batchRequestReschedule,
+    isPending: isBatchRequestRescheduling,
+  } = useMutation({
+    mutationFn: mutate(batchApi.batchRequest),
+    onSuccess: (response) => {
+      toast.success(t("appointment_rescheduled"));
+      queryClient.invalidateQueries({
+        queryKey: ["appointment", appointment.id],
+      });
+
+      setIsRescheduleOpen(false);
+      setSelectedSlotId(undefined);
+      setRescheduleReason("");
+      const newAppointment = extractAppointmentFromBatchResponse(
+        response as AppointmentBatchResponse,
+      );
+      navigate(
+        `/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${newAppointment.id}`,
+      );
+    },
+  });
+
+  const handleRescheduleAppointment = () => {
+    const requests: BatchRequestBody<
+      AppointmentRescheduleRequest | TokenUpdate
+    >["requests"] = [];
+    if (selectedSlotId) {
+      requests.push({
+        url: scheduleApis.appointments.reschedule.path
+          .replace("{facilityId}", facilityId)
+          .replace("{id}", appointment.id),
+        method: scheduleApis.appointments.reschedule.method,
+        reference_id: "reschedule-appointment",
+        body: {
+          new_slot: selectedSlotId,
+          previous_booking_note: oldNote,
+          new_booking_note: newNote,
+          tags: appointment.tags.map((tag) => tag.id),
+        },
+      });
+    }
+
+    if (
+      appointment?.token &&
+      TokenActiveStatuses.includes(appointment.token.status)
+    ) {
+      requests.push({
+        url: tokenApi.update.path
+          .replace("{facility_id}", facilityId)
+          .replace("{queue_id}", appointment.token.queue.id)
+          .replace("{id}", appointment.token.id),
+        method: tokenApi.update.method,
+        reference_id: "token-cancelled",
+        body: {
+          note: "",
+          sub_queue: appointment.token.sub_queue?.id || null,
+          status: TokenStatus.CANCELLED,
+        },
+      });
+    }
+    batchRequestReschedule({
+      requests: requests,
+    });
+  };
+
+  const handleAppointmentTokenUpdate = ({
+    reason,
+    note,
+  }: {
+    reason: "cancelled" | "entered_in_error";
+    note?: string;
+  }) => {
+    const requests: BatchRequestBody<
+      AppointmentCancelRequest | TokenUpdate
+    >["requests"] = [];
+    requests.push({
+      url: scheduleApis.appointments.cancel.path
+        .replace("{facilityId}", facilityId)
+        .replace("{id}", appointment.id),
+      method: scheduleApis.appointments.cancel.method,
+      reference_id: "cancel-appointment",
+      body: {
+        reason: reason,
+        note: note || "",
+      },
+    });
+    if (
+      appointment?.token &&
+      TokenActiveStatuses.includes(appointment.token.status)
+    ) {
+      requests.push({
+        url: tokenApi.update.path
+          .replace("{facility_id}", facilityId)
+          .replace("{queue_id}", appointment.token.queue.id)
+          .replace("{id}", appointment.token.id),
+        method: tokenApi.update.method,
+        reference_id: "token-cancelled",
+        body: {
+          note: "",
+          sub_queue: appointment.token.sub_queue?.id || null,
+          status: TokenStatus.CANCELLED,
+        },
+      });
+    }
+    batchRequsetAppointment({
+      requests: requests,
+    });
+  };
 
   if (AppointmentFinalStatuses.includes(currentStatus)) {
     return null;
@@ -1061,19 +1146,12 @@ const AppointmentActions = ({
                           </Button>
                           <Button
                             variant="default"
-                            disabled={!selectedSlotId || isRescheduling}
-                            onClick={() => {
-                              if (selectedSlotId) {
-                                rescheduleAppointment({
-                                  new_slot: selectedSlotId,
-                                  previous_booking_note: oldNote,
-                                  new_booking_note: newNote,
-                                  tags: appointment.tags.map((tag) => tag.id),
-                                });
-                              }
-                            }}
+                            disabled={
+                              !selectedSlotId || isBatchRequestRescheduling
+                            }
+                            onClick={handleRescheduleAppointment}
                           >
-                            {isRescheduling
+                            {isBatchRequestRescheduling
                               ? t("rescheduling")
                               : t("reschedule")}
                           </Button>
@@ -1123,13 +1201,6 @@ const AppointmentActions = ({
                           status: AppointmentStatus.NO_SHOW,
                           note: note,
                         });
-                        if (appointment.token) {
-                          updateToken({
-                            status: TokenStatus.CANCELLED,
-                            sub_queue: appointment.token.sub_queue?.id || null,
-                            note: "",
-                          });
-                        }
                       }}
                       className={cn(buttonVariants({ variant: "destructive" }))}
                       disabled={!note.trim()}
@@ -1177,7 +1248,7 @@ const AppointmentActions = ({
                     <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                     <AlertDialogAction
                       onClick={() =>
-                        cancelAppointment({
+                        handleAppointmentTokenUpdate({
                           reason: "cancelled",
                           note: note,
                         })
@@ -1185,7 +1256,7 @@ const AppointmentActions = ({
                       className={cn(buttonVariants({ variant: "destructive" }))}
                       disabled={!note.trim()}
                     >
-                      {isCancelling ? (
+                      {isBatchRequestPending ? (
                         <Loader2 className="size-4 animate-spin mr-2" />
                       ) : (
                         t("confirm")
@@ -1222,11 +1293,13 @@ const AppointmentActions = ({
                   <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
                   <AlertDialogAction
                     onClick={() =>
-                      cancelAppointment({ reason: "entered_in_error" })
+                      handleAppointmentTokenUpdate({
+                        reason: "entered_in_error",
+                      })
                     }
                     className={cn(buttonVariants({ variant: "destructive" }))}
                   >
-                    {isCancelling ? (
+                    {isBatchRequestPending ? (
                       <Loader2 className="size-4 animate-spin mr-2" />
                     ) : (
                       t("confirm")

--- a/src/pages/Appointments/utils.ts
+++ b/src/pages/Appointments/utils.ts
@@ -11,7 +11,9 @@ import {
 
 import query from "@/Utils/request/query";
 import { dateQueryString, getMonthStartAndEnd } from "@/Utils/utils";
+import { BatchSuccessResponse } from "@/types/base/batch/batch";
 import {
+  Appointment,
   AvailabilityHeatmapResponse,
   PublicAppointment,
   SchedulableResourceType,
@@ -136,6 +138,16 @@ const getInfiniteAvailabilityHeatmap = ({
   }
 
   return result;
+};
+
+export interface AppointmentBatchResponse {
+  results: BatchSuccessResponse<{ appointment: Appointment }>;
+}
+
+export const extractAppointmentFromBatchResponse = (
+  response: AppointmentBatchResponse,
+): Appointment => {
+  return response.results.data?.appointment;
 };
 
 export const formatAppointmentSlotTime = (appointment: PublicAppointment) => {


### PR DESCRIPTION
## Proposed Changes

Fix #15777

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel and reschedule actions now execute as batched operations, improving consistency and navigation to newly created appointments after reschedule.
  * UI shows improved loading/disabled states while batch operations are in progress.

* **Bug Fixes**
  * Appointment cancellations and no-shows now also mark associated tokens as cancelled and refresh token-related views so token state stays consistent with appointment transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->