### PR TITLE
Show tags in Activity Definition and Charge Item Definition lists

### DIFF
--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
@@ -20,6 +20,8 @@ import {
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
+import TagBadge from "@/components/Tags/TagBadge";
+
 import { ActionButtons } from "@/pages/Facility/settings/ActionButtons";
 
 import useFilters from "@/hooks/useFilters";
@@ -76,6 +78,13 @@ function ActivityDefinitionCard({
               <div className="mt-2 text-xs text-gray-400">
                 {t("kind")}: {t(definition.kind)}
               </div>
+              {definition.tags.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {definition.tags.map((tag) => (
+                    <TagBadge key={tag.id} tag={tag} className="text-xs" />
+                  ))}
+                </div>
+              )}
             </div>
           </div>
           <div className="ml-auto flex flex-wrap gap-2">
@@ -132,6 +141,17 @@ function ActivityDefinitionTableRow({
       </TableCell>
       <TableCell className="text-sm text-gray-500">
         {t(definition.kind)}
+      </TableCell>
+      <TableCell>
+        <div className="flex flex-wrap gap-1">
+          {definition.tags.length > 0 ? (
+            definition.tags.map((tag) => (
+              <TagBadge key={tag.id} tag={tag} className="text-xs" />
+            ))
+          ) : (
+            <span className="text-gray-400">&mdash;</span>
+          )}
+        </div>
       </TableCell>
       <TableCell>
         <div className="flex gap-2">
@@ -266,12 +286,13 @@ export function ActivityDefinitionList({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-[30%]">{t("title")}</TableHead>
-                    <TableHead className="w-[15%]">
+                    <TableHead className="w-[25%]">{t("title")}</TableHead>
+                    <TableHead className="w-[12%]">
                       {t("classification")}
                     </TableHead>
-                    <TableHead className="w-[15%]">{t("status")}</TableHead>
-                    <TableHead className="w-[15%]">{t("kind")}</TableHead>
+                    <TableHead className="w-[10%]">{t("status")}</TableHead>
+                    <TableHead className="w-[10%]">{t("kind")}</TableHead>
+                    <TableHead className="w-[20%]">{t("tags")}</TableHead>
                     <TableHead className="w-[5%]">{t("actions")}</TableHead>
                   </TableRow>
                 </TableHeader>

--- a/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/activityDefinition/ActivityDefinitionListComponent.tsx
@@ -149,7 +149,7 @@ function ActivityDefinitionTableRow({
               <TagBadge key={tag.id} tag={tag} className="text-xs" />
             ))
           ) : (
-            <span className="text-gray-400">&mdash;</span>
+            <span className="text-gray-400">—</span>
           )}
         </div>
       </TableCell>

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
@@ -136,7 +136,7 @@ function ChargeItemTableRow({
               <TagBadge key={tag.id} tag={tag} className="text-xs" />
             ))
           ) : (
-            <span className="text-gray-400">&mdash;</span>
+            <span className="text-gray-400">—</span>
           )}
         </div>
       </TableCell>

--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionListComponent.tsx
@@ -20,6 +20,8 @@ import {
 
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 
+import TagBadge from "@/components/Tags/TagBadge";
+
 import { ActionButtons } from "@/pages/Facility/settings/ActionButtons";
 
 import useFilters from "@/hooks/useFilters";
@@ -65,6 +67,13 @@ function ChargeItemCard({
                 <p className="mt-1 text-sm text-gray-500 line-clamp-2">
                   {definition.description}
                 </p>
+              )}
+              {definition.tags.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {definition.tags.map((tag) => (
+                    <TagBadge key={tag.id} tag={tag} className="text-xs" />
+                  ))}
+                </div>
               )}
             </div>
           </div>
@@ -119,6 +128,17 @@ function ChargeItemTableRow({
         {definition.price_components.length > 0
           ? `${definition.price_components.length} ${t("price_components")}`
           : t("no_price_components")}
+      </TableCell>
+      <TableCell>
+        <div className="flex flex-wrap gap-1">
+          {definition.tags.length > 0 ? (
+            definition.tags.map((tag) => (
+              <TagBadge key={tag.id} tag={tag} className="text-xs" />
+            ))
+          ) : (
+            <span className="text-gray-400">&mdash;</span>
+          )}
+        </div>
       </TableCell>
       <TableCell>
         <div className="flex justify-center gap-2">
@@ -236,13 +256,14 @@ export function ChargeItemList({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-[35%]">{t("title")}</TableHead>
-                    <TableHead className="w-[15%]">{t("status")}</TableHead>
-                    <TableHead className="w-[20%]">{t("category")}</TableHead>
-                    <TableHead className="w-[15%]">
+                    <TableHead className="w-[25%]">{t("title")}</TableHead>
+                    <TableHead className="w-[10%]">{t("status")}</TableHead>
+                    <TableHead className="w-[15%]">{t("category")}</TableHead>
+                    <TableHead className="w-[12%]">
                       {t("price_components")}
                     </TableHead>
-                    <TableHead className="w-[15%] text-center">
+                    <TableHead className="w-[20%]">{t("tags")}</TableHead>
+                    <TableHead className="w-[10%] text-center">
                       {t("actions")}
                     </TableHead>
                   </TableRow>

--- a/src/types/emr/activityDefinition/activityDefinition.ts
+++ b/src/types/emr/activityDefinition/activityDefinition.ts
@@ -4,6 +4,7 @@ import { SlugConfig } from "@/types/base/slug/slugConfig";
 import { ChargeItemDefinitionRead } from "@/types/billing/chargeItemDefinition/chargeItemDefinition";
 import { ObservationDefinitionReadSpec } from "@/types/emr/observationDefinition/observationDefinition";
 import { SpecimenDefinitionRead } from "@/types/emr/specimenDefinition/specimenDefinition";
+import { TagConfig } from "@/types/emr/tagConfig/tagConfig";
 import { HealthcareServiceReadSpec } from "@/types/healthcareService/healthcareService";
 import { LocationRead } from "@/types/location/location";
 
@@ -79,6 +80,7 @@ export interface ActivityDefinitionUpdateSpec extends Omit<
 
 export interface ActivityDefinitionReadSpec extends BaseActivityDefinitionSpec {
   version?: number;
+  tags: TagConfig[];
   specimen_requirements: SpecimenDefinitionRead[];
   charge_item_definitions: ChargeItemDefinitionRead[];
   observation_result_requirements: ObservationDefinitionReadSpec[];


### PR DESCRIPTION
## Summary

- Display tags for each item in the Activity Definition list and Charge Item Definition list, in both desktop table view (new "Tags" column) and mobile card view
- Uses the existing `TagBadge` component for consistent rendering with color support

Closes #15898

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering changes plus a type/interface extension; low risk aside from potential assumptions that `tags` is always present on API responses.
> 
> **Overview**
> Adds tag visibility to facility settings lists by rendering `TagBadge` for each Activity Definition and Charge Item Definition in both mobile card view and desktop table view.
> 
> Desktop tables gain a new **Tags** column (with adjusted column widths), and rows display an em-dash placeholder when no tags are present. The Activity Definition read type is extended to include `tags: TagConfig[]` to support the UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6076b2de05b0bf9ce3785ddbdd0aa30f6c4e0f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<img width="2056" height="1254" alt="image" src="https://github.com/user-attachments/assets/5b5169c9-9f85-40e3-ae20-36539ca50903" />

<img width="514" height="1109" alt="image" src="https://github.com/user-attachments/assets/b5b07f11-e929-429a-98ce-e02bd49b8d0e" />

![Uploading image.png…]()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tags for activity and charge item definitions are now shown in mobile cards and desktop list rows.
  * A new Tags column/header appears in desktop tables; entries show tag badges or a dash if none.
  * Table layout and column widths have been adjusted for clearer display of tags alongside existing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->