### PR TITLE
fix: add overflow-auto to SheetContent for better template display

### DIFF
--- a/src/pages/Encounters/TemplateBuilder/TemplateReportSheet.tsx
+++ b/src/pages/Encounters/TemplateBuilder/TemplateReportSheet.tsx
@@ -50,7 +50,7 @@ export default function TemplateReportSheet({
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>{trigger}</SheetTrigger>
-      <SheetContent className="w-full sm:max-w-lg">
+      <SheetContent className="w-full sm:max-w-lg overflow-auto">
         <SheetHeader>
           <SheetTitle className="flex flex-col sm:flex-row justify-between mt-4">
             <span>{t("available_templates")}</span>


### PR DESCRIPTION
Fixes #16088

<img width="519" height="1005" alt="image" src="https://github.com/user-attachments/assets/19986bcd-a4c5-4f57-93c9-7435cc46ada7" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved UI layout handling by enabling scrolling for content containers that exceed available space, preventing content overflow and ensuring better visibility of all elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->