### PR TITLE
Show Empty state outside of table

### DIFF
--- a/src/components/Files/ReportSubTab.tsx
+++ b/src/components/Files/ReportSubTab.tsx
@@ -159,66 +159,58 @@ export function ReportSubTab({ associatingId, reportType }: ReportTabProps) {
 
   const RenderCards = () => (
     <div className="xl:hidden flex flex-col gap-3 pt-3 px-2">
-      {filteredReports && filteredReports.length > 0
-        ? filteredReports.map((report) => {
-            return (
-              <Card
-                key={report.id}
-                className={cn(
-                  report.is_archived ? "bg-white/50 opacity-70" : "bg-white",
-                )}
-              >
-                <CardContent className="p-4 space-y-3">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex items-start gap-3 flex-1 min-w-0">
-                      <span className="p-2 rounded-full bg-gray-100 shrink-0">
-                        <CareIcon
-                          icon={getReportTypeIcon(report.report_type)}
-                          className="text-xl"
-                        />
-                      </span>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-medium text-gray-900 truncate w-full">
-                          {report.name}
-                        </p>
-                        <p className="text-xs text-gray-500 mt-1">
-                          {t(report.report_type)}
-                        </p>
-                      </div>
+      {filteredReports &&
+        filteredReports.length > 0 &&
+        filteredReports.map((report) => {
+          return (
+            <Card
+              key={report.id}
+              className={cn(
+                report.is_archived ? "bg-white/50 opacity-70" : "bg-white",
+              )}
+            >
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-start gap-3 flex-1 min-w-0">
+                    <span className="p-2 rounded-full bg-gray-100 shrink-0">
+                      <CareIcon
+                        icon={getReportTypeIcon(report.report_type)}
+                        className="text-xl"
+                      />
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-gray-900 truncate w-full">
+                        {report.name}
+                      </p>
+                      <p className="text-xs text-gray-500 mt-1">
+                        {t(report.report_type)}
+                      </p>
                     </div>
                   </div>
+                </div>
 
-                  <div className="grid grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <div className="text-gray-500">{t("date")}</div>
-                      <div className="font-medium">
-                        {dayjs(report.created_date).format(
-                          "DD MMM YYYY, hh:mm A",
-                        )}
-                      </div>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <div className="text-gray-500">{t("date")}</div>
+                    <div className="font-medium">
+                      {dayjs(report.created_date).format(
+                        "DD MMM YYYY, hh:mm A",
+                      )}
                     </div>
                   </div>
+                </div>
 
-                  <div className="pt-2 flex justify-end">
-                    {report.is_archived ? (
-                      getArchivedMessage(report)
-                    ) : (
-                      <DetailButtons report={report} />
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })
-        : !reportsLoading && (
-            <EmptyState
-              icon={
-                <CareIcon icon="l-file-alt" className="text-primary size-6" />
-              }
-              title={t("no_reports_found")}
-              description={t("no_reports_found_description")}
-            />
-          )}
+                <div className="pt-2 flex justify-end">
+                  {report.is_archived ? (
+                    getArchivedMessage(report)
+                  ) : (
+                    <DetailButtons report={report} />
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
     </div>
   );
 
@@ -240,96 +232,81 @@ export function ReportSubTab({ associatingId, reportType }: ReportTabProps) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {filteredReports && filteredReports.length > 0
-            ? filteredReports.map((report) => {
-                return (
-                  <TableRow
-                    key={report.id}
-                    className={cn("shadow rounded-md overflow-hidden group")}
+          {filteredReports &&
+            filteredReports.length > 0 &&
+            filteredReports.map((report) => {
+              return (
+                <TableRow
+                  key={report.id}
+                  className={cn("shadow rounded-md overflow-hidden group")}
+                >
+                  <TableCell
+                    className={cn(
+                      "font-medium rounded-l-md rounded-y-md group-hover:bg-transparent",
+                      report.is_archived ? "bg-white/50" : "bg-white",
+                    )}
                   >
-                    <TableCell
-                      className={cn(
-                        "font-medium rounded-l-md rounded-y-md group-hover:bg-transparent",
-                        report.is_archived ? "bg-white/50" : "bg-white",
-                      )}
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className="p-2 rounded-full bg-gray-100 shrink-0">
-                          <CareIcon
-                            icon={getReportTypeIcon(report.report_type)}
-                            className="text-xl"
-                          />
-                        </span>
-                        {report.name && report.name.length > 30 ? (
-                          <TooltipComponent content={report.name}>
-                            <span className="text-gray-900 truncate block">
-                              {report.name}
-                            </span>
-                          </TooltipComponent>
-                        ) : (
+                    <div className="flex items-center gap-2">
+                      <span className="p-2 rounded-full bg-gray-100 shrink-0">
+                        <CareIcon
+                          icon={getReportTypeIcon(report.report_type)}
+                          className="text-xl"
+                        />
+                      </span>
+                      {report.name && report.name.length > 30 ? (
+                        <TooltipComponent content={report.name}>
                           <span className="text-gray-900 truncate block">
                             {report.name}
                           </span>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell
-                      className={cn(
-                        "rounded-y-md group-hover:bg-transparent",
-                        report.is_archived ? "bg-white/50" : "bg-white",
-                      )}
-                    >
-                      {t(report.report_type)}
-                    </TableCell>
-                    <TableCell
-                      className={cn(
-                        "rounded-y-md group-hover:bg-transparent",
-                        report.is_archived ? "bg-white/50" : "bg-white",
-                      )}
-                    >
-                      <TooltipComponent
-                        content={dayjs(report.created_date).format(
-                          "DD MMM YYYY, hh:mm A",
-                        )}
-                      >
-                        <span>
-                          {dayjs(report.created_date).format("DD MMM YYYY")}
-                        </span>
-                      </TooltipComponent>
-                    </TableCell>
-                    <TableCell
-                      className={cn(
-                        "text-right rounded-r-md rounded-y-md group-hover:bg-transparent",
-                        report.is_archived ? "bg-white/50" : "bg-white",
-                      )}
-                    >
-                      {report.is_archived ? (
-                        getArchivedMessage(report)
+                        </TooltipComponent>
                       ) : (
-                        <div className="flex flex-row gap-2 justify-end">
-                          <DetailButtons report={report} />
-                        </div>
+                        <span className="text-gray-900 truncate block">
+                          {report.name}
+                        </span>
                       )}
-                    </TableCell>
-                  </TableRow>
-                );
-              })
-            : !reportsLoading && (
-                <TableRow>
-                  <TableCell colSpan={5} className="py-4">
-                    <EmptyState
-                      icon={
-                        <CareIcon
-                          icon="l-file-alt"
-                          className="text-primary size-6"
-                        />
-                      }
-                      title={t("no_reports_found")}
-                      description={t("no_reports_found_description")}
-                    />
+                    </div>
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      "rounded-y-md group-hover:bg-transparent",
+                      report.is_archived ? "bg-white/50" : "bg-white",
+                    )}
+                  >
+                    {t(report.report_type)}
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      "rounded-y-md group-hover:bg-transparent",
+                      report.is_archived ? "bg-white/50" : "bg-white",
+                    )}
+                  >
+                    <TooltipComponent
+                      content={dayjs(report.created_date).format(
+                        "DD MMM YYYY, hh:mm A",
+                      )}
+                    >
+                      <span>
+                        {dayjs(report.created_date).format("DD MMM YYYY")}
+                      </span>
+                    </TooltipComponent>
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      "text-right rounded-r-md rounded-y-md group-hover:bg-transparent",
+                      report.is_archived ? "bg-white/50" : "bg-white",
+                    )}
+                  >
+                    {report.is_archived ? (
+                      getArchivedMessage(report)
+                    ) : (
+                      <div className="flex flex-row gap-2 justify-end">
+                        <DetailButtons report={report} />
+                      </div>
+                    )}
                   </TableCell>
                 </TableRow>
-              )}
+              );
+            })}
         </TableBody>
       </Table>
     </div>
@@ -402,9 +379,18 @@ export function ReportSubTab({ associatingId, reportType }: ReportTabProps) {
         archivedLabel="archived_reports"
       />
 
-      {/* Report List */}
-      <RenderCards />
-      <RenderTable />
+      {!reportsLoading && filteredReports.length === 0 ? (
+        <EmptyState
+          icon={<CareIcon icon="l-file-alt" className="text-primary size-6" />}
+          title={t("no_reports_found")}
+          description={t("no_reports_found_description")}
+        />
+      ) : (
+        <>
+          <RenderCards />
+          <RenderTable />
+        </>
+      )}
 
       {/* Pagination */}
       {filteredReports.length > 0 && (

--- a/src/components/Files/ReportSubTab.tsx
+++ b/src/components/Files/ReportSubTab.tsx
@@ -379,7 +379,7 @@ export function ReportSubTab({ associatingId, reportType }: ReportTabProps) {
         archivedLabel="archived_reports"
       />
 
-      {!reportsLoading && filteredReports.length === 0 ? (
+      {!reportsLoading ? (
         <EmptyState
           icon={<CareIcon icon="l-file-alt" className="text-primary size-6" />}
           title={t("no_reports_found")}

--- a/src/components/Files/ReportSubTab.tsx
+++ b/src/components/Files/ReportSubTab.tsx
@@ -379,7 +379,7 @@ export function ReportSubTab({ associatingId, reportType }: ReportTabProps) {
         archivedLabel="archived_reports"
       />
 
-      {!reportsLoading ? (
+      {!reportsLoading && filteredReports.length === 0 ? (
         <EmptyState
           icon={<CareIcon icon="l-file-alt" className="text-primary size-6" />}
           title={t("no_reports_found")}

--- a/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
@@ -350,11 +350,20 @@ export function BedChargeItemsTable({
       </div>
       {isLoading || isEncounterLoading ? (
         <TableSkeleton count={3} />
-      ) : encounterId == undefined || !encounterId || !encounter ? (
+      ) : encounterId == undefined ||
+        !encounterId ||
+        !encounter ||
+        !locationHistory.length ? (
         <EmptyState
           icon={<CareIcon icon="l-bed" className="text-primary size-6" />}
-          title={t("no_encounter_associated")}
-          description={t("no_encounter_associated_description")}
+          title={
+            !encounterId ? t("no_encounter_associated") : t("no_locations")
+          }
+          description={
+            !encounterId
+              ? t("no_encounter_associated_description")
+              : t("no_locations_description")
+          }
         />
       ) : (
         <div className="rounded-md overflow-x-auto border-2 border-white shadow-md">
@@ -389,22 +398,7 @@ export function BedChargeItemsTable({
               </TableRow>
             </TableHeader>
             <TableBody className="bg-white">
-              {!locationHistory.length ? (
-                <TableRow>
-                  <TableCell colSpan={9} className="py-4">
-                    <EmptyState
-                      icon={
-                        <CareIcon
-                          icon="l-map-pin"
-                          className="text-primary size-6"
-                        />
-                      }
-                      title={t("no_locations")}
-                      description={t("no_locations_description")}
-                    />
-                  </TableCell>
-                </TableRow>
-              ) : (
+              {locationHistory.length > 0 &&
                 locationHistory.flatMap((location) => {
                   const items = groupedChargeItems[location.id] || [];
 
@@ -568,8 +562,7 @@ export function BedChargeItemsTable({
                           ].filter(Boolean);
                         })),
                   ];
-                })
-              )}
+                })}
             </TableBody>
           </Table>
         </div>


### PR DESCRIPTION
## Proposed Changes
Fix #15941
<img width="1632" height="485" alt="image" src="https://github.com/user-attachments/assets/fe3c1d15-36c2-43f9-94da-d75c38162665" />
<img width="1644" height="459" alt="image" src="https://github.com/user-attachments/assets/36cdcb8b-f105-43a8-9f91-77d21a718a43" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified report rendering so card and table views use the same rendering path, reducing per-item branching and standardizing layout, spacing, and tooltip behavior.

* **Bug Fix / UX**
  * Centralized empty-state handling and clarified messages: empty states now indicate whether encounter data or location history is missing, avoid in-table empty blocks, and present consistent action controls per row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->