### PR TITLE
feat: add edit button near patient name

### DIFF
--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -42,8 +42,19 @@ export const PatientInfoHoverCard = ({
           <div className="size-12">
             <Avatar name={patient.name} />
           </div>
-          <div className="flex flex-col">
+          <div className="flex items-center gap-2">
             <h5 className="text-lg font-semibold">{patient.name}</h5>
+            <Button variant="ghost" asChild>
+              <Link
+                href={
+                  facilityId
+                    ? `/facility/${facilityId}/patient/${patient.id}`
+                    : `/patient/${patient.id}`
+                }
+              >
+                {t("edit")}
+              </Link>
+            </Button>
             <span className="text-gray-700 text-sm font-medium">
               {formatPatientAge(patient, true)},{" "}
               {t(`GENDER__${patient.gender}`)}


### PR DESCRIPTION
@john-d03  I would like to work on this issue
Currently, to edit a patient's details the user has to: 
Patient Name then View Profile then Edit
This adds unnecessary steps, especially in fast paced environments like reception where quick edits are important.

Proposed Solution
Add an Edit button directly next to the patient name  in the Patient info section.
This will simplify the flow to:
Edit then Directly navigate to edit profile.

Implementation Plan
1. Add an Edit button next to the patient name in PatientInfoCard.tsx.
2. Use existing navigation to redirect to the edit page.
3. Route:
 /facility/${facilityId}/patient/${patient.id}/update
4. Ensure the button follows existing UI styles 
5. Keep layout consistent and responsive.

Timeline:
I can complete this within 1 day of assignment.
Please let me know if I can proceed. Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Edit" button to the patient information card for quick access to patient details.
  * Improved the patient header layout for enhanced usability and visual presentation.
  * Enhanced patient routing to support facility-specific navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->