### PR TITLE
fix: buttons scroll out of view

### DIFF
--- a/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
+++ b/src/pages/Facility/billing/account/components/AddChargeItemsBillingSheet.tsx
@@ -373,31 +373,31 @@ export default function AddChargeItemsBillingSheet({
                 defaultOpen={open}
               />
             </div>
-
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isPending}
-              >
-                {t("cancel")}
-                <ShortcutBadge actionId="cancel-action" />
-              </Button>
-              <Button
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleSubmit();
-                }}
-                disabled={isPending || selectedItems.length === 0 || disabled}
-                className="flex flex-row items-center gap-2 justify-between"
-              >
-                {t("add_items")}
-                {open && <ShortcutBadge actionId="enter-action" />}
-              </Button>
-            </div>
           </div>
         </ScrollArea>
+
+        <div className="sticky bottom-0 bg-white p-4 border-t flex justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {t("cancel")}
+            <ShortcutBadge actionId="cancel-action" />
+          </Button>
+          <Button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleSubmit();
+            }}
+            disabled={isPending || selectedItems.length === 0 || disabled}
+            className="flex flex-row items-center gap-2 justify-between"
+          >
+            {t("add_items")}
+            {open && <ShortcutBadge actionId="enter-action" />}
+          </Button>
+        </div>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
Hey @abhimanyurajeesh @gauritejusa , I would like to work on this issue

The save / cancel action buttons in AddChargeItemsBillingSheet.tsx are currently placed inside the ScrollArea. When multiple charge items are added, these buttons scroll out of view, making them inaccessible.

Proposed Fix
1. Move the action buttons outside the ScrollArea
2. Place them in a sticky footer section
3. Follow the existing pattern used in AddChargeItemSheet.tsx

Implementation Plan
1. Extract the button container (Cancel/ Add Items)
2. Wrap it in a sticky footer (sticky bottom-0 bg-white p-4 border-t)
3. Ensure it remains visible regardless of scroll
4. Test responsiveness on mobile and desktop

Expected Timeline
End date : 1 day from assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing sheet usability by ensuring add/cancel action buttons remain visible when scrolling through charge items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->