### PR TITLE
fix: ensure camera is disabled when dialog closes in GenericQRScanDialog

### DIFF
--- a/src/components/Scan/GenericQRScanDialog.tsx
+++ b/src/components/Scan/GenericQRScanDialog.tsx
@@ -52,7 +52,7 @@ export function GenericQRScanDialog({
   useEffect(() => {
     if (!open) {
       setInputValue("");
-      setScanning(autoStartScanning);
+      setScanning(false);
       setHasPermission(true);
     } else if (autoStartScanning) {
       setScanning(true);


### PR DESCRIPTION
Fixes #16101

<img width="857" height="316" alt="image" src="https://github.com/user-attachments/assets/eac9ad71-4860-41a5-b550-9131ea077f86" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed QR scan dialog behavior to properly reset the scanning state when the dialog closes, ensuring clean state management when reopening the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->