### PR TITLE
fix: responsive layout of accounts tab in patient profile

### DIFF
--- a/src/components/Patient/PatientHome.tsx
+++ b/src/components/Patient/PatientHome.tsx
@@ -136,7 +136,7 @@ export const PatientHome = (props: {
           </div>
         </div>
         <div className="lg:flex">
-          <div className="h-full lg:mr-7 lg:basis-5/6">
+          <div className="h-full min-w-0 lg:mr-7 lg:basis-5/6">
             {Tab?.component && (
               <Tab.component
                 facilityId={

--- a/src/pages/Facility/billing/account/AccountList.tsx
+++ b/src/pages/Facility/billing/account/AccountList.tsx
@@ -203,8 +203,8 @@ export function AccountList({
               isEdit={!!editingAccount}
             />
           )}
-          <div className="flex flex-col md:flex-row items-start gap-2">
-            <div className="w-full md:w-auto">
+          <div className="flex flex-wrap items-start gap-2">
+            <div className="w-full sm:w-auto sm:shrink-0">
               <PatientIdentifierFilter
                 onSelect={(patientId, patientName) =>
                   updateQuery({
@@ -218,21 +218,21 @@ export function AccountList({
                 patientName={qParams.patient_name}
               />
             </div>
-            <div className="flex flex-col sm:flex-row">
+            <div className="w-full sm:w-auto">
               <MultiFilter
                 selectedFilters={selectedFilters}
                 onFilterChange={handleFilterChange}
                 onOperationChange={handleOperationChange}
                 onClearAll={handleClearAll}
                 onClearFilter={handleClearFilter}
-                className="flex sm:flex-row flex-wrap sm:items-center"
+                className="w-full items-start sm:w-auto sm:flex-row sm:flex-wrap sm:items-center"
                 triggerButtonClassName="self-start sm:self-center"
                 clearAllButtonClassName="self-center"
                 facilityId={facilityId}
               />
             </div>
           </div>
-          <div className="justify-end flex">
+          <div className="flex justify-end w-full">
             {patientId && canCreateAccount && (
               <Button
                 className="w-full sm:w-auto mt-2"


### PR DESCRIPTION
## Proposed Changes

Fixes #15888 

<img width="1197" height="803" alt="image" src="https://github.com/user-attachments/assets/1fc6a0ea-b6d7-4a09-bafa-5bbd390ef19f" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout behavior in the patient home component to prevent overflow issues when toggling the sidebar.
  * Enhanced the account list header layout to be more flexible and wrap properly on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->