### PR TITLE
added created_by field in dispense order view page

### DIFF
--- a/src/pages/Facility/services/pharmacy/DispensesView.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensesView.tsx
@@ -20,7 +20,7 @@ import dispenseOrderApi from "@/types/emr/dispenseOrder/dispenseOrderApi";
 import { MedicationDispenseStatus } from "@/types/emr/medicationDispense/medicationDispense";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import query from "@/Utils/request/query";
-import { formatDateTime } from "@/Utils/utils";
+import { formatDateTime, formatName } from "@/Utils/utils";
 
 import { PatientHeader } from "@/components/Patient/PatientHeader";
 import { PrescriptionSummary } from "@/types/emr/prescription/prescription";
@@ -150,6 +150,14 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
               <p className="text-sm text-gray-600">{dispenseOrder.note}</p>
             )}
             <div className="flex items-center gap-4 text-sm text-gray-700">
+              {dispenseOrder.created_by && (
+                <div>
+                  <span className="text-gray-500">{t("created_by")}:</span>{" "}
+                  <span className="font-medium">
+                    {formatName(dispenseOrder.created_by)}
+                  </span>
+                </div>
+              )}
               <div>
                 <span className="text-gray-500">{t("created_at")}:</span>{" "}
                 <span className="font-medium">

--- a/src/types/emr/dispenseOrder/dispenseOrder.ts
+++ b/src/types/emr/dispenseOrder/dispenseOrder.ts
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { BatchSuccessResponse } from "@/types/base/batch/batch";
 import { PatientListRead, PatientRead } from "@/types/emr/patient/patient";
 import { LocationRead } from "@/types/location/location";
+import { UserReadMinimal } from "@/types/user/user";
 
 export interface DispenseOrderBatchResponse {
   results: BatchSuccessResponse<{ order: DispenseOrderRead }>[];
@@ -34,6 +35,7 @@ export interface DispenseOrderBase {
 export interface DispenseOrderRead extends DispenseOrderBase {
   patient: PatientRead;
   location: LocationRead;
+  created_by: UserReadMinimal;
   created_date: string;
   modified_date: string;
 }

--- a/src/types/emr/dispenseOrder/dispenseOrder.ts
+++ b/src/types/emr/dispenseOrder/dispenseOrder.ts
@@ -35,7 +35,7 @@ export interface DispenseOrderBase {
 export interface DispenseOrderRead extends DispenseOrderBase {
   patient: PatientRead;
   location: LocationRead;
-  created_by: UserReadMinimal;
+  created_by: UserReadMinimal | null;
   created_date: string;
   modified_date: string;
 }


### PR DESCRIPTION
## Proposed Changes

Fixes #15796 

<img width="1606" height="962" alt="image" src="https://github.com/user-attachments/assets/a9d810d5-d533-4514-b98b-2a51bd37b0f9" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dispense orders now display the creator's name in the order header when available, improving attribution and tracking visibility.
  * Creator attribution is optional and does not alter existing timestamps or other header details.
  * Appears only when creator information is present, preserving current views otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->