### PR TITLE
fix: preserve navigation guard on failed questionnaire submission

### DIFF
--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -417,6 +417,7 @@ export function QuestionnaireForm({
   const { mutate: submitBatch, isPending: isSubmitPending } = useMutation({
     mutationFn: mutate(batchApi.batchRequest, { silent: true }),
     onSuccess: () => {
+      setIsDirty(false);
       setServerErrors(undefined);
       toast.success(t("questionnaire_submitted_successfully"));
       onSubmit?.();
@@ -733,8 +734,6 @@ export function QuestionnaireForm({
   };
 
   const handleSubmit = async () => {
-    setIsDirty(false);
-
     // Clear existing errors first
     const formsWithClearedErrors = questionnaireForms.map((form) => ({
       ...form,

--- a/tests/facility/patient/questionnaire-dirty-state.spec.ts
+++ b/tests/facility/patient/questionnaire-dirty-state.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Page } from "@playwright/test";
+import { format, subDays } from "date-fns";
+import { getFacilityId } from "tests/support/facilityId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+/**
+ * Navigate to an encounter's questionnaire form and wait for
+ * full page load at each step.
+ */
+async function navigateToEncounterForm(page: Page) {
+  const facilityId = getFacilityId();
+  const createdDateAfter = format(subDays(new Date(), 90), "yyyy-MM-dd");
+  const createdDateBefore = format(new Date(), "yyyy-MM-dd");
+
+  await page.goto(
+    `/facility/${facilityId}/encounters/patients/all?created_date_after=${createdDateAfter}&created_date_before=${createdDateBefore}&status=in_progress`,
+  );
+
+  await page.getByText("View Encounter").first().click();
+  await page.waitForLoadState("networkidle");
+
+  await page.getByRole("link", { name: "Update Encounter" }).click();
+  await page.waitForLoadState("networkidle");
+}
+
+test.describe("QuestionnaireForm Dirty State Guard", () => {
+  test("navigation guard remains active after failed form submission", async ({
+    page,
+  }) => {
+    await navigateToEncounterForm(page);
+
+    // Open the form selector
+    const formSelector = page
+      .getByRole("combobox")
+      .filter({ hasText: /add form/i });
+    await expect(formSelector).toBeVisible({ timeout: 10_000 });
+    await formSelector.click();
+
+    // Wait for search input using data-slot selector
+    const searchInput = page.locator('[data-slot="command-input"]');
+    await expect(searchInput).toBeVisible();
+
+    // Pick the first available form
+    const firstOption = page.locator('[data-slot="command-item"]').first();
+    await expect(firstOption).toBeVisible({ timeout: 10_000 });
+    await firstOption.click();
+
+    // Wait for the form to render by asserting the submit button is visible
+    const submitButton = page.getByRole("button", { name: /submit/i });
+    await expect(submitButton).toBeVisible({ timeout: 10_000 });
+
+    // Submit without filling required fields — should trigger validation errors
+    await submitButton.click();
+
+    // Wait for validation to produce an error (deterministic wait)
+    const validationError = page.getByText(/required|invalid|error/i).first();
+    await expect(validationError)
+      .toBeVisible({ timeout: 5_000 })
+      .catch(
+        // If no validation error appears (form has no required fields),
+        // the form may have submitted successfully — skip this test case
+        () => test.skip(),
+      );
+
+    // Navigate away using an in-app link to trigger the raviger guard
+    const navLink = page
+      .getByRole("link", { name: /home|dashboard|facility/i })
+      .first();
+    await expect(navLink).toBeVisible();
+    await navLink.click();
+
+    // The unsaved changes dialog should appear
+    await expect(page.getByText(/unsaved changes/i)).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});


### PR DESCRIPTION
## Proposed Changes

Fixes #15855

- Move `setIsDirty(false)` from the beginning of `handleSubmit` to the `submitBatch` mutation's `onSuccess` callback.
- Ensure the `useNavigationPrompt` guard remains active during client-side validation failures and server-side submission errors.
- Prevent silent loss of questionnaire data when users navigate away after a failed submission attempt.

This change preserves existing happy-path behavior while preventing unintended data loss.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature. (Added `questionnaire-dirty-state.spec.ts` — verifies navigation guard stays active after failed submission)
- [ ] Update [product documentation](https://docs.ohc.network). (Not required – no user-facing feature change)
- [x] Ensure that UI text is placed in I18n files. (No new UI text added)
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unsaved-changes indicator now remains active during submission and is only cleared after a successful batch save, ensuring failed submissions still trigger unsaved-change warnings.
* **Tests**
  * Added end-to-end tests that verify unsaved changes prompts appear after failed questionnaire submissions and when navigating away.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->