### PR TITLE
Fix/questionnaire navigation guard

### DIFF
--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -417,6 +417,7 @@ export function QuestionnaireForm({
   const { mutate: submitBatch, isPending: isSubmitPending } = useMutation({
     mutationFn: mutate(batchApi.batchRequest, { silent: true }),
     onSuccess: () => {
+      setIsDirty(false);
       setServerErrors(undefined);
       toast.success(t("questionnaire_submitted_successfully"));
       onSubmit?.();
@@ -733,8 +734,6 @@ export function QuestionnaireForm({
   };
 
   const handleSubmit = async () => {
-    setIsDirty(false);
-
     // Clear existing errors first
     const formsWithClearedErrors = questionnaireForms.map((form) => ({
       ...form,


### PR DESCRIPTION
## Proposed Changes

Fixes #15855 

- Move `setIsDirty(false)` from the beginning of `handleSubmit` to the `submitBatch` mutation’s `onSuccess` callback.
- Ensure the `useNavigationPrompt` guard remains active during client-side validation failures and server-side submission errors.
- Prevent silent loss of questionnaire data when users navigate away after a failed submission attempt.

This change preserves existing happy-path behavior while preventing unintended data loss.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature. (Not applicable – behavioral fix within existing flow)
- [ ] Update [product documentation](https://docs.ohc.network). (Not required – no functional change to product features)
- [x] Ensure that UI text is placed in I18n files. (No new UI text added)
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Enhanced form state management for tracking unsaved changes. The "unsaved changes" indicator now correctly clears immediately after successful form submission, providing clearer user feedback. The warning status remains active throughout the validation phase to ensure optimal data accuracy and help prevent accidental loss of important information entered in the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->