### PR TITLE
Enhancement: Remove Child Tag Section from Child Tag Detail Page

### DIFF
--- a/src/pages/Admin/TagConfig/TagConfigView.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigView.tsx
@@ -231,14 +231,16 @@ export default function TagConfigView({
                   {tagConfig.system_generated ? t("yes") : t("no")}
                 </div>
               </div>
-              <div>
-                <label className="text-sm font-medium text-gray-600">
-                  {t("has_children")}
-                </label>
-                <div className="mt-1 text-sm">
-                  {tagConfig.has_children ? t("yes") : t("no")}
+              {!tagConfig.parent && (
+                <div>
+                  <label className="text-sm font-medium text-gray-600">
+                    {t("has_children")}
+                  </label>
+                  <div className="mt-1 text-sm">
+                    {tagConfig.has_children ? t("yes") : t("no")}
+                  </div>
                 </div>
-              </div>
+              )}
               <div>
                 <label className="text-sm font-medium text-gray-600">
                   {t("managing_organization")}
@@ -286,45 +288,43 @@ export default function TagConfigView({
         </Card>
 
         {/* Child Tags Section */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <CardTitle className="flex items-center gap-2">
-                <CareIcon icon="l-sitemap" className="size-5" />
-                {t("child_tags")}
-              </CardTitle>
-              <TagConfigFormDrawer
-                title={t("add_child_tag")}
-                parentId={tagId}
-                onSuccess={handleAddChildSuccess}
-                facilityId={facilityId}
-                trigger={
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!!tagConfig.parent}
-                  >
-                    <CareIcon icon="l-plus" className="size-4 mr-2" />
-                    {t("add_child_tag")}
-                  </Button>
-                }
+        {!tagConfig.parent && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="flex items-center gap-2">
+                  <CareIcon icon="l-sitemap" className="size-5" />
+                  {t("child_tags")}
+                </CardTitle>
+                <TagConfigFormDrawer
+                  title={t("add_child_tag")}
+                  parentId={tagId}
+                  onSuccess={handleAddChildSuccess}
+                  facilityId={facilityId}
+                  trigger={
+                    <Button variant="outline" size="sm">
+                      <CareIcon icon="l-plus" className="size-4 mr-2" />
+                      {t("add_child_tag")}
+                    </Button>
+                  }
+                />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <TagConfigTable
+                configs={children}
+                isLoading={isLoadingChildren}
+                onView={handleViewChild}
+                onArchive={handleArchiveChild}
+                showChildrenColumn={false}
+                showArchiveAction={true}
+                emptyStateTitle={t("no_child_tags_found")}
+                emptyStateDescription={t("no_child_tags_found_description")}
+                emptyStateIcon={"l-sitemap" as IconName}
               />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <TagConfigTable
-              configs={children}
-              isLoading={isLoadingChildren}
-              onView={handleViewChild}
-              onArchive={handleArchiveChild}
-              showChildrenColumn={false}
-              showArchiveAction={true}
-              emptyStateTitle={t("no_child_tags_found")}
-              emptyStateDescription={t("no_child_tags_found_description")}
-              emptyStateIcon={"l-sitemap" as IconName}
-            />
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        )}
       </div>
     </Page>
   );


### PR DESCRIPTION
## Proposed Changes

- Fixes https://github.com/ohcnetwork/care_fe/issues/15757


<img width="1168" height="806" alt="Image" src="https://github.com/user-attachments/assets/dc8196ea-acec-4982-9180-91803395ae2b" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tag configuration interface now conditionally displays child tag management features based on parent tag assignment. Child tags section and related controls are hidden when a parent tag is assigned, streamlining the configuration view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->