### PR TITLE
fix: medication dispense as a clickable link in charge items tab

### DIFF
--- a/src/Routers/routes/FacilityRoutes.tsx
+++ b/src/Routers/routes/FacilityRoutes.tsx
@@ -191,13 +191,13 @@ const FacilityRoutes: AppRoutes = {
   "/facility/:facilityId/template/builder/:slug": ({ facilityId, slug }) => (
     <TemplateBuilder facilityId={facilityId} slug={slug} />
   ),
-  "/facility/:facilityId/medication_dispense/redirect/:serviceResourceId": ({
+  "/facility/:facilityId/medication_dispense/redirect/:medicationDispenseId": ({
     facilityId,
-    serviceResourceId,
+    medicationDispenseId,
   }) => (
     <MedicationDispenseRedirect
       facilityId={facilityId}
-      serviceResourceId={serviceResourceId}
+      medicationDispenseId={medicationDispenseId}
     />
   ),
 };

--- a/src/Routers/routes/FacilityRoutes.tsx
+++ b/src/Routers/routes/FacilityRoutes.tsx
@@ -2,6 +2,7 @@ import { Redirect } from "raviger";
 
 import FacilityUsers from "@/components/Facility/FacilityUsers";
 import ResourceCreate from "@/components/Resource/ResourceForm";
+import MedicationDispenseRedirect from "@/pages/Facility/billing/account/components/MedicationDispenseRedirect";
 
 import BedAvailabilityDashboard from "@/pages/Facility/BedAvailabilityDashboard";
 
@@ -189,6 +190,15 @@ const FacilityRoutes: AppRoutes = {
   ),
   "/facility/:facilityId/template/builder/:slug": ({ facilityId, slug }) => (
     <TemplateBuilder facilityId={facilityId} slug={slug} />
+  ),
+  "/facility/:facilityId/medication_dispense/redirect/:service_resource_id": ({
+    facilityId,
+    service_resource_id,
+  }) => (
+    <MedicationDispenseRedirect
+      facilityId={facilityId}
+      service_resource_id={service_resource_id}
+    />
   ),
 };
 

--- a/src/Routers/routes/FacilityRoutes.tsx
+++ b/src/Routers/routes/FacilityRoutes.tsx
@@ -191,13 +191,13 @@ const FacilityRoutes: AppRoutes = {
   "/facility/:facilityId/template/builder/:slug": ({ facilityId, slug }) => (
     <TemplateBuilder facilityId={facilityId} slug={slug} />
   ),
-  "/facility/:facilityId/medication_dispense/redirect/:service_resource_id": ({
+  "/facility/:facilityId/medication_dispense/redirect/:serviceResourceId": ({
     facilityId,
-    service_resource_id,
+    serviceResourceId,
   }) => (
     <MedicationDispenseRedirect
       facilityId={facilityId}
-      service_resource_id={service_resource_id}
+      serviceResourceId={serviceResourceId}
     />
   ),
 };

--- a/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
@@ -280,6 +280,8 @@ export function ChargeItemsTable({
         return `/facility/${facilityId}/service_requests/${item.service_resource_id}`;
       case ChargeItemServiceResource.appointment:
         return `/facility/${facilityId}/patient/${patientId}/appointments/${item.service_resource_id}`;
+      case ChargeItemServiceResource.medication_dispense:
+        return `/facility/${facilityId}/medication_dispense/redirect/${item.service_resource_id}`;
       default:
         return "";
     }

--- a/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
+++ b/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
@@ -18,7 +18,6 @@ const MedicationDispenseRedirect = ({
     queryFn: query(medicationDispenseApi.get, {
       pathParams: { id: medicationDispenseId },
     }),
-    enabled: !!medicationDispenseId,
   });
 
   if (isLoading) {
@@ -33,7 +32,7 @@ const MedicationDispenseRedirect = ({
       />
     );
   }
-  return <Loading />;
+  return <></>;
 };
 
 export default MedicationDispenseRedirect;

--- a/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
+++ b/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
@@ -1,5 +1,6 @@
 import query from "@/Utils/request/query";
 import Loading from "@/components/Common/Loading";
+import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import { useQuery } from "@tanstack/react-query";
 import { Redirect } from "raviger";
@@ -32,7 +33,7 @@ const MedicationDispenseRedirect = ({
       />
     );
   }
-  return <></>;
+  return <ErrorPage />;
 };
 
 export default MedicationDispenseRedirect;

--- a/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
+++ b/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
@@ -1,0 +1,40 @@
+import query from "@/Utils/request/query";
+import Loading from "@/components/Common/Loading";
+import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
+import { useQuery } from "@tanstack/react-query";
+import { Redirect } from "raviger";
+
+interface MedicationDispenseRedirectProps {
+  facilityId: string;
+  service_resource_id: string;
+}
+
+const MedicationDispenseRedirect = ({
+  facilityId,
+  service_resource_id,
+}: MedicationDispenseRedirectProps) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ["medication_dispense", service_resource_id],
+    queryFn: query(medicationDispenseApi.get, {
+      pathParams: { id: service_resource_id },
+    }),
+    enabled: !!service_resource_id,
+  });
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  const locationId = data?.location?.id;
+  const dispenseOrderId = data?.order?.id;
+  if (facilityId && locationId && dispenseOrderId) {
+    return (
+      <Redirect
+        to={`/facility/${facilityId}/locations/${locationId}/medication_dispense/order/${dispenseOrderId}`}
+      />
+    );
+  }
+  return <Loading />;
+};
+
+export default MedicationDispenseRedirect;

