### PR TITLE
Support for substitute medicines

### DIFF
--- a/src/components/Medication/SubstitutionSheet.tsx
+++ b/src/components/Medication/SubstitutionSheet.tsx
@@ -55,7 +55,6 @@ interface SubstitutionSheetProps {
     reason?: SubstitutionReason;
   };
   /** Pre-selected substitute product (optional) */
-  preSelectedProduct?: ProductKnowledgeBase;
   onSave: (
     substitutionDetails?: {
       substitutedProductKnowledge: ProductKnowledgeBase;
@@ -63,7 +62,6 @@ interface SubstitutionSheetProps {
       reason: SubstitutionReason;
     } | null, // null to clear substitution
   ) => void;
-  facilityId: string;
 }
 
 const substitutionSchema = z.object({
@@ -82,22 +80,18 @@ export function SubstitutionSheet({
   originalProductKnowledge,
   originalMedicationName,
   currentSubstitution,
-  preSelectedProduct,
   onSave,
-  facilityId: _facilityId,
 }: SubstitutionSheetProps) {
   const { t } = useTranslation();
   const [selectedSubstitute, setSelectedSubstitute] = useState<
     ProductKnowledgeBase | undefined
-  >(currentSubstitution?.substitutedProductKnowledge || preSelectedProduct);
+  >(currentSubstitution?.substitutedProductKnowledge);
 
   const form = useForm<SubstitutionFormValues>({
     resolver: zodResolver(substitutionSchema),
     defaultValues: {
       substitutedProductKnowledge:
-        currentSubstitution?.substitutedProductKnowledge ||
-        preSelectedProduct ||
-        undefined,
+        currentSubstitution?.substitutedProductKnowledge || undefined,
       type: currentSubstitution?.type || SubstitutionType.E,
       reason: currentSubstitution?.reason || SubstitutionReason.OS,
     },
@@ -105,8 +99,7 @@ export function SubstitutionSheet({
 
   useEffect(() => {
     if (open) {
-      const initialProduct =
-        currentSubstitution?.substitutedProductKnowledge || preSelectedProduct;
+      const initialProduct = currentSubstitution?.substitutedProductKnowledge;
       form.reset({
         substitutedProductKnowledge: initialProduct || undefined,
         type: currentSubstitution?.type || SubstitutionType.E,
@@ -114,7 +107,7 @@ export function SubstitutionSheet({
       });
       setSelectedSubstitute(initialProduct);
     }
-  }, [open, currentSubstitution, preSelectedProduct, form]);
+  }, [open, currentSubstitution, form]);
 
   useEffect(() => {
     form.setValue("substitutedProductKnowledge", selectedSubstitute, {

--- a/src/components/Medication/SubstitutionSheet.tsx
+++ b/src/components/Medication/SubstitutionSheet.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
@@ -30,6 +30,7 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  SheetTrigger,
 } from "@/components/ui/sheet";
 import { ProductKnowledgeSelect } from "@/pages/Facility/services/inventory/ProductKnowledgeSelect";
 
@@ -43,110 +44,86 @@ import {
 } from "@/types/emr/medicationDispense/medicationDispense";
 import { ProductKnowledgeBase } from "@/types/inventory/productKnowledge/productKnowledge";
 
-interface SubstitutionSheetProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  originalProductKnowledge?: ProductKnowledgeBase;
-  /** Used when no original product knowledge exists (e.g., medication without linked product) */
-  originalMedicationName?: string;
-  currentSubstitution?: {
-    substitutedProductKnowledge?: ProductKnowledgeBase;
-    type?: SubstitutionType;
-    reason?: SubstitutionReason;
-  };
-  /** Pre-selected substitute product (optional) */
-  onSave: (
-    substitutionDetails?: {
-      substitutedProductKnowledge: ProductKnowledgeBase;
-      type: SubstitutionType;
-      reason: SubstitutionReason;
-    } | null, // null to clear substitution
-  ) => void;
-}
-
-const substitutionSchema = z.object({
-  substitutedProductKnowledge: z.any().refine((val) => val?.slug, {
-    message: "Product selection is required",
-  }),
+export const substitutionSchema = z.object({
+  substitutedProductKnowledge: z
+    .custom<ProductKnowledgeBase>()
+    .refine((value) => value !== undefined, {
+      message: "Substituted product knowledge is required",
+    }),
   type: z.nativeEnum(SubstitutionType),
   reason: z.nativeEnum(SubstitutionReason),
 });
 
-type SubstitutionFormValues = z.infer<typeof substitutionSchema>;
+export type SubstitutionFormValues = z.infer<typeof substitutionSchema>;
+
+interface SubstitutionSheetProps {
+  original: {
+    /** Used when original product knowledge exists */
+    productKnowledge?: ProductKnowledgeBase | null;
+    /** Used when no original product knowledge exists (e.g., medication without linked product) */
+    medicationName?: string | null;
+  };
+  initialValue?: SubstitutionFormValues | null;
+  onSave: (value: SubstitutionFormValues) => void;
+  onClear: () => void;
+  trigger?: React.ReactNode;
+}
 
 export function SubstitutionSheet({
-  open,
-  onOpenChange,
-  originalProductKnowledge,
-  originalMedicationName,
-  currentSubstitution,
+  original,
+  initialValue,
   onSave,
+  onClear,
+  trigger,
 }: SubstitutionSheetProps) {
   const { t } = useTranslation();
-  const [selectedSubstitute, setSelectedSubstitute] = useState<
-    ProductKnowledgeBase | undefined
-  >(currentSubstitution?.substitutedProductKnowledge);
+  const [open, setOpen] = useState(false);
+
+  const defaultValues = useMemo(() => {
+    return (
+      initialValue ?? {
+        substitutedProductKnowledge: undefined,
+        type: SubstitutionType.E,
+        reason: SubstitutionReason.OS,
+      }
+    );
+  }, [initialValue]);
 
   const form = useForm<SubstitutionFormValues>({
     resolver: zodResolver(substitutionSchema),
-    defaultValues: {
-      substitutedProductKnowledge:
-        currentSubstitution?.substitutedProductKnowledge || undefined,
-      type: currentSubstitution?.type || SubstitutionType.E,
-      reason: currentSubstitution?.reason || SubstitutionReason.OS,
-    },
+    defaultValues,
   });
 
-  useEffect(() => {
-    if (open) {
-      const initialProduct = currentSubstitution?.substitutedProductKnowledge;
-      form.reset({
-        substitutedProductKnowledge: initialProduct || undefined,
-        type: currentSubstitution?.type || SubstitutionType.E,
-        reason: currentSubstitution?.reason || SubstitutionReason.OS,
-      });
-      setSelectedSubstitute(initialProduct);
-    }
-  }, [open, currentSubstitution, form]);
-
-  useEffect(() => {
-    form.setValue("substitutedProductKnowledge", selectedSubstitute, {
-      shouldValidate: true,
-      shouldDirty: true,
-    });
-  }, [selectedSubstitute, form]);
-
   const onSubmit = (values: SubstitutionFormValues) => {
-    if (!values.substitutedProductKnowledge) return;
-    onSave({
-      substitutedProductKnowledge: values.substitutedProductKnowledge,
-      type: values.type,
-      reason: values.reason,
-    });
-    onOpenChange(false);
-  };
-
-  const handleProductSelect = (product: ProductKnowledgeBase | undefined) => {
-    if (!product) return;
-    setSelectedSubstitute(product);
+    onSave(values);
+    setOpen(false);
+    form.reset();
   };
 
   const displayName =
-    originalProductKnowledge?.name || originalMedicationName || "";
+    original?.productKnowledge?.name || original?.medicationName;
 
-  const handleClearSubstitution = () => {
-    onSave(null); // Pass null to indicate clearing
-    onOpenChange(false);
+  const handleClear = () => {
+    onClear();
+    setOpen(false);
+    form.reset();
   };
 
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [defaultValues, form]);
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        {trigger || <Button variant="outline">{t("sub")}</Button>}
+      </SheetTrigger>
       <SheetContent className="flex h-full w-full flex-col sm:max-w-2xl">
         <SheetHeader className="space-y-3 pb-6">
           <SheetTitle className="text-xl font-semibold">
             {t("substitute_medication")}
           </SheetTitle>
-          <SheetDescription className="text-base">
+          <SheetDescription className="text-base" asChild>
             <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <span>{t("substituting_for")}:</span>
@@ -162,38 +139,31 @@ export function SubstitutionSheet({
         <ScrollArea className="flex-1 pr-6">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-              {/* Product Selection */}
               <FormField
                 control={form.control}
                 name="substitutedProductKnowledge"
-                render={() => (
+                render={({ field }) => (
                   <FormItem>
                     <FormLabel className="text-base font-medium" aria-required>
                       {t("select_substitute_product")}
                     </FormLabel>
-
-                    <div className="space-y-3">
-                      <ProductKnowledgeSelect
-                        value={selectedSubstitute}
-                        onChange={handleProductSelect}
-                        placeholder={t("search_substitute_medications")}
-                        className="w-full"
-                      />
-                    </div>
+                    <ProductKnowledgeSelect
+                      {...field}
+                      placeholder={t("search_substitute_medications")}
+                      className="w-full"
+                    />
                     <FormMessage />
                   </FormItem>
                 )}
               />
 
-              {/* Substitution Type */}
               <FormField
                 control={form.control}
                 name="type"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="text-base font-medium">
+                    <FormLabel className="text-base font-medium" aria-required>
                       {t("substitution_type")}
-                      <span className="text-destructive ml-1">*</span>
                     </FormLabel>
                     <Select
                       onValueChange={field.onChange}
@@ -208,14 +178,14 @@ export function SubstitutionSheet({
                           </SelectValue>
                         </SelectTrigger>
                       </FormControl>
-                      <SelectContent className="max-w-[var(--radix-select-trigger-width)] w-full">
+                      <SelectContent className="max-w-(--radix-select-trigger-width) w-full">
                         {Object.values(SubstitutionType).map((type) => (
                           <SelectItem key={type} value={type} className="py-3">
                             <div className="space-y-1">
                               <p className="font-medium">
                                 {getSubstitutionTypeDisplay(t, type)}
                               </p>
-                              <p className="text-xs text-muted-foreground">
+                              <p className="text-xs text-gray-600">
                                 {getSubstitutionTypeDescription(t, type)}
                               </p>
                             </div>
@@ -228,15 +198,13 @@ export function SubstitutionSheet({
                 )}
               />
 
-              {/* Substitution Reason */}
               <FormField
                 control={form.control}
                 name="reason"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="text-base font-medium">
+                    <FormLabel className="text-base font-medium" aria-required>
                       {t("substitution_reason")}
-                      <span className="text-destructive ml-1">*</span>
                     </FormLabel>
                     <Select
                       onValueChange={field.onChange}
@@ -251,7 +219,7 @@ export function SubstitutionSheet({
                           </SelectValue>
                         </SelectTrigger>
                       </FormControl>
-                      <SelectContent className="max-w-[var(--radix-select-trigger-width)] w-full">
+                      <SelectContent className="max-w-(--radix-select-trigger-width) w-full">
                         {Object.values(SubstitutionReason).map((reason) => (
                           <SelectItem
                             key={reason}
@@ -262,7 +230,7 @@ export function SubstitutionSheet({
                               <p className="font-medium">
                                 {getSubstitutionReasonDisplay(t, reason)}
                               </p>
-                              <p className="text-xs text-muted-foreground">
+                              <p className="text-xs text-gray-600">
                                 {getSubstitutionReasonDescription(t, reason)}
                               </p>
                             </div>
@@ -284,11 +252,8 @@ export function SubstitutionSheet({
               <Button
                 type="button"
                 variant="outline"
-                onClick={handleClearSubstitution}
-                disabled={
-                  !currentSubstitution?.substitutedProductKnowledge &&
-                  !selectedSubstitute
-                }
+                onClick={handleClear}
+                disabled={!initialValue}
                 className="flex-1 sm:flex-initial"
               >
                 {t("clear")}
@@ -305,7 +270,7 @@ export function SubstitutionSheet({
               <Button
                 type="submit"
                 onClick={form.handleSubmit(onSubmit)}
-                disabled={!form.formState.isValid || !selectedSubstitute}
+                disabled={!form.formState.isValid}
                 className="flex-1 sm:flex-initial"
               >
                 {t("save")}

--- a/src/pages/Facility/services/inventory/InventoryItemsSelector.tsx
+++ b/src/pages/Facility/services/inventory/InventoryItemsSelector.tsx
@@ -30,13 +30,13 @@ import { PaginatedResponse } from "@/Utils/request/types";
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
-export const LotSelectionSchema = z.object({
+export const lotSelectionSchema = z.object({
   item: z.custom<InventoryRead>(),
   quantity: zodDecimal({ min: 0 }),
   autoSelected: z.boolean().optional(),
 });
 
-export type LotSelection = z.infer<typeof LotSelectionSchema>;
+export type LotSelection = z.infer<typeof lotSelectionSchema>;
 
 // interface AutoSelectOptions {
 //   quantity: Decimal;
@@ -140,14 +140,7 @@ export const InventoryItemsSelector = ({
 
   // No stock state
   if (!items || items.length === 0) {
-    return (
-      <Badge
-        variant="destructive"
-        // className={cn(disabled && "opacity-50")}
-      >
-        {t("no_stock")}
-      </Badge>
-    );
+    return <Badge variant="destructive">{t("no_stock")}</Badge>;
   }
 
   return (

--- a/src/pages/Facility/services/pharmacy/AllMedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/AllMedicationBillForm.tsx
@@ -49,8 +49,6 @@ export default function AllMedicationBillForm({ patientId }: Props) {
   >(null);
   const [originalProductForSubstitution, setOriginalProductForSubstitution] =
     useState<ProductKnowledgeBase | undefined>();
-  const [preSelectedSubstituteProduct, setPreSelectedSubstituteProduct] =
-    useState<ProductKnowledgeBase | undefined>();
   const [originalMedicationName, setOriginalMedicationName] = useState<
     string | undefined
   >();
@@ -156,10 +154,9 @@ export default function AllMedicationBillForm({ patientId }: Props) {
             setEditingItemIndex(idx);
             setIsAddMedicationSheetOpen(true);
           }}
-          onSubstitute={(idx, productKnowledge, preSelectedProduct) => {
+          onSubstitute={(idx, productKnowledge) => {
             setSubstitutingItemIndex(idx);
             setOriginalProductForSubstitution(productKnowledge);
-            setPreSelectedSubstituteProduct(preSelectedProduct);
             // Get medication name for display when no product knowledge
             if (!productKnowledge) {
               const item = form.getValues(`items.${idx}`);
@@ -329,19 +326,16 @@ export default function AllMedicationBillForm({ patientId }: Props) {
             if (!open) {
               setSubstitutingItemIndex(null);
               setOriginalProductForSubstitution(undefined);
-              setPreSelectedSubstituteProduct(undefined);
               setOriginalMedicationName(undefined);
             }
           }}
           originalProductKnowledge={originalProductForSubstitution}
           originalMedicationName={originalMedicationName}
-          preSelectedProduct={preSelectedSubstituteProduct}
           currentSubstitution={
             substitutingItemIndex !== null
               ? form.watch(`items.${substitutingItemIndex}.substitution`)
               : undefined
           }
-          facilityId={facilityId}
           onSave={(substitutionDetails) => {
             if (substitutingItemIndex === null) return;
 
@@ -385,7 +379,6 @@ export default function AllMedicationBillForm({ patientId }: Props) {
             }
             setSubstitutingItemIndex(null);
             setOriginalProductForSubstitution(undefined);
-            setPreSelectedSubstituteProduct(undefined);
             setOriginalMedicationName(undefined);
             setIsSubstitutionSheetOpen(false);
           }}

--- a/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationBillForm.tsx
@@ -53,8 +53,6 @@ export default function MedicationBillForm({
   >(null);
   const [originalProductForSubstitution, setOriginalProductForSubstitution] =
     useState<ProductKnowledgeBase | undefined>();
-  const [preSelectedSubstituteProduct, setPreSelectedSubstituteProduct] =
-    useState<ProductKnowledgeBase | undefined>();
   const [originalMedicationName, setOriginalMedicationName] = useState<
     string | undefined
   >();
@@ -190,10 +188,9 @@ export default function MedicationBillForm({
             setEditingItemIndex(idx);
             setIsAddMedicationSheetOpen(true);
           }}
-          onSubstitute={(idx, productKnowledge, preSelectedProduct) => {
+          onSubstitute={(idx, productKnowledge) => {
             setSubstitutingItemIndex(idx);
             setOriginalProductForSubstitution(productKnowledge);
-            setPreSelectedSubstituteProduct(preSelectedProduct);
             // Get medication name for display when no product knowledge
             if (!productKnowledge) {
               const item = form.getValues(`items.${idx}`);
@@ -362,19 +359,16 @@ export default function MedicationBillForm({
             if (!open) {
               setSubstitutingItemIndex(null);
               setOriginalProductForSubstitution(undefined);
-              setPreSelectedSubstituteProduct(undefined);
               setOriginalMedicationName(undefined);
             }
           }}
           originalProductKnowledge={originalProductForSubstitution}
           originalMedicationName={originalMedicationName}
-          preSelectedProduct={preSelectedSubstituteProduct}
           currentSubstitution={
             substitutingItemIndex !== null
               ? form.watch(`items.${substitutingItemIndex}.substitution`)
               : undefined
           }
-          facilityId={facilityId}
           onSave={(substitutionDetails) => {
             if (substitutingItemIndex === null) return;
 
@@ -418,7 +412,6 @@ export default function MedicationBillForm({
             }
             setSubstitutingItemIndex(null);
             setOriginalProductForSubstitution(undefined);
-            setPreSelectedSubstituteProduct(undefined);
             setOriginalMedicationName(undefined);
             setIsSubstitutionSheetOpen(false);
           }}

--- a/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsPrescriptionCard.tsx
+++ b/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsPrescriptionCard.tsx
@@ -1,3 +1,4 @@
+import { SubstitutionSheet } from "@/components/Medication/SubstitutionSheet";
 import {
   formatDosage,
   formatDuration,
@@ -16,10 +17,7 @@ import {
   InventoryItemsSelector,
   LotSelection,
 } from "@/pages/Facility/services/inventory/InventoryItemsSelector";
-import {
-  BillMedicationLineItemSchemaType,
-  billMedicationsByPrescriptionsFormSchema,
-} from "@/pages/Facility/services/pharmacy/billMedications/formSchema";
+import { billMedicationsByPrescriptionsFormSchema } from "@/pages/Facility/services/pharmacy/billMedications/formSchema";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import {
   getBasePrice,
@@ -36,6 +34,7 @@ import { formatName } from "@/Utils/utils";
 import { DotsVerticalIcon } from "@radix-ui/react-icons";
 import { format } from "date-fns";
 import { BadgeInfo, PrinterIcon } from "lucide-react";
+import { useState } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
@@ -240,7 +239,6 @@ const MedicineLineItem = ({ name, form }: MedicineLineItemProps) => {
   const { facilityId } = useCurrentFacility();
   const { locationId } = useCurrentLocation();
 
-  const item = form.watch(name);
   const isSelected = form.watch(`${name}.isSelected`);
   const medication = form.watch(`${name}.medication`);
   const productKnowledge = form.watch(`${name}.productKnowledge`);
@@ -273,7 +271,7 @@ const MedicineLineItem = ({ name, form }: MedicineLineItemProps) => {
 
       {/* Medicine */}
       <div className="bg-white py-2 px-3 flex justify-between items-center">
-        <MedicineLineItemMedication item={item} />
+        <MedicineLineItemMedication form={form} name={name} />
       </div>
 
       {/* Select Lot */}
@@ -395,15 +393,18 @@ const MedicineLineItem = ({ name, form }: MedicineLineItemProps) => {
 };
 
 const MedicineLineItemMedication = ({
-  item,
+  form,
+  name,
 }: {
-  item: BillMedicationLineItemSchemaType;
+  form: UseFormReturn<z.infer<typeof billMedicationsByPrescriptionsFormSchema>>;
+  name: `prescriptions.${number}.items.${number}`;
 }) => {
   const { t } = useTranslation();
+  const [isSubstitutionSheetOpen, setIsSubstitutionSheetOpen] = useState(false);
 
-  const medication = item.medication;
-  const productKnowledge = item.productKnowledge;
-  const substitution = item.substitution;
+  const medication = form.watch(`${name}.medication`);
+  const productKnowledge = form.watch(`${name}.productKnowledge`);
+  const substitution = form.watch(`${name}.substitution`);
 
   const effectiveProductKnowledge =
     substitution?.substitutedProductKnowledge || productKnowledge;
@@ -464,12 +465,32 @@ const MedicineLineItemMedication = ({
           size="icon"
           className="text-sm font-semibold text-gray-950 px-6"
           onClick={() => {
-            // TODO: wire this
+            setIsSubstitutionSheetOpen(true);
           }}
         >
           {t("sub")}
         </Button>
       </div>
+      <SubstitutionSheet
+        open={isSubstitutionSheetOpen}
+        onOpenChange={setIsSubstitutionSheetOpen}
+        originalProductKnowledge={productKnowledge || undefined}
+        originalMedicationName={medication?.medication.display}
+        currentSubstitution={substitution || undefined}
+        onSave={(substitutionDetails) => {
+          if (substitutionDetails) {
+            form.setValue(`${name}.substitution`, substitutionDetails, {
+              shouldDirty: true,
+              shouldTouch: true,
+            });
+          } else {
+            form.setValue(`${name}.substitution`, null, {
+              shouldDirty: true,
+              shouldTouch: true,
+            });
+          }
+        }}
+      />
     </>
   );
 };

--- a/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsPrescriptionCard.tsx
+++ b/src/pages/Facility/services/pharmacy/billMedications/BillMedicationsPrescriptionCard.tsx
@@ -34,7 +34,6 @@ import { formatName } from "@/Utils/utils";
 import { DotsVerticalIcon } from "@radix-ui/react-icons";
 import { format } from "date-fns";
 import { BadgeInfo, Check, PrinterIcon } from "lucide-react";
-import { useState } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
@@ -307,7 +306,7 @@ const MedicineLineItem = ({ name, form }: MedicineLineItemProps) => {
               facilityId={facilityId}
               locationId={locationId}
               // TODO: handle this?
-              productKnowledgeId={productKnowledge?.id || ""}
+              productKnowledgeId={effectiveProductKnowledge?.id || ""}
               showOnlyAvailable
             />
           </div>
@@ -400,7 +399,6 @@ const MedicineLineItemMedication = ({
   name: `prescriptions.${number}.items.${number}`;
 }) => {
   const { t } = useTranslation();
-  const [isSubstitutionSheetOpen, setIsSubstitutionSheetOpen] = useState(false);
 
   const medication = form.watch(`${name}.medication`);
   const productKnowledge = form.watch(`${name}.productKnowledge`);
@@ -461,37 +459,46 @@ const MedicineLineItemMedication = ({
         <Button variant="outline" size="icon" className="text-gray-950">
           <BadgeInfo />
         </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          className="text-sm font-semibold text-gray-950 px-6"
-          onClick={() => {
-            setIsSubstitutionSheetOpen(true);
-          }}
-        >
-          {t("sub")}
-        </Button>
+
+        <FormField
+          control={form.control}
+          name={`${name}.substitution`}
+          render={({ field }) => (
+            <FormItem>
+              <SubstitutionSheet
+                original={{
+                  productKnowledge: productKnowledge,
+                  medicationName: medication?.medication.display,
+                }}
+                initialValue={field.value}
+                onSave={(value) => {
+                  field.onChange(value);
+                  form.setValue(`${name}.lots`, [], {
+                    shouldDirty: true,
+                    shouldTouch: true,
+                  });
+                }}
+                onClear={() => {
+                  field.onChange(null);
+                  form.setValue(`${name}.lots`, [], {
+                    shouldDirty: true,
+                    shouldTouch: true,
+                  });
+                }}
+                trigger={
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="text-sm font-semibold text-gray-950 px-6"
+                  >
+                    {t("sub")}
+                  </Button>
+                }
+              />
+            </FormItem>
+          )}
+        />
       </div>
-      <SubstitutionSheet
-        open={isSubstitutionSheetOpen}
-        onOpenChange={setIsSubstitutionSheetOpen}
-        originalProductKnowledge={productKnowledge || undefined}
-        originalMedicationName={medication?.medication.display}
-        currentSubstitution={substitution || undefined}
-        onSave={(substitutionDetails) => {
-          if (substitutionDetails) {
-            form.setValue(`${name}.substitution`, substitutionDetails, {
-              shouldDirty: true,
-              shouldTouch: true,
-            });
-          } else {
-            form.setValue(`${name}.substitution`, null, {
-              shouldDirty: true,
-              shouldTouch: true,
-            });
-          }
-        }}
-      />
     </>
   );
 };

--- a/src/pages/Facility/services/pharmacy/billMedications/formSchema.ts
+++ b/src/pages/Facility/services/pharmacy/billMedications/formSchema.ts
@@ -1,4 +1,4 @@
-import { LotSelectionSchema } from "@/pages/Facility/services/inventory/InventoryItemsSelector";
+import { lotSelectionSchema } from "@/pages/Facility/services/inventory/InventoryItemsSelector";
 import {
   SubstitutionReason,
   SubstitutionType,
@@ -39,7 +39,7 @@ const billMedicationLineItemSchema = z.object({
       reason: z.nativeEnum(SubstitutionReason),
     })
     .nullable(),
-  lots: z.array(LotSelectionSchema),
+  lots: z.array(lotSelectionSchema),
   allGiven: z.boolean(),
 });
 


### PR DESCRIPTION
## Proposed Changes

<img width="1700" height="996" alt="image" src="https://github.com/user-attachments/assets/195134db-6339-4043-ba86-f123a9a2f591" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/workflow change in medication billing: substitution now affects effective product selection (and thus inventory lot selection) and refactors `SubstitutionSheet` props/behavior, which could cause regressions or type-level breakages at remaining call sites.
> 
> **Overview**
> Adds an in-form medicine substitution flow to the prescription billing UI, allowing users to pick a substitute product plus substitution type/reason and then treating the substitute as the **effective** product for subsequent stock/lot selection.
> 
> Refactors `SubstitutionSheet` into a self-controlled sheet with an optional custom trigger, exported `substitutionSchema`/types, and simplified React Hook Form wiring (including clearer save/clear behavior and reset logic). Also normalizes lot selection schema naming (`LotSelectionSchema` → `lotSelectionSchema`) and applies small UI cleanups in `InventoryItemsSelector`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8974c87aca02abf16e8bc9e951369c653907a38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->