### PR TITLE
Fix: Location-Switcher text overflow

### DIFF
--- a/src/components/ui/sidebar/facility/location/location-switcher.tsx
+++ b/src/components/ui/sidebar/facility/location/location-switcher.tsx
@@ -29,6 +29,7 @@ import PaginationComponent from "@/components/Common/Pagination";
 
 import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 
+import { TooltipComponent } from "@/components/ui/tooltip";
 import useCurrentLocation from "@/pages/Facility/locations/utils/useCurrentLocation";
 import { LocationRead } from "@/types/location/location";
 import locationApi from "@/types/location/locationApi";
@@ -84,15 +85,19 @@ export function LocationSwitcher() {
             className="w-full flex items-center justify-between gap-3 py-6 px-2 rounded-md bg-white border border-gray-200"
             onClick={() => setOpenDialog(true)}
           >
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               <MapPinIcon className="size-5 text-green-600" />
-              <div className="flex flex-col items-start">
-                <span className="text-xs text-gray-500">
-                  {t("current_location")}
-                </span>
-                <span className="text-sm font-medium text-gray-900">
-                  {location?.name}
-                </span>
+              <div className="min-w-0 flex-1">
+                <TooltipComponent content={location?.name}>
+                  <div className="flex min-w-0 flex-col items-start">
+                    <span className="text-xs text-gray-500">
+                      {t("current_location")}
+                    </span>
+                    <span className="w-full truncate text-left text-sm font-medium text-gray-900">
+                      {location?.name}
+                    </span>
+                  </div>
+                </TooltipComponent>
               </div>
             </div>
             <CareIcon icon="l-sort" />

--- a/src/components/ui/sidebar/facility/location/location-switcher.tsx
+++ b/src/components/ui/sidebar/facility/location/location-switcher.tsx
@@ -88,7 +88,10 @@ export function LocationSwitcher() {
             <div className="flex min-w-0 items-center gap-2">
               <MapPinIcon className="size-5 text-green-600" />
               <div className="min-w-0 flex-1">
-                <TooltipComponent content={location?.name}>
+                <TooltipComponent
+                  content={location?.name}
+                  className="hidden lg:block max-w-xs"
+                >
                   <div className="flex min-w-0 flex-col items-start">
                     <span className="text-xs text-gray-500">
                       {t("current_location")}
@@ -213,21 +216,24 @@ export function LocationSelectorDialog({
     const locationList = buildLocationPath(location);
 
     return (
-      <div className="flex flex-row items-center gap-1 text-sm font-normal">
+      <div className="flex flex-row items-center gap-1 text-sm font-normal flex-wrap">
         <span className="text-gray-500">{t("current_location")}:</span>
-        <div className="flex flex-row gap-1 items-center p-1 rounded-md bg-gray-100">
+        <div className="flex flex-row gap-1 items-center p-2 rounded-md bg-gray-100 flex-wrap overflow-hidden">
           {locationList.map((loc, index) => (
-            <div className="flex flex-row gap-1 items-center" key={loc.id}>
+            <div
+              className="flex flex-row gap-1 items-center truncate max-w-xs"
+              key={loc.id}
+            >
               {loc.has_children ? (
                 <Button
                   variant="link"
-                  className="p-0 text-nowrap h-5"
+                  className="p-0 text-nowrap h-5 justify-start overflow-hidden"
                   onClick={() => handleLocationClick(loc)}
                 >
-                  {loc.name}
+                  <span className="text-nowrap h-5 truncate">{loc.name}</span>
                 </Button>
               ) : (
-                <span className="text-nowrap h-5">{loc.name}</span>
+                <span className="text-nowrap h-5 truncate">{loc.name}</span>
               )}
               {index < locationList.length - 1 && (
                 <CareIcon icon="l-arrow-right" />
@@ -251,7 +257,7 @@ export function LocationSelectorDialog({
       }}
     >
       <DialogContent className="p-3 min-w-[calc(50vw)]">
-        <DialogHeader>
+        <DialogHeader className="overflow-hidden">
           <DialogTitle>{getCurrentLocation()}</DialogTitle>
         </DialogHeader>
         {locationLevel.length > 0 && (


### PR DESCRIPTION
## Proposed Changes

Fixes #15877 

- CSS Changes for text truncation (location name)
- Tooltip component for full name display on hover

Relevant Screenshots:
1. Truncated name:
    <img width="850" height="337" alt="image" src="https://github.com/user-attachments/assets/44e515f2-c84e-4e51-80c7-f0f6dac3bc5e" />
    
2. Tootip:
    <img width="775" height="361" alt="image" src="https://github.com/user-attachments/assets/2615de8e-94b6-4449-9e7a-80ace936175a" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location switcher layout on narrow screens with better text truncation and constraint handling.
  * Enhanced location selector dialog with improved breadcrumb overflow handling and flex-wrapping support.
  * Fixed location name display with truncation and maximum width constraints across the interface.
  * Added location path visibility when searching, displaying the full breadcrumb hierarchy as a secondary line.
  * Improved tooltip support for location names on larger screens for better accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->