### PR TITLE
Restrict Encounter Status dropdown and lock after discharge

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
@@ -243,6 +243,16 @@ export function EncounterQuestion({
     return <div>{t("loading_encounter")}</div>;
   }
 
+  const isDischarged = encounter.status === EncounterStatus.DISCHARGED;
+
+  const statusOptions = isDischarged
+    ? [EncounterStatus.DISCHARGED]
+    : Object.values(EncounterStatus).filter(
+        (status) =>
+          status !== EncounterStatus.DISCHARGED &&
+          status !== EncounterStatus.UNKNOWN,
+      );
+
   return (
     <div className="space-y-6">
       <QuestionLabel question={question} />
@@ -265,18 +275,11 @@ export function EncounterQuestion({
               <SelectValue placeholder={t("select_status")} />
             </SelectTrigger>
             <SelectContent>
-              {Object.values(EncounterStatus)
-    .filter((status) =>
-      encounter.status === EncounterStatus.DISCHARGED
-        ? status === EncounterStatus.DISCHARGED
-        : status !== EncounterStatus.DISCHARGED &&
-          status !== EncounterStatus.UNKNOWN
-    )
-    .map((status) => (
-      <SelectItem key={status} value={status}>
-        {t(`encounter_status__${status}`)}
-      </SelectItem>
-    ))}
+              {statusOptions.map((status) => (
+                <SelectItem key={status} value={status}>
+                  {t(`encounter_status__${status}`)}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/EncounterQuestion.tsx
@@ -266,17 +266,17 @@ export function EncounterQuestion({
             </SelectTrigger>
             <SelectContent>
               {Object.values(EncounterStatus)
-                .filter((encounterStatus: EncounterStatus) =>
-                  encounter.status === EncounterStatus.DISCHARGED
-                    ? encounterStatus === EncounterStatus.DISCHARGED
-                    : encounterStatus !== EncounterStatus.DISCHARGED &&
-                      encounterStatus !== EncounterStatus.UNKNOWN,
-                )
-                .map((encounterStatus: EncounterStatus) => (
-                  <SelectItem key={encounterStatus} value={encounterStatus}>
-                    {t(`encounter_status__${encounterStatus}`)}
-                  </SelectItem>
-                ))}
+    .filter((status) =>
+      encounter.status === EncounterStatus.DISCHARGED
+        ? status === EncounterStatus.DISCHARGED
+        : status !== EncounterStatus.DISCHARGED &&
+          status !== EncounterStatus.UNKNOWN
+    )
+    .map((status) => (
+      <SelectItem key={status} value={status}>
+        {t(`encounter_status__${status}`)}
+      </SelectItem>
+    ))}
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #14536

- Removed `DISCHARGED` and `UNKNOWN` from the Encounter Status dropdown.
- Ensured `DISCHARGED` can only be set via the "Mark as Discharged" button.
- Locked the dropdown once an encounter is marked as `DISCHARGED`.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update product documentation.
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified encounter status dropdown logic.
  * Dropdown now shows only "Discharged" when the encounter is discharged; otherwise it excludes "Discharged" and "Unknown" options for clearer choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->