### PR TITLE
fix : Patient Navigation in completed queue navigates to correct page not 404

### DIFF
--- a/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
@@ -93,6 +93,7 @@ export function ManageQueueFinishedTab({
                 <TableCell>
                   {token.patient ? (
                     <Link
+                      basePath="/"
                       href={`/facility/${facilityId}/patients/verify?${new URLSearchParams(
                         {
                           phone_number: token.patient.phone_number,
@@ -114,6 +115,7 @@ export function ManageQueueFinishedTab({
                 </TableCell>
                 <TableCell>
                   <Link
+                    basePath="/"
                     href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
                     className="hover:underline transition-colors flex items-center gap-1"
                   >


### PR DESCRIPTION
## Proposed Changes

Fixes #15929
- Added basepath to patient name link.
- Added basepath to encounter link.

**Screen Recording**

https://github.com/user-attachments/assets/d40fbdbf-3f52-475b-81dc-96400b3f4768




Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal link handling in queue management to improve routing resolution. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->