### PR TITLE
Fix encounter drawing E2E test locator for View Encounter

### DIFF
--- a/tests/facility/patient/encounter/files/drawings/encounterDrawing.spec.ts
+++ b/tests/facility/patient/encounter/files/drawings/encounterDrawing.spec.ts
@@ -21,7 +21,7 @@ test.describe("Encounter Drawing Management", () => {
 
   async function navigateToEncounterDrawings(page: Page) {
     // Open the first available encounter
-    await page.getByRole("button", { name: "View Encounter" }).first().click();
+    await page.getByText("View Encounter").first().click();
 
     // Navigate to Files tab and then Drawings tab
     await page.getByRole("tab", { name: "Files" }).click();


### PR DESCRIPTION
## Proposed Changes

Fixes #16253

The "View Encounter" element is a `<Link>` (`<a>`) inside a `<Button>` in `EncounterCard.tsx`, so `getByRole('button')` never matches it. Changed to `getByText('View Encounter')` which is consistent with other passing tests.

## File Changed

- `tests/facility/patient/encounter/files/drawings/encounterDrawing.spec.ts`

@ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test navigation selectors for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->