### PR TITLE
fix: add validation for API route format

### DIFF
--- a/src/Utils/request/utils.ts
+++ b/src/Utils/request/utils.ts
@@ -5,21 +5,19 @@ import { HttpMethod, QueryParams, Type } from "@/Utils/request/types";
 export const API = <TResponse, TBody = undefined>(
   route: `${HttpMethod} ${string}`,
 ) => {
-  if (!route || typeof route !== "string") {
-    throw new Error("Route must be a non-empty string");
-  }
+  const trimmedRoute = route.trim();
+  const firstSpace = trimmedRoute.indexOf(" ");
 
-  const parts = route.trim().split(" ");
-
-  if (parts.length !== 2) {
+  if (firstSpace === -1) {
     throw new Error(
       `Invalid route format "${route}". Expected format: "METHOD /path"`,
     );
   }
 
-  const [method, path] = parts as [HttpMethod, string];
+  const method = trimmedRoute.slice(0, firstSpace) as HttpMethod;
+  const path = trimmedRoute.slice(firstSpace + 1);
 
-  const validMethods: HttpMethod[] = ["GET", "POST", "PUT", "DELETE", "PATCH"];
+  const validMethods = Object.values(HttpMethod);
 
   if (!validMethods.includes(method)) {
     throw new Error(`Invalid HTTP method: ${method}`);

--- a/src/Utils/request/utils.ts
+++ b/src/Utils/request/utils.ts
@@ -1,5 +1,4 @@
 import { LocalStorageKeys } from "@/common/constants";
-
 import { HttpMethod, QueryParams, Type } from "@/Utils/request/types";
 
 const VALID_METHODS = Object.values(HttpMethod);
@@ -18,6 +17,12 @@ export const API = <TResponse, TBody = undefined>(
 
   const method = trimmedRoute.slice(0, firstSpace) as HttpMethod;
   const path = trimmedRoute.slice(firstSpace + 1);
+
+  if (path.trim().includes(" ")) {
+    throw new Error(
+      `Invalid route format "${route}". Path must not contain spaces`,
+    );
+  }
 
   if (!VALID_METHODS.includes(method)) {
     throw new Error(`Invalid HTTP method: ${method}`);
@@ -81,7 +86,6 @@ export function makeHeaders(
 ) {
   const headers = new Headers(additionalHeaders);
 
-  // Don't set Content-Type for FormData - let browser set it with boundary
   if (!isFormData) {
     headers.set("Content-Type", "application/json");
   }

--- a/src/Utils/request/utils.ts
+++ b/src/Utils/request/utils.ts
@@ -5,7 +5,30 @@ import { HttpMethod, QueryParams, Type } from "@/Utils/request/types";
 export const API = <TResponse, TBody = undefined>(
   route: `${HttpMethod} ${string}`,
 ) => {
-  const [method, path] = route.split(" ") as [HttpMethod, string];
+  if (!route || typeof route !== "string") {
+    throw new Error("Route must be a non-empty string");
+  }
+
+  const parts = route.trim().split(" ");
+
+  if (parts.length !== 2) {
+    throw new Error(
+      `Invalid route format "${route}". Expected format: "METHOD /path"`,
+    );
+  }
+
+  const [method, path] = parts as [HttpMethod, string];
+
+  const validMethods: HttpMethod[] = ["GET", "POST", "PUT", "DELETE", "PATCH"];
+
+  if (!validMethods.includes(method)) {
+    throw new Error(`Invalid HTTP method: ${method}`);
+  }
+
+  if (!path || !path.startsWith("/")) {
+    throw new Error(`Invalid path "${path}". Must start with "/"`);
+  }
+
   return {
     path,
     method,

--- a/src/Utils/request/utils.ts
+++ b/src/Utils/request/utils.ts
@@ -2,6 +2,8 @@ import { LocalStorageKeys } from "@/common/constants";
 
 import { HttpMethod, QueryParams, Type } from "@/Utils/request/types";
 
+const VALID_METHODS = Object.values(HttpMethod);
+
 export const API = <TResponse, TBody = undefined>(
   route: `${HttpMethod} ${string}`,
 ) => {
@@ -17,9 +19,7 @@ export const API = <TResponse, TBody = undefined>(
   const method = trimmedRoute.slice(0, firstSpace) as HttpMethod;
   const path = trimmedRoute.slice(firstSpace + 1);
 
-  const validMethods = Object.values(HttpMethod);
-
-  if (!validMethods.includes(method)) {
+  if (!VALID_METHODS.includes(method)) {
     throw new Error(`Invalid HTTP method: ${method}`);
   }
 


### PR DESCRIPTION
## Proposed Changes

Fixes #15028

- Added validation to ensure route is a non-empty string
- Ensured route splits into exactly two parts (METHOD and PATH)
- Validated HTTP method against allowed values
- Verified path is non-empty and starts with "/"
- Added clear error messages for invalid inputs


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API route parsing and validation: route strings are now strictly checked and invalid formats produce clear errors. This reduces malformed requests and unexpected failures, so users should see fewer request errors and more consistent behavior when calling endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->