### PR TITLE
Opt out of parallel tests on CI by reducing workers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,8 +30,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
 
   retries: process.env.CI ? 2 : 0,
-  /* Run tests in parallel on CI with 2 workers. */
-  workers: process.env.CI ? 2 : undefined,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
     ? [["html"], ["json", { outputFile: "test-results.json" }], ["list"]]


### PR DESCRIPTION
Changed the number of workers for CI from 2 to 1 to opt out of parallel tests.

## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal CI testing configuration to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->