### PR TITLE
fix date issue in payment print

### DIFF
--- a/src/pages/Facility/billing/paymentReconciliation/PrintPaymentReconciliation.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PrintPaymentReconciliation.tsx
@@ -173,7 +173,7 @@ export function PrintPaymentReconciliation({
             <div className="space-y-1">
               <DetailRow
                 label={`${t("date")}`}
-                value={formatDateTime(new Date(), "DD-MM-YYYY")}
+                value={formatDateTime(payment.created_date, "DD-MM-YYYY")}
                 width="w-24"
               />
               {payment.account.patient?.instance_identifiers


### PR DESCRIPTION
## Proposed Changes

Fixes #15817

<img width="828" height="729" alt="image" src="https://github.com/user-attachments/assets/bbd06568-97fd-48c3-9257-bdeacc7c3be6" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment reconciliation print to display the correct payment creation date instead of the current date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->