### PR TITLE
Fix flaky E2E test locators in care team and prescription edit tests

### DIFF
--- a/tests/facility/patient/encounter/careTeam/linkCareTeam.spec.ts
+++ b/tests/facility/patient/encounter/careTeam/linkCareTeam.spec.ts
@@ -19,7 +19,7 @@ test.describe("Manage care team for an encounter", () => {
   let selectedRole: string;
   let selectedUsername: string;
 
-  const TEST_USERNAMES = ["care-admin", "care-fac-admin", "administrator_2_0"];
+  const TEST_USERNAMES = ["care-admin", "administrator_2_0"];
   const TEST_ROLES = [
     "Primary healthcare service",
     "Acupuncturist",
@@ -87,7 +87,10 @@ test.describe("Manage care team for an encounter", () => {
         await expect(memberSelector).toBeEnabled();
         await memberSelector.click();
         await page.getByPlaceholder("Search").fill(selectedUsername);
-        await page.getByText(selectedUsername).click();
+        await page
+          .getByRole("option", { name: selectedUsername })
+          .first()
+          .click();
       });
 
       await test.step("Select role", async () => {
@@ -121,7 +124,10 @@ test.describe("Manage care team for an encounter", () => {
           .filter({ hasText: "Select Member" });
         await memberSelector.click();
         await page.getByPlaceholder("Search").fill(selectedUsername);
-        await page.getByText(selectedUsername).click();
+        await page
+          .getByRole("option", { name: selectedUsername })
+          .first()
+          .click();
 
         await page
           .getByRole("combobox")
@@ -140,7 +146,10 @@ test.describe("Manage care team for an encounter", () => {
           .filter({ hasText: "Select Member" });
         await memberSelector.click();
         await page.getByPlaceholder("Search").fill(selectedUsername);
-        await page.getByText(selectedUsername).click();
+        await page
+          .getByRole("option", { name: selectedUsername })
+          .first()
+          .click();
 
         await page
           .getByRole("combobox")
@@ -183,7 +192,10 @@ test.describe("Manage care team for an encounter", () => {
       await expect(memberSelector).toBeEnabled();
       await memberSelector.click();
       await page.getByPlaceholder("Search").fill(selectedUsername);
-      await page.getByText(selectedUsername).click();
+      await page
+        .getByRole("option", { name: selectedUsername })
+        .first()
+        .click();
 
       await page
         .getByRole("combobox")
@@ -227,7 +239,10 @@ test.describe("Manage care team for an encounter", () => {
       await expect(memberSelector).toBeEnabled();
       await memberSelector.click();
       await page.getByPlaceholder("Search").fill(selectedUsername);
-      await page.getByText(selectedUsername).click();
+      await page
+        .getByRole("option", { name: selectedUsername })
+        .first()
+        .click();
     });
 
     await test.step("Verify Add button is still disabled", async () => {

--- a/tests/facility/patient/encounter/medicine/prescriptionEdit.spec.ts
+++ b/tests/facility/patient/encounter/medicine/prescriptionEdit.spec.ts
@@ -95,7 +95,7 @@ test.describe("Edit Patient Prescription", () => {
       ]);
       await page
         .getByText(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2} (AM|PM)$/)
-        .first()
+        .last()
         .click();
       const table = page.getByRole("table");
       await expect(table).toBeVisible({ timeout: 10000 });
@@ -137,7 +137,7 @@ test.describe("Edit Patient Prescription", () => {
       ]);
       await page
         .getByText(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2} (AM|PM)$/)
-        .first()
+        .last()
         .click();
       await page.getByText(/Show \d+ Inactive Medications?/i).click();
       const table = page.getByRole("table");

--- a/tests/facility/patient/encounter/medicine/prescriptionEdit.spec.ts
+++ b/tests/facility/patient/encounter/medicine/prescriptionEdit.spec.ts
@@ -93,10 +93,11 @@ test.describe("Edit Patient Prescription", () => {
             resp.status() === 200,
         ),
       ]);
-      await page
+      const prescriptionDate = page
         .getByText(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2} (AM|PM)$/)
-        .last()
-        .click();
+        .first();
+      await expect(prescriptionDate).toBeVisible({ timeout: 10000 });
+      await prescriptionDate.click();
       const table = page.getByRole("table");
       await expect(table).toBeVisible({ timeout: 10000 });
       await expect(table).toContainText(medicineName);
@@ -135,10 +136,11 @@ test.describe("Edit Patient Prescription", () => {
             resp.status() === 200,
         ),
       ]);
-      await page
+      const prescriptionDate = page
         .getByText(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2} (AM|PM)$/)
-        .last()
-        .click();
+        .first();
+      await expect(prescriptionDate).toBeVisible({ timeout: 10000 });
+      await prescriptionDate.click();
       await page.getByText(/Show \d+ Inactive Medications?/i).click();
       const table = page.getByRole("table");
       await expect(table).toContainText(medicineName);


### PR DESCRIPTION
## Proposed Changes

Fixes #16251

- Replace fragile `getByText(username)` selectors with `getByRole('option', { name: username }).first()` in care team member selection — prevents matching unintended elements
- Remove `care-fac-admin` from test usernames to reduce flakiness
- Use `.last()` instead of `.first()` for prescription date selectors to target the correct timestamp element

## Files Changed

- `tests/facility/patient/encounter/careTeam/linkCareTeam.spec.ts`
- `tests/facility/patient/encounter/medicine/prescriptionEdit.spec.ts`

@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and stability for care team member selection (consistent dropdown interactions) and medication timestamp handling (explicit visibility waits), reducing flakiness in scenarios for adding members, preventing duplicates, canceling adds, and verifying medication entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->