### PR TITLE
Delivery order details - show extensions, add serial no

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -1,4 +1,5 @@
 {
+  "#": "#",
   "2FA_backup_code": "2FA Backup Code",
   "404_message": "This page doesn't exist or may have been moved. Please check the URL and try again.",
   "APPETITE__CANNOT_BE_ASSESSED": "Cannot be assessed",
@@ -2058,7 +2059,6 @@
   "enable_when__any": "Any one or more of the conditions must be met",
   "enable_when_conditions": "Enable when conditions",
   "enabled": "Enabled",
-  "include_filters": "Include filters",
   "enabled_only_for_partially_dispensed": "Enabled only for partially dispensed medications",
   "encounter": "Encounter",
   "encounter_actions": "Encounter Actions",
@@ -2713,6 +2713,7 @@
   "inactive": "Inactive",
   "include": "Include",
   "include_cancelled": "Include Cancelled",
+  "include_filters": "Include filters",
   "include_rules": "Include rules",
   "includes_all_taxes": "Includes all applicable taxes",
   "incoming": "Incoming",

--- a/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
+++ b/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
@@ -36,6 +36,7 @@ import { MonetaryComponentType } from "@/types/base/monetaryComponent/monetaryCo
 import { ExtensionEntityType } from "@/types/extensions/extensions";
 import { DeliveryOrderStatus } from "@/types/inventory/deliveryOrder/deliveryOrder";
 import {
+  ACTIVE_SUPPLY_DELIVERY_STATUSES,
   SUPPLY_DELIVERY_CONDITION_COLORS,
   SUPPLY_DELIVERY_STATUS_COLORS,
   SupplyDeliveryRead,
@@ -143,6 +144,22 @@ export function SupplyDeliveryTable({
     selectedDeliveries.length,
   ]);
 
+  // Build a map of delivery id -> serial number for non-cancelled deliveries
+  const serialNumberMap = useMemo(() => {
+    const map = new Map<string, number>();
+    let serial = 1;
+    for (const delivery of deliveries) {
+      if (
+        ACTIVE_SUPPLY_DELIVERY_STATUSES.includes(
+          delivery.status as (typeof ACTIVE_SUPPLY_DELIVERY_STATUSES)[number],
+        )
+      ) {
+        map.set(delivery.id, serial++);
+      }
+    }
+    return map;
+  }, [deliveries]);
+
   return (
     <Table>
       <TableHeader>
@@ -160,6 +177,7 @@ export function SupplyDeliveryTable({
               <ShortcutBadge actionId="select-all" alwaysShow={false} />
             </TableHead>
           )}
+          <TableHead rowSpan={2}>{t("#")}</TableHead>
           <TableHead rowSpan={2}>{t("item")}</TableHead>
           <TableHead rowSpan={2}>{t("batch")}</TableHead>
           <TableHead rowSpan={2}>{t("requested_qty")}</TableHead>
@@ -219,6 +237,7 @@ export function SupplyDeliveryTable({
                 )}
               </TableCell>
             )}
+            <TableCell>{serialNumberMap.get(delivery.id)}</TableCell>
             <TableCell
               className={cn(onDeliveryClick && "cursor-pointer underline")}
               onClick={() => onDeliveryClick?.(delivery)}

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
@@ -219,6 +219,7 @@ export function DeliveryOrderShow({
         queryParams: {
           order: deliveryOrderId,
           facility: facilityId,
+          ordering: "created_date",
         },
       }),
       enabled: !!deliveryOrderId,

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
@@ -9,7 +9,7 @@ import {
   Truck,
 } from "lucide-react";
 import { Link } from "raviger";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -45,10 +45,17 @@ import {
 import { EmptyState } from "@/components/ui/empty-state";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  getExtensionFieldsWithName,
+  getExtensionValue,
+  NamespacedExtensionData,
+} from "@/hooks/useExtensions";
+import useExtensionSchemas from "@/hooks/useExtensionSchemas";
 import { AddSupplyDeliveryForm } from "@/pages/Facility/services/inventory/externalSupply/deliveryOrder/AddSupplyDeliveryForm";
 import { getInventoryBasePath } from "@/pages/Facility/services/inventory/externalSupply/utils/inventoryUtils";
 import { ProductKnowledgeSelect } from "@/pages/Facility/services/inventory/ProductKnowledgeSelect";
 import { SupplyDeliveryTable } from "@/pages/Facility/services/inventory/SupplyDeliveryTable";
+import { ExtensionEntityType } from "@/types/extensions/extensions";
 import {
   DELIVERY_ORDER_STATUS_COLORS,
   DeliveryOrderRetrieve,
@@ -65,6 +72,7 @@ import supplyDeliveryApi from "@/types/inventory/supplyDelivery/supplyDeliveryAp
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { formatDateTime } from "@/Utils/utils";
 
 interface Props {
   facilityId: string;
@@ -163,6 +171,18 @@ export function DeliveryOrderShow({
 }: Props) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const { getExtensions } = useExtensionSchemas();
+
+  const allExtensions = getExtensions(
+    ExtensionEntityType.supply_delivery_order,
+    "read",
+  );
+
+  const extensionFields = useMemo(
+    () => getExtensionFieldsWithName(allExtensions),
+    [allExtensions],
+  );
+
   const [selectedDeliveries, setSelectedDeliveries] = useState<string[]>([]);
   const [confirmDialog, setConfirmDialog] = useState({
     open: false,
@@ -620,6 +640,31 @@ export function DeliveryOrderShow({
                   </div>
                 </div>
               </div>
+
+              {extensionFields.map((field) => {
+                const value = getExtensionValue(
+                  deliveryOrder.extensions as NamespacedExtensionData,
+                  field.extensionName,
+                  field.name,
+                );
+                if (value === undefined || value === null) return null;
+
+                const displayValue =
+                  field.format === "date" || field.format === "date-time"
+                    ? formatDateTime(value as string)
+                    : String(value);
+
+                return (
+                  <div key={`${field.extensionName}-${field.name}`}>
+                    <label className="text-sm font-medium text-gray-700">
+                      {field.label}
+                    </label>
+                    <div className="text-lg font-semibold text-gray-950">
+                      {displayValue}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </CardContent>
         </Card>

--- a/src/types/inventory/supplyDelivery/supplyDelivery.ts
+++ b/src/types/inventory/supplyDelivery/supplyDelivery.ts
@@ -9,6 +9,11 @@ export enum SupplyDeliveryStatus {
   entered_in_error = "entered_in_error",
 }
 
+export const ACTIVE_SUPPLY_DELIVERY_STATUSES = [
+  SupplyDeliveryStatus.in_progress,
+  SupplyDeliveryStatus.completed,
+] as const;
+
 export const SUPPLY_DELIVERY_STATUS_COLORS = {
   in_progress: "blue",
   completed: "green",


### PR DESCRIPTION
Show bill number, date etc,  add serial no

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delivery Order details now show dynamic custom extension fields with formatted values (including dates).
  * Supply deliveries are listed by creation date and include a new serial-number column for active deliveries.

* **Chores**
  * Added a new locale translation key.
  * Introduced a constant grouping for active delivery statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->