### PR TITLE
Fix select all checkbox in the Bill medication table

### DIFF
--- a/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsByPrescriptions.tsx
+++ b/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsByPrescriptions.tsx
@@ -82,8 +82,6 @@ export default function BillMedicationsByPrescriptions({
     return <Loading />;
   }
 
-  console.log(form.getValues());
-
   return (
     <Page title={t("bill_medications")} hideTitleOnPage={true}>
       <Form {...form}>

--- a/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsPrescriptionCard.tsx
+++ b/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsPrescriptionCard.tsx
@@ -51,7 +51,7 @@ export const BillMedicationsPrescriptionCard = ({
   return (
     <>
       <Summary prescription={prescription} form={form} name={name} />
-      <HeaderRow />
+      <HeaderRow form={form} name={name} />
 
       {/* TODO: we may need to exclude medications based on their status (enterred in errors?) */}
       {items.map((_, index) => (
@@ -154,14 +154,43 @@ const Summary = ({
   );
 };
 
-const HeaderRow = () => {
+const HeaderRow = ({
+  form,
+  name,
+}: {
+  form: UseFormReturn<z.infer<typeof billMedicationsByPrescriptionsFormSchema>>;
+  name: `prescriptions.${number}`;
+}) => {
   const { t } = useTranslation();
 
   return (
     <>
       <div className="col-start-1 bg-gray-100 py-1 px-3 flex items-center">
-        {/* TODO: wire this? */}
-        <Checkbox />
+        <FormField
+          control={form.control}
+          name={`${name}.items`}
+          render={() => (
+            <FormItem>
+              <FormControl>
+                <Checkbox
+                  checked={
+                    form.watch(`${name}.items`).length > 0 &&
+                    form.watch(`${name}.items`).every((q) => q.isSelected)
+                  }
+                  onCheckedChange={(checked) => {
+                    const items = form.getValues(`${name}.items`);
+                    items.forEach((_, index) => {
+                      form.setValue(
+                        `${name}.items.${index}.isSelected`,
+                        !!checked,
+                      );
+                    });
+                  }}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
       </div>
       <div className="bg-gray-100 py-1 px-3 flex items-center">
         <span className="text-sm font-medium text-gray-700">
@@ -217,8 +246,6 @@ const MedicineLineItem = ({ name, form }: MedicineLineItemProps) => {
 
   const effectiveProductKnowledge =
     substitution?.substitutedProductKnowledge || productKnowledge;
-
-  console.log(medication);
 
   return (
     <>


### PR DESCRIPTION
## Proposed Changes

<img width="1153" height="583" alt="image" src="https://github.com/user-attachments/assets/31af347c-32b5-4b40-9587-5713e97bf3ef" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-prescription billing workflow enabling simultaneous billing of multiple prescriptions.
  * Updated prescription queue with bulk selection capabilities and batch operations (print, bill).
  * New inventory lot selector for streamlined medicine selection during billing.
  * Enhanced pharmacy billing interface with prescription cards, lot management, and consolidated pricing display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->