### PR TITLE
fix: Service point drop down responsive issue

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -5488,6 +5488,7 @@
   "selected_organizations": "Selected Organizations",
   "selected_payments": "Selected payments",
   "selected_practitioner": "Selected practitioner",
+  "selected_service_points": "{{count}} Service points",
   "selected_slot_not_found": "Selected Slot Not Found",
   "selected_substitute": "Selected Substitute",
   "selected_tags": "Selected Tags",

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -51,10 +51,10 @@ export const ServicePointsDropDown = () => {
                 return (
                   <div
                     key={subQueue.id}
-                    className="flex sm:w-auto w-full items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
+                    className="flex w-full max-w-full items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-sm border border-gray-300 bg-gray-50 px-1.5 py-0.5 sm:w-auto sm:max-w-xs"
                   >
-                    <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full" />
-                    <span className="text-sm text-gray-950 font-medium truncate">
+                    <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full shrink-0" />
+                    <span className="min-w-0 truncate text-sm font-medium text-gray-950">
                       {subQueue.name}
                     </span>
                   </div>

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -41,7 +41,7 @@ export const ServicePointsDropDown = () => {
             {t("assign_service_points")}
           </span>
         ) : (
-          <div className="flex flex-col md:flex-row gap-1 items-center justify-center w-full">
+          <div className="flex flex-col lg:flex-row gap-1 items-center justify-center w-full">
             {allServicePoints
               .filter((subQueue) =>
                 assignedServicePointIds.includes(subQueue.id),

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -18,7 +18,7 @@ export const ServicePointsDropDown = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { assignedServicePointIds, allServicePoints, toggleServicePoint } =
     useQueueServicePoints();
-  const defaultServicePoints = useBreakpoints({ default: 4, sm: 2, lg: 4 });
+  const defaultServicePoints = useBreakpoints({ default: 4, lg: 4 });
 
   if (!allServicePoints) {
     return (
@@ -35,40 +35,52 @@ export const ServicePointsDropDown = () => {
 
   return (
     <div className="flex">
-      <div className="flex w-full gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white">
+      <div
+        className="flex w-full gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white cursor-pointer"
+        onClick={() => setIsOpen(true)}
+      >
         {assignedServicePointIds.length === 0 ? (
           <span className="text-sm font-medium">
             {t("assign_service_points")}
           </span>
         ) : (
-          <div className="flex flex-col lg:flex-row gap-1 items-center justify-center w-full">
-            {allServicePoints
-              .filter((subQueue) =>
-                assignedServicePointIds.includes(subQueue.id),
-              )
-              .slice(0, defaultServicePoints)
-              .map((subQueue) => {
-                return (
-                  <div
-                    key={subQueue.id}
-                    className="flex w-full max-w-full items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-sm border border-gray-300 bg-gray-50 px-1.5 py-0.5 sm:w-auto sm:max-w-xs"
-                  >
-                    <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full shrink-0" />
-                    <span className="min-w-0 truncate text-sm font-medium text-gray-950">
-                      {subQueue.name}
-                    </span>
-                  </div>
-                );
-              })}
-            {activeServicePointCount > defaultServicePoints && (
-              <span className="text-sm text-gray-950 font-medium">
-                {"+"}
-                {t("count_more", {
-                  count: activeServicePointCount - defaultServicePoints,
+          <>
+            <div className="hidden lg:flex flex-col lg:flex-row gap-1 items-center justify-center w-full">
+              {allServicePoints
+                .filter((subQueue) =>
+                  assignedServicePointIds.includes(subQueue.id),
+                )
+                .slice(0, defaultServicePoints)
+                .map((subQueue) => {
+                  return (
+                    <div
+                      key={subQueue.id}
+                      className="flex w-full max-w-full items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-sm border border-gray-300 bg-gray-50 px-1.5 py-0.5 sm:w-auto sm:max-w-xs"
+                    >
+                      <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full shrink-0" />
+                      <span className="min-w-0 truncate text-sm font-medium text-gray-950">
+                        {subQueue.name}
+                      </span>
+                    </div>
+                  );
+                })}
+              {activeServicePointCount > defaultServicePoints && (
+                <span className="text-sm text-gray-950 font-medium">
+                  {"+"}
+                  {t("count_more", {
+                    count: activeServicePointCount - defaultServicePoints,
+                  })}
+                </span>
+              )}
+            </div>
+            <div className="lg:hidden flex items-center justify-center w-full">
+              <span className="text-sm font-medium whitespace-nowrap">
+                {t("selected_service_points", {
+                  count: assignedServicePointIds.length,
                 })}
               </span>
-            )}
-          </div>
+            </div>
+          </>
         )}
       </div>
       <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -41,7 +41,7 @@ export const ServicePointsDropDown = () => {
             {t("assign_service_points")}
           </span>
         ) : (
-          <div className="flex flex-col xl:flex-row gap-1 items-center justify-center w-full">
+          <div className="flex flex-col md:flex-row gap-1 items-center justify-center w-full">
             {allServicePoints
               .filter((subQueue) =>
                 assignedServicePointIds.includes(subQueue.id),
@@ -51,7 +51,7 @@ export const ServicePointsDropDown = () => {
                 return (
                   <div
                     key={subQueue.id}
-                    className="flex sm:w-48 w-full items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
+                    className="flex sm:w-20 w-full items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
                   >
                     <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full" />
                     <span className="text-sm text-gray-950 font-medium truncate">

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -18,7 +18,7 @@ export const ServicePointsDropDown = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { assignedServicePointIds, allServicePoints, toggleServicePoint } =
     useQueueServicePoints();
-  const defaultServicePoints = useBreakpoints({ default: 4, sm: 6 });
+  const defaultServicePoints = useBreakpoints({ default: 4, sm: 2, lg: 4 });
 
   if (!allServicePoints) {
     return (
@@ -35,13 +35,13 @@ export const ServicePointsDropDown = () => {
 
   return (
     <div className="flex">
-      <div className="flex w-full sm:w-auto gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white">
+      <div className="flex w-full gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white">
         {assignedServicePointIds.length === 0 ? (
           <span className="text-sm font-medium">
             {t("assign_service_points")}
           </span>
         ) : (
-          <div className="flex gap-1 items-center justify-center">
+          <div className="flex flex-col xl:flex-row gap-1 items-center justify-center w-full">
             {allServicePoints
               .filter((subQueue) =>
                 assignedServicePointIds.includes(subQueue.id),
@@ -51,7 +51,7 @@ export const ServicePointsDropDown = () => {
                 return (
                   <div
                     key={subQueue.id}
-                    className="flex w-48 items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
+                    className="flex sm:w-48 w-full items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
                   >
                     <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full" />
                     <span className="text-sm text-gray-950 font-medium truncate">

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -51,7 +51,7 @@ export const ServicePointsDropDown = () => {
                 return (
                   <div
                     key={subQueue.id}
-                    className="flex sm:w-20 w-full items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
+                    className="flex sm:w-auto w-full items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
                   >
                     <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full" />
                     <span className="text-sm text-gray-950 font-medium truncate">


### PR DESCRIPTION
## Proposed Changes

Fixes #16257
<img width="936" height="500" alt="image" src="https://github.com/user-attachments/assets/3b019cfc-01b8-4a16-a923-d3109e3a87d1" />
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved responsiveness of the assigned service points area: items stack on small screens and align horizontally on larger screens.
  * Chips now use responsive sizing and truncation so they fill narrow viewports and compact on wide screens; overflow shows a concise summary on small screens.
  * Main selection container is interactive (clickable) and opens the dropdown for easier access.

* **Localization**
  * Added a localized string for displaying the count of selected service points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->