### PR TITLE
Hide ref number field for cash payment

### DIFF
--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -642,7 +642,7 @@ export function PaymentReconciliationSheet({
                         <Input {...field} value={field.value || ""} />
                       </FormControl>
                       <FormDescription className="text-gray-700 italic -mt-1.5">
-                        {!isCashPayment && t("reference_number_description")}
+                        {t("reference_number_description")}
                       </FormDescription>
                       <FormMessage />
                     </FormItem>

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -244,6 +244,7 @@ export function PaymentReconciliationSheet({
         "returned_amount",
         round(Decimal.max(0, tenderedAmount || "0").minus(amount || "0")),
       );
+      form.setValue("reference_number", "");
     } else {
       // For non-cash payments, tendered amount equals payment amount and returned is 0
       form.setValue("tendered_amount", amount || "0");
@@ -625,27 +626,29 @@ export function PaymentReconciliationSheet({
                 </div>
               )}
 
-              <FormField
-                control={form.control}
-                name="reference_number"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-gray-950">
-                      {t("reference_number")}
-                      <span className="text-gray-600 italic">
-                        ({t("optional")})
-                      </span>
-                    </FormLabel>
-                    <FormControl>
-                      <Input {...field} value={field.value || ""} />
-                    </FormControl>
-                    <FormDescription className="text-gray-700 italic -mt-1.5">
-                      {!isCashPayment && t("reference_number_description")}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              {!isCashPayment && (
+                <FormField
+                  control={form.control}
+                  name="reference_number"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-gray-950">
+                        {t("reference_number")}
+                        <span className="text-gray-600 italic">
+                          ({t("optional")})
+                        </span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input {...field} value={field.value || ""} />
+                      </FormControl>
+                      <FormDescription className="text-gray-700 italic -mt-1.5">
+                        {!isCashPayment && t("reference_number_description")}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
 
               <FormField
                 control={form.control}


### PR DESCRIPTION
<img width="1462" height="931" alt="image" src="https://github.com/user-attachments/assets/2ba9c941-9d4f-4550-945d-41958f2c96cd" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reference number field is now only displayed for non-cash payments and is cleared automatically when switching to cash.
  * Non-cash reference field consistently shows its label and description when rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->