### PR TITLE
test : Added Playwright Test coverage for Facility-Level Service Request List/Show

### DIFF
--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -1,0 +1,275 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import en from "public/locale/en.json";
+import { generateServiceRequestTestData } from "tests/facility/patient/encounter/serviceRequests/serviceRequest";
+import {
+  expectToast,
+  selectFromDefinitionCategoryPicker,
+} from "tests/helper/ui";
+import { getEncounterId } from "tests/support/encounterId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
+
+function tr(key: string) {
+  const value = (en as Record<string, unknown>)[key];
+  if (typeof value !== "string") {
+    throw new Error(`Missing or non-string i18n key: ${key}`);
+  }
+  return value;
+}
+
+interface CreatedServiceRequest {
+  activityDefinition: string;
+}
+
+async function getAnyLocationId(page: Page, facilityId: string) {
+  await page.goto(`/facility/${facilityId}/overview`);
+  await page.waitForLoadState("networkidle");
+
+  const links = page.getByRole("link");
+  await expect(links.first()).toBeVisible();
+
+  const hrefs = await links.evaluateAll((elements) =>
+    elements
+      .map((el) => el.getAttribute("href"))
+      .filter((href): href is string => typeof href === "string"),
+  );
+
+  const match = hrefs
+    .map((href) => ({
+      href,
+      match: href.match(
+        new RegExp(`/facility/${facilityId}/locations/([^/]+)`),
+      ),
+    }))
+    .find((x) => x.match?.[1]);
+
+  const locationId = match?.match?.[1];
+  if (!locationId) {
+    throw new Error(
+      `Could not find a location link for facility ${facilityId} on overview page.`,
+    );
+  }
+
+  return locationId;
+}
+
+async function createEncounterServiceRequest(
+  page: Page,
+  params: {
+    facilityId: string;
+    patientId: string;
+    encounterId: string;
+  },
+): Promise<CreatedServiceRequest> {
+  const data = generateServiceRequestTestData(false);
+
+  await page.goto(
+    `/facility/${params.facilityId}/patient/${params.patientId}/encounter/${params.encounterId}/service_requests`,
+  );
+  await page.waitForLoadState("networkidle");
+
+  await page
+    .getByRole("button", { name: tr("create_service_request") })
+    .click();
+
+  const activityDefinitionPicker = page
+    .getByRole("combobox")
+    .filter({ hasText: tr("select_activity_definition") })
+    .first();
+  await expect(activityDefinitionPicker).toBeVisible();
+
+  await selectFromDefinitionCategoryPicker(page, activityDefinitionPicker, {
+    navigateCategories: data.navigateCategories,
+    search: data.activityDefinition,
+  });
+
+  await expect(
+    page
+      .getByRole("combobox")
+      .filter({ hasText: data.activityDefinition })
+      .first(),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: tr("submit") }).click();
+  await expectToast(page, tr("questionnaire_submitted_successfully"));
+  await page.waitForLoadState("networkidle");
+
+  return { activityDefinition: data.activityDefinition };
+}
+
+async function openServiceRequestList(
+  page: Page,
+  params: { facilityId: string; locationId: string },
+) {
+  await page.goto(
+    `/facility/${params.facilityId}/locations/${params.locationId}/service_requests`,
+  );
+  await page.waitForLoadState("networkidle");
+
+  await expect(
+    page.getByRole("heading", { name: tr("service_requests") }),
+  ).toBeVisible();
+}
+
+async function getServiceRequestTable(page: Page) {
+  const table = page.getByRole("table");
+  await expect(table).toBeVisible();
+  return table;
+}
+
+function rowForCreated(table: Locator, activityTitle: string) {
+  return table.getByRole("row").filter({ hasText: activityTitle }).first();
+}
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Facility Service Requests (List + Show)", () => {
+  let facilityId: string;
+  let locationId: string;
+  let patientId: string;
+  let encounterId: string;
+  let created: CreatedServiceRequest;
+
+  test.beforeAll(async () => {
+    facilityId = getFacilityId();
+    patientId = getPatientId();
+    encounterId = getEncounterId();
+  });
+
+  test("Navigate to facility service request list and verify rows are visible", async ({
+    page,
+  }) => {
+    await test.step("Resolve lab location and create a service request", async () => {
+      locationId = await getAnyLocationId(page, facilityId);
+      created = await createEncounterServiceRequest(page, {
+        facilityId,
+        patientId,
+        encounterId,
+      });
+    });
+
+    await test.step("Open facility location service request list", async () => {
+      await openServiceRequestList(page, { facilityId, locationId });
+      await expect(page).toHaveURL(/\/service_requests/);
+    });
+
+    await test.step("Verify table renders with at least one data row", async () => {
+      const rows = (await getServiceRequestTable(page)).getByRole("row");
+      const rowCount = await rows.count();
+      expect(rowCount).toBeGreaterThan(1);
+    });
+
+    await test.step("Verify the newly created service request is visible as a row", async () => {
+      const table = await getServiceRequestTable(page);
+      await expect(
+        rowForCreated(table, created.activityDefinition),
+      ).toBeVisible();
+    });
+  });
+
+  test("Filter by activity definition, date range, and status", async ({
+    page,
+  }) => {
+    await openServiceRequestList(page, { facilityId, locationId });
+
+    await test.step("Filter by activity definition", async () => {
+      await page.getByRole("button", { name: tr("filters") }).click();
+      await page
+        .getByRole("menuitem", { name: tr("activity_definition") })
+        .click();
+
+      const search = page.getByPlaceholder(tr("search_activity_definition"));
+      await expect(search).toBeVisible();
+      await search.fill(created.activityDefinition);
+
+      await page
+        .getByRole("menuitem", { name: created.activityDefinition })
+        .first()
+        .click();
+
+      await page.keyboard.press("Escape");
+      await expect(page).toHaveURL(/activity_definition=/);
+      await page.waitForLoadState("networkidle");
+
+      const table = await getServiceRequestTable(page);
+      await expect(
+        rowForCreated(table, created.activityDefinition),
+      ).toBeVisible();
+
+      await page.getByRole("button", { name: tr("filters") }).click();
+      await page
+        .getByRole("menuitem", { name: tr("activity_definition") })
+        .click();
+      const selectedActivity = page
+        .getByRole("menuitem", { name: created.activityDefinition })
+        .first();
+      await expect(selectedActivity.getByRole("checkbox")).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      await page.keyboard.press("Escape");
+    });
+
+    await test.step("Filter by date range", async () => {
+      await page.getByRole("button", { name: tr("filters") }).click();
+      await page.getByRole("menuitem", { name: tr("date") }).click();
+
+      await page.getByRole("menuitem", { name: tr("today") }).click();
+
+      await page.keyboard.press("Escape");
+      await expect(page).toHaveURL(/created_date_(after|before)=/);
+      await page.waitForLoadState("networkidle");
+
+      const table = await getServiceRequestTable(page);
+      await expect(
+        rowForCreated(table, created.activityDefinition),
+      ).toBeVisible();
+    });
+
+    await test.step("Filter by status using tabs and validate badges", async () => {
+      await page.getByRole("tab", { name: tr("active") }).click();
+      await expect(page).toHaveURL(/status=active/);
+      await page.waitForLoadState("networkidle");
+
+      const table = await getServiceRequestTable(page);
+      const createdRow = rowForCreated(table, created.activityDefinition);
+      await expect(createdRow).toBeVisible();
+
+      await expect(
+        createdRow.getByText(tr("active"), { exact: true }),
+      ).toBeVisible();
+    });
+  });
+
+  test("Open a service request and verify specimen workflow card renders", async ({
+    page,
+  }) => {
+    await openServiceRequestList(page, { facilityId, locationId });
+
+    await test.step("Open the matching service request from the list", async () => {
+      const table = await getServiceRequestTable(page);
+      const createdRow = rowForCreated(table, created.activityDefinition);
+
+      await createdRow.getByRole("button", { name: tr("see_details") }).click();
+      await expect(page).toHaveURL(/\/service_requests\/[^/]+$/);
+      await page.waitForLoadState("networkidle");
+      await expect(
+        page.getByRole("button", { name: tr("back") }),
+      ).toBeVisible();
+    });
+
+    await test.step("Verify specimen workflow section is visible", async () => {
+      await expect(
+        page.getByRole("heading", { name: tr("specimens") }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole("button", {
+          name: tr("specimen_collection_instructions"),
+        }),
+      ).toBeVisible();
+    });
+  });
+});

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -298,10 +298,7 @@ test.describe("Facility Service Requests (List + Show)", () => {
       const todayItem = page
         .getByRole("menuitem", { name: tr("today") })
         .first();
-      await expect(todayItem.getByRole("checkbox")).toHaveAttribute(
-        "aria-checked",
-        "true",
-      );
+      await expect(todayItem).toHaveClass(/border-green-500/);
       await page.keyboard.press("Escape");
     });
 

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -15,6 +15,7 @@ function tr(key: string) {
 
 interface CreatedServiceRequest {
   activityDefinition: string;
+  activityDefinitionSlug: string;
   priority: string;
   serviceRequestId: string;
 }
@@ -42,6 +43,7 @@ async function getLocationIdFromServiceRequestShow(
   const data = (await response.json()) as {
     locations?: Array<{ id?: string }>;
     encounter?: { current_location?: { id?: string } };
+    activity_definition?: { slug?: string };
   };
 
   const locationId =
@@ -53,6 +55,37 @@ async function getLocationIdFromServiceRequestShow(
 
   throw new Error(
     `Could not resolve a locationId from service request ${serviceRequestId} for facility ${facilityId}.`,
+  );
+}
+
+async function getActivityDefinitionSlugFromServiceRequestShow(
+  page: Page,
+  facilityId: string,
+  serviceRequestId: string,
+) {
+  const retrievePathSubstring = `/api/v1/facility/${facilityId}/service_request/${serviceRequestId}`;
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      response.url().includes(retrievePathSubstring) &&
+      response.ok(),
+    { timeout: 45_000 },
+  );
+
+  await page.goto(
+    `/facility/${facilityId}/service_requests/${serviceRequestId}`,
+  );
+  const response = await responsePromise;
+  await page.waitForLoadState("networkidle");
+
+  const data = (await response.json()) as {
+    activity_definition?: { slug?: string };
+  };
+  const slug = data.activity_definition?.slug;
+  if (slug) return slug;
+
+  throw new Error(
+    `Could not resolve activity definition slug from service request ${serviceRequestId} for facility ${facilityId}.`,
   );
 }
 
@@ -152,11 +185,18 @@ test.describe("Facility Service Requests (List + Show)", () => {
           facilityId,
           serviceRequestId,
         );
+        const activityDefinitionSlug =
+          await getActivityDefinitionSlugFromServiceRequestShow(
+            page,
+            facilityId,
+            serviceRequestId,
+          );
 
         listShowFixture = {
           locationId: locationIdResolved,
           created: {
             activityDefinition: data.activityDefinition,
+            activityDefinitionSlug,
             priority: data.priority,
             serviceRequestId,
           },
@@ -205,23 +245,32 @@ test.describe("Facility Service Requests (List + Show)", () => {
     await openServiceRequestList(page, { facilityId, locationId });
 
     await test.step("Filter by activity definition", async () => {
-      await page.getByRole("button", { name: tr("filters") }).click();
-      await page
-        .getByRole("menuitem", { name: tr("activity_definition") })
-        .click();
+      const url = new URL(page.url());
+      url.searchParams.set(
+        "activity_definition",
+        created.activityDefinitionSlug,
+      );
 
-      const search = page.getByPlaceholder(tr("search_activity_definition"));
-      await expect(search).toBeVisible();
-      await search.fill(created.activityDefinition);
+      const listPathPart = `/api/v1/facility/${facilityId}/service_request/`;
+      const responsePromise = page.waitForResponse(
+        (r) =>
+          r.request().method() === "GET" &&
+          r.url().includes(listPathPart) &&
+          r
+            .url()
+            .includes(
+              `activity_definition=${created.activityDefinitionSlug}`,
+            ) &&
+          (r.ok() || r.status() === 304),
+        { timeout: 45_000 },
+      );
 
-      await page
-        .getByRole("menuitem", { name: created.activityDefinition })
-        .first()
-        .click();
-
-      await page.keyboard.press("Escape");
-      await expect(page).toHaveURL(/activity_definition=/);
+      await page.goto(url.toString());
+      await responsePromise;
       await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(
+        new RegExp(`activity_definition=${created.activityDefinitionSlug}`),
+      );
 
       const table = await getServiceRequestTable(page);
       const dataRows = table.getByRole("row").filter({
@@ -232,19 +281,6 @@ test.describe("Facility Service Requests (List + Show)", () => {
       for (let i = 0; i < rowCount; i += 1) {
         await expect(dataRows.nth(i)).toContainText(created.activityDefinition);
       }
-
-      await page.getByRole("button", { name: tr("filters") }).click();
-      await page
-        .getByRole("menuitem", { name: tr("activity_definition") })
-        .click();
-      const selectedActivity = page
-        .getByRole("menuitem", { name: created.activityDefinition })
-        .first();
-      await expect(selectedActivity.getByRole("checkbox")).toHaveAttribute(
-        "aria-checked",
-        "true",
-      );
-      await page.keyboard.press("Escape");
     });
 
     await test.step("Filter by date range", async () => {

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -19,87 +19,34 @@ interface CreatedServiceRequest {
   serviceRequestId: string;
 }
 
-function pathnameOnly(hrefOrUrl: string) {
-  if (hrefOrUrl.startsWith("http")) {
-    try {
-      return new URL(hrefOrUrl).pathname;
-    } catch {
-      return hrefOrUrl.split("?")[0];
-    }
-  }
-  return hrefOrUrl.split("?")[0];
-}
-
-function extractLocationIdFromUrl(url: string, facilityId: string) {
-  const path = pathnameOnly(url);
-  const marker = `/facility/${facilityId}/locations/`;
-  const idx = path.indexOf(marker);
-  if (idx === -1) return null;
-  const tail = path.slice(idx + marker.length);
-  const segment = tail.split("/").filter(Boolean)[0];
-  return segment ?? null;
-}
-
-function extractServiceRequestsLocationIdFromHref(
-  href: string,
-  facilityId: string,
-) {
-  const path = pathnameOnly(href);
-  const marker = `/facility/${facilityId}/locations/`;
-  const idx = path.indexOf(marker);
-  if (idx === -1) return null;
-  const tail = path.slice(idx + marker.length);
-  const parts = tail.split("/").filter(Boolean);
-  if (parts.length >= 2 && parts[1] === "service_requests") return parts[0];
-  return null;
-}
-
-async function getLinkHrefsWithIndex(page: Page) {
-  const links = page.getByRole("link");
-  if ((await links.count()) === 0) return [];
-
-  const hrefs = await links.evaluateAll((elements) =>
-    elements.map((el) => el.getAttribute("href")),
-  );
-
-  return hrefs
-    .map((href, index) => ({ href, index }))
-    .filter(
-      (x): x is { href: string; index: number } => typeof x.href === "string",
-    );
-}
-
-async function findLocationIdInLinks(page: Page, facilityId: string) {
-  const hrefs = await getLinkHrefsWithIndex(page);
-  for (const { href } of hrefs) {
-    const id = extractLocationIdFromUrl(href, facilityId);
-    if (id) return id;
-  }
-
-  return null;
-}
-
 async function getLocationIdFromServiceRequestShow(
   page: Page,
   facilityId: string,
   serviceRequestId: string,
 ) {
-  await page.goto(
-    `/facility/${facilityId}/service_requests/${serviceRequestId}`,
+  const response = await page.request.get(
+    `/api/v1/facility/${facilityId}/service_request/${serviceRequestId}/`,
   );
-  await page.waitForLoadState("networkidle");
-
-  const hrefs = await getLinkHrefsWithIndex(page);
-  for (const { href } of hrefs) {
-    const id = extractServiceRequestsLocationIdFromHref(href, facilityId);
-    if (id) return id;
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to fetch service request ${serviceRequestId} for facility ${facilityId}: ${response.status()} ${response.statusText()}`,
+    );
   }
 
-  const anyLocation = await findLocationIdInLinks(page, facilityId);
-  if (anyLocation) return anyLocation;
+  const data = (await response.json()) as {
+    locations?: Array<{ id?: string }>;
+    encounter?: { current_location?: { id?: string } };
+  };
+
+  const locationId =
+    data.locations?.find((x) => typeof x.id === "string")?.id ??
+    data.encounter?.current_location?.id ??
+    null;
+
+  if (locationId) return locationId;
 
   throw new Error(
-    `Could not resolve a locationId from service request show for facility ${facilityId}.`,
+    `Could not resolve a locationId from service request ${serviceRequestId} for facility ${facilityId}.`,
   );
 }
 

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -79,53 +79,27 @@ async function findLocationIdInLinks(page: Page, facilityId: string) {
   return null;
 }
 
-function isServiceLocationsListHref(href: string, facilityId: string) {
-  const path = pathnameOnly(href);
-  const prefix = `/facility/${facilityId}/services/`;
-  if (!path.startsWith(prefix)) return false;
-  const rest = path.slice(prefix.length);
-  const segments = rest.split("/").filter(Boolean);
-  return (
-    segments.length === 2 &&
-    segments[1] === "locations" &&
-    segments[0].length > 0
+async function getLocationIdFromServiceRequestShow(
+  page: Page,
+  facilityId: string,
+  serviceRequestId: string,
+) {
+  await page.goto(
+    `/facility/${facilityId}/service_requests/${serviceRequestId}`,
   );
-}
-
-async function getServiceRequestsLocationId(page: Page, facilityId: string) {
-  await page.goto(`/facility/${facilityId}/overview`);
   await page.waitForLoadState("networkidle");
 
-  const overviewLocationId = await findLocationIdInLinks(page, facilityId);
-  if (overviewLocationId) return overviewLocationId;
-
-  await page.goto(`/facility/${facilityId}/services`);
-  await page.waitForLoadState("networkidle");
-
-  const indexHrefPairs = await getLinkHrefsWithIndex(page);
-  const serviceLocationHrefs = indexHrefPairs
-    .filter(({ href }) => isServiceLocationsListHref(href, facilityId))
-    .map(({ href }) => href);
-
-  for (const locationsHref of serviceLocationHrefs) {
-    await page.goto(locationsHref);
-    await page.waitForLoadState("networkidle");
-
-    const idFromUrl = extractServiceRequestsLocationIdFromHref(
-      page.url(),
-      facilityId,
-    );
-    if (idFromUrl) return idFromUrl;
-
-    const pageHrefs = await getLinkHrefsWithIndex(page);
-    for (const { href } of pageHrefs) {
-      const id = extractServiceRequestsLocationIdFromHref(href, facilityId);
-      if (id) return id;
-    }
+  const hrefs = await getLinkHrefsWithIndex(page);
+  for (const { href } of hrefs) {
+    const id = extractServiceRequestsLocationIdFromHref(href, facilityId);
+    if (id) return id;
   }
 
+  const anyLocation = await findLocationIdInLinks(page, facilityId);
+  if (anyLocation) return anyLocation;
+
   throw new Error(
-    `Could not resolve a locationId for facility ${facilityId} with a lab /service_requests link (checked each service's locations page).`,
+    `Could not resolve a locationId from service request show for facility ${facilityId}.`,
   );
 }
 
@@ -179,10 +153,6 @@ test.describe("Facility Service Requests (List + Show)", () => {
     if (listShowFixture) return listShowFixture;
     if (!listShowFixtureInit) {
       listShowFixtureInit = (async () => {
-        const locationIdResolved = await getServiceRequestsLocationId(
-          page,
-          facilityId,
-        );
         const data = await createServiceRequest(
           page,
           facilityId,
@@ -191,17 +161,25 @@ test.describe("Facility Service Requests (List + Show)", () => {
           false,
         );
 
-        await openServiceRequestList(page, {
-          facilityId,
-          locationId: locationIdResolved,
+        await page.goto(
+          `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
+        );
+        await page.waitForLoadState("networkidle");
+
+        const serviceRequestsTab = page.getByRole("tab", {
+          name: /service requests/i,
         });
-        const table = await getServiceRequestTable(page);
-        const createdRow = rowForCreated(table, {
+        await expect(serviceRequestsTab).toBeVisible();
+        await serviceRequestsTab.click();
+        await page.waitForLoadState("networkidle");
+
+        const encounterTable = await getServiceRequestTable(page);
+        const encounterRow = rowForCreated(encounterTable, {
           activityDefinition: data.activityDefinition,
           priority: data.priority,
         });
-        await expect(createdRow).toBeVisible();
-        await createdRow
+        await expect(encounterRow).toBeVisible();
+        await encounterRow
           .getByRole("button", { name: tr("see_details") })
           .click();
         await page.waitForLoadState("networkidle");
@@ -215,6 +193,12 @@ test.describe("Facility Service Requests (List + Show)", () => {
             `Failed to extract serviceRequestId from URL: ${url}`,
           );
         }
+
+        const locationIdResolved = await getLocationIdFromServiceRequestShow(
+          page,
+          facilityId,
+          serviceRequestId,
+        );
 
         listShowFixture = {
           locationId: locationIdResolved,

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -24,14 +24,20 @@ async function getLocationIdFromServiceRequestShow(
   facilityId: string,
   serviceRequestId: string,
 ) {
-  const response = await page.request.get(
-    `/api/v1/facility/${facilityId}/service_request/${serviceRequestId}/`,
+  const retrievePathSubstring = `/api/v1/facility/${facilityId}/service_request/${serviceRequestId}`;
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      response.url().includes(retrievePathSubstring) &&
+      response.ok(),
+    { timeout: 45_000 },
   );
-  if (!response.ok()) {
-    throw new Error(
-      `Failed to fetch service request ${serviceRequestId} for facility ${facilityId}: ${response.status()} ${response.statusText()}`,
-    );
-  }
+
+  await page.goto(
+    `/facility/${facilityId}/service_requests/${serviceRequestId}`,
+  );
+  const response = await responsePromise;
+  await page.waitForLoadState("networkidle");
 
   const data = (await response.json()) as {
     locations?: Array<{ id?: string }>;

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import en from "public/locale/en.json";
-import { generateServiceRequestTestData } from "tests/facility/patient/encounter/serviceRequests/serviceRequest";
-import {
-  expectToast,
-  selectFromDefinitionCategoryPicker,
-} from "tests/helper/ui";
+import { createServiceRequest } from "tests/facility/patient/encounter/serviceRequests/serviceRequest";
 import { getEncounterId } from "tests/support/encounterId";
 import { getFacilityId } from "tests/support/facilityId";
 import { getPatientId } from "tests/support/patientId";
@@ -68,6 +64,12 @@ async function findLocationIdInLinks(page: Page, facilityId: string) {
   return null;
 }
 
+function isServiceLocationsListHref(href: string, facilityId: string) {
+  return new RegExp(
+    `^/facility/${facilityId.replace(/-/g, "\\-")}/services/[^/]+/locations$`,
+  ).test(href);
+}
+
 async function getServiceRequestsLocationId(page: Page, facilityId: string) {
   await page.goto(`/facility/${facilityId}/overview`);
   await page.waitForLoadState("networkidle");
@@ -75,84 +77,34 @@ async function getServiceRequestsLocationId(page: Page, facilityId: string) {
   const overviewLocationId = await findLocationIdInLinks(page, facilityId);
   if (overviewLocationId) return overviewLocationId;
 
-  // Fallback: facility services flow always leads to a location-scoped page
-  await page.goto(`/facility/${facilityId}/services/`);
+  await page.goto(`/facility/${facilityId}/services`);
   await page.waitForLoadState("networkidle");
 
-  const visited = new Set<string>();
-  for (let depth = 0; depth < 6; depth += 1) {
+  const indexHrefPairs = await getLinkHrefsWithIndex(page);
+  const serviceLocationHrefs = indexHrefPairs
+    .filter(({ href }) => isServiceLocationsListHref(href, facilityId))
+    .map(({ href }) => href);
+
+  for (const locationsHref of serviceLocationHrefs) {
+    await page.goto(locationsHref);
+    await page.waitForLoadState("networkidle");
+
     const idFromUrl = extractServiceRequestsLocationIdFromHref(
       page.url(),
       facilityId,
     );
     if (idFromUrl) return idFromUrl;
 
-    const hrefs = await getLinkHrefsWithIndex(page);
-
-    for (const { href } of hrefs) {
+    const pageHrefs = await getLinkHrefsWithIndex(page);
+    for (const { href } of pageHrefs) {
       const id = extractServiceRequestsLocationIdFromHref(href, facilityId);
       if (id) return id;
     }
-
-    const next = hrefs.find(({ href }) => {
-      if (visited.has(href)) return false;
-      return href.startsWith(`/facility/${facilityId}/services/`);
-    });
-
-    if (!next) break;
-    visited.add(next.href);
-
-    await page.getByRole("link").nth(next.index).click();
-    await page.waitForLoadState("networkidle");
   }
 
   throw new Error(
-    `Could not resolve a locationId for facility ${facilityId} via overview or services navigation.`,
+    `Could not resolve a locationId for facility ${facilityId} with a lab /service_requests link (checked each service's locations page).`,
   );
-}
-
-async function createEncounterServiceRequest(
-  page: Page,
-  params: {
-    facilityId: string;
-    patientId: string;
-    encounterId: string;
-  },
-): Promise<CreatedServiceRequest> {
-  const data = generateServiceRequestTestData(false);
-
-  await page.goto(
-    `/facility/${params.facilityId}/patient/${params.patientId}/encounter/${params.encounterId}/service_requests`,
-  );
-  await page.waitForLoadState("networkidle");
-
-  await page
-    .getByRole("button", { name: tr("create_service_request") })
-    .click();
-
-  const activityDefinitionPicker = page
-    .getByRole("combobox")
-    .filter({ hasText: tr("select_activity_definition") })
-    .first();
-  await expect(activityDefinitionPicker).toBeVisible();
-
-  await selectFromDefinitionCategoryPicker(page, activityDefinitionPicker, {
-    navigateCategories: data.navigateCategories,
-    search: data.activityDefinition,
-  });
-
-  await expect(
-    page
-      .getByRole("combobox")
-      .filter({ hasText: data.activityDefinition })
-      .first(),
-  ).toBeVisible();
-
-  await page.getByRole("button", { name: tr("submit") }).click();
-  await expectToast(page, tr("questionnaire_submitted_successfully"));
-  await page.waitForLoadState("networkidle");
-
-  return { activityDefinition: data.activityDefinition };
 }
 
 async function openServiceRequestList(
@@ -201,11 +153,14 @@ test.describe("Facility Service Requests (List + Show)", () => {
   }) => {
     await test.step("Resolve lab location and create a service request", async () => {
       locationId = await getServiceRequestsLocationId(page, facilityId);
-      created = await createEncounterServiceRequest(page, {
+      const data = await createServiceRequest(
+        page,
         facilityId,
         patientId,
         encounterId,
-      });
+        false,
+      );
+      created = { activityDefinition: data.activityDefinition };
     });
 
     await test.step("Open facility location service request list", async () => {

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -15,6 +15,8 @@ function tr(key: string) {
 
 interface CreatedServiceRequest {
   activityDefinition: string;
+  priority: string;
+  serviceRequestId: string;
 }
 
 function pathnameOnly(hrefOrUrl: string) {
@@ -147,8 +149,15 @@ async function getServiceRequestTable(page: Page) {
   return table;
 }
 
-function rowForCreated(table: Locator, activityTitle: string) {
-  return table.getByRole("row").filter({ hasText: activityTitle }).first();
+function rowForCreated(
+  table: Locator,
+  created: Pick<CreatedServiceRequest, "activityDefinition" | "priority">,
+) {
+  return table
+    .getByRole("row")
+    .filter({ hasText: created.activityDefinition })
+    .filter({ hasText: created.priority })
+    .first();
 }
 
 test.use({ storageState: "tests/.auth/user.json" });
@@ -181,9 +190,39 @@ test.describe("Facility Service Requests (List + Show)", () => {
           encounterId,
           false,
         );
+
+        await openServiceRequestList(page, {
+          facilityId,
+          locationId: locationIdResolved,
+        });
+        const table = await getServiceRequestTable(page);
+        const createdRow = rowForCreated(table, {
+          activityDefinition: data.activityDefinition,
+          priority: data.priority,
+        });
+        await expect(createdRow).toBeVisible();
+        await createdRow
+          .getByRole("button", { name: tr("see_details") })
+          .click();
+        await page.waitForLoadState("networkidle");
+        await expect(page).toHaveURL(/\/service_requests\/[^/]+$/);
+        const url = page.url();
+        const serviceRequestId = url
+          .split("/service_requests/")[1]
+          ?.split(/[/?#]/)[0];
+        if (!serviceRequestId) {
+          throw new Error(
+            `Failed to extract serviceRequestId from URL: ${url}`,
+          );
+        }
+
         listShowFixture = {
           locationId: locationIdResolved,
-          created: { activityDefinition: data.activityDefinition },
+          created: {
+            activityDefinition: data.activityDefinition,
+            priority: data.priority,
+            serviceRequestId,
+          },
         };
       })();
     }
@@ -218,9 +257,7 @@ test.describe("Facility Service Requests (List + Show)", () => {
 
     await test.step("Verify the newly created service request is visible as a row", async () => {
       const table = await getServiceRequestTable(page);
-      await expect(
-        rowForCreated(table, created.activityDefinition),
-      ).toBeVisible();
+      await expect(rowForCreated(table, created)).toBeVisible();
     });
   });
 
@@ -250,9 +287,14 @@ test.describe("Facility Service Requests (List + Show)", () => {
       await page.waitForLoadState("networkidle");
 
       const table = await getServiceRequestTable(page);
-      await expect(
-        rowForCreated(table, created.activityDefinition),
-      ).toBeVisible();
+      const dataRows = table.getByRole("row").filter({
+        has: page.getByRole("button", { name: tr("see_details") }),
+      });
+      const rowCount = await dataRows.count();
+      expect(rowCount).toBeGreaterThan(0);
+      for (let i = 0; i < rowCount; i += 1) {
+        await expect(dataRows.nth(i)).toContainText(created.activityDefinition);
+      }
 
       await page.getByRole("button", { name: tr("filters") }).click();
       await page
@@ -278,10 +320,16 @@ test.describe("Facility Service Requests (List + Show)", () => {
       await expect(page).toHaveURL(/created_date_(after|before)=/);
       await page.waitForLoadState("networkidle");
 
-      const table = await getServiceRequestTable(page);
-      await expect(
-        rowForCreated(table, created.activityDefinition),
-      ).toBeVisible();
+      await page.getByRole("button", { name: tr("filters") }).click();
+      await page.getByRole("menuitem", { name: tr("date") }).click();
+      const todayItem = page
+        .getByRole("menuitem", { name: tr("today") })
+        .first();
+      await expect(todayItem.getByRole("checkbox")).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      await page.keyboard.press("Escape");
     });
 
     await test.step("Filter by status using tabs and validate badges", async () => {
@@ -290,28 +338,29 @@ test.describe("Facility Service Requests (List + Show)", () => {
       await page.waitForLoadState("networkidle");
 
       const table = await getServiceRequestTable(page);
-      const createdRow = rowForCreated(table, created.activityDefinition);
-      await expect(createdRow).toBeVisible();
-
-      await expect(
-        createdRow.getByText(tr("active"), { exact: true }),
-      ).toBeVisible();
+      const dataRows = table.getByRole("row").filter({
+        has: page.getByRole("button", { name: tr("see_details") }),
+      });
+      const rowCount = await dataRows.count();
+      expect(rowCount).toBeGreaterThan(0);
+      for (let i = 0; i < rowCount; i += 1) {
+        await expect(
+          dataRows.nth(i).getByText(tr("active"), { exact: true }),
+        ).toBeVisible();
+      }
     });
   });
 
   test("Open a service request and verify specimen workflow card renders", async ({
     page,
   }) => {
-    const { locationId, created } = await ensureListShowFixture(page);
-    await openServiceRequestList(page, { facilityId, locationId });
+    const { created } = await ensureListShowFixture(page);
+    await page.goto(
+      `/facility/${facilityId}/service_requests/${created.serviceRequestId}`,
+    );
+    await page.waitForLoadState("networkidle");
 
     await test.step("Open the matching service request from the list", async () => {
-      const table = await getServiceRequestTable(page);
-      const createdRow = rowForCreated(table, created.activityDefinition);
-
-      await createdRow.getByRole("button", { name: tr("see_details") }).click();
-      await expect(page).toHaveURL(/\/service_requests\/[^/]+$/);
-      await page.waitForLoadState("networkidle");
       await expect(
         page.getByRole("button", { name: tr("back") }),
       ).toBeVisible();

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -17,31 +17,44 @@ interface CreatedServiceRequest {
   activityDefinition: string;
 }
 
+function pathnameOnly(hrefOrUrl: string) {
+  if (hrefOrUrl.startsWith("http")) {
+    try {
+      return new URL(hrefOrUrl).pathname;
+    } catch {
+      return hrefOrUrl.split("?")[0];
+    }
+  }
+  return hrefOrUrl.split("?")[0];
+}
+
 function extractLocationIdFromUrl(url: string, facilityId: string) {
-  return (
-    url.match(new RegExp(`/facility/${facilityId}/locations/([^/]+)`))?.[1] ??
-    null
-  );
+  const path = pathnameOnly(url);
+  const marker = `/facility/${facilityId}/locations/`;
+  const idx = path.indexOf(marker);
+  if (idx === -1) return null;
+  const tail = path.slice(idx + marker.length);
+  const segment = tail.split("/").filter(Boolean)[0];
+  return segment ?? null;
 }
 
 function extractServiceRequestsLocationIdFromHref(
   href: string,
   facilityId: string,
 ) {
-  return (
-    href.match(
-      new RegExp(`/facility/${facilityId}/locations/([^/]+)/service_requests`),
-    )?.[1] ?? null
-  );
+  const path = pathnameOnly(href);
+  const marker = `/facility/${facilityId}/locations/`;
+  const idx = path.indexOf(marker);
+  if (idx === -1) return null;
+  const tail = path.slice(idx + marker.length);
+  const parts = tail.split("/").filter(Boolean);
+  if (parts.length >= 2 && parts[1] === "service_requests") return parts[0];
+  return null;
 }
 
 async function getLinkHrefsWithIndex(page: Page) {
   const links = page.getByRole("link");
-  const hasAnyLinks = await links
-    .first()
-    .isVisible()
-    .catch(() => false);
-  if (!hasAnyLinks) return [];
+  if ((await links.count()) === 0) return [];
 
   const hrefs = await links.evaluateAll((elements) =>
     elements.map((el) => el.getAttribute("href")),
@@ -65,9 +78,16 @@ async function findLocationIdInLinks(page: Page, facilityId: string) {
 }
 
 function isServiceLocationsListHref(href: string, facilityId: string) {
-  return new RegExp(
-    `^/facility/${facilityId.replace(/-/g, "\\-")}/services/[^/]+/locations$`,
-  ).test(href);
+  const path = pathnameOnly(href);
+  const prefix = `/facility/${facilityId}/services/`;
+  if (!path.startsWith(prefix)) return false;
+  const rest = path.slice(prefix.length);
+  const segments = rest.split("/").filter(Boolean);
+  return (
+    segments.length === 2 &&
+    segments[1] === "locations" &&
+    segments[0].length > 0
+  );
 }
 
 async function getServiceRequestsLocationId(page: Page, facilityId: string) {
@@ -137,10 +157,42 @@ test.describe.configure({ mode: "serial" });
 
 test.describe("Facility Service Requests (List + Show)", () => {
   let facilityId: string;
-  let locationId: string;
   let patientId: string;
   let encounterId: string;
-  let created: CreatedServiceRequest;
+
+  let listShowFixture: {
+    locationId: string;
+    created: CreatedServiceRequest;
+  } | null = null;
+  let listShowFixtureInit: Promise<void> | null = null;
+
+  async function ensureListShowFixture(page: Page) {
+    if (listShowFixture) return listShowFixture;
+    if (!listShowFixtureInit) {
+      listShowFixtureInit = (async () => {
+        const locationIdResolved = await getServiceRequestsLocationId(
+          page,
+          facilityId,
+        );
+        const data = await createServiceRequest(
+          page,
+          facilityId,
+          patientId,
+          encounterId,
+          false,
+        );
+        listShowFixture = {
+          locationId: locationIdResolved,
+          created: { activityDefinition: data.activityDefinition },
+        };
+      })();
+    }
+    await listShowFixtureInit;
+    if (!listShowFixture) {
+      throw new Error("List + show fixture failed to initialize");
+    }
+    return listShowFixture;
+  }
 
   test.beforeAll(async () => {
     facilityId = getFacilityId();
@@ -151,17 +203,7 @@ test.describe("Facility Service Requests (List + Show)", () => {
   test("Navigate to facility service request list and verify rows are visible", async ({
     page,
   }) => {
-    await test.step("Resolve lab location and create a service request", async () => {
-      locationId = await getServiceRequestsLocationId(page, facilityId);
-      const data = await createServiceRequest(
-        page,
-        facilityId,
-        patientId,
-        encounterId,
-        false,
-      );
-      created = { activityDefinition: data.activityDefinition };
-    });
+    const { locationId, created } = await ensureListShowFixture(page);
 
     await test.step("Open facility location service request list", async () => {
       await openServiceRequestList(page, { facilityId, locationId });
@@ -185,6 +227,7 @@ test.describe("Facility Service Requests (List + Show)", () => {
   test("Filter by activity definition, date range, and status", async ({
     page,
   }) => {
+    const { locationId, created } = await ensureListShowFixture(page);
     await openServiceRequestList(page, { facilityId, locationId });
 
     await test.step("Filter by activity definition", async () => {
@@ -259,6 +302,7 @@ test.describe("Facility Service Requests (List + Show)", () => {
   test("Open a service request and verify specimen workflow card renders", async ({
     page,
   }) => {
+    const { locationId, created } = await ensureListShowFixture(page);
     await openServiceRequestList(page, { facilityId, locationId });
 
     await test.step("Open the matching service request from the list", async () => {

--- a/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
+++ b/tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts
@@ -21,36 +21,94 @@ interface CreatedServiceRequest {
   activityDefinition: string;
 }
 
-async function getAnyLocationId(page: Page, facilityId: string) {
+function extractLocationIdFromUrl(url: string, facilityId: string) {
+  return (
+    url.match(new RegExp(`/facility/${facilityId}/locations/([^/]+)`))?.[1] ??
+    null
+  );
+}
+
+function extractServiceRequestsLocationIdFromHref(
+  href: string,
+  facilityId: string,
+) {
+  return (
+    href.match(
+      new RegExp(`/facility/${facilityId}/locations/([^/]+)/service_requests`),
+    )?.[1] ?? null
+  );
+}
+
+async function getLinkHrefsWithIndex(page: Page) {
+  const links = page.getByRole("link");
+  const hasAnyLinks = await links
+    .first()
+    .isVisible()
+    .catch(() => false);
+  if (!hasAnyLinks) return [];
+
+  const hrefs = await links.evaluateAll((elements) =>
+    elements.map((el) => el.getAttribute("href")),
+  );
+
+  return hrefs
+    .map((href, index) => ({ href, index }))
+    .filter(
+      (x): x is { href: string; index: number } => typeof x.href === "string",
+    );
+}
+
+async function findLocationIdInLinks(page: Page, facilityId: string) {
+  const hrefs = await getLinkHrefsWithIndex(page);
+  for (const { href } of hrefs) {
+    const id = extractLocationIdFromUrl(href, facilityId);
+    if (id) return id;
+  }
+
+  return null;
+}
+
+async function getServiceRequestsLocationId(page: Page, facilityId: string) {
   await page.goto(`/facility/${facilityId}/overview`);
   await page.waitForLoadState("networkidle");
 
-  const links = page.getByRole("link");
-  await expect(links.first()).toBeVisible();
+  const overviewLocationId = await findLocationIdInLinks(page, facilityId);
+  if (overviewLocationId) return overviewLocationId;
 
-  const hrefs = await links.evaluateAll((elements) =>
-    elements
-      .map((el) => el.getAttribute("href"))
-      .filter((href): href is string => typeof href === "string"),
-  );
+  // Fallback: facility services flow always leads to a location-scoped page
+  await page.goto(`/facility/${facilityId}/services/`);
+  await page.waitForLoadState("networkidle");
 
-  const match = hrefs
-    .map((href) => ({
-      href,
-      match: href.match(
-        new RegExp(`/facility/${facilityId}/locations/([^/]+)`),
-      ),
-    }))
-    .find((x) => x.match?.[1]);
-
-  const locationId = match?.match?.[1];
-  if (!locationId) {
-    throw new Error(
-      `Could not find a location link for facility ${facilityId} on overview page.`,
+  const visited = new Set<string>();
+  for (let depth = 0; depth < 6; depth += 1) {
+    const idFromUrl = extractServiceRequestsLocationIdFromHref(
+      page.url(),
+      facilityId,
     );
+    if (idFromUrl) return idFromUrl;
+
+    const hrefs = await getLinkHrefsWithIndex(page);
+
+    for (const { href } of hrefs) {
+      const id = extractServiceRequestsLocationIdFromHref(href, facilityId);
+      if (id) return id;
+    }
+
+    const next = hrefs.find(({ href }) => {
+      if (visited.has(href)) return false;
+      return href.startsWith(`/facility/${facilityId}/services/`);
+    });
+
+    if (!next) break;
+    visited.add(next.href);
+
+    await page.getByRole("link").nth(next.index).click();
+    await page.waitForLoadState("networkidle");
   }
 
-  return locationId;
+  throw new Error(
+    `Could not resolve a locationId for facility ${facilityId} via overview or services navigation.`,
+  );
 }
 
 async function createEncounterServiceRequest(
@@ -142,7 +200,7 @@ test.describe("Facility Service Requests (List + Show)", () => {
     page,
   }) => {
     await test.step("Resolve lab location and create a service request", async () => {
-      locationId = await getAnyLocationId(page, facilityId);
+      locationId = await getServiceRequestsLocationId(page, facilityId);
       created = await createEncounterServiceRequest(page, {
         facilityId,
         patientId,


### PR DESCRIPTION
## Proposed Changes

Fixes #16155
- Added `tests/facility/services/serviceRequests/serviceRequestListShow.spec.ts` file covering all 3 playwright tests.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end serial test suite for Facility Service Requests: verifies list rendering, navigation to detail view, and specimens workflow UI.
  * Creates a location-scoped service request fixture once per worker and confirms the request appears in the location-specific list and detail page.
  * Exercises filters (activity, date range, status) and adds stricter runtime checks for missing i18n keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->