### PR TITLE
Fix/add charge items scroll footer

### DIFF
--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -371,7 +371,7 @@ export default function AddChargeItemsBillingSheet({
             )}
           </div>
         </ScrollArea>
-        <SheetFooter className="p-4 border-t bg-background sm:space-x-0">
+        <SheetFooter className="p-4 border-t bg-background gap-2">
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}

--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -156,12 +156,37 @@ export default function AddChargeItemsBillingSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:max-w-3xl p-0 flex flex-col">
+      <SheetContent className="w-full sm:max-w-3xl p-0 flex flex-col overflow-hidden">
         <SheetHeader className="px-4 py-4">
           <SheetTitle>{t("add_charge_items")}</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex-1 px-4 pt-0">
-          <div className="mt-4 space-y-4">
+        <div className="px-4 pb-4 border-b">
+          <ResourceDefinitionCategoryPicker<ChargeItemDefinitionBase>
+            facilityId={facilityId}
+            value={selectedDefinition || undefined}
+            onValueChange={(selectedDef) => {
+              if (!selectedDef) {
+                setSelectedDefinition(null);
+                return;
+              }
+              setSelectedDefinition(selectedDef as ChargeItemDefinitionRead);
+            }}
+            placeholder={t("select_charge_item_definition")}
+            disabled={disabled}
+            className="w-full"
+            resourceType={ResourceCategoryResourceType.charge_item_definition}
+            listDefinitions={{
+              queryFn: chargeItemDefinitionApi.listChargeItemDefinition,
+              pathParams: { facilityId },
+              queryParams: { status: ChargeItemDefinitionStatus.active },
+            }}
+            translationBaseKey="charge_item_definition"
+            data-shortcut-id="keydown-action"
+            defaultOpen={open}
+          />
+        </div>
+        <ScrollArea className="min-h-0 flex-1 px-4">
+          <div className="py-4 space-y-4">
             {selectedItems.length > 0 && (
               <div className="space-y-2">
                 <h3 className="text-base font-medium">{t("selected_items")}</h3>
@@ -344,36 +369,6 @@ export default function AddChargeItemsBillingSheet({
                 )}
               </div>
             )}
-
-            <div className="space-y-2">
-              <ResourceDefinitionCategoryPicker<ChargeItemDefinitionBase>
-                facilityId={facilityId}
-                value={selectedDefinition || undefined}
-                onValueChange={(selectedDef) => {
-                  if (!selectedDef) {
-                    setSelectedDefinition(null);
-                    return;
-                  }
-                  setSelectedDefinition(
-                    selectedDef as ChargeItemDefinitionRead,
-                  );
-                }}
-                placeholder={t("select_charge_item_definition")}
-                disabled={disabled}
-                className="w-full"
-                resourceType={
-                  ResourceCategoryResourceType.charge_item_definition
-                }
-                listDefinitions={{
-                  queryFn: chargeItemDefinitionApi.listChargeItemDefinition,
-                  pathParams: { facilityId },
-                  queryParams: { status: ChargeItemDefinitionStatus.active },
-                }}
-                translationBaseKey="charge_item_definition"
-                data-shortcut-id="keydown-action"
-                defaultOpen={open}
-              />
-            </div>
           </div>
         </ScrollArea>
         <SheetFooter className="p-4 border-t bg-background sm:space-x-0">

--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -17,6 +17,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -159,7 +160,7 @@ export default function AddChargeItemsBillingSheet({
         <SheetHeader className="px-4 py-4">
           <SheetTitle>{t("add_charge_items")}</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex-1 pb-12 px-4 pt-0">
+        <ScrollArea className="flex-1 px-4 pt-0">
           <div className="mt-4 space-y-4">
             {selectedItems.length > 0 && (
               <div className="space-y-2">
@@ -373,31 +374,29 @@ export default function AddChargeItemsBillingSheet({
                 defaultOpen={open}
               />
             </div>
-
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isPending}
-              >
-                {t("cancel")}
-                <ShortcutBadge actionId="cancel-action" />
-              </Button>
-              <Button
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleSubmit();
-                }}
-                disabled={isPending || selectedItems.length === 0 || disabled}
-                className="flex flex-row items-center gap-2 justify-between"
-              >
-                {t("add_items")}
-                {open && <ShortcutBadge actionId="enter-action" />}
-              </Button>
-            </div>
           </div>
         </ScrollArea>
+        <SheetFooter className="p-4 border-t bg-background sm:space-x-0">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {t("cancel")}
+            <ShortcutBadge actionId="cancel-action" />
+          </Button>
+          <Button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleSubmit();
+            }}
+            disabled={isPending || selectedItems.length === 0 || disabled}
+          >
+            {t("add_items")}
+            {open && <ShortcutBadge actionId="enter-action" />}
+          </Button>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
## Proposed Changes

Fixes #16099 
- Added a scrollable container for the charge items list in AddChargeItemsBillingSheet
- Implemented a fixed/sticky footer to keep Save/Cancel buttons visible

Additional context:
- Moves the selection input to the top for better accessibility

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<img width="1920" height="948" alt="Screenshot (71)" src="https://github.com/user-attachments/assets/99490cd4-b465-44b7-81d2-82adae990723" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the billing “Add Charge Items” sheet layout: the definition picker is now fixed at the top, the scrollable content is better contained, and action buttons (Cancel, Add Items) are moved to a dedicated footer for clearer access and improved spacing. Submission behavior and selection controls remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->