### PR TITLE
added created_by field in Request and Delivery Order See details pages

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
@@ -65,6 +65,7 @@ import supplyDeliveryApi from "@/types/inventory/supplyDelivery/supplyDeliveryAp
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { formatDateTime, formatName } from "@/Utils/utils";
 
 interface Props {
   facilityId: string;
@@ -620,6 +621,21 @@ export function DeliveryOrderShow({
                   </div>
                 </div>
               </div>
+              {deliveryOrder.created_by && (
+                <div>
+                  <label className="text-sm font-medium text-gray-700">
+                    {t("created_by")}
+                  </label>
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-md font-semibold text-gray-950">
+                      {formatName(deliveryOrder.created_by)}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {formatDateTime(deliveryOrder.created_date)}
+                    </span>
+                  </div>
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/pages/Facility/services/inventory/externalSupply/requestOrder/RequestOrderShow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/requestOrder/RequestOrderShow.tsx
@@ -62,6 +62,7 @@ import { add, isPositive, round, subtract } from "@/Utils/decimal";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { formatDateTime, formatName } from "@/Utils/utils";
 import Decimal from "decimal.js";
 
 interface AllSupplyDeliveriesProps {
@@ -472,7 +473,7 @@ export function RequestOrderShow({
 
         <Card className="border-none rounded-lg">
           <CardContent className="space-y-1 p-4">
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
               <div>
                 <label className="text-sm font-medium text-gray-700">
                   {t("deliver_to")}
@@ -573,6 +574,21 @@ export function RequestOrderShow({
                   </Badge>
                 </div>
               </div>
+              {requestOrder.created_by && (
+                <div>
+                  <label className="text-sm font-medium text-gray-700">
+                    {t("created_by")}
+                  </label>
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-md font-semibold text-gray-950">
+                      {formatName(requestOrder.created_by)}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {formatDateTime(requestOrder.created_date)}
+                    </span>
+                  </div>
+                </div>
+              )}
             </div>
 
             {requestOrder.note && (


### PR DESCRIPTION
## Proposed Changes

Fixes #15794 

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added creator information display to order details screens, showing the name of the person who created the delivery order or request order, along with the creation timestamp.
  * Enhanced responsive grid layout on request order details for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->