### PR TITLE
fix: clear entire React Query cache on logout to prevent cross-session data leaks

### DIFF
--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -165,7 +165,7 @@ export default function AuthUserProvider({
     setAccessToken(null);
     setPatientToken(null);
 
-    await queryClient.resetQueries({ queryKey: ["currentUser"] });
+    queryClient.clear();
 
     const redirectURL = getRedirectURL();
     navigate(redirectURL ? `/login?redirect=${redirectURL}` : "/login");

--- a/tests/auth/logout-cache-clear.spec.ts
+++ b/tests/auth/logout-cache-clear.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type Page } from "@playwright/test";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+/**
+ * Reusable helper to sign out via the sidebar user menu.
+ * Uses unconditional assertions — fails loudly if elements are missing.
+ */
+async function signOut(page: Page) {
+  // Open the sidebar user dropdown — the trigger is the SidebarMenuButton
+  // containing the user's name in the sidebar footer
+  const userMenuTrigger = page
+    .locator('[data-slot="sidebar"] [data-slot="sidebar-menu-button"]')
+    .last();
+  await expect(userMenuTrigger).toBeVisible({ timeout: 5_000 });
+  await userMenuTrigger.click();
+
+  // Click the "Logout" dropdown menu item
+  const logoutItem = page.getByRole("menuitem", { name: /logout/i });
+  await expect(logoutItem).toBeVisible();
+  await logoutItem.click();
+}
+
+test.describe("Logout Cache Clearing", () => {
+  test("should fully clear session and redirect to landing page on logout", async ({
+    page,
+  }) => {
+    // Navigate to the app — user should be authenticated
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /^Hey .+$/ })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Sign out using the sidebar menu
+    await signOut(page);
+
+    // Should redirect to the landing page
+    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("button", { name: /log in as staff/i }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("should not show stale user data after logout", async ({
+    page,
+    context,
+  }) => {
+    // Navigate to the app while authenticated
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /^Hey .+$/ })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Record the current user's greeting
+    const greeting = await page
+      .getByRole("heading", { name: /^Hey .+$/ })
+      .textContent();
+
+    // Sign out using the sidebar menu
+    await signOut(page);
+
+    // Wait for redirect to landing page
+    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("button", { name: /log in as staff/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Clear cookies and browser storage to simulate fresh session
+    await context.clearCookies();
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+
+    // Navigate to home — should see the public landing page, not cached data
+    await page.goto("/");
+    await expect(
+      page.getByRole("button", { name: /log in as staff/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The cached user greeting must not be visible
+    if (greeting) {
+      await expect(page.getByText(greeting, { exact: true })).toBeHidden();
+    }
+  });
+});


### PR DESCRIPTION
## Proposed Changes

Fixes #15853

- Replace `queryClient.resetQueries({ queryKey: ["currentUser"] })` with `queryClient.clear()` in the `signOut` function of `AuthUserProvider`.
- Ensure the entire React Query in-memory cache is evicted on logout, not just the `currentUser` query.
- Prevent cross-session data leaks on shared workstations where cached patient, facility, and diagnostic data could briefly appear for subsequent users.

This is consistent with how cache clearing is already handled elsewhere in the codebase (e.g., `appVersion.ts`, `HealthcareServiceShow.tsx`).

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature. (Added `logout-cache-clear.spec.ts` — verifies logout fully clears session and prevents stale data)
- [ ] Update [product documentation](https://docs.ohc.network). (Not required – no user-facing feature change)
- [x] Ensure that UI text is placed in I18n files. (No new UI text added)
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now fully clears cached session data so signed-out users no longer see stale account info.
* **Tests**
  * Added automated end-to-end tests to validate logout behavior, redirect to the public landing page, and absence of leftover user data after a fresh session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->