### PR TITLE
feat: add hideQuantity prop to StockLotSelector and update usage in AddMedicationReturnItemForm

### DIFF
--- a/src/pages/Facility/services/inventory/StockLotSelector.tsx
+++ b/src/pages/Facility/services/inventory/StockLotSelector.tsx
@@ -49,6 +49,7 @@ interface StockLotSelectorProps {
   disabled?: boolean;
   showUnitPrice?: boolean;
   net_content_gt?: number;
+  hideQuantity?: boolean;
 }
 
 export default function StockLotSelector({
@@ -67,6 +68,7 @@ export default function StockLotSelector({
   disabled = false,
   showUnitPrice = true,
   net_content_gt = 0,
+  hideQuantity = false,
 }: StockLotSelectorProps) {
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState("");
@@ -161,7 +163,7 @@ export default function StockLotSelector({
                 return (
                   <div
                     key={lot.selectedInventoryId}
-                    className="flex flex-col w-full bg-gray-50 px-1 py-0.5 border-gray-200 border rounded-sm text-gray-950 gap-0.5"
+                    className="flex flex-wrap w-full bg-gray-50 px-1 py-0.5 border-gray-200 border rounded-sm text-gray-950 gap-0.5"
                   >
                     <div className="flex items-center justify-between gap-1">
                       <span
@@ -192,21 +194,23 @@ export default function StockLotSelector({
                             />
                           </Badge>
                         )}
-                        <Badge
-                          variant={
-                            selectedInventory?.status === "active" &&
-                            isPositive(selectedInventory?.net_content || 0)
-                              ? "primary"
-                              : "destructive"
-                          }
-                          className="border-none rounded-sm text-xs px-1 py-0"
-                        >
-                          {selectedInventory && (
-                            <>{round(selectedInventory.net_content)} </>
-                          )}
-                          {selectedInventory?.product.product_knowledge
-                            .base_unit.display || t("units")}
-                        </Badge>
+                        {!hideQuantity && (
+                          <Badge
+                            variant={
+                              selectedInventory?.status === "active" &&
+                              isPositive(selectedInventory?.net_content || 0)
+                                ? "primary"
+                                : "destructive"
+                            }
+                            className="border-none rounded-sm text-xs px-1 py-0"
+                          >
+                            {selectedInventory && (
+                              <>{round(selectedInventory.net_content)} </>
+                            )}
+                            {selectedInventory?.product.product_knowledge
+                              .base_unit.display || t("units")}
+                          </Badge>
+                        )}
                       </div>
                     </div>
                     {showexpiry &&

--- a/src/pages/Facility/services/pharmacy/components/AddMedicationReturnItemForm.tsx
+++ b/src/pages/Facility/services/pharmacy/components/AddMedicationReturnItemForm.tsx
@@ -329,6 +329,7 @@ export function AddMedicationReturnItemForm({
                                     <FormControl>
                                       <StockLotSelector
                                         net_content_gt={-1}
+                                        hideQuantity
                                         selectedLots={
                                           field.value
                                             ? [


### PR DESCRIPTION
Fixes #15788

<img width="1098" height="448" alt="image" src="https://github.com/user-attachments/assets/3b7c64e3-abe6-4c20-a4d1-9e6df543e093" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to hide quantity displays in stock lot selection, providing more flexible UI configurations for medication returns and inventory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->