### PR TITLE
Uncheck "Select All" button in medication return dialog

### DIFF
--- a/src/pages/Facility/services/pharmacy/components/AddMedicationReturnItemForm.tsx
+++ b/src/pages/Facility/services/pharmacy/components/AddMedicationReturnItemForm.tsx
@@ -121,7 +121,7 @@ export function AddMedicationReturnItemForm({
 
   const loadFromMedicationDispenses = () => {
     setIsSelectDialogOpen(true);
-    handleSelectAll(true);
+    handleSelectAll(false);
   };
 
   const handleSelectAll = (checked: boolean) => {


### PR DESCRIPTION
## Proposed Changes

Fixes #15781 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default selection behavior in the medication dispense dialog. Previously, all items were automatically selected; now none are pre-selected by default. Users must manually choose the items they wish to return.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->