### PR TITLE
Fix: Managing Organization not pre-selected in Edit Tag Config #16028

### DIFF
--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -42,6 +42,35 @@ import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { isIOSDevice } from "@/Utils/utils";
 
+// Helper to extract ID from organization object or string without using 'any'
+const extractOrgId = (value: string | { id: string } | null | undefined) => {
+  if (!value) return undefined;
+  return typeof value === "string" ? value : value.id;
+};
+
+const OrgSchema = z.union([
+  z.string(),
+  z.object({ id: z.string() }).passthrough(),
+]);
+
+const getTagConfigSchema = (t: (key: string) => string) =>
+  z.object({
+    display: z.string().trim().min(1, t("field_required")),
+    category: z.nativeEnum(TagCategory, {
+      required_error: t("field_required"),
+    }),
+    description: z.string().trim().optional(),
+    priority: z.number().min(0, t("priority_non_negative")),
+    status: z.nativeEnum(TagStatus, {
+      required_error: t("field_required"),
+    }),
+    resource: z.nativeEnum(TagResource, {
+      required_error: t("field_required"),
+    }),
+    facility_organization: OrgSchema.optional(),
+    organization: OrgSchema.optional(),
+  });
+
 interface TagConfigFormProps {
   configId?: string;
   parentId?: string;
@@ -61,28 +90,7 @@ export default function TagConfigForm({
   const isCreatingChild = Boolean(parentId);
   const isMobile = useBreakpoints({ default: true, sm: false });
 
-  // FIXED: Replaced z.any() with a specific union to satisfy code reviews
-  const OrgSchema = z.union([
-    z.string(),
-    z.object({ id: z.string() }).passthrough(),
-  ]);
-
-  const tagConfigSchema = z.object({
-    display: z.string().trim().min(1, t("field_required")),
-    category: z.nativeEnum(TagCategory, {
-      required_error: t("field_required"),
-    }),
-    description: z.string().trim().optional(),
-    priority: z.number().min(0, t("priority_non_negative")),
-    status: z.nativeEnum(TagStatus, {
-      required_error: t("field_required"),
-    }),
-    resource: z.nativeEnum(TagResource, {
-      required_error: t("field_required"),
-    }),
-    facility_organization: OrgSchema.optional(),
-    organization: OrgSchema.optional(),
-  });
+  const tagConfigSchema = useMemo(() => getTagConfigSchema(t), [t]);
 
   type TagConfigFormValues = z.infer<typeof tagConfigSchema>;
 
@@ -187,11 +195,10 @@ export default function TagConfigForm({
       ...(parentId && { parent: parentId }),
       ...(facilityId && { facility: facilityId }),
       ...(data.facility_organization && {
-        facility_organization:
-          (data.facility_organization as any).id || data.facility_organization,
+        facility_organization: extractOrgId(data.facility_organization),
       }),
       ...(data.organization && {
-        organization: (data.organization as any).id || data.organization,
+        organization: extractOrgId(data.organization),
       }),
     };
 
@@ -371,11 +378,7 @@ export default function TagConfigForm({
                 <FormControl>
                   <FacilityOrganizationSelector
                     facilityId={facilityId}
-                    value={
-                      field.value
-                        ? [(field.value as any).id || field.value]
-                        : null
-                    }
+                    value={field.value ? [extractOrgId(field.value)!] : null}
                     onChange={(value: string[] | null) => {
                       field.onChange(value?.[0] || null);
                     }}
@@ -401,11 +404,7 @@ export default function TagConfigForm({
                 <FormLabel>Organization</FormLabel>
                 <FormControl>
                   <RoleOrgSelector
-                    value={
-                      field.value
-                        ? [(field.value as any).id || field.value]
-                        : null
-                    }
+                    value={field.value ? [extractOrgId(field.value)!] : null}
                     onChange={(value: string[] | null) => {
                       field.onChange(value?.[0] || null);
                     }}
@@ -424,7 +423,7 @@ export default function TagConfigForm({
           />
         )}
 
-        {/* RESTORED: Parent tag info block for child tag creation */}
+        {/* Show parent tag details when creating a child tag to provide context */}
         {isCreatingChild && parentTag && (
           <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
             <div className="flex items-center gap-2 text-sm text-blue-800">

--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import CareIcon from "@/CAREUI/icons/CareIcon";
 import RoleOrgSelector from "@/components/Common/RoleOrgSelector";
 import FacilityOrganizationSelector from "@/pages/Facility/settings/organizations/components/FacilityOrganizationSelector";
 
@@ -60,6 +61,12 @@ export default function TagConfigForm({
   const isCreatingChild = Boolean(parentId);
   const isMobile = useBreakpoints({ default: true, sm: false });
 
+  // FIXED: Replaced z.any() with a specific union to satisfy code reviews
+  const OrgSchema = z.union([
+    z.string(),
+    z.object({ id: z.string() }).passthrough(),
+  ]);
+
   const tagConfigSchema = z.object({
     display: z.string().trim().min(1, t("field_required")),
     category: z.nativeEnum(TagCategory, {
@@ -73,8 +80,8 @@ export default function TagConfigForm({
     resource: z.nativeEnum(TagResource, {
       required_error: t("field_required"),
     }),
-    facility_organization: z.any().optional(),
-    organization: z.any().optional(),
+    facility_organization: OrgSchema.optional(),
+    organization: OrgSchema.optional(),
   });
 
   type TagConfigFormValues = z.infer<typeof tagConfigSchema>;
@@ -120,7 +127,6 @@ export default function TagConfigForm({
         priority: existingConfig.priority,
         status: existingConfig.status,
         resource: existingConfig.resource,
-        // FIX: Pass the whole object so the selector can see the name
         facility_organization: existingConfig.facility_organization,
         organization: existingConfig.organization,
       });
@@ -180,13 +186,12 @@ export default function TagConfigForm({
       resource: data.resource,
       ...(parentId && { parent: parentId }),
       ...(facilityId && { facility: facilityId }),
-      // FIX: Send only the ID to the API
       ...(data.facility_organization && {
         facility_organization:
-          data.facility_organization.id || data.facility_organization,
+          (data.facility_organization as any).id || data.facility_organization,
       }),
       ...(data.organization && {
-        organization: data.organization.id || data.organization,
+        organization: (data.organization as any).id || data.organization,
       }),
     };
 
@@ -366,8 +371,11 @@ export default function TagConfigForm({
                 <FormControl>
                   <FacilityOrganizationSelector
                     facilityId={facilityId}
-                    // FIX: Extract ID for the internal value
-                    value={field.value ? [field.value.id || field.value] : null}
+                    value={
+                      field.value
+                        ? [(field.value as any).id || field.value]
+                        : null
+                    }
                     onChange={(value: string[] | null) => {
                       field.onChange(value?.[0] || null);
                     }}
@@ -393,8 +401,11 @@ export default function TagConfigForm({
                 <FormLabel>Organization</FormLabel>
                 <FormControl>
                   <RoleOrgSelector
-                    // FIX: Extract ID for the internal value
-                    value={field.value ? [field.value.id || field.value] : null}
+                    value={
+                      field.value
+                        ? [(field.value as any).id || field.value]
+                        : null
+                    }
                     onChange={(value: string[] | null) => {
                       field.onChange(value?.[0] || null);
                     }}
@@ -411,6 +422,33 @@ export default function TagConfigForm({
               </FormItem>
             )}
           />
+        )}
+
+        {/* RESTORED: Parent tag info block for child tag creation */}
+        {isCreatingChild && parentTag && (
+          <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
+            <div className="flex items-center gap-2 text-sm text-blue-800">
+              <CareIcon icon="l-info-circle" className="size-4" />
+              <span>
+                {t("creating_child_tag_for")}{" "}
+                <strong>{parentTag.display}</strong>
+              </span>
+            </div>
+            <div className="mt-2 grid grid-cols-2 gap-2 text-sm text-blue-700">
+              <div>
+                <span className="font-medium">{t("category")}:</span>{" "}
+                {t(parentTag.category)}
+              </div>
+              <div>
+                <span className="font-medium">{t("resource")}:</span>{" "}
+                {t(parentTag.resource)}
+              </div>
+              <div>
+                <span className="font-medium">{t("priority")}:</span>{" "}
+                {parentTag.priority}
+              </div>
+            </div>
+          </div>
         )}
 
         <div

--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
 
-import CareIcon from "@/CAREUI/icons/CareIcon";
 import RoleOrgSelector from "@/components/Common/RoleOrgSelector";
 import FacilityOrganizationSelector from "@/pages/Facility/settings/organizations/components/FacilityOrganizationSelector";
 
@@ -74,13 +73,12 @@ export default function TagConfigForm({
     resource: z.nativeEnum(TagResource, {
       required_error: t("field_required"),
     }),
-    facility_organization: z.string().optional(),
-    organization: z.string().optional(),
+    facility_organization: z.any().optional(),
+    organization: z.any().optional(),
   });
 
   type TagConfigFormValues = z.infer<typeof tagConfigSchema>;
 
-  // Fetch parent tag data when creating a child
   const { data: parentTag } = useQuery({
     queryKey: ["tagConfig", parentId, facilityId],
     queryFn: query(tagConfigApi.retrieve, {
@@ -104,7 +102,6 @@ export default function TagConfigForm({
     },
   });
 
-  // Fetch existing config data when editing
   const { data: existingConfig, isLoading: isLoadingConfig } = useQuery({
     queryKey: ["tagConfig", configId, facilityId],
     queryFn: query(tagConfigApi.retrieve, {
@@ -114,7 +111,6 @@ export default function TagConfigForm({
     enabled: isEditing,
   });
 
-  // Populate form when editing data is loaded
   useEffect(() => {
     if (existingConfig && isEditing) {
       form.reset({
@@ -124,13 +120,13 @@ export default function TagConfigForm({
         priority: existingConfig.priority,
         status: existingConfig.status,
         resource: existingConfig.resource,
-        facility_organization: existingConfig.facility_organization?.id,
-        organization: existingConfig.organization?.id,
+        // FIX: Pass the whole object so the selector can see the name
+        facility_organization: existingConfig.facility_organization,
+        organization: existingConfig.organization,
       });
     }
   }, [existingConfig, isEditing, form]);
 
-  // Update form when parent tag data is loaded
   useEffect(() => {
     if (parentTag && isCreatingChild) {
       form.reset({
@@ -184,11 +180,13 @@ export default function TagConfigForm({
       resource: data.resource,
       ...(parentId && { parent: parentId }),
       ...(facilityId && { facility: facilityId }),
+      // FIX: Send only the ID to the API
       ...(data.facility_organization && {
-        facility_organization: data.facility_organization,
+        facility_organization:
+          data.facility_organization.id || data.facility_organization,
       }),
       ...(data.organization && {
-        organization: data.organization,
+        organization: data.organization.id || data.organization,
       }),
     };
 
@@ -368,7 +366,8 @@ export default function TagConfigForm({
                 <FormControl>
                   <FacilityOrganizationSelector
                     facilityId={facilityId}
-                    value={field.value ? [field.value] : null}
+                    // FIX: Extract ID for the internal value
+                    value={field.value ? [field.value.id || field.value] : null}
                     onChange={(value: string[] | null) => {
                       field.onChange(value?.[0] || null);
                     }}
@@ -394,7 +393,8 @@ export default function TagConfigForm({
                 <FormLabel>Organization</FormLabel>
                 <FormControl>
                   <RoleOrgSelector
-                    value={field.value ? [field.value] : null}
+                    // FIX: Extract ID for the internal value
+                    value={field.value ? [field.value.id || field.value] : null}
                     onChange={(value: string[] | null) => {
                       field.onChange(value?.[0] || null);
                     }}
@@ -411,33 +411,6 @@ export default function TagConfigForm({
               </FormItem>
             )}
           />
-        )}
-
-        {/* Add parent tag info when creating a child */}
-        {isCreatingChild && parentTag && (
-          <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
-            <div className="flex items-center gap-2 text-sm text-blue-800">
-              <CareIcon icon="l-info-circle" className="size-4" />
-              <span>
-                {t("creating_child_tag_for")}{" "}
-                <strong>{parentTag.display}</strong>
-              </span>
-            </div>
-            <div className="mt-2 grid grid-cols-2 gap-2 text-sm text-blue-700">
-              <div>
-                <span className="font-medium">{t("category")}:</span>{" "}
-                {t(parentTag.category)}
-              </div>
-              <div>
-                <span className="font-medium">{t("resource")}:</span>{" "}
-                {t(parentTag.resource)}
-              </div>
-              <div>
-                <span className="font-medium">{t("priority")}:</span>{" "}
-                {parentTag.priority}
-              </div>
-            </div>
-          </div>
         )}
 
         <div

--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -17,7 +17,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
-  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -160,7 +159,7 @@ export default function AddChargeItemsBillingSheet({
         <SheetHeader className="px-4 py-4">
           <SheetTitle>{t("add_charge_items")}</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex-1 px-4 pt-0">
+        <ScrollArea className="flex-1 pb-12 px-4 pt-0">
           <div className="mt-4 space-y-4">
             {selectedItems.length > 0 && (
               <div className="space-y-2">
@@ -172,6 +171,7 @@ export default function AddChargeItemsBillingSheet({
                         key={index}
                         className="bg-white rounded-lg border p-4 space-y-3"
                       >
+                        {/* Title and Remove Button */}
                         <div className="flex items-start justify-between gap-2">
                           <h4 className="font-medium text-base flex-1">
                             {item.charge_item_definition_object.title}
@@ -186,6 +186,7 @@ export default function AddChargeItemsBillingSheet({
                           </Button>
                         </div>
 
+                        {/* Quantity and Price */}
                         <div className="flex flex-wrap gap-4 items-center">
                           <div className="space-y-1">
                             <label className="text-sm text-gray-500">
@@ -372,31 +373,31 @@ export default function AddChargeItemsBillingSheet({
                 defaultOpen={open}
               />
             </div>
+
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                {t("cancel")}
+                <ShortcutBadge actionId="cancel-action" />
+              </Button>
+              <Button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleSubmit();
+                }}
+                disabled={isPending || selectedItems.length === 0 || disabled}
+                className="flex flex-row items-center gap-2 justify-between"
+              >
+                {t("add_items")}
+                {open && <ShortcutBadge actionId="enter-action" />}
+              </Button>
+            </div>
           </div>
         </ScrollArea>
-        {/* Fixed Footer with Action Buttons */}
-        <SheetFooter className="p-4 border-t bg-white sticky bottom-0 flex-row justify-end gap-2">
-          <Button
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isPending}
-          >
-            {t("cancel")}
-            <ShortcutBadge actionId="cancel-action" />
-          </Button>
-          <Button
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              handleSubmit();
-            }}
-            disabled={isPending || selectedItems.length === 0 || disabled}
-            className="flex flex-row items-center gap-2"
-          >
-            {t("add_items")}
-            {open && <ShortcutBadge actionId="enter-action" />}
-          </Button>
-        </SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -17,6 +17,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -159,7 +160,7 @@ export default function AddChargeItemsBillingSheet({
         <SheetHeader className="px-4 py-4">
           <SheetTitle>{t("add_charge_items")}</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex-1 pb-12 px-4 pt-0">
+        <ScrollArea className="flex-1 px-4 pt-0">
           <div className="mt-4 space-y-4">
             {selectedItems.length > 0 && (
               <div className="space-y-2">
@@ -171,7 +172,6 @@ export default function AddChargeItemsBillingSheet({
                         key={index}
                         className="bg-white rounded-lg border p-4 space-y-3"
                       >
-                        {/* Title and Remove Button */}
                         <div className="flex items-start justify-between gap-2">
                           <h4 className="font-medium text-base flex-1">
                             {item.charge_item_definition_object.title}
@@ -186,7 +186,6 @@ export default function AddChargeItemsBillingSheet({
                           </Button>
                         </div>
 
-                        {/* Quantity and Price */}
                         <div className="flex flex-wrap gap-4 items-center">
                           <div className="space-y-1">
                             <label className="text-sm text-gray-500">
@@ -373,31 +372,31 @@ export default function AddChargeItemsBillingSheet({
                 defaultOpen={open}
               />
             </div>
-
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isPending}
-              >
-                {t("cancel")}
-                <ShortcutBadge actionId="cancel-action" />
-              </Button>
-              <Button
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleSubmit();
-                }}
-                disabled={isPending || selectedItems.length === 0 || disabled}
-                className="flex flex-row items-center gap-2 justify-between"
-              >
-                {t("add_items")}
-                {open && <ShortcutBadge actionId="enter-action" />}
-              </Button>
-            </div>
           </div>
         </ScrollArea>
+        {/* Fixed Footer with Action Buttons */}
+        <SheetFooter className="p-4 border-t bg-white sticky bottom-0 flex-row justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {t("cancel")}
+            <ShortcutBadge actionId="cancel-action" />
+          </Button>
+          <Button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleSubmit();
+            }}
+            disabled={isPending || selectedItems.length === 0 || disabled}
+            className="flex flex-row items-center gap-2"
+          >
+            {t("add_items")}
+            {open && <ShortcutBadge actionId="enter-action" />}
+          </Button>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
## Proposed Changes
Fixes #16028

- Updated `TagConfigForm` to initialize with the full organization object instead of just the ID.
- This allows the `RoleOrgSelector` and `FacilityOrganizationSelector` components to correctly display the pre-selected organization name during editing.
- Modified `onSubmit` to extract the ID from the object before sending the request to the API, maintaining back-end compatibility.

Tagging: @ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced organization field handling in tag configuration forms to support both IDs and object values.

* **Improvements**
  * Improved parent tag context display when creating child tags for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->