### PR TITLE
fix: queue board mobile layout

### DIFF
--- a/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
@@ -62,7 +62,7 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex justify-between items-end gap-4">
+      <div className="flex flex-col sm:flex-row justify-between items-start mt-2 gap-4">
         <div className="flex flex-col gap-2">
           <Label className="text-gray-950 text-sm font-medium">
             {t("search_patients")}

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -105,7 +105,7 @@ export function OngoingQueueTokenCard({
             )}
             {/* TODO: do we show tags here? or something else? */}
           </div>
-          <div className="flex w-full md:w-auto items-center gap-3 md:gap-1 mt-2">
+          <div className="flex w-full md:w-auto items-center gap-3 mt-1">
             {token ? (
               <>
                 <Button variant="outline" asChild>

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -81,12 +81,12 @@ export function OngoingQueueTokenCard({
       <ContextMenuTrigger ref={contextMenuTriggerRef}>
         <div
           className={cn(
-            "relative flex gap-3 items-center justify-between p-3 bg-gray-50 rounded-lg shadow",
+            "relative flex flex-col md:flex-row gap-1 md:gap-3 items-start md:items-center justify-between p-3 bg-gray-50 rounded-lg shadow",
             token?.status === TokenStatus.IN_PROGRESS &&
               "border border-primary-500",
           )}
         >
-          <div className="flex flex-col">
+          <div className="w-full md:w-auto">
             {token ? (
               <Link
                 basePath="/"
@@ -105,9 +105,9 @@ export function OngoingQueueTokenCard({
             )}
             {/* TODO: do we show tags here? or something else? */}
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 md:gap-1 mt-2">
             {token ? (
-              <div className="flex gap-3 justify-center items-center">
+              <>
                 <Button variant="outline" asChild>
                   <Link
                     basePath="/"
@@ -121,31 +121,33 @@ export function OngoingQueueTokenCard({
                     {renderTokenNumber(token)}
                   </span>
                 </div>
-              </div>
+                {options}
+                <div className="ml-auto">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      const rect = e.currentTarget.getBoundingClientRect();
+                      const x = rect.left + rect.width / 2;
+                      const y = rect.bottom;
+                      contextMenuTriggerRef.current?.dispatchEvent(
+                        new MouseEvent("contextmenu", {
+                          bubbles: true,
+                          cancelable: true,
+                          clientX: x,
+                          clientY: y,
+                        }),
+                      );
+                    }}
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </div>
+              </>
             ) : (
               <Skeleton className="h-12 w-20" />
             )}
-            {options}
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={(e) => {
-                e.preventDefault();
-                const rect = e.currentTarget.getBoundingClientRect();
-                const x = rect.left + rect.width / 2;
-                const y = rect.bottom;
-                contextMenuTriggerRef.current?.dispatchEvent(
-                  new MouseEvent("contextmenu", {
-                    bubbles: true,
-                    cancelable: true,
-                    clientX: x,
-                    clientY: y,
-                  }),
-                );
-              }}
-            >
-              <MoreHorizontal className="size-4" />
-            </Button>
           </div>
         </div>
       </ContextMenuTrigger>

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -105,7 +105,7 @@ export function OngoingQueueTokenCard({
             )}
             {/* TODO: do we show tags here? or something else? */}
           </div>
-          <div className="flex items-center gap-3 md:gap-1 mt-2">
+          <div className="flex w-full md:w-auto items-center gap-3 md:gap-1 mt-2">
             {token ? (
               <>
                 <Button variant="outline" asChild>
@@ -116,7 +116,7 @@ export function OngoingQueueTokenCard({
                     {t("encounter")}
                   </Link>
                 </Button>
-                <div className="flex gap-2 items-center justify-center p-2 bg-gray-100 border border-gray-200 rounded-lg">
+                <div className="flex gap-2 items-center justify-center p-1 bg-gray-100 border border-gray-200 rounded-lg">
                   <span className="text-lg font-bold text-black">
                     {renderTokenNumber(token)}
                   </span>
@@ -153,7 +153,7 @@ export function OngoingQueueTokenCard({
       </ContextMenuTrigger>
       {token && (
         <>
-          <ContextMenuContent>
+          <ContextMenuContent collisionPadding={8} avoidCollisions={true}>
             {token.status === TokenStatus.CREATED && token.sub_queue && (
               <>
                 <ContextMenuItem


### PR DESCRIPTION
## Proposed Changes

Fixes #15810 

<img width="356" height="633" alt="image" src="https://github.com/user-attachments/assets/c4c737fe-bfc7-45e2-8daf-9c829c8b345c" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout of the facility queue control bar: stacks vertically on small screens and switches to horizontal on larger screens for better alignment, spacing, and consistent start alignment.
  * Updated responsive layout of queue token cards: header, metadata and action area reflow across viewports, actions are grouped inline, context menu trigger behavior and positioning refined for more predictable interaction and tighter spacing on larger screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->