### PR TITLE
Fix/query cache phi leakage

### DIFF
--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -165,7 +165,7 @@ export default function AuthUserProvider({
     setAccessToken(null);
     setPatientToken(null);
 
-    await queryClient.resetQueries({ queryKey: ["currentUser"] });
+    queryClient.clear();
 
     const redirectURL = getRedirectURL();
     navigate(redirectURL ? `/login?redirect=${redirectURL}` : "/login");

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -60,7 +60,7 @@ import { dateQueryString } from "@/Utils/utils";
 import validators from "@/Utils/validators";
 import careConfig from "@careConfig";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format, isBefore, isFuture, subYears } from "date-fns";
 import { TFunction } from "i18next";
 import { isValidPhoneNumber } from "libphonenumber-js";
@@ -82,6 +82,7 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
   useShortcutSubContext();
   const { t } = useTranslation();
   const { goBack } = useAppHistory();
+  const queryClient = useQueryClient();
   const { facility, facilityId } = useCurrentFacility();
   const [{ phone_number, flow }] = useQueryParams<QParams>();
 
@@ -248,6 +249,7 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
       pathParams: { id: patientId || "" },
     }),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["patient", patientId] });
       toast.success(t("patient_update_success"));
       goBack();
     },


### PR DESCRIPTION
Fixes : #15854

## Proposed Changes

- Replace `queryClient.resetQueries({ queryKey: ["currentUser"] })` with `queryClient.clear()` in `AuthUserProvider.signOut` to fully evict React Query cache on logout and prevent cross-session data persistence.
- Invalidate `["patient", patientId]` in `PatientRegistration.onSuccess` to prevent stale patient data from rendering after successful updates.

Tagging: @ohcnetwork/care-fe-code-reviewers

---

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network). (Not required – no product behavior change)
- [x] Ensure that UI text is placed in I18n files. (No new UI text added)
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes. (Optional – can be added if requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sign-out now clears all cached data for a complete session reset
  * Patient information automatically refreshes after successful updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->