### PR TITLE
feat: enhance SupplyDeliveryTable with linkToProduct prop

### DIFF
--- a/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
+++ b/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
+import { EllipsisVertical } from "lucide-react";
+import { Link } from "raviger";
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -46,7 +48,6 @@ import supplyDeliveryApi from "@/types/inventory/supplyDelivery/supplyDeliveryAp
 import { add, round } from "@/Utils/decimal";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
-import { EllipsisVertical } from "lucide-react";
 
 interface SupplyDeliveryTableProps {
   deliveries: SupplyDeliveryRead[];
@@ -59,6 +60,8 @@ interface SupplyDeliveryTableProps {
   deliveryOrderStatus?: DeliveryOrderStatus;
   autoSelectOnMount?: boolean;
   isRequester?: boolean;
+  facilityId?: string;
+  linkToProduct?: boolean;
 }
 
 export function SupplyDeliveryTable({
@@ -72,6 +75,8 @@ export function SupplyDeliveryTable({
   deliveryOrderStatus,
   autoSelectOnMount = false,
   isRequester = false,
+  facilityId,
+  linkToProduct = false,
 }: SupplyDeliveryTableProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -242,12 +247,29 @@ export function SupplyDeliveryTable({
               className={cn(onDeliveryClick && "cursor-pointer underline")}
               onClick={() => onDeliveryClick?.(delivery)}
             >
-              <div className="font-medium">
-                {internal
+              {(() => {
+                const productId = internal
+                  ? delivery.supplied_inventory_item?.product?.id
+                  : delivery.supplied_item?.id;
+                const productName = internal
                   ? delivery.supplied_inventory_item?.product?.product_knowledge
                       ?.name
-                  : delivery.supplied_item?.product_knowledge?.name}
-              </div>
+                  : delivery.supplied_item?.product_knowledge?.name;
+
+                if (linkToProduct && facilityId && productId) {
+                  return (
+                    <Link
+                      href={`/facility/${facilityId}/settings/product/${productId}`}
+                      className="font-medium text-primary-600 hover:underline"
+                      onClick={(e) => e.stopPropagation()}
+                      basePath="/"
+                    >
+                      {productName}
+                    </Link>
+                  );
+                }
+                return <div className="font-medium">{productName}</div>;
+              })()}
             </TableCell>
             <TableCell>
               {delivery.supplied_inventory_item?.product?.batch?.lot_number ||

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderShow.tsx
@@ -149,6 +149,8 @@ function AllSupplyDeliveriesComponent({
             <SupplyDeliveryTable
               deliveries={allSupplyDeliveries.results}
               internal={internal}
+              facilityId={facilityId}
+              linkToProduct
             />
           </>
         ) : (


### PR DESCRIPTION
Fixes #15832

https://github.com/user-attachments/assets/ef69324d-bb9f-4ee3-8bcf-a3ce9b76b73d



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product names in delivery tables are now clickable links that navigate to the corresponding product details and settings pages, providing quick access to product information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->