### PR TITLE
Invoice Tweaks; 

### DIFF
--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -391,7 +391,11 @@ export function InvoiceShow({
       <div className="space-y-8 relative">
         <div className="flex items-start justify-between flex-col sm:flex-row gap-4 sm:items-center border-b-3 border-double pb-4">
           <div className="flex gap-3 sm:gap-6 flex-col md:flex-row">
-            <BackButton variant="link" className="px-0 justify-start">
+            <BackButton
+              variant="link"
+              className="px-0 justify-start"
+              to={`/facility/${facilityId}/billing/account/${invoice.account.id}`}
+            >
               <ChevronLeft />
               <span>{t("back")}</span>
             </BackButton>

--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -124,9 +124,10 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
   const getWatermark = () => {
     if (invoice.status === InvoiceStatus.cancelled) {
       return { text: t("cancelled"), color: "red" as const };
-    }
-    if (invoice.status === InvoiceStatus.entered_in_error) {
+    } else if (invoice.status === InvoiceStatus.entered_in_error) {
       return { text: t("entered_in_error"), color: "red" as const };
+    } else if (invoice.status === InvoiceStatus.draft) {
+      return { text: t("draft"), color: "gray" as const };
     }
     return undefined;
   };


### PR DESCRIPTION
## Proposed Changes
This pull request introduces two improvements to the invoice-related pages: enhancing navigation and refining the print view watermark logic.

Navigation improvement:

* The `BackButton` in `InvoiceShow.tsx` now navigates directly to the related account's billing page using the correct URL, improving user navigation within the billing section.

Print invoice watermark logic:

* The `PrintInvoice.tsx` component now displays a "draft" watermark in gray when the invoice status is set to draft, providing clearer status indication on printed invoices.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only routing and display changes; no backend, auth, or data processing logic is modified.
> 
> **Overview**
> Improves invoice navigation by wiring the `InvoiceShow` back button to route directly to the invoice’s associated billing account page.
> 
> Updates `PrintInvoice` to show a gray **draft** watermark when `invoice.status` is `draft` (in addition to existing cancelled/entered-in-error watermarks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a45ff0eab50da79b50a61e4b99639e3b46ac2dcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicator for draft invoices.

* **Bug Fixes**
  * Corrected back button navigation on invoice detail pages to return to the associated account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->