### PR TITLE
Fix empty page titles for browser tab accessibility

### DIFF
--- a/src/pages/Encounters/ConsentDetail.tsx
+++ b/src/pages/Encounters/ConsentDetail.tsx
@@ -105,7 +105,7 @@ export function ConsentDetailPage({ consentId }: ConsentDetailPageProps) {
 
   if (!consent) {
     return (
-      <Page title="">
+      <Page title={t("consent_not_found")} hideTitleOnPage>
         <div className="flex flex-col items-center justify-center min-h-[50vh]">
           <FileText className="size-16 text-gray-300 mb-4" />
           <h2 className="text-xl font-semibold mb-2">
@@ -141,7 +141,7 @@ export function ConsentDetailPage({ consentId }: ConsentDetailPageProps) {
         <ArrowLeft />
         <span>{t("back")}</span>
       </BackButton>
-      <Page title="">
+      <Page title={t("consent_details")} hideTitleOnPage>
         <div className="container mx-auto py-4">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div className="lg:col-span-2 order-last lg:order-first">

--- a/src/pages/Facility/overview.tsx
+++ b/src/pages/Facility/overview.tsx
@@ -117,7 +117,7 @@ export function FacilityOverview({ facilityId }: FacilityOverviewProps) {
   );
 
   return (
-    <Page title="">
+    <Page title={t("overview")} hideTitleOnPage>
       <div className="container mx-auto space-y-8">
         {/* Welcome Header */}
         <div className="rounded-lg">


### PR DESCRIPTION
## Summary
Fixed empty `<Page title="">` in `ConsentDetail.tsx` and `overview.tsx` that caused the browser tab to show only "Care" with no page context, hurting accessibility and navigation.

## Changes
- **ConsentDetail.tsx (error state):** `<Page title="">` → `<Page title={t("consent_not_found")} hideTitleOnPage>` — browser tab now shows "Consent not found | Care"
- **ConsentDetail.tsx (detail view):** `<Page title="">` → `<Page title={t("consent_details")} hideTitleOnPage>` — browser tab now shows "Consent Details | Care"
- **overview.tsx (dashboard):** `<Page title="">` → `<Page title={t("overview")} hideTitleOnPage>` — browser tab now shows "Overview | Care"

## Why `hideTitleOnPage`?
All three pages already render their own visible headings. Without `hideTitleOnPage`, the `Page` component would add a duplicate `<h2>`. This flag sets only the browser tab title (`document.title`) with zero visual change.

## No locale changes needed
All three translation keys (`consent_not_found`, `consent_details`, `overview`) already exist in `public/locale/en.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blank page titles in the Consent Details and Facility Overview pages. Headers now properly display localized titles for various scenarios with improved visibility controls, ensuring consistent navigation and clearer interface presentation throughout the application for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->