### PR TITLE
fix: display charge item notes in expanded view

### DIFF
--- a/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
@@ -534,6 +534,25 @@ export function BedChargeItemsTable({
                             </TableRow>
                           );
 
+                          const noteText = item.note?.trim();
+                          const noteRow = noteText ? (
+                            <TableRow
+                              key={`${item.id}-note`}
+                              className="bg-muted/30 text-xs text-gray-500"
+                            >
+                              <TableCell className="pl-12"></TableCell>
+                              <TableCell className="text-gray-950">
+                                {t("note")}
+                              </TableCell>
+                              <TableCell
+                                colSpan={7}
+                                className="whitespace-pre-wrap break-words"
+                              >
+                                {noteText}
+                              </TableCell>
+                            </TableRow>
+                          ) : null;
+
                           const emptyRow = (
                             <TableRow
                               key={`${item.id}-empty`}
@@ -547,6 +566,7 @@ export function BedChargeItemsTable({
                             mainRow,
                             ...detailRows,
                             summaryRow,
+                            noteRow,
                             emptyRow,
                           ].filter(Boolean);
                         })),

--- a/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/ChargeItemsTable.tsx
@@ -653,6 +653,24 @@ export function ChargeItemsTable({
                   </TableRow>
                 );
 
+                const noteText = item.note?.trim();
+                const noteRow = noteText ? (
+                  <TableRow
+                    key={`${item.id}-note`}
+                    className="bg-muted/30 text-xs text-gray-500"
+                  >
+                    <TableCell></TableCell>
+                    <TableCell></TableCell>
+                    <TableCell className="text-gray-950">{t("note")}</TableCell>
+                    <TableCell
+                      colSpan={8}
+                      className="whitespace-pre-wrap break-words"
+                    >
+                      {noteText}
+                    </TableCell>
+                  </TableRow>
+                ) : null;
+
                 const emptyRow = (
                   <TableRow key={`${item.id}-empty`} className="bg-muted">
                     <TableCell colSpan={11}></TableCell>
@@ -664,6 +682,7 @@ export function ChargeItemsTable({
                   mrpRow,
                   ...detailRows,
                   summaryRow,
+                  noteRow,
                   emptyRow,
                 ].filter(Boolean);
               })}


### PR DESCRIPTION
Proposed Changes
Display notes in expanded charge item view in billing tables.
Tagging: @ohcnetwork/care-fe-code-reviewers

Merge Checklist
 Ensure that UI text is placed in I18n files
 Prepare a screenshot or demo video for the changelog entry and attach it to the issue
 Request peer reviews
 Complete QA on mobile devices
 Complete QA on desktop devices

Summary by CodeRabbit
New Features
Added support for displaying item notes in billing account charge tables. Notes are now visible in expanded item details with proper styling, improving readability and information clarity.