### PR TITLE
Make Conditions Optional in Observation Definition

### DIFF
--- a/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
+++ b/src/pages/Facility/services/diagnosticReports/components/DiagnosticReportResultsTable.tsx
@@ -11,13 +11,16 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-import { Interpretation } from "@/types/base/qualifiedRange/qualifiedRange";
+import {
+  Interpretation,
+  QualifiedRange,
+} from "@/types/base/qualifiedRange/qualifiedRange";
 import {
   ObservationComponent,
   ObservationRead,
   ObservationReferenceRange,
-  QuestionnaireSubmitResultValue,
 } from "@/types/emr/observation/observation";
+import { ObservationDefinitionReadSpec } from "@/types/emr/observationDefinition/observationDefinition";
 
 interface DiagnosticReportResultsTableProps {
   observations: ObservationRead[];
@@ -41,6 +44,11 @@ export function DiagnosticReportResultsTable({
           component.reference_range && component.reference_range.length > 0,
       ),
   );
+  const hasComponentQualifiedRanges = observations.some((observation) =>
+    observation.observation_definition?.component?.some(
+      (dc) => dc.qualified_ranges && dc.qualified_ranges.length > 0,
+    ),
+  );
   const hasComponentInterpretation = observations.some(
     (observation) =>
       observation.component &&
@@ -48,39 +56,56 @@ export function DiagnosticReportResultsTable({
         (component) => component.interpretation?.display,
       ),
   );
-  const showReferenceRange = hasReferenceRange || hasComponentReferenceRange;
+  const showReferenceRange =
+    hasReferenceRange ||
+    hasComponentReferenceRange ||
+    hasComponentQualifiedRanges;
   const showInterpretation = hasInterpretation || hasComponentInterpretation;
 
   const renderReferenceRange = (
-    referenceRange: ObservationReferenceRange[],
-    value: QuestionnaireSubmitResultValue,
+    qualifiedRanges: QualifiedRange[],
+    referenceRange?: ObservationReferenceRange[],
   ) => {
-    if (!referenceRange || !referenceRange[0]) return "-";
-    let range = null;
-    if (value.value) {
-      for (const r of referenceRange) {
-        if (r.min && Number(value.value) < r.min) {
-          continue;
-        }
-        if (r.max && Number(value.value) > r.max) {
-          continue;
-        }
-        range = r;
-        break;
-      }
-    }
-    if (!range) return "-";
-    let innerContent = "";
-    if (range.min && range.max) {
-      innerContent = `${range.min} - ${range.max}`;
-    } else if (range.min) {
-      innerContent = `> ${range.min}`;
-    } else if (range.max) {
-      innerContent = `< ${range.max}`;
-    }
+    if (!qualifiedRanges.length) return "-";
+
     return (
-      <div className="flex items-center gap-1 text-gray-500">
-        <span>{innerContent}</span>
+      <div className="flex flex-col items-start gap-1 text-gray-500">
+        {qualifiedRanges.flatMap((qr, qrIndex) => {
+          const isApplicable =
+            !!referenceRange?.length &&
+            qr.ranges.length === referenceRange.length &&
+            qr.ranges.every((range, i) => {
+              const ref = referenceRange[i];
+              const minMatch =
+                range.min == null
+                  ? ref.min == null
+                  : ref.min != null && Number(range.min) === Number(ref.min);
+              const maxMatch =
+                range.max == null
+                  ? ref.max == null
+                  : ref.max != null && Number(range.max) === Number(ref.max);
+              return minMatch && maxMatch;
+            });
+          return qr.ranges.map((range, rangeIndex) => {
+            let rangeContent = "";
+            if (range.min && range.max) {
+              rangeContent = `${range.min} - ${range.max}`;
+            } else if (range.min) {
+              rangeContent = `> ${range.min}`;
+            } else if (range.max) {
+              rangeContent = `< ${range.max}`;
+            }
+            const label = range.interpretation?.display;
+            return (
+              <span
+                key={`${qrIndex}-${rangeIndex}`}
+                className={isApplicable ? "font-semibold text-gray-900" : ""}
+              >
+                {label ? `${label}: ${rangeContent}` : rangeContent}
+              </span>
+            );
+          });
+        })}
       </div>
     );
   };
@@ -98,7 +123,10 @@ export function DiagnosticReportResultsTable({
     );
   };
 
-  const renderObservationComponents = (components: ObservationComponent[]) => {
+  const renderObservationComponents = (
+    components: ObservationComponent[],
+    observationDefinition: ObservationDefinitionReadSpec | null | undefined,
+  ) => {
     return components.map((component, index) => (
       <TableRow
         key={component.code?.code}
@@ -124,8 +152,12 @@ export function DiagnosticReportResultsTable({
         </TableCell>
         {showReferenceRange && (
           <TableCell className="border-r border-b border-gray-300 whitespace-normal wrap-break-word">
-            {component.reference_range &&
-              renderReferenceRange(component.reference_range, component.value)}
+            {renderReferenceRange(
+              observationDefinition?.component?.find(
+                (dc) => dc.code.code === component.code?.code,
+              )?.qualified_ranges ?? [],
+              component.reference_range,
+            )}
           </TableCell>
         )}
         {showInterpretation && (
@@ -148,15 +180,25 @@ export function DiagnosticReportResultsTable({
           key={observation.id}
           className={cn(
             "divide-x divide-gray-300 text-sm text-gray-950",
-            hasComponents && "border-b-0",
             observation.interpretation && "font-semibold",
           )}
         >
-          <TableCell className="whitespace-normal wrap-break-word">
+          <TableCell
+            className={cn(
+              "whitespace-normal wrap-break-word",
+              hasComponents && "border-b border-gray-300",
+            )}
+          >
             {observation.observation_definition?.title ||
               observation.observation_definition?.code?.display}
           </TableCell>
-          <TableCell className="whitespace-normal wrap-break-word">
+          <TableCell
+            className={cn(
+              "whitespace-normal wrap-break-word",
+              hasComponents && "border-b border-gray-300",
+            )}
+          >
+            {" "}
             {!hasComponents && (
               <div className="whitespace-normal">
                 <span>{observation.value.value}</span>
@@ -170,17 +212,26 @@ export function DiagnosticReportResultsTable({
             )}
           </TableCell>
           {showReferenceRange && (
-            <TableCell className="whitespace-normal wrap-break-word">
+            <TableCell
+              className={cn(
+                "whitespace-normal wrap-break-word",
+                hasComponents && "border-b border-gray-300",
+              )}
+            >
               {!hasComponents &&
-                observation.reference_range &&
                 renderReferenceRange(
+                  observation.observation_definition?.qualified_ranges ?? [],
                   observation.reference_range,
-                  observation.value,
                 )}
             </TableCell>
           )}
           {showInterpretation && (
-            <TableCell className="whitespace-normal wrap-break-word">
+            <TableCell
+              className={cn(
+                "whitespace-normal wrap-break-word",
+                hasComponents && "border-b border-gray-300",
+              )}
+            >
               {!hasComponents &&
                 observation.interpretation &&
                 renderInterpretation(observation.interpretation)}
@@ -189,7 +240,10 @@ export function DiagnosticReportResultsTable({
         </TableRow>
         {hasComponents &&
           observation.component &&
-          renderObservationComponents(observation.component)}
+          renderObservationComponents(
+            observation.component,
+            observation.observation_definition,
+          )}
       </>
     );
   };

--- a/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
@@ -210,7 +210,6 @@ export function DiagnosticReportForm({
     if (fullReport) {
       // When we get the full report details, ensure UI is in correct state
       setSelectedReportCode(fullReport.code || null);
-      setIsExpanded(true);
     }
   }, [fullReport]);
 
@@ -252,6 +251,7 @@ export function DiagnosticReportForm({
         queryClient.invalidateQueries({
           queryKey: ["diagnosticReport", latestReport?.id],
         });
+        setIsExpanded(false);
       },
       onError: () => {
         toast.success(t("failed_to_update_conclusion"));

--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
@@ -212,7 +212,7 @@ function ObservationDefinitionFormContent({
                   c.qualified_ranges?.map((range, index) => ({
                     ...range,
                     id: index,
-                    conditions: range?.conditions.map((condition) => ({
+                    conditions: range?.conditions?.map((condition) => ({
                       ...condition,
                       _conditionType: getConditionDiscriminatorValue(
                         condition.metric,
@@ -229,7 +229,7 @@ function ObservationDefinitionFormContent({
               existingData.qualified_ranges?.map((range, index) => ({
                 ...range,
                 id: index,
-                conditions: range?.conditions.map((condition) => ({
+                conditions: range?.conditions?.map((condition) => ({
                   ...condition,
                   _conditionType: getConditionDiscriminatorValue(
                     condition.metric,

--- a/src/pages/Facility/settings/observationDefinition/ObservationInterpretation.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationInterpretation.tsx
@@ -132,7 +132,7 @@ export function ObservationInterpretation<
   const hasExistingData = () => {
     return qualifiedRanges.some(
       (range) =>
-        range.conditions.length > 0 ||
+        (range.conditions?.length ?? 0) > 0 ||
         range.ranges.length > 0 ||
         (range.valueset_interpretation?.length || 0) > 0,
     );
@@ -294,7 +294,7 @@ export function ObservationInterpretation<
       newRanges = [
         ...newRanges.map((r) => ({
           ...r,
-          conditions: r.conditions.map((condition) => ({
+          conditions: r.conditions?.map((condition) => ({
             ...condition,
             _conditionType: getConditionDiscriminatorValue(
               condition.metric,
@@ -333,7 +333,7 @@ export function ObservationInterpretation<
   const getInterpretationSummary = (range: QualifiedRange, index: number) => {
     const rangeCount = range.ranges.length;
     const valuesetCount = range.valueset_interpretation?.length || 0;
-    let operationSummary = range.conditions
+    let operationSummary = (range.conditions ?? [])
       .slice(0, 2)
       .map((condition, index) => {
         return (
@@ -343,8 +343,8 @@ export function ObservationInterpretation<
           />
         );
       });
-    if (range.conditions.length > 2) {
-      operationSummary.push(<span>+{range.conditions.length - 2}...</span>);
+    if ((range.conditions?.length ?? 0) > 2) {
+      operationSummary.push(<span>+{range.conditions!.length - 2}...</span>);
     }
     const rangeSummary = range.ranges?.slice(0, 2).map((range, index) => {
       return <span key={`range-${index}`}>{getRangeSummary(range)}</span>;
@@ -370,12 +370,14 @@ export function ObservationInterpretation<
     return (
       <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 items-start flex-1 text-sm">
         <span>#{index + 1}</span>
-        <div className="flex flex-col gap-1 sm:w-1/2">
-          <span className="text-xs font-medium">{t("conditions")}</span>
-          <div className="flex flex-col gap-1 text-gray-500">
-            {operationSummary}
+        {operationSummary.length > 0 && (
+          <div className="flex flex-col gap-1 sm:w-1/2">
+            <span className="text-xs font-medium">{t("conditions")}</span>
+            <div className="flex flex-col gap-1 text-gray-500">
+              {operationSummary}
+            </div>
           </div>
-        </div>
+        )}
         {rangeCount > 0 && (
           <div className="flex flex-col gap-1 sm:w-1/2">
             <span className="text-xs font-medium">{t("effect")}</span>
@@ -621,7 +623,7 @@ function QualifiedRangeEditor<TFieldValues extends FieldValues = FieldValues>({
     <div>
       <div className="flex flex-col gap-3 mt-6 p-3 max-h-[calc(100vh-200px)] overflow-y-auto">
         <ConditionComponent
-          conditions={editedRange.conditions}
+          conditions={editedRange.conditions ?? []}
           setConditions={handleSetConditions}
           form={form}
           fieldName={`${fieldName}.conditions`}
@@ -1120,12 +1122,7 @@ export function ConditionComponent<
 
   const metrics = data?.filter((m) => !m.name.includes("patient_tag"));
 
-  useEffect(() => {
-    if (metrics?.[0] && conditions.length === 0) {
-      const defaultCondition = getDefaultCondition(metrics);
-      setConditions([defaultCondition]);
-    }
-  }, [metrics, conditions]);
+  // No longer enforce a default condition — conditions are optional
 
   const handleSetMetric = (metric: string, index: number) => {
     const newMetric = metrics?.find((m) => m.name === metric) || metrics?.[0];

--- a/src/types/base/condition/condition.ts
+++ b/src/types/base/condition/condition.ts
@@ -279,7 +279,7 @@ export const removeConditionType = (
 ): QualifiedRange[] => {
   return qualifiedRanges.map((range) => ({
     ...range,
-    conditions: range.conditions.map((condition) => ({
+    conditions: range.conditions?.map((condition) => ({
       ...stripConditionType(condition as ConditionForm),
     })),
   }));

--- a/src/types/base/qualifiedRange/qualifiedRange.ts
+++ b/src/types/base/qualifiedRange/qualifiedRange.ts
@@ -28,7 +28,7 @@ export enum InterpretationType {
 export interface QualifiedRange {
   // used for local state management
   id?: number;
-  conditions: Condition[];
+  conditions?: Condition[];
   ranges: NumericRange[];
   normal_coded_value_set?: string;
   critical_coded_value_set?: string;
@@ -45,7 +45,7 @@ const interpretationSchema = z.object({
 export const qualifiedRangeSchema = z.array(
   z
     .object({
-      conditions: z.array(conditionSchema),
+      conditions: z.array(conditionSchema).optional(),
       ranges: z.array(
         z
           .object({


### PR DESCRIPTION
## Proposed Changes

This pull request updates how conditions are handled in observation definitions and interpretations, making the `conditions` field optional throughout the codebase and improving robustness against missing or empty conditions. The changes ensure that components and functions gracefully handle cases where `conditions` may be undefined, preventing runtime errors and simplifying the logic for optional conditions.

**Making conditions optional and improving handling:**

* Changed the `QualifiedRange` interface to make the `conditions` field optional, and updated the validation schema to reflect this.
* Updated all relevant mapping and access logic to use optional chaining and default values when handling `conditions`, ensuring safe access and preventing errors when `conditions` is undefined. 

**Behavioral changes in UI components:**

* Removed the enforcement of a default condition in the `ConditionComponent`, allowing for cases where no conditions are present. 
* Updated summary and editor components to properly handle and display cases with zero or undefined conditions, including conditional rendering and summary calculations. 

These updates make the handling of observation conditions more flexible and robust, preventing errors and supporting cases where conditions may be absent.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core clinical configuration types and interpretation UI, plus changes how reference ranges are displayed in diagnostic reports, which could alter what users see even when data is valid.
> 
> **Overview**
> Makes `QualifiedRange.conditions` optional end-to-end by updating the type and `qualifiedRangeSchema`, and hardening all interpretation/definition mapping and save logic to tolerate `conditions` being `undefined`.
> 
> Updates the Observation Definition interpretation UI to treat conditions as optional (no default condition is auto-created, summaries hide the conditions section when empty), and adjusts `removeConditionType` accordingly.
> 
> Changes diagnostic report results tables to render reference ranges from observation-definition `qualified_ranges` (including component qualified ranges) rather than deriving a single range from the entered value, and tweaks the diagnostic report form to collapse after successfully updating the conclusion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce29276adc7014af9920241788049893d76dc9f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for component-level qualified ranges in results tables, showing multiple labeled ranges and highlighting applicable ones.
  * Updated diagnostic report form behavior: no longer auto-expands on load and now collapses after successful update.

* **Bug Fixes**
  * Fixed runtime errors when conditions are undefined in observation definitions.
  * Made conditions optional on qualified ranges and improved resilience across interpretation and form flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->