### PR TITLE
add deceased badge to info hover card

### DIFF
--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -2,6 +2,7 @@ import { Avatar } from "@/components/Common/Avatar";
 import { PatientAddressLink } from "@/components/Patient/PatientAddressLink";
 import { PatientTagsDisplay } from "@/components/Patient/PatientTagsDisplay";
 import { formatPatientAddress } from "@/components/Patient/utils";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   PatientListRead,
@@ -49,6 +50,11 @@ export const PatientInfoHoverCard = ({
             </span>
           </div>
         </div>
+        {"deceased_datetime" in patient && patient.deceased_datetime && (
+          <Badge variant="destructive" className="text-xs h-5 mt-1">
+            {t("deceased")}
+          </Badge>
+        )}
       </div>
       <div className="flex items-center gap-2">
         {!isPatientHomePage && facilityId && (


### PR DESCRIPTION
## Proposed Changes

- Fixes #15762 

<img width="407" height="420" alt="image" src="https://github.com/user-attachments/assets/ed6d729f-94eb-4917-aef3-0dd0941fcf69" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "deceased" indicator badge that displays in patient information cards when a patient record indicates they are deceased.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->