### PR TITLE
fix: keep action buttons visible in add charge items sheet

### DIFF
--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -17,6 +17,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -159,7 +160,7 @@ export default function AddChargeItemsBillingSheet({
         <SheetHeader className="px-4 py-4">
           <SheetTitle>{t("add_charge_items")}</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex-1 pb-12 px-4 pt-0">
+        <ScrollArea className="flex-1 px-4 pt-0">
           <div className="mt-4 space-y-4">
             {selectedItems.length > 0 && (
               <div className="space-y-2">
@@ -373,31 +374,29 @@ export default function AddChargeItemsBillingSheet({
                 defaultOpen={open}
               />
             </div>
-
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isPending}
-              >
-                {t("cancel")}
-                <ShortcutBadge actionId="cancel-action" />
-              </Button>
-              <Button
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleSubmit();
-                }}
-                disabled={isPending || selectedItems.length === 0 || disabled}
-                className="flex flex-row items-center gap-2 justify-between"
-              >
-                {t("add_items")}
-                {open && <ShortcutBadge actionId="enter-action" />}
-              </Button>
-            </div>
           </div>
         </ScrollArea>
+        <SheetFooter className="p-4 border-t bg-background sm:space-x-0">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {t("cancel")}
+            <ShortcutBadge actionId="cancel-action" />
+          </Button>
+          <Button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleSubmit();
+            }}
+            disabled={isPending || selectedItems.length === 0 || disabled}
+          >
+            {t("add_items")}
+            {open && <ShortcutBadge actionId="enter-action" />}
+          </Button>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
Fix: Keep action buttons visible in Add Charge Items sheet

Problem: The "Cancel" and "Add Items" buttons were inside the ScrollArea, causing them to scroll out of view when many charge items were added.

Solution

1. Moved action buttons outside the ScrollArea into a SheetFooter
2. Removed pb-12 spacing workaround
3. Ensured ScrollArea only handles scrollable content
4. Used theme-aware styling (bg-background) for dark mode support
5. Preserved default responsive behavior of SheetFooter

Testing

Verified buttons remain visible while scrolling
Tested on desktop and mobile views
No layout or styling regressions observed
Lint and build passed

This Improves usability by keeping critical actions always accessible

Fixes #16099



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the billing form layout by moving action buttons to a dedicated footer section for improved visual organization and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->