### PR TITLE
Resolved broken ui in bill medications

### DIFF
--- a/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
+++ b/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
@@ -136,7 +136,7 @@ export function MedicationBillRow({
           )}
         />
       </TableCell>
-      <TableCell className={cn(tableCellClass, "max-w-xs")}>
+      <TableCell className={cn(tableCellClass, "max-w-xl")}>
         <div
           className={cn(
             "flex items-center justify-between gap-2",


### PR DESCRIPTION
## Proposed Changes
Fix #16115

<img width="1620" height="869" alt="image" src="https://github.com/user-attachments/assets/b21261ad-f351-4195-b5a7-738253ea299c" />
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout spacing for the medication bill display, increasing the width constraint to provide better visibility and improved readability of medication information in the pharmacy section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->