### PR TITLE
fix: respect singleSelection in preferred org auto-select

### DIFF
--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
@@ -564,6 +564,7 @@ export default function FacilityOrganizationSelector(
               return (
                 <div
                   key={index}
+                  data-slot="selected-org-item"
                   className="flex-1 flex items-center gap-3 rounded-md border border-sky-100 bg-sky-50/50 p-2.5"
                 >
                   <Building className="size-4 text-sky-600 shrink-0" />

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
@@ -224,8 +224,11 @@ export default function FacilityOrganizationSelector(
       !hasAutoSelectedPreferred &&
       !value?.length
     ) {
-      setSelectedOrganizations(preferredOrganizations.results);
-      onChange(preferredOrganizations.results.map((org) => org.id));
+      const orgsToSelect = singleSelection
+        ? [preferredOrganizations.results[0]]
+        : preferredOrganizations.results;
+      setSelectedOrganizations(orgsToSelect);
+      onChange(orgsToSelect.map((org) => org.id));
       setHasAutoSelectedPreferred(true);
     }
   }, [
@@ -233,6 +236,7 @@ export default function FacilityOrganizationSelector(
     preferredOrganizations,
     selectedOrganizations,
     hasAutoSelectedPreferred,
+    singleSelection,
     value,
     onChange,
   ]);

--- a/tests/facility/settings/departments/orgSelectorSingleSelection.spec.ts
+++ b/tests/facility/settings/departments/orgSelectorSingleSelection.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import { getFacilityId } from "tests/support/facilityId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("Organization Selector — Single Selection Mode", () => {
+  let facilityId: string;
+
+  test.beforeEach(() => {
+    facilityId = getFacilityId();
+  });
+
+  test("should only allow selecting one department when in single selection mode", async ({
+    page,
+  }) => {
+    // Navigate to a healthcare service form which uses singleSelection={true}
+    await page.goto(
+      `/facility/${facilityId}/settings/services/healthcare-services/create`,
+    );
+
+    // Assert the org selector is present
+    const orgSelector = page.getByRole("combobox", {
+      name: /select department/i,
+    });
+    await expect(orgSelector).toBeVisible({ timeout: 5_000 });
+    await orgSelector.click();
+
+    // Assert the command input is visible using data-slot attribute
+    const searchInput = page.locator('[data-slot="command-input"]');
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill("Admin");
+
+    // Wait for search results to appear
+    const firstDept = page.locator('[data-slot="command-item"]').first();
+    await expect(firstDept).toBeVisible({ timeout: 5_000 });
+
+    const firstDeptText = await firstDept.textContent();
+    expect(firstDeptText).not.toBeNull();
+    await firstDept.click();
+
+    // Use stable data-slot selector for selected orgs
+    const selectedOrgs = page.locator('[data-slot="selected-org-item"]');
+    await expect(selectedOrgs).toHaveCount(1, { timeout: 5_000 });
+
+    // Verify the selected org name is visible — scoped to the selection area
+    await expect(selectedOrgs.getByText(firstDeptText!.trim())).toBeVisible();
+  });
+
+  test("preferred auto-selection should respect single selection mode", async ({
+    page,
+  }) => {
+    // Navigate to healthcare service form
+    await page.goto(
+      `/facility/${facilityId}/settings/services/healthcare-services/create`,
+    );
+
+    // Wait for the page to fully load
+    await page.waitForLoadState("networkidle");
+
+    // Assert the org selector is present
+    const orgSelector = page.getByRole("combobox", {
+      name: /select department/i,
+    });
+    await expect(orgSelector).toBeVisible({ timeout: 5_000 });
+
+    // Use stable data-slot selector for selected orgs
+    const selectedOrgs = page.locator('[data-slot="selected-org-item"]');
+
+    // In single selection mode: at most 1 org should be auto-selected.
+    // If the test environment seeds preferred orgs, exactly 1 is expected.
+    // If none are seeded, 0 is valid. Either way, > 1 was the bug.
+    await expect(async () => {
+      const count = await selectedOrgs.count();
+      expect(count).toBeLessThanOrEqual(1);
+    }).toPass({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## Proposed Changes

Fixes #15712

- Update the auto-select preferred departments `useEffect` in `FacilityOrganizationSelector` to respect the `singleSelection` prop.
- When `singleSelection` is true, limit auto-selection to only the first preferred organization instead of selecting all preferred organizations.
- Add `singleSelection` to the `useEffect` dependency array since the effect now reads it.

This is consistent with the existing `handleConfirmSelection` callback, which already uses a ternary to choose between single and multi-selection.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature. (Added `orgSelectorSingleSelection.spec.ts` — verifies single selection mode enforces ≤1 department)
- [ ] Update [product documentation](https://docs.ohc.network). (Not required – no user-facing feature change)
- [x] Ensure that UI text is placed in I18n files. (No new UI text added)
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organization selector now respects single-selection mode when auto-selecting preferred organizations (selects at most one).
  * Added test-friendly identifiers to selected organization items to improve UI testability.

* **Tests**
  * Added end-to-end tests validating single-selection behavior and preferred-item auto-selection in the organization selector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->