### PR TITLE
medicine adminstrations: show note and method of medication request

### DIFF
--- a/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
+++ b/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
@@ -95,7 +95,7 @@ const IndividualMedicationRow: React.FC<{
       {/* Medication details - indented */}
       <div
         className={cn(
-          "p-3 pl-12 border-t border-r border-gray-100 bg-gray-50",
+          "p-3 pl-12 border-t border-r border-gray-100 bg-gray-50 min-w-0",
           isInactive && "opacity-50",
         )}
       >
@@ -109,6 +109,7 @@ const IndividualMedicationRow: React.FC<{
             {[
               formatDosage(medication.dosage_instruction[0]),
               formatFrequency(medication.dosage_instruction[0]),
+              medication.dosage_instruction[0]?.method?.display,
             ]
               .filter(Boolean)
               .join(", ")}
@@ -120,6 +121,11 @@ const IndividualMedicationRow: React.FC<{
             {t(medication.status)}
           </Badge>
         </div>
+        {medication.note && (
+          <div className="text-xs text-gray-500 mt-0.5 italic wrap-break-word">
+            {medication.note}
+          </div>
+        )}
         <div className="text-xs text-gray-500 mt-0.5">
           {t("added_on")}:{" "}
           {format(
@@ -324,12 +330,29 @@ export const GroupedMedicationRow: React.FC<GroupedMedicationRowProps> = ({
                   const freq = formatFrequency(
                     latestActiveRequest.dosage_instruction[0],
                   );
+                  const method =
+                    latestActiveRequest.dosage_instruction[0]?.method;
                   return (
-                    <div className="text-sm text-gray-600 mt-0.5">
-                      {formatDosage(latestActiveRequest.dosage_instruction[0])}
-                      {freq && <span className="text-gray-400"> · </span>}
-                      {freq}
-                    </div>
+                    <>
+                      <div className="text-sm text-gray-600 mt-0.5 whitespace-pre-wrap">
+                        {formatDosage(
+                          latestActiveRequest.dosage_instruction[0],
+                        )}
+                        {freq && <span className="text-gray-400"> · </span>}
+                        {freq}
+                        {method && (
+                          <>
+                            <span className="text-gray-400"> · </span>
+                            {method.display}
+                          </>
+                        )}
+                      </div>
+                      {latestActiveRequest.note && (
+                        <div className="text-xs text-gray-500 mt-0.5 italic whitespace-pre-wrap">
+                          {latestActiveRequest.note}
+                        </div>
+                      )}
+                    </>
                   );
                 })()}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only rendering changes that read existing fields (`method`, `note`) without altering medication or administration workflows.
> 
> **Overview**
> Medication administration rows now surface additional prescription context by displaying the `dosage_instruction.method.display` alongside dosage/frequency for both grouped and individual medication requests.
> 
> Adds rendering of `MedicationRequest.note` under the dose summary (with wrapping/whitespace handling tweaks like `min-w-0`/`whitespace-pre-wrap`) so notes and longer text are visible without breaking layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79ee18e0fb29be90a4f0815094c576746d4ac23c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of dosage methods with medication frequency information.
  * Introduced medication and prescription notes visibility within the medication administration interface.

* **Style**
  * Enhanced layout and spacing to improve readability and text wrapping for medication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->