### PR TITLE
Fix text overflow in Services - Current Location (Closes #15877)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6617,7 +6617,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {

--- a/src/components/ui/sidebar/facility/location/location-switcher.tsx
+++ b/src/components/ui/sidebar/facility/location/location-switcher.tsx
@@ -84,18 +84,18 @@ export function LocationSwitcher() {
             className="w-full flex items-center justify-between gap-3 py-6 px-2 rounded-md bg-white border border-gray-200"
             onClick={() => setOpenDialog(true)}
           >
-            <div className="flex items-center gap-2">
-              <MapPinIcon className="size-5 text-green-600" />
-              <div className="flex flex-col items-start">
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <MapPinIcon className="size-5 text-green-600 shrink-0" />
+              <div className="flex flex-col items-start min-w-0 flex-1">
                 <span className="text-xs text-gray-500">
                   {t("current_location")}
                 </span>
-                <span className="text-sm font-medium text-gray-900">
+                <span className="text-sm font-medium text-gray-900 truncate w-full">
                   {location?.name}
                 </span>
               </div>
             </div>
-            <CareIcon icon="l-sort" />
+            <CareIcon icon="l-sort" className="shrink-0" />
           </Button>
           <Separator className="mt-4" />
         </div>


### PR DESCRIPTION
## Proposed Changes

Fixes #15877 

### Summary
Fixed text overflow bug in the "Current Location" display within the Services sidebar. Long location names (e.g., "Lab Collection Point (Room 118)") were overflowing their container and breaking the layout.

### Changes Made
- Added `truncate w-full` classes to location name span to enable text truncation with ellipsis
- Added `min-w-0 flex-1` to parent containers to allow proper flex shrinking
- Added `shrink-0` to icon elements to prevent icon compression
- Improved responsive behavior of location switcher component

### Technical Details
**File Modified:** `src/components/ui/sidebar/facility/location/location-switcher.tsx`

**CSS Classes Added:**
- `min-w-0 flex-1` on outer flex container (line 87)
- `shrink-0` on MapPinIcon (line 88)
- `min-w-0 flex-1` on text container (line 89)
- `truncate w-full` on location name span (line 93)
- `shrink-0` on sort icon (line 97)

### Result
- ✅ Long location names now display as: "Lab Collection Point (Ro..."
- ✅ No text overflow or layout breaking
- ✅ Clean, professional UI appearance maintained
- ✅ Icons remain properly sized and positioned


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network). _(UI fix, no doc update needed)_
- [x] Ensure that UI text is placed in I18n files. _(No text changes, only CSS)_
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location switcher display to properly handle and truncate long location names, preventing layout overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->