### PR TITLE
show deceased status in appointment card

### DIFF
--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -742,7 +742,7 @@ function AppointmentCard({
           </p>
         </div>
         <div className="flex flex-col gap-2">
-          {appointment.patient.deceased_datetime && (
+          {patient.deceased_datetime && (
             <Badge variant="destructive" className="h-5 justify-center text-xs">
               {t("deceased")}
             </Badge>
@@ -964,7 +964,7 @@ function AppointmentRowItem({ appointment }: { appointment: Appointment }) {
             </span>
           </span>
         </span>
-        {appointment.patient.deceased_datetime && (
+        {patient.deceased_datetime && (
           <Badge
             variant="destructive"
             className="h-6 justify-center text-xs mt-1"

--- a/src/pages/Appointments/AppointmentsPage.tsx
+++ b/src/pages/Appointments/AppointmentsPage.tsx
@@ -741,17 +741,23 @@ function AppointmentCard({
             )}
           </p>
         </div>
-
-        {appointment.token && (
-          <div className="flex">
-            <div className="bg-gray-100 px-2 py-1 ml-px text-center rounded-md">
-              <p className="text-[10px] uppercase">{t("token")}</p>
-              <p className="font-bold text-lg uppercase">
-                {renderTokenNumber(appointment.token)}
-              </p>
+        <div className="flex flex-col gap-2">
+          {appointment.patient.deceased_datetime && (
+            <Badge variant="destructive" className="h-5 justify-center text-xs">
+              {t("deceased")}
+            </Badge>
+          )}
+          {appointment.token && (
+            <div className="flex">
+              <div className="bg-gray-100 px-2 py-1 ml-px text-center rounded-md">
+                <p className="text-[10px] uppercase">{t("token")}</p>
+                <p className="font-bold text-lg uppercase">
+                  {renderTokenNumber(appointment.token)}
+                </p>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
       <div className="flex flex-wrap gap-1">
         {appointment.tags.map((tag) => (
@@ -944,7 +950,7 @@ function AppointmentRowItem({ appointment }: { appointment: Appointment }) {
 
   return (
     <>
-      <TableCell className="py-6 group-hover:bg-gray-100 bg-white rounded-l-lg">
+      <TableCell className="flex flex-row gap-2 py-6 group-hover:bg-gray-100 bg-white rounded-l-lg">
         <span className="flex flex-row items-center gap-2">
           <CareIcon
             icon="l-draggabledots"
@@ -958,6 +964,14 @@ function AppointmentRowItem({ appointment }: { appointment: Appointment }) {
             </span>
           </span>
         </span>
+        {appointment.patient.deceased_datetime && (
+          <Badge
+            variant="destructive"
+            className="h-6 justify-center text-xs mt-1"
+          >
+            {t("deceased")}
+          </Badge>
+        )}
       </TableCell>
       {/* TODO: Replace with relevant information */}
       {appointment.resource_type === SchedulableResourceType.Practitioner && (


### PR DESCRIPTION
## Proposed Changes

Fixes #15930 

<img width="1378" height="917" alt="image" src="https://github.com/user-attachments/assets/15d99992-634d-4d91-a9a1-2fcd4ee23d39" />


<img width="1380" height="647" alt="image" src="https://github.com/user-attachments/assets/eaa351a5-b709-47b0-9adb-647c970c3799" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deceased badge indicator that displays in both appointment card and list views for clearer patient status visibility.
* **Style**
  * Adjusted appointment token and row layouts so the badge integrates cleanly above or beside the token and below patient info without disrupting list or board views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->