### PR TITLE
Improve patient access error message clarity (#16014)

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -4099,7 +4099,7 @@
   "patient_name_uhid": "Patient Name/UHID",
   "patient_next_location": "Patient's Next Location",
   "patient_no": "OP/IP No",
-  "patient_not_found": "Patient Not Found",
+  "patient_not_found": "Patient not found or not accessible. Access requires an active encounter with your facility.",
   "patient_notes_thread__Doctors": "Doctor's Discussions",
   "patient_notes_thread__Nurses": "Nurse's Discussions",
   "patient_phone_number": "Patient Phone Number",


### PR DESCRIPTION
Fixes #16014

## Summary
Previously, when navigating to a patient page without access, the system displayed "Patient Not Found", which could be misleading.

This update improves the error message to clarify that:
- the patient may not exist, or
- the user may not have access because there is no active encounter with their facility.

## Changes
- Updated the `patient_not_found` translation string in `public/locale/en.json`.

## Merge Checklist
- [x] I have read the contributing guidelines.
- [x] I have tested the changes locally.
- [x] The change is minimal and focused on the issue.
- [ ] I have added tests (not applicable for this change).
- [ ] I have updated documentation (not required for this change).