### PR TITLE
fix: wrap long product names in ProductKnowledgeCard #14521

### DIFF
--- a/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
+++ b/src/pages/Facility/settings/productKnowledge/ProductKnowledgeListComponent.tsx
@@ -70,11 +70,11 @@ function ProductKnowledgeCard({
                   {t(product.status)}
                 </Badge>
               </div>
-              <h3 className="font-medium text-gray-900 truncate text-lg">
+              <h3 className="font-medium text-gray-900 break-words leading-tight text-lg">
                 {product.name}
               </h3>
               {product.alternate_identifier && (
-                <p className="mt-1 text-sm text-gray-500">
+                <p className="mt-1 text-sm text-gray-500 break-all">
                   {t("product_knowledge_alternate_identifier")}:{" "}
                   {product.alternate_identifier}
                 </p>


### PR DESCRIPTION
## Proposed Changes

Fixes #14521
- Removed truncate from the product name heading in "ProductKnowledgeCard.tsx"
- Implemented break-words and leading-tight to allow multi-line text wrapping.
- Verified that the layout remains responsive on mobile viewports (320px+)

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Complete QA on mobile devices (Verified on iPhone SE 320px breakpoint).
- [x] Complete QA on desktop devices.
- [x] Prepare a screenshot or demo video. (dropped below)
- [ ] Add specs that demonstrate the bug or test the new feature. (N/A for simple CSS fix , had better idea that i will discuss in the portfolio for gsoc)

<img width="521" height="815" alt="Screenshot 2026-03-17 224912" src="https://github.com/user-attachments/assets/10374262-0536-4511-9957-73678e224e90" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile display rendering in the product knowledge list component. Product titles and alternate identifiers now wrap gracefully across multiple lines instead of being truncated, eliminating ellipsis and ensuring full text visibility on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->