### PR TITLE
Fix/encounter complete double submit

### DIFF
--- a/src/pages/Encounters/MarkEncounterAsCompletedDialog.tsx
+++ b/src/pages/Encounters/MarkEncounterAsCompletedDialog.tsx
@@ -22,6 +22,7 @@ export function MarkEncounterAsCompletedDialog(
   const { t } = useTranslation();
   const {
     selectedEncounter: encounter,
+    isEndEncounterPending,
     actions: { endEncounter },
   } = useEncounter();
 
@@ -46,6 +47,7 @@ export function MarkEncounterAsCompletedDialog(
           <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
           <AlertDialogAction
             className={buttonVariants({ variant: "primary" })}
+            disabled={isEndEncounterPending}
             onClick={() => endEncounter(encounter, true)}
           >
             {t("mark_as_complete")}

--- a/src/pages/Encounters/utils/utils.tsx
+++ b/src/pages/Encounters/utils/utils.tsx
@@ -83,6 +83,9 @@ export function useEncounterProgressController() {
           toast.success(t("appointment_closed_successfully"));
         }
       },
+      onError: () => {
+        toast.error(t("encounter_completion_failed"));
+      },
     });
 
   const endEncounter = (


### PR DESCRIPTION
## Proposed Changes

Fixes #15867

- Added `disabled={isEndEncounterPending}` to the confirm button in `MarkEncounterAsCompletedDialog` to prevent multiple concurrent submissions while a completion request is in flight.
- Added an explicit `onError` handler to the batch mutation in `utils/utils.tsx` to surface a toast error if encounter completion fails.
- No changes to existing success logic or workflow behavior.

This ensures:
- Duplicate batch requests cannot be triggered via rapid clicks.
- Users receive explicit feedback if encounter completion fails.
- The fix remains minimal and scoped strictly to the affected workflow.

Tagging: @ohcnetwork/care-fe-code-reviewers

---

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature. (Not added – minimal UI guard fix)
- [ ] Update [product documentation](https://docs.ohc.network). (Not required – no product behavior change)
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented duplicate submissions during encounter completion by disabling the action while the end operation is pending.
  * Improved error visibility by showing a notification when encounter completion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->