### PR TITLE
feat: update pharmacy keyboard shortcuts to use shift modifier for dispense and return actions

### DIFF
--- a/src/config/keyboardShortcuts.json
+++ b/src/config/keyboardShortcuts.json
@@ -63,8 +63,8 @@
   ],
 
   "facility:pharmacy": [
-    { "key": "d", "action": "dispense-button", "description": "Dispense Medication", "when": "always" },
-    { "key": "r", "action": "medication-return", "description": "Return Medication", "when": "always" },
+    { "key": "shift+d", "action": "dispense-button", "description": "Dispense Medication", "when": "always" },
+    { "key": "shift+r", "action": "medication-return", "description": "Return Medication", "when": "always" },
     { "key": "b", "action": "billing-action", "description": "Billing related action", "when": "always" },
     { "key": "shift+p", "action": "view-prescriptions", "description": "View Prescription", "when": "always" },
     { "key": "a", "action": "view-account", "description": "View Account", "when": "always" }


### PR DESCRIPTION

Fixes #15911

## Proposed Changes
<img width="1293" height="266" alt="image" src="https://github.com/user-attachments/assets/411b60ca-9ab4-420c-a5f3-b6d4360e4dc6" />

disable keyboard interaction with QR

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated keyboard shortcuts in the pharmacy module. Dispensing and medication return operations now use shift-modified key combinations instead of single-key bindings for improved shortcut accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->