### PR TITLE
fix: correct optional chaining in autoPrintPreference and update QR code size and level in PrintInvoice

### DIFF
--- a/src/CAREUI/misc/PrintPreview.tsx
+++ b/src/CAREUI/misc/PrintPreview.tsx
@@ -42,7 +42,7 @@ export default function PrintPreview(props: Props) {
   const { t } = useTranslation();
   useShortcutSubContext();
 
-  const autoPrintPreference = props.facility?.print_templates?.find(
+  const autoPrintPreference = props.facility?.print_templates?.find?.(
     (t) => t.slug === (props.templateSlug ?? "default"),
   )?.print_setup?.auto_print;
 

--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -210,8 +210,8 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
               </div>
               <QRCodeSVG
                 value={invoice.account.patient.id}
-                size={50}
-                level="Q"
+                size={100}
+                level="M"
                 marginSize={0}
               />
             </div>


### PR DESCRIPTION


Fixes  #15987

## Proposed Changes

<img width="821" height="1007" alt="image" src="https://github.com/user-attachments/assets/bc2c7e77-e195-4a53-9ee5-9d7a0560d25c" />
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safety checks when retrieving print template preferences.
  * Improved QR code generation with larger size and enhanced error correction for better reliability and scanning performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->