### PR TITLE
Fix: Service-Switcher text overflow

### DIFF
--- a/src/components/ui/sidebar/facility/service/service-switcher.tsx
+++ b/src/components/ui/sidebar/facility/service/service-switcher.tsx
@@ -30,6 +30,7 @@ import PaginationComponent from "@/components/Common/Pagination";
 import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 
 import query from "@/Utils/request/query";
+import { TooltipComponent } from "@/components/ui/tooltip";
 import useCurrentService from "@/pages/Facility/services/utils/useCurrentService";
 import { HealthcareServiceReadSpec } from "@/types/healthcareService/healthcareService";
 import healthcareServiceApi from "@/types/healthcareService/healthcareServiceApi";
@@ -83,15 +84,19 @@ export function ServiceSwitcher() {
             className="w-full flex items-center justify-between gap-3 py-6 px-2 rounded-md bg-white border border-gray-200"
             onClick={() => setOpenDialog(true)}
           >
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               <MapPinIcon className="size-5 text-green-600" />
-              <div className="flex flex-col items-start">
-                <span className="text-xs text-gray-500">
-                  {t("current_service")}
-                </span>
-                <span className="text-sm font-medium text-gray-900">
-                  {selectedService?.name}
-                </span>
+              <div className="min-w-0 flex-1">
+                <TooltipComponent content={selectedService?.name}>
+                  <div className="flex min-w-0 flex-col items-start">
+                    <span className="text-xs text-gray-500">
+                      {t("current_service")}
+                    </span>
+                    <span className="w-full truncate text-sm font-medium text-gray-900">
+                      {selectedService?.name}
+                    </span>
+                  </div>
+                </TooltipComponent>
               </div>
             </div>
             <CareIcon icon="l-sort" />


### PR DESCRIPTION
## Proposed Changes

Fixes #16222 
- CSS Changes in `ServiceSwitcher` component to handle text overflow
- Addition of TooltipComponent for tooltip showing full service name

Relevant Screenshot for fix:

<img width="1108" height="526" alt="image" src="https://github.com/user-attachments/assets/a8a9deb5-360c-4b20-a434-15cb18b1bcd9" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tooltip for the currently selected service name in the service switcher to reveal the full name on hover.

* **Bug Fixes**
  * Improved truncation and overflow handling for the service name display to prevent clipping and preserve layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->