### PR TITLE
🧪 Adds Playwright test coverage for Encounter Discharge Flow #15860

### DIFF
--- a/tests/facility/patient/encounter/discharge-flow.spec.ts
+++ b/tests/facility/patient/encounter/discharge-flow.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+import { format, subDays } from "date-fns";
+import { getFacilityId } from "tests/support/facilityId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("Encounter Discharge Flow", () => {
+  async function navigateToUpdateEncounter(page) {
+    const facilityId = getFacilityId();
+    const createdDateAfter = format(subDays(new Date(), 90), "yyyy-MM-dd");
+    const createdDateBefore = format(new Date(), "yyyy-MM-dd");
+
+    await page.goto(
+      `/facility/${facilityId}/encounters/patients/all?created_date_after=${createdDateAfter}&created_date_before=${createdDateBefore}&status=in_progress`,
+    );
+
+    await page.getByText("View Encounter").first().click();
+    await page.getByRole("link", { name: "Update Encounter" }).click();
+  }
+
+  test("should not show DISCHARGED and UNKNOWN in dropdown before discharge", async ({
+    page,
+  }) => {
+    await navigateToUpdateEncounter(page);
+
+    await page.getByLabel(/encounter status/i).click();
+
+    await expect(
+      page.getByRole("option", { name: /discharged/i }),
+    ).not.toBeVisible();
+
+    await expect(
+      page.getByRole("option", { name: /unknown/i }),
+    ).not.toBeVisible();
+  });
+
+  test("should allow discharge only via Mark for Discharge button and lock status after", async ({
+    page,
+  }) => {
+    await navigateToUpdateEncounter(page);
+
+    const dischargeButton = page.getByRole("button", {
+      name: /mark for discharge/i,
+    });
+
+    await expect(dischargeButton).toBeVisible();
+
+    await dischargeButton.click();
+
+    // Status should now show DISCHARGED
+    await expect(
+      page.getByRole("combobox", { name: /encounter status/i }),
+    ).toHaveText(/discharged/i);
+
+    // Dropdown should be disabled
+    await expect(
+      page.getByRole("combobox", { name: /encounter status/i }),
+    ).toBeDisabled();
+
+    // Reload and verify persistence
+    await page.reload();
+
+    await expect(
+      page.getByRole("combobox", { name: /encounter status/i }),
+    ).toHaveText(/discharged/i);
+
+    await expect(
+      page.getByRole("combobox", { name: /encounter status/i }),
+    ).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Fixes #15860

## Proposed Changes

- Adds Playwright test coverage for Encounter Discharge Flow
- Ensures DISCHARGED and UNKNOWN are not selectable before discharge
- Verifies discharge can only be triggered via "Mark for Discharge"
- Confirms status dropdown locks after discharge
- Ensures persistence after reload

This is an atomic test-only PR and does not change existing behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for discharge flow functionality, including validation of status transitions, action availability, and persistence across page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->