### PR TITLE
 Fix token refresh stale closure in AuthUserProvider

### DIFF
--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -11,7 +11,7 @@ import { AuthUserContext } from "@/hooks/useAuthUser";
 import { LocalStorageKeys } from "@/common/constants";
 
 import mutate from "@/Utils/request/mutate";
-import query from "@/Utils/request/query";
+import query, { callApi } from "@/Utils/request/query";
 import { userAtom } from "@/atoms/user-atom";
 import {
   JwtTokenObtainPair,
@@ -65,16 +65,20 @@ export default function AuthUserProvider({
   useEffect(() => {
     setUser(user);
   }, [user, setUser]);
-  const refreshToken = localStorage.getItem(LocalStorageKeys.refreshToken);
-
   const tokenRefreshQuery = useQuery({
     queryKey: ["user-refresh-token"],
-    queryFn: query(authApi.tokenRefresh, {
-      body: { refresh: refreshToken || "" },
-    }),
+    queryFn: ({ signal }) => {
+      const currentRefreshToken = localStorage.getItem(
+        LocalStorageKeys.refreshToken,
+      );
+      return callApi(authApi.tokenRefresh, {
+        body: { refresh: currentRefreshToken || "" },
+        signal,
+      });
+    },
     refetchIntervalInBackground: true,
     refetchInterval: careConfig.auth.tokenRefreshInterval,
-    enabled: !!refreshToken && !!user,
+    enabled: !!localStorage.getItem(LocalStorageKeys.refreshToken) && !!user,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Proposed Changes

Fixes #16040
- Fixed stale closure bug where `refreshToken` was captured at render time in `AuthUserProvider`
- Modified `queryFn` to read `refreshToken` from `localStorage` at call time instead of from render scope
- Imported `callApi` directly instead of using `query()` wrapper to enable fresh token reading on each refetch
- Updated `enabled` condition to read from `localStorage` directly
- This ensures token refresh requests always send the current refresh token after backend rotation, preventing authentication failures

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes