### PR TITLE
Add date and created_by filters to Print Charge Items page

### DIFF
--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -16,6 +16,13 @@ import PrintFooter from "@/components/Common/PrintFooter";
 import { Button } from "@/components/ui/button";
 import { MonetaryDisplay } from "@/components/ui/monetary-display";
 import {
+  createdByFilter,
+  dateFilter,
+} from "@/components/ui/multi-filter/filterConfigs";
+import MultiFilter from "@/components/ui/multi-filter/MultiFilter";
+import useMultiFilterState from "@/components/ui/multi-filter/utils/useMultiFilterState";
+import { FilterDateRange } from "@/components/ui/multi-filter/utils/Utils";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -51,6 +58,7 @@ import {
 } from "@/types/billing/paymentReconciliation/paymentReconciliation";
 import paymentReconciliationApi from "@/types/billing/paymentReconciliation/paymentReconciliationApi";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
+import { UserReadMinimal } from "@/types/user/user";
 
 import useFilters from "@/hooks/useFilters";
 
@@ -124,6 +132,76 @@ export const PrintChargeItems = (props: {
 
   const { qParams, updateQuery } = useFilters({ disableCache: true });
 
+  const filters = [
+    dateFilter("created_date", t("created_date")),
+    createdByFilter("created_by"),
+  ];
+
+  const onFilterUpdate = (filterQuery: Record<string, unknown>) => {
+    let updatedQuery = { ...filterQuery };
+
+    if ("created_date" in filterQuery) {
+      const dateRange = filterQuery.created_date as
+        | FilterDateRange
+        | undefined;
+      updatedQuery = {
+        ...updatedQuery,
+        created_date: undefined,
+        created_date_after: dateRange?.from?.toISOString() || undefined,
+        created_date_before: dateRange?.to?.toISOString() || undefined,
+      };
+    }
+
+    if ("created_by" in filterQuery) {
+      const createdByValue = filterQuery.created_by as
+        | UserReadMinimal
+        | UserReadMinimal[]
+        | undefined;
+      const user = Array.isArray(createdByValue)
+        ? createdByValue[0]
+        : createdByValue;
+      updatedQuery = {
+        ...updatedQuery,
+        created_by: user?.id || undefined,
+      };
+    }
+
+    updateQuery(updatedQuery);
+  };
+
+  const {
+    selectedFilters,
+    handleFilterChange,
+    handleOperationChange,
+    handleClearAll,
+    handleClearFilter,
+  } = useMultiFilterState(filters, onFilterUpdate, {
+    ...qParams,
+    created_date:
+      qParams.created_date_after || qParams.created_date_before
+        ? {
+            from: qParams.created_date_after
+              ? new Date(qParams.created_date_after as string)
+              : undefined,
+            to: qParams.created_date_before
+              ? new Date(qParams.created_date_before as string)
+              : undefined,
+          }
+        : undefined,
+    created_by: [],
+  });
+
+  const getDateQueryParams = () => {
+    const dateRange = selectedFilters.created_date?.selected as
+      | FilterDateRange
+      | undefined;
+    if (!dateRange) return {};
+    return {
+      created_date_after: dateRange.from?.toISOString(),
+      created_date_before: dateRange.to?.toISOString(),
+    };
+  };
+
   const hideCategoryLabel = `${t("hide_category_grouping")}`;
   const hidePaymentTypeLabel = `${t("hide_payment_type_grouping")}`;
   const summaryLabel = `${t("summary")}`;
@@ -141,13 +219,23 @@ export const PrintChargeItems = (props: {
   });
 
   const { data: chargeItems, isLoading } = useQuery({
-    queryKey: ["chargeItems", accountId, selectedStatuses, qParams.ordering],
+    queryKey: [
+      "chargeItems",
+      accountId,
+      selectedStatuses,
+      qParams.ordering,
+      qParams.created_by,
+      qParams.created_date_after,
+      qParams.created_date_before,
+    ],
     queryFn: query.paginated(chargeItemApi.listChargeItem, {
       pathParams: { facilityId },
       queryParams: {
         account: accountId,
         status: selectedStatuses.join(","),
         ordering: qParams.ordering,
+        created_by: qParams.created_by,
+        ...getDateQueryParams(),
       },
       pageSize: 100,
     }),
@@ -220,6 +308,16 @@ export const PrintChargeItems = (props: {
   return (
     <div>
       <div className="max-w-5xl mx-auto no-print mb-4 flex flex-wrap justify-start items-center gap-4 p-4 bg-gray-50 border rounded-md border-gray-200">
+        <MultiFilter
+          selectedFilters={selectedFilters}
+          onFilterChange={handleFilterChange}
+          onOperationChange={handleOperationChange}
+          onClearAll={handleClearAll}
+          onClearFilter={handleClearFilter}
+          className="flex flex-row-reverse flex-wrap sm:items-center"
+          facilityId={facilityId}
+        />
+
         <div className="gap-2 flex items-center">
           <Switch
             id="summary-mode"

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -141,9 +141,7 @@ export const PrintChargeItems = (props: {
     let updatedQuery = { ...filterQuery };
 
     if ("created_date" in filterQuery) {
-      const dateRange = filterQuery.created_date as
-        | FilterDateRange
-        | undefined;
+      const dateRange = filterQuery.created_date as FilterDateRange | undefined;
       updatedQuery = {
         ...updatedQuery,
         created_date: undefined,
@@ -202,6 +200,14 @@ export const PrintChargeItems = (props: {
     };
   };
 
+  const hasDateFilter = !!(
+    qParams.created_date_after || qParams.created_date_before
+  );
+  const hasCreatedByFilter = !!qParams.created_by;
+  const hasCategoryFilter = !!selectedCategory;
+  const canShowAccountSummary =
+    !hasDateFilter && !hasCreatedByFilter && !hasCategoryFilter;
+
   const hideCategoryLabel = `${t("hide_category_grouping")}`;
   const hidePaymentTypeLabel = `${t("hide_payment_type_grouping")}`;
   const summaryLabel = `${t("summary")}`;
@@ -242,7 +248,13 @@ export const PrintChargeItems = (props: {
   });
 
   const { data: paymentsResponse, isLoading: isLoadingPayments } = useQuery({
-    queryKey: ["payments", accountId],
+    queryKey: [
+      "payments",
+      accountId,
+      qParams.created_by,
+      qParams.created_date_after,
+      qParams.created_date_before,
+    ],
     queryFn: query.paginated(
       paymentReconciliationApi.listPaymentReconciliation,
       {
@@ -250,6 +262,8 @@ export const PrintChargeItems = (props: {
         queryParams: {
           account: accountId,
           ordering: "-payment_datetime",
+          created_by: qParams.created_by,
+          ...getDateQueryParams(),
         },
         pageSize: 100,
       },
@@ -308,16 +322,6 @@ export const PrintChargeItems = (props: {
   return (
     <div>
       <div className="max-w-5xl mx-auto no-print mb-4 flex flex-wrap justify-start items-center gap-4 p-4 bg-gray-50 border rounded-md border-gray-200">
-        <MultiFilter
-          selectedFilters={selectedFilters}
-          onFilterChange={handleFilterChange}
-          onOperationChange={handleOperationChange}
-          onClearAll={handleClearAll}
-          onClearFilter={handleClearFilter}
-          className="flex flex-row-reverse flex-wrap sm:items-center"
-          facilityId={facilityId}
-        />
-
         <div className="gap-2 flex items-center">
           <Switch
             id="summary-mode"
@@ -510,6 +514,16 @@ export const PrintChargeItems = (props: {
               </div>
             );
           })()}
+
+        <MultiFilter
+          selectedFilters={selectedFilters}
+          onFilterChange={handleFilterChange}
+          onOperationChange={handleOperationChange}
+          onClearAll={handleClearAll}
+          onClearFilter={handleClearFilter}
+          className="flex flex-row-reverse flex-wrap sm:items-center"
+          facilityId={facilityId}
+        />
       </div>
       <PrintPreview
         title={t("charge_items")}
@@ -1702,7 +1716,7 @@ export const PrintChargeItems = (props: {
                       )}
 
                       {/* Account Summary Section */}
-                      {account && (
+                      {account && canShowAccountSummary && (
                         <div className="overflow-hidden mt-4">
                           <Table className="w-full border [&_th]:text-xs [&_td]:text-xs">
                             <TableHeader className="[&_tr]:border [&_th]:p-0.5 [&_th]:h-auto">


### PR DESCRIPTION
## Summary
- Adds `MultiFilter` component to the Print Charge Items page with `created_date` (date range) and `created_by` (user) filters
- Filters are rendered in the non-printable toolbar alongside existing display options
- API query includes the new filter parameters (`created_date_after`, `created_date_before`, `created_by`)

Closes #15779

## Test plan
- [ ] Navigate to a billing account's Print Charge Items page
- [ ] Verify the MultiFilter dropdown appears in the toolbar
- [ ] Test filtering by date range (preset options and custom range)
- [ ] Test filtering by created_by user
- [ ] Verify both filters can be used together
- [ ] Verify clearing individual filters and "Clear All" works
- [ ] Verify filtered results update the printed table content
- [ ] Verify the filter UI does not appear in print output


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced multi-filter UI for billing charge items: filter by creation date range and creator.
  * Header-integrated filter controls for quick filtering and print workflows.
  * Consistent filtering behavior across listings, pagination, and print views.
  * Account summary now conditionally shown based on active filters for clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->