### PR TITLE
fix incorrect location search query param in delivery and request order form

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderForm.tsx
@@ -126,7 +126,7 @@ export default function DeliveryOrderForm({
     queryFn: query.debounced(locationApi.list, {
       pathParams: { facility_id: facilityId },
       queryParams: {
-        search: searchDeliveryFrom,
+        name: searchDeliveryFrom,
         limit: 100,
         mode: "kind",
         ordering: "sort_index",

--- a/src/pages/Facility/services/inventory/externalSupply/requestOrder/RequestOrderForm.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/requestOrder/RequestOrderForm.tsx
@@ -143,7 +143,7 @@ export default function RequestOrderForm({
     queryFn: query.debounced(locationApi.list, {
       pathParams: { facility_id: facilityId },
       queryParams: {
-        search: searchDeliveryFrom,
+        name: searchDeliveryFrom,
         limit: 100,
         mode: "kind",
         ordering: "sort_index",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small frontend-only change to query parameters for location autocomplete; low risk aside from potentially affecting location search results.
> 
> **Overview**
> Fixes the “delivery from” location autocomplete in `DeliveryOrderForm` and `RequestOrderForm` by switching the `locationApi.list` filter param from `search` to `name`.
> 
> This aligns these forms with the expected backend query parameter so location filtering works correctly when typing in the location selector.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4293a961fd98e61dfc2fdf04c653ae5effe046f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed location search filtering in delivery order and request order forms to correctly display available delivery-from locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->