### PR TITLE
rendering on FacilityOrganizationList: use facility permissions instead of org perms

### DIFF
--- a/src/pages/Facility/settings/organizations/FacilityOrganizationList.tsx
+++ b/src/pages/Facility/settings/organizations/FacilityOrganizationList.tsx
@@ -41,7 +41,7 @@ export default function FacilityOrganizationList({
     Set<string>
   >(new Set([]));
 
-  const { facilityId } = useCurrentFacility();
+  const { facilityId, facility } = useCurrentFacility();
 
   const { data: org } = useQuery({
     queryKey: ["facilityOrganization", organizationId],
@@ -248,14 +248,14 @@ export default function FacilityOrganizationList({
                     <FacilityOrganizationUsers
                       id={organizationId}
                       facilityId={facilityId}
-                      permissions={org?.permissions ?? []}
+                      permissions={facility?.permissions ?? []}
                       isServiceAccount={currentTab === "service_accounts"}
                     />
                   ) : (
                     <FacilityOrganizationView
                       id={organizationId}
                       facilityId={facilityId}
-                      permissions={org?.permissions ?? []}
+                      permissions={facility?.permissions ?? []}
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Proposed Changes

- Switch to using facility permissions for now (until BE perms are merged), should eventually use organization permissions here

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal permission data sourcing in facility organization settings to improve data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->