--- a/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
+++ b/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
@@ -6,25 +6,24 @@ import { Redirect } from "raviger";
 
 interface MedicationDispenseRedirectProps {
   facilityId: string;
-  serviceResourceId: string;
+  medicationDispenseId: string;
 }
 
 const MedicationDispenseRedirect = ({
   facilityId,
-  serviceResourceId,
+  medicationDispenseId,
 }: MedicationDispenseRedirectProps) => {
   const { data, isLoading } = useQuery({
-    queryKey: ["medication_dispense", serviceResourceId],
+    queryKey: ["medication_dispense", medicationDispenseId],
     queryFn: query(medicationDispenseApi.get, {
-      pathParams: { id: serviceResourceId },
+      pathParams: { id: medicationDispenseId },
     }),
-    enabled: !!serviceResourceId,
+    enabled: !!medicationDispenseId,
   });
 
   if (isLoading) {
     return <Loading />;
   }
-
   const locationId = data?.location?.id;
   const dispenseOrderId = data?.order?.id;
   if (facilityId && locationId && dispenseOrderId) {

--- a/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
+++ b/src/pages/Facility/billing/account/components/MedicationDispenseRedirect.tsx
@@ -6,19 +6,19 @@ import { Redirect } from "raviger";
 
 interface MedicationDispenseRedirectProps {
   facilityId: string;
-  service_resource_id: string;
+  serviceResourceId: string;
 }
 
 const MedicationDispenseRedirect = ({
   facilityId,
-  service_resource_id,
+  serviceResourceId,
 }: MedicationDispenseRedirectProps) => {
   const { data, isLoading } = useQuery({
-    queryKey: ["medication_dispense", service_resource_id],
+    queryKey: ["medication_dispense", serviceResourceId],
     queryFn: query(medicationDispenseApi.get, {
-      pathParams: { id: service_resource_id },
+      pathParams: { id: serviceResourceId },
     }),
-    enabled: !!service_resource_id,
+    enabled: !!serviceResourceId,
   });
 
   if (isLoading) {

--- a/src/pages/Facility/services/pharmacy/DispensesView.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensesView.tsx
@@ -46,11 +46,7 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
 
   const medicationDispenseStatus = qParams.status as MedicationDispenseStatus;
 
-  const {
-    data: dispenseOrder,
-    isLoading: isLoadingOrder,
-    isError,
-  } = useQuery({
+  const { data: dispenseOrder, isLoading: isLoadingOrder } = useQuery({
     queryKey: ["dispenseOrder", facilityId, dispenseOrderId],
     queryFn: query(dispenseOrderApi.get, {
       pathParams: { facilityId, id: dispenseOrderId },
@@ -88,7 +84,7 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
     return <TableSkeleton count={5} />;
   }
 
-  if (isError || !dispenseOrder) {
+  if (!dispenseOrder) {
     return <ErrorPage />;
   }
 

--- a/src/pages/Facility/services/pharmacy/DispensesView.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensesView.tsx
@@ -9,6 +9,7 @@ import { Card } from "@/components/ui/card";
 
 import Page from "@/components/Common/Page";
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
+import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 
 import useFilters from "@/hooks/useFilters";
 import useCurrentLocation from "@/pages/Facility/locations/utils/useCurrentLocation";
@@ -45,7 +46,11 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
 
   const medicationDispenseStatus = qParams.status as MedicationDispenseStatus;
 
-  const { data: dispenseOrder, isLoading: isLoadingOrder } = useQuery({
+  const {
+    data: dispenseOrder,
+    isLoading: isLoadingOrder,
+    isError,
+  } = useQuery({
     queryKey: ["dispenseOrder", facilityId, dispenseOrderId],
     queryFn: query(dispenseOrderApi.get, {
       pathParams: { facilityId, id: dispenseOrderId },
@@ -83,8 +88,8 @@ export default function DispensesView({ facilityId, dispenseOrderId }: Props) {
     return <TableSkeleton count={5} />;
   }
 
-  if (!dispenseOrder) {
-    return null;
+  if (isError || !dispenseOrder) {
+    return <ErrorPage />;
   }
 
   // Filter medications by current status


### PR DESCRIPTION
## Proposed Changes

Fixes #15823

<img width="1627" height="583" alt="image" src="https://github.com/user-attachments/assets/1f68440e-63d8-42a1-80f2-6a43adebc62d" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a medication-dispense redirect allowing direct navigation to medication dispense orders from billing/account.
  * New route enables direct access via medication-dispense links.
  * Charge items now include links that route users into the medication-dispense redirect flow for faster navigation.

* **Bug Fixes**
  * Improved error handling in the dispense view to show an error page when dispense order data is missing; loading states retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->