### PR TITLE
test : Added Playwright Test Coverage for Invoice Create Flow (Billing)

### DIFF
--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -143,68 +143,88 @@ async function openAccountShow(
   await expect(tabLocator(page, tr("payments"))).toBeVisible();
 }
 
-async function ensureAtLeastOneChargeItemSelected(
+async function findAddChargeItemsButton(page: Page): Promise<Locator | null> {
+  const labelKey = tr("add_charge_items");
+  const labelPattern = new RegExp(escapeRegex(labelKey), "i");
+
+  const byRole = page.getByRole("button", { name: labelPattern });
+  if ((await byRole.count()) > 0) return byRole.first();
+
+  const byFilter = page.getByRole("button").filter({ hasText: labelPattern });
+  if ((await byFilter.count()) > 0) return byFilter.first();
+
+  const allButtons = page.getByRole("button");
+  const count = await allButtons.count();
+  for (let i = 0; i < count; i++) {
+    const btn = allButtons.nth(i);
+    const text = (await btn.textContent()) ?? "";
+    const ariaLabel = (await btn.getAttribute("aria-label")) ?? "";
+    if (labelPattern.test(text.trim()) || labelPattern.test(ariaLabel.trim())) {
+      return btn;
+    }
+  }
+
+  return null;
+}
+
+async function navigateToCreateInvoicePage(
   page: Page,
   facilityId: string,
   accountId: string,
 ) {
   const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
+  const pathNeedle = `/api/v1/facility/${facilityId}/charge_item/`;
 
-  function chargeItemsListResponsePromise() {
-    const pathNeedle = `/api/v1/facility/${facilityId}/charge_item/`;
-    return page.waitForResponse(
-      (r) =>
-        r.request().method() === "GET" &&
-        r.url().includes(pathNeedle) &&
-        r.url().includes(accountId) &&
-        (r.status() === 200 || r.status() === 304),
-      { timeout: 60_000 },
-    );
-  }
+  const responsePromise = page.waitForResponse(
+    (r) =>
+      r.request().method() === "GET" &&
+      r.url().includes(pathNeedle) &&
+      r.url().includes(accountId) &&
+      (r.status() === 200 || r.status() === 304),
+    { timeout: 60_000 },
+  );
 
-  async function openCreateInvoiceAndAwaitChargeItems() {
-    const responsePromise = chargeItemsListResponsePromise();
-    await page.goto(createInvoiceUrl, { waitUntil: "domcontentloaded" });
-    await responsePromise;
-    await page.waitForLoadState("networkidle");
-  }
+  await page.goto(createInvoiceUrl, { waitUntil: "domcontentloaded" });
+  await responsePromise;
+  await page.waitForLoadState("networkidle");
 
-  await openCreateInvoiceAndAwaitChargeItems();
-
-  await expect(page).toHaveURL(new RegExp(`${createInvoiceUrl}(?:\\?|$)`));
+  await expect(page).toHaveURL(
+    new RegExp(`${escapeRegex(createInvoiceUrl)}(?:\\?|$)`),
+  );
   await expect(
     page.getByText(tr("create_invoice"), { exact: true }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+async function ensureAtLeastOneChargeItemSelected(
+  page: Page,
+  facilityId: string,
+  accountId: string,
+) {
+  await navigateToCreateInvoicePage(page, facilityId, accountId);
 
   const invoiceForm = page.locator("form.space-y-6");
   await expect(invoiceForm).toBeVisible({ timeout: 30_000 });
 
-  async function clickOpenAddChargeItemsSheet() {
-    const labelPattern = new RegExp(escapeRegex(tr("add_charge_items")), "i");
-    const byRole = page.getByRole("button", { name: labelPattern });
-    const byFilter = page.getByRole("button").filter({ hasText: labelPattern });
-    const btn =
-      (await byRole.count()) > 0
-        ? byRole.first()
-        : (await byFilter.count()) > 0
-          ? byFilter.first()
-          : byRole.first();
-    await expect(btn).toBeVisible({ timeout: 30_000 });
-    await btn.scrollIntoViewIfNeeded();
-    await btn.click({ timeout: 30_000 });
-  }
-
-  let noBillable = invoiceForm.getByText(tr("no_billable_items"), {
-    exact: true,
-  });
+  const noBillableText = tr("no_billable_items");
+  const noBillable = invoiceForm.getByText(noBillableText, { exact: true });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
-    await clickOpenAddChargeItemsSheet();
+    const addBtn = await findAddChargeItemsButton(page);
+    if (!addBtn) {
+      throw new Error(
+        `Could not find "${tr("add_charge_items")}" button on the create invoice page. ` +
+          `Ensure charge items are enabled for this facility.`,
+      );
+    }
+    await expect(addBtn).toBeVisible({ timeout: 30_000 });
+    await addBtn.scrollIntoViewIfNeeded();
+    await addBtn.click();
     await page.waitForLoadState("networkidle");
 
     let sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
-    await expect(sheet).toBeVisible();
+    await expect(sheet).toBeVisible({ timeout: 15_000 });
 
     let picked = await addChargeItemsFromPickerInSheet(page, sheet, "");
     if (!picked) {
@@ -212,38 +232,40 @@ async function ensureAtLeastOneChargeItemSelected(
       await page.waitForLoadState("networkidle");
       picked = await addChargeItemsFromPickerInSheet(page, sheet, "a");
     }
+
     if (!picked) {
       await page.keyboard.press("Escape");
       await page.waitForLoadState("networkidle");
-      await sheet.getByRole("button", { name: tr("cancel") }).click();
-      await expect(
-        page.getByRole("dialog", { name: tr("add_charge_items") }),
-      ).toBeHidden();
+
+      const cancelBtn = sheet.getByRole("button", { name: tr("cancel") });
+      if (await cancelBtn.isVisible().catch(() => false)) {
+        await cancelBtn.click();
+        await expect(
+          page.getByRole("dialog", { name: tr("add_charge_items") }),
+        ).toBeHidden();
+      }
 
       const newDefinitionTitle = await createMinimalChargeItemDefinition(
         page,
         facilityId,
       );
 
-      const reloadList = chargeItemsListResponsePromise();
-      await page.goto(
-        `/facility/${facilityId}/billing/account/${accountId}/invoices/create`,
-        { waitUntil: "domcontentloaded" },
-      );
-      await reloadList;
-      await page.waitForLoadState("networkidle");
-      await expect(
-        page.getByText(tr("create_invoice"), { exact: true }),
-      ).toBeVisible();
+      await navigateToCreateInvoicePage(page, facilityId, accountId);
+      await expect(invoiceForm).toBeVisible({ timeout: 30_000 });
 
-      noBillable = invoiceForm.getByText(tr("no_billable_items"), {
-        exact: true,
-      });
-
-      await clickOpenAddChargeItemsSheet();
+      const addBtn2 = await findAddChargeItemsButton(page);
+      if (!addBtn2) {
+        throw new Error(
+          `"${tr("add_charge_items")}" button not found after creating definition`,
+        );
+      }
+      await expect(addBtn2).toBeVisible({ timeout: 30_000 });
+      await addBtn2.scrollIntoViewIfNeeded();
+      await addBtn2.click();
       await page.waitForLoadState("networkidle");
+
       sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
-      await expect(sheet).toBeVisible();
+      await expect(sheet).toBeVisible({ timeout: 15_000 });
 
       picked = await addChargeItemsFromPickerInSheet(
         page,
@@ -257,7 +279,7 @@ async function ensureAtLeastOneChargeItemSelected(
       }
     }
 
-    await expect(noBillable).not.toBeVisible();
+    await expect(noBillable).not.toBeVisible({ timeout: 15_000 });
   }
 
   const rowCheckboxes = invoiceForm.getByRole("checkbox");
@@ -290,7 +312,6 @@ async function extractInvoiceNumber(page: Page) {
 }
 
 test.use({ storageState: "tests/.auth/user.json" });
-
 test.describe.configure({ mode: "serial" });
 
 let facilityId: string;
@@ -373,22 +394,6 @@ test.describe("Create Invoice (facility billing)", () => {
   }) => {
     await openAccountShow(page, facilityId, accountId);
 
-    await test.step("Open Create Invoice page", async () => {
-      const createInvoiceLink = page.getByRole("link", {
-        name: tr("create_invoice"),
-      });
-      const hasLink = await createInvoiceLink.isVisible().catch(() => false);
-      if (hasLink) {
-        await createInvoiceLink.click();
-      } else {
-        await page.getByRole("button", { name: tr("create_invoice") }).click();
-      }
-      await expect(
-        page.getByText(tr("create_invoice"), { exact: true }),
-      ).toBeVisible();
-      await page.waitForLoadState("networkidle");
-    });
-
     await test.step("Ensure at least one charge item is selected", async () => {
       await ensureAtLeastOneChargeItemSelected(page, facilityId, accountId);
     });
@@ -398,7 +403,7 @@ test.describe("Create Invoice (facility billing)", () => {
         name: tr("payment_terms_and_note"),
         exact: true,
       });
-      await expect(toggleOptional).toBeVisible();
+      await expect(toggleOptional).toBeVisible({ timeout: 15_000 });
       await toggleOptional.click();
 
       await page

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -1,0 +1,390 @@
+import { faker } from "@faker-js/faker";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import en from "public/locale/en.json";
+import { closeAnyOpenPopovers, expectToast } from "tests/helper/ui";
+import { getAccountId } from "tests/support/accountId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
+
+function tr(key: string) {
+  const value = (en as Record<string, unknown>)[key];
+  if (typeof value !== "string") {
+    throw new Error(`Missing or non-string i18n key: ${key}`);
+  }
+  return value;
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function firstMeaningfulLine(text: string) {
+  return text
+    .split("\n")
+    .map((s) => s.trim())
+    .find((line) => line.length > 0);
+}
+
+const CHARGE_ITEM_DEFINITION_CATEGORY = "Medications";
+
+async function createMinimalChargeItemDefinition(
+  page: Page,
+  facilityId: string,
+) {
+  const title = `E2E ${faker.string.alphanumeric(12)}`;
+  const slug = title.replace(/\s+/g, "-").toLowerCase().slice(0, 25);
+  const basePrice = faker.commerce.price({ dec: 0 });
+
+  await page.goto(`/facility/${facilityId}/settings/charge_item_definitions/`);
+  await page.waitForLoadState("networkidle");
+
+  await page
+    .getByRole("textbox", { name: tr("search") })
+    .fill(CHARGE_ITEM_DEFINITION_CATEGORY);
+  await page.waitForLoadState("networkidle");
+  await page
+    .getByRole("heading", { name: CHARGE_ITEM_DEFINITION_CATEGORY })
+    .click();
+  await page.waitForLoadState("networkidle");
+  await page.getByRole("button", { name: tr("add_definition") }).click();
+  await page.getByRole("textbox", { name: tr("title") }).fill(title);
+  await page.getByRole("textbox", { name: tr("slug") }).fill(slug);
+  await page.getByRole("textbox", { name: tr("base_price") }).fill(basePrice);
+  await page.getByRole("button", { name: tr("create") }).click();
+  await expectToast(page, tr("charge_item_definition_created_successfully"));
+  await page.waitForLoadState("networkidle");
+  return title;
+}
+
+async function waitForChargeItemSearchSettled(page: Page) {
+  const searchingIndicator = page.getByText(tr("searching"), { exact: true });
+  if (await searchingIndicator.isVisible().catch(() => false)) {
+    await searchingIndicator.waitFor({ state: "hidden" });
+  }
+  await page.waitForLoadState("networkidle");
+}
+
+async function addChargeItemsFromPickerInSheet(
+  page: Page,
+  sheet: Locator,
+  definitionSearch: string,
+) {
+  await closeAnyOpenPopovers(page);
+
+  const picker = sheet.getByRole("combobox", {
+    name: tr("select_charge_item_definition"),
+  });
+  await expect(picker).toBeVisible();
+  await picker.click();
+
+  const search = page.getByPlaceholder(tr("search_charge_item_definition"));
+  await expect(search).toBeVisible();
+  await search.fill("");
+  await search.fill(definitionSearch);
+  await waitForChargeItemSearchSettled(page);
+
+  const listbox = page.getByRole("listbox").last();
+  const listboxVisible = await listbox.isVisible().catch(() => false);
+  if (!listboxVisible) return null;
+
+  const options = listbox.getByRole("option");
+  const count = await options.count();
+  if (count === 0) return null;
+
+  const option = options.first();
+  await expect(option).toBeVisible();
+  const optionText = (await option.textContent()) ?? "";
+  const chargeItemTitle = firstMeaningfulLine(optionText) ?? "";
+  if (!chargeItemTitle) return null;
+
+  await option.click();
+  await expect(
+    sheet.getByText(chargeItemTitle, { exact: false }),
+  ).toBeVisible();
+  await sheet.getByRole("button", { name: tr("add_items") }).click();
+  await expectToast(page, tr("charge_items_added_successfully"));
+  await page.waitForLoadState("networkidle");
+  return chargeItemTitle;
+}
+
+async function openAccountList(
+  page: Page,
+  facilityId: string,
+  patientId?: string,
+) {
+  const params = new URLSearchParams({ status: "active" });
+  if (patientId) params.set("patient_filter", patientId);
+
+  await page.goto(
+    `/facility/${facilityId}/billing/account?${params.toString()}`,
+  );
+  await page.waitForLoadState("networkidle");
+  await expect(
+    page.getByRole("heading", { name: tr("accounts") }),
+  ).toBeVisible();
+}
+
+async function openAccountShow(
+  page: Page,
+  facilityId: string,
+  accountId: string,
+) {
+  await page.goto(`/facility/${facilityId}/billing/account/${accountId}`);
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.getByRole("tab", { name: tr("invoices") })).toBeVisible();
+  await expect(
+    page.getByRole("tab", { name: tr("charge_items") }),
+  ).toBeVisible();
+  await expect(page.getByRole("tab", { name: tr("payments") })).toBeVisible();
+}
+
+async function ensureAtLeastOneChargeItemSelected(
+  page: Page,
+  facilityId: string,
+  accountId: string,
+) {
+  const noBillable = page.getByText(tr("no_billable_items"), { exact: true });
+  const hasNoBillable = await noBillable.isVisible().catch(() => false);
+
+  const table = page.getByRole("table");
+  await expect(table).toBeVisible();
+
+  let chargeItemTitle: string;
+
+  if (hasNoBillable) {
+    await page.getByRole("button", { name: tr("add_charge_items") }).click();
+    await page.waitForLoadState("networkidle");
+
+    let sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
+    await expect(sheet).toBeVisible();
+
+    let picked = await addChargeItemsFromPickerInSheet(page, sheet, "");
+    if (!picked) {
+      await page.keyboard.press("Escape");
+      await page.waitForLoadState("networkidle");
+      picked = await addChargeItemsFromPickerInSheet(page, sheet, "a");
+    }
+    if (!picked) {
+      await page.keyboard.press("Escape");
+      await page.waitForLoadState("networkidle");
+      await sheet.getByRole("button", { name: tr("cancel") }).click();
+      await expect(
+        page.getByRole("dialog", { name: tr("add_charge_items") }),
+      ).toBeHidden();
+
+      const newDefinitionTitle = await createMinimalChargeItemDefinition(
+        page,
+        facilityId,
+      );
+
+      await page.goto(
+        `/facility/${facilityId}/billing/account/${accountId}/invoices/create`,
+      );
+      await page.waitForLoadState("networkidle");
+      await expect(
+        page.getByText(tr("create_invoice"), { exact: true }),
+      ).toBeVisible();
+
+      await page.getByRole("button", { name: tr("add_charge_items") }).click();
+      await page.waitForLoadState("networkidle");
+      sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
+      await expect(sheet).toBeVisible();
+
+      picked = await addChargeItemsFromPickerInSheet(
+        page,
+        sheet,
+        newDefinitionTitle,
+      );
+      if (!picked) {
+        throw new Error(
+          "Charge item picker had no options after creating a definition",
+        );
+      }
+    }
+
+    chargeItemTitle = picked;
+    await expect(noBillable).not.toBeVisible();
+  } else {
+    const dataRow = table.getByRole("row").nth(1);
+    await expect(dataRow).toBeVisible();
+    await expect(dataRow).not.toContainText(tr("no_billable_items"));
+
+    const titleCell = dataRow.getByRole("cell").nth(1);
+    const titleText = (await titleCell.textContent()) ?? "";
+    chargeItemTitle = firstMeaningfulLine(titleText) ?? "";
+    expect(chargeItemTitle).not.toEqual("");
+  }
+
+  const itemRow = table
+    .getByRole("row")
+    .filter({ hasText: new RegExp(escapeRegex(chargeItemTitle), "i") });
+  await expect(itemRow.first()).toBeVisible();
+
+  const rowCheckbox = itemRow.first().getByRole("checkbox").first();
+  const isChecked =
+    (await rowCheckbox.getAttribute("aria-checked").catch(() => null)) ===
+    "true";
+  if (!isChecked) await rowCheckbox.click();
+}
+
+async function extractInvoiceNumber(page: Page) {
+  const invoiceLabel = escapeRegex(tr("invoice"));
+  const invoiceLine = page
+    .getByText(new RegExp(`${invoiceLabel}\\s*:\\s*`, "i"))
+    .first();
+  await expect(invoiceLine).toBeVisible();
+
+  const text = (await invoiceLine.textContent())?.trim() || "";
+  return text.replace(new RegExp(`^${tr("invoice")}\\s*:\\s*`, "i"), "").trim();
+}
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe.configure({ mode: "serial" });
+
+let facilityId: string;
+let patientId: string;
+let accountId: string;
+let createdInvoiceNumber = "";
+
+test.beforeAll(async () => {
+  facilityId = getFacilityId();
+  patientId = getPatientId();
+  accountId = getAccountId();
+});
+
+test.describe("Create Invoice (facility billing)", () => {
+  test("Navigate Billing → Account List → open fixture account from list", async ({
+    page,
+  }) => {
+    await test.step("Open account list scoped to fixture patient", async () => {
+      await openAccountList(page, facilityId, patientId);
+    });
+
+    await test.step("Open the setup account from list (match URL to getAccountId)", async () => {
+      const table = page.getByRole("table");
+      await expect(table).toBeVisible();
+
+      const dataRows = table.getByRole("row").filter({
+        has: page.getByRole("button", { name: tr("go_to_account") }),
+      });
+      await expect(dataRows.first()).toBeVisible();
+
+      const accountPath = `/billing/account/${accountId}`;
+      let opened = false;
+      const rowCount = await dataRows.count();
+      for (let i = 0; i < rowCount; i += 1) {
+        await dataRows
+          .nth(i)
+          .getByRole("button", { name: tr("go_to_account") })
+          .click();
+        await page.waitForLoadState("networkidle");
+        if (page.url().includes(accountPath)) {
+          opened = true;
+          break;
+        }
+        await page.goBack();
+        await page.waitForLoadState("networkidle");
+        await expect(table).toBeVisible();
+      }
+      expect(opened).toBe(true);
+    });
+
+    await test.step("Verify account workspace tabs", async () => {
+      await expect(
+        page.getByRole("tab", { name: tr("invoices") }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("tab", { name: tr("charge_items") }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("tab", { name: tr("payments") }),
+      ).toBeVisible();
+    });
+  });
+
+  test("Create invoice from account and verify success toast", async ({
+    page,
+  }) => {
+    await openAccountShow(page, facilityId, accountId);
+
+    await test.step("Open Create Invoice page", async () => {
+      const createInvoiceLink = page.getByRole("link", {
+        name: tr("create_invoice"),
+      });
+      const hasLink = await createInvoiceLink.isVisible().catch(() => false);
+      if (hasLink) {
+        await createInvoiceLink.click();
+      } else {
+        await page.getByRole("button", { name: tr("create_invoice") }).click();
+      }
+      await expect(
+        page.getByText(tr("create_invoice"), { exact: true }),
+      ).toBeVisible();
+      await page.waitForLoadState("networkidle");
+    });
+
+    await test.step("Ensure at least one charge item is selected", async () => {
+      await ensureAtLeastOneChargeItemSelected(page, facilityId, accountId);
+    });
+
+    await test.step("Fill optional fields", async () => {
+      const toggleOptional = page.getByRole("button", {
+        name: tr("payment_terms_and_note"),
+        exact: true,
+      });
+      await expect(toggleOptional).toBeVisible();
+      await toggleOptional.click();
+
+      await page
+        .getByPlaceholder(tr("payment_terms_placeholder"))
+        .fill(`PT-${faker.string.alphanumeric(8)}`);
+      await page
+        .getByPlaceholder(tr("invoice_note_placeholder"))
+        .fill(faker.lorem.sentence());
+    });
+
+    await test.step("Submit invoice and verify success", async () => {
+      await page.getByRole("button", { name: tr("create_invoice") }).click();
+      await expectToast(page, tr("invoice_created_successfully"));
+
+      await page.waitForLoadState("networkidle");
+      createdInvoiceNumber = await extractInvoiceNumber(page);
+      expect(createdInvoiceNumber).not.toEqual("");
+    });
+  });
+
+  test("Verify invoice appears in Invoices tab", async ({ page }) => {
+    await test.step("Navigate back to invoices list", async () => {
+      const back = page.getByRole("link", { name: tr("back_to_invoices") });
+      const hasBack = await back.isVisible().catch(() => false);
+      if (hasBack) {
+        await back.click();
+      } else {
+        await openAccountShow(page, facilityId, accountId);
+        await page.getByRole("tab", { name: tr("invoices") }).click();
+      }
+      await page.waitForLoadState("networkidle");
+    });
+
+    await test.step("Search invoice number and verify row + draft badge", async () => {
+      expect(createdInvoiceNumber.length).toBeGreaterThan(0);
+
+      const search = page.getByPlaceholder(tr("search_invoices"));
+      await expect(search).toBeVisible();
+      await search.fill(createdInvoiceNumber);
+      await page.waitForLoadState("networkidle");
+
+      const table = page.getByRole("table");
+      await expect(table).toBeVisible();
+
+      const row = table
+        .getByRole("row")
+        .filter({ hasText: createdInvoiceNumber })
+        .first();
+      await expect(row).toBeVisible();
+      await expect(row.getByText(tr("draft"), { exact: true })).toBeVisible();
+    });
+  });
+});

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -1,10 +1,19 @@
 import { faker } from "@faker-js/faker";
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type Response,
+} from "@playwright/test";
 import en from "public/locale/en.json";
 import { closeAnyOpenPopovers, expectToast } from "tests/helper/ui";
 import { getAccountId } from "tests/support/accountId";
 import { getFacilityId } from "tests/support/facilityId";
 import { getPatientId } from "tests/support/patientId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+test.describe.configure({ mode: "serial" });
 
 function tr(key: string) {
   const value = (en as Record<string, unknown>)[key];
@@ -24,12 +33,26 @@ function tabLocator(page: Page, tabText: string) {
   });
 }
 
+function createInvoiceForm(page: Page): Locator {
+  return page.getByRole("form");
+}
+
 function addChargeItemsBillingSheetPanel(page: Page): Locator {
-  return page.locator('[data-slot="sheet-content"]').filter({
-    has: page
-      .locator('[data-slot="sheet-title"]')
-      .getByText(tr("add_charge_items"), { exact: true }),
+  return page.getByRole("dialog").filter({
+    has: page.getByRole("heading", { name: tr("add_charge_items") }),
   });
+}
+
+function accountRetrieveResponsePredicate(
+  facilityId: string,
+  accountId: string,
+) {
+  const needle = `/api/v1/facility/${facilityId}/account/${accountId}/`;
+  return (response: Response) =>
+    response.request().method() === "GET" &&
+    response.url().includes(needle) &&
+    !response.url().includes("/rebalance/") &&
+    (response.status() === 200 || response.status() === 304);
 }
 
 function firstNonEmptyLine(text: string) {
@@ -68,7 +91,13 @@ async function addChargeItemsFromPickerInSheet(
   await search.fill(definitionSearch);
   await waitForChargeItemSearchSettled(page);
 
-  const listbox = page.getByRole("listbox").last();
+  const definitionSearchPlaceholder = tr("search_charge_item_definition");
+  const pickerPopover = page
+    .locator("[data-radix-popper-content-wrapper]")
+    .filter({ has: page.getByPlaceholder(definitionSearchPlaceholder) })
+    .filter({ visible: true })
+    .last();
+  const listbox = pickerPopover.getByRole("listbox");
   const listboxVisible = await listbox.isVisible().catch(() => false);
   if (!listboxVisible) return null;
 
@@ -128,7 +157,24 @@ async function ensureAtLeastOneChargeItemSelected(
   accountId: string,
 ) {
   const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
+  const accountResponsePromise = page.waitForResponse(
+    accountRetrieveResponsePredicate(facilityId, accountId),
+  );
+
   await page.goto(createInvoiceUrl, { waitUntil: "domcontentloaded" });
+  const accountResponse = await accountResponsePromise;
+
+  if (accountResponse.status() === 200) {
+    const accountData = (await accountResponse.json()) as {
+      patient?: { id?: string } | string | null;
+    };
+    if (!accountData.patient) {
+      throw new Error(
+        `Billing account ${accountId} has no linked patient; Create Invoice cannot add charge items.`,
+      );
+    }
+  }
+
   await page.waitForLoadState("networkidle");
 
   await expect(page).toHaveURL(
@@ -138,7 +184,7 @@ async function ensureAtLeastOneChargeItemSelected(
     page.getByText(tr("create_invoice"), { exact: true }),
   ).toBeVisible();
 
-  const invoiceForm = page.locator("form.space-y-6");
+  const invoiceForm = createInvoiceForm(page);
   await expect(invoiceForm).toBeVisible();
 
   const noBillableText = tr("no_billable_items");
@@ -158,10 +204,7 @@ async function ensureAtLeastOneChargeItemSelected(
 
     const sheet = addChargeItemsBillingSheetPanel(page);
 
-    const invoiceHeader = page.locator("div.justify-between").filter({
-      has: page.getByText(tr("create_invoice"), { exact: true }),
-    });
-    const toolbarBtn = invoiceHeader.getByRole("button", {
+    const toolbarBtn = page.getByRole("button", {
       name: tr("add_charge_items"),
     });
     await expect(toolbarBtn).toBeVisible();
@@ -225,9 +268,6 @@ async function extractInvoiceNumber(page: Page) {
   return text.replace(new RegExp(`^${tr("invoice")}\\s*:\\s*`, "i"), "").trim();
 }
 
-test.use({ storageState: "tests/.auth/user.json" });
-test.describe.configure({ mode: "serial" });
-
 let facilityId: string;
 let patientId: string;
 let accountId: string;
@@ -242,7 +282,11 @@ test.beforeAll(async () => {
 async function openFixtureAccountFromBillingList(page: Page) {
   await openAccountList(page, facilityId, patientId);
 
-  const goToAccount = page.getByRole("button", { name: tr("go_to_account") });
+  const accountsTable = page.getByRole("table");
+  await expect(accountsTable).toBeVisible();
+  const goToAccount = accountsTable.getByRole("button", {
+    name: tr("go_to_account"),
+  });
   await expect(goToAccount.first()).toBeVisible();
   await goToAccount.first().click();
   await page.waitForLoadState("networkidle");
@@ -277,23 +321,26 @@ test.describe("Create Invoice (facility billing)", () => {
     });
 
     await test.step("Fill optional fields", async () => {
-      const toggleOptional = page.getByRole("button", {
+      const form = createInvoiceForm(page);
+      const toggleOptional = form.getByRole("button", {
         name: tr("payment_terms_and_note"),
         exact: true,
       });
       await expect(toggleOptional).toBeVisible();
       await toggleOptional.click();
 
-      await page
+      await form
         .getByPlaceholder(tr("payment_terms_placeholder"))
         .fill(`PT-${faker.string.alphanumeric(8)}`);
-      await page
+      await form
         .getByPlaceholder(tr("invoice_note_placeholder"))
         .fill(faker.lorem.sentence());
     });
 
     await test.step("Submit invoice and verify success", async () => {
-      await page.getByRole("button", { name: tr("create_invoice") }).click();
+      await createInvoiceForm(page)
+        .getByRole("button", { name: tr("create_invoice") })
+        .click();
       await expectToast(page, tr("invoice_created_successfully"));
 
       await page.waitForLoadState("networkidle");

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -39,35 +39,6 @@ function firstNonEmptyLine(text: string) {
   );
 }
 
-async function createMinimalChargeItemDefinition(
-  page: Page,
-  facilityId: string,
-) {
-  const title = `E2E ${faker.string.alphanumeric(12)}`;
-  const slug = title.replace(/\s+/g, "-").toLowerCase().slice(0, 25);
-  const basePrice = faker.commerce.price({ dec: 0 });
-  const categoryQuery = tr("medication");
-
-  await page.goto(`/facility/${facilityId}/settings/charge_item_definitions/`);
-  await page.waitForLoadState("networkidle");
-
-  await page.getByRole("textbox", { name: tr("search") }).fill(categoryQuery);
-  await page.waitForLoadState("networkidle");
-  await page
-    .getByRole("heading", { name: new RegExp(escapeRegex(categoryQuery), "i") })
-    .first()
-    .click();
-  await page.waitForLoadState("networkidle");
-  await page.getByRole("button", { name: tr("add_definition") }).click();
-  await page.getByRole("textbox", { name: tr("title") }).fill(title);
-  await page.getByRole("textbox", { name: tr("slug") }).fill(slug);
-  await page.getByRole("textbox", { name: tr("base_price") }).fill(basePrice);
-  await page.getByRole("button", { name: tr("create") }).click();
-  await expectToast(page, tr("charge_item_definition_created_successfully"));
-  await page.waitForLoadState("networkidle");
-  return title;
-}
-
 async function waitForChargeItemSearchSettled(page: Page) {
   const searchingIndicator = page.getByText(tr("searching"), { exact: true });
   if (await searchingIndicator.isVisible().catch(() => false)) {
@@ -119,55 +90,6 @@ async function addChargeItemsFromPickerInSheet(
   return chargeItemTitle;
 }
 
-async function addChargeItemsViaInlinePicker(
-  page: Page,
-  scope: Locator,
-  definitionSearch: string,
-) {
-  await closeAnyOpenPopovers(page);
-
-  const picker = scope.getByRole("combobox", {
-    name: tr("select_charge_item_definition"),
-  });
-  await expect(picker).toBeVisible();
-  await picker.click();
-
-  const search = page.getByPlaceholder(tr("search_charge_item_definition"));
-  await expect(search).toBeVisible();
-  await search.fill("");
-  await search.fill(definitionSearch);
-  await waitForChargeItemSearchSettled(page);
-
-  const listbox = page.getByRole("listbox").last();
-  if (!(await listbox.isVisible().catch(() => false))) return null;
-
-  const options = listbox.getByRole("option");
-  if ((await options.count()) === 0) return null;
-
-  const option = options.first();
-  await expect(option).toBeVisible();
-  const optionText = (await option.textContent()) ?? "";
-  const chargeItemTitle = firstNonEmptyLine(optionText);
-  if (!chargeItemTitle) return null;
-
-  await option.click();
-  await expect(
-    scope.getByText(chargeItemTitle, { exact: false }),
-  ).toBeVisible();
-
-  const confirmBtn = scope
-    .locator(
-      `button[data-slot="button"][title*="${escapeRegex(tr("confirm"))}"]`,
-    )
-    .first();
-  await expect(confirmBtn).toBeVisible();
-  await confirmBtn.click();
-
-  await expectToast(page, tr("charge_items_added_successfully"));
-  await page.waitForLoadState("networkidle");
-  return chargeItemTitle;
-}
-
 async function openAccountList(
   page: Page,
   facilityId: string,
@@ -208,28 +130,6 @@ function chargeItemsListResponsePredicate(
     response.url().includes(pathNeedle) &&
     response.url().includes(accountId) &&
     (response.status() === 200 || response.status() === 304);
-}
-
-async function gotoCreateInvoicePage(
-  page: Page,
-  facilityId: string,
-  accountId: string,
-) {
-  const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
-  const responsePromise = page.waitForResponse(
-    chargeItemsListResponsePredicate(facilityId, accountId),
-  );
-
-  await page.goto(createInvoiceUrl, { waitUntil: "domcontentloaded" });
-  await responsePromise;
-  await page.waitForLoadState("networkidle");
-
-  await expect(page).toHaveURL(
-    new RegExp(`${escapeRegex(createInvoiceUrl)}(?:\\?|$)`),
-  );
-  await expect(
-    page.getByText(tr("create_invoice"), { exact: true }),
-  ).toBeVisible();
 }
 
 async function openCreateInvoiceFromAccountWorkspace(
@@ -287,78 +187,33 @@ async function ensureAtLeastOneChargeItemSelected(
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
-    const inlinePicker = invoiceForm.getByRole("combobox", {
-      name: tr("select_charge_item_definition"),
-    });
+    const sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
 
-    let picked: string | null = null;
-    if (await inlinePicker.isVisible().catch(() => false)) {
-      picked = await addChargeItemsViaInlinePicker(page, invoiceForm, "");
-      if (!picked) {
-        picked = await addChargeItemsViaInlinePicker(page, invoiceForm, "a");
-      }
-    }
+    await openAddChargeItemsSheetDialog(page);
+    await page.waitForLoadState("networkidle");
+    await expect(sheet).toBeVisible();
 
-    let sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
-
+    let picked = await addChargeItemsFromPickerInSheet(page, sheet, "");
     if (!picked) {
-      await openAddChargeItemsSheetDialog(page);
+      await page.keyboard.press("Escape");
       await page.waitForLoadState("networkidle");
-      await expect(sheet).toBeVisible();
-
-      picked = await addChargeItemsFromPickerInSheet(page, sheet, "");
-      if (!picked) {
-        await page.keyboard.press("Escape");
-        await page.waitForLoadState("networkidle");
-        picked = await addChargeItemsFromPickerInSheet(page, sheet, "a");
-      }
+      picked = await addChargeItemsFromPickerInSheet(page, sheet, "a");
     }
 
     if (!picked) {
       await page.keyboard.press("Escape");
       await page.waitForLoadState("networkidle");
 
-      const cancelBtn = sheet.getByRole("button", { name: tr("cancel") });
+      const dialog = page.getByRole("dialog", { name: tr("add_charge_items") });
+      const cancelBtn = dialog.getByRole("button", { name: tr("cancel") });
       if (await cancelBtn.isVisible().catch(() => false)) {
         await cancelBtn.click();
-        await expect(
-          page.getByRole("dialog", { name: tr("add_charge_items") }),
-        ).toBeHidden();
+        await expect(dialog).toBeHidden();
       }
 
-      const newDefinitionTitle = await createMinimalChargeItemDefinition(
-        page,
-        facilityId,
+      throw new Error(
+        "No billable charge items could be added from the picker; ensure fixture data exposes charge item definitions with options.",
       );
-
-      await gotoCreateInvoicePage(page, facilityId, accountId);
-      await expect(invoiceForm).toBeVisible();
-
-      picked = null;
-      if (await inlinePicker.isVisible().catch(() => false)) {
-        picked = await addChargeItemsViaInlinePicker(
-          page,
-          invoiceForm,
-          newDefinitionTitle,
-        );
-      }
-      if (!picked) {
-        await openAddChargeItemsSheetDialog(page);
-        await page.waitForLoadState("networkidle");
-        sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
-        await expect(sheet).toBeVisible();
-
-        picked = await addChargeItemsFromPickerInSheet(
-          page,
-          sheet,
-          newDefinitionTitle,
-        );
-      }
-      if (!picked) {
-        throw new Error(
-          "Charge item picker had no options after creating a definition",
-        );
-      }
     }
 
     await expect(noBillable).not.toBeVisible();
@@ -404,55 +259,19 @@ let createdInvoiceNumber = "";
 test.beforeAll(async () => {
   facilityId = getFacilityId();
   patientId = getPatientId();
-  accountId = "";
-  try {
-    accountId = getAccountId();
-  } catch {
-    accountId = "";
-  }
+  accountId = getAccountId();
 });
 
-async function ensureAccountExistsAndOpen(page: Page) {
+async function openFixtureAccountFromBillingList(page: Page) {
   await openAccountList(page, facilityId, patientId);
 
-  const table = page.getByRole("table");
-  const hasTable = await table.isVisible().catch(() => false);
-
-  const goToAccountName = tr("go_to_account");
-  const hasGoToAccount =
-    hasTable &&
-    (await table
-      .getByRole("button", { name: goToAccountName })
-      .first()
-      .isVisible()
-      .catch(() => false));
-
-  if (!hasGoToAccount) {
-    await page.getByRole("button", { name: tr("create_account") }).click();
-    await page.waitForLoadState("networkidle");
-
-    await page
-      .getByRole("textbox", { name: tr("name") })
-      .fill(
-        `E2E ${faker.finance.accountName()} ${faker.string.alphanumeric(6)}`,
-      );
-
-    await page.getByRole("button", { name: tr("create") }).click();
-    await page.waitForLoadState("networkidle");
-  }
-
-  const openButtons = page.getByRole("button", { name: goToAccountName });
-  await expect(openButtons.first()).toBeVisible();
-  await openButtons.first().click();
+  const goToAccount = page.getByRole("button", { name: tr("go_to_account") });
+  await expect(goToAccount.first()).toBeVisible();
+  await goToAccount.first().click();
   await page.waitForLoadState("networkidle");
 
-  const match = page.url().match(/\/billing\/account\/([a-f0-9-]+)/i);
-  if (!match?.[1])
-    throw new Error(`Failed to extract accountId from URL: ${page.url()}`);
-  accountId = match[1];
-
   await expect(page).toHaveURL(
-    new RegExp(`/billing/account/${accountId}(?:/|$)`),
+    new RegExp(`/billing/account/${escapeRegex(accountId)}(?:/|$)`),
   );
 }
 
@@ -460,8 +279,8 @@ test.describe("Create Invoice (facility billing)", () => {
   test("Navigate Billing → Account List → open fixture account from list", async ({
     page,
   }) => {
-    await test.step("Ensure account exists and open it", async () => {
-      await ensureAccountExistsAndOpen(page);
+    await test.step("Open fixture account from billing list", async () => {
+      await openFixtureAccountFromBillingList(page);
     });
 
     await test.step("Verify account workspace tabs", async () => {

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -34,7 +34,9 @@ function tabLocator(page: Page, tabText: string) {
 }
 
 function createInvoiceForm(page: Page): Locator {
-  return page.locator("form").filter({ has: page.getByRole("table") });
+  return page.locator("form").filter({
+    has: page.getByRole("button", { name: tr("create_invoice") }),
+  });
 }
 
 function addChargeItemsBillingSheetPanel(page: Page): Locator {
@@ -183,6 +185,11 @@ async function ensureAtLeastOneChargeItemSelected(
   await expect(
     page.getByText(tr("create_invoice"), { exact: true }),
   ).toBeVisible();
+
+  const submitInvoice = page.getByRole("button", {
+    name: tr("create_invoice"),
+  });
+  await expect(submitInvoice).toBeVisible();
 
   const invoiceForm = createInvoiceForm(page);
   await expect(invoiceForm).toBeVisible();

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -149,39 +149,43 @@ async function ensureAtLeastOneChargeItemSelected(
   accountId: string,
 ) {
   const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
-  if (!page.url().includes(createInvoiceUrl)) {
-    await page.goto(createInvoiceUrl);
+
+  function chargeItemsListResponsePromise() {
+    const pathNeedle = `/api/v1/facility/${facilityId}/charge_item/`;
+    return page.waitForResponse(
+      (r) =>
+        r.request().method() === "GET" &&
+        r.url().includes(pathNeedle) &&
+        r.url().includes(accountId) &&
+        (r.status() === 200 || r.status() === 304),
+      { timeout: 60_000 },
+    );
   }
+
+  async function openCreateInvoiceAndAwaitChargeItems() {
+    const responsePromise = chargeItemsListResponsePromise();
+    await page.goto(createInvoiceUrl, { waitUntil: "domcontentloaded" });
+    await responsePromise;
+    await page.waitForLoadState("networkidle");
+  }
+
+  await openCreateInvoiceAndAwaitChargeItems();
 
   await expect(page).toHaveURL(new RegExp(`${createInvoiceUrl}(?:\\?|$)`));
   await expect(
     page.getByText(tr("create_invoice"), { exact: true }),
   ).toBeVisible();
-  await page.waitForLoadState("networkidle");
-
-  async function waitForChargeItemsLoadAttempt() {
-    const pathPart = `/api/v1/facility/${facilityId}/charge_item/`;
-    await page
-      .waitForResponse(
-        (r) =>
-          r.request().method() === "GET" &&
-          r.url().includes(pathPart) &&
-          r.url().includes(`account=${accountId}`),
-        { timeout: 30_000 },
-      )
-      .catch(() => null);
-  }
-
-  await waitForChargeItemsLoadAttempt();
 
   let noBillable = page.getByText(tr("no_billable_items"), { exact: true });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
-  if (hasNoBillable) {
-    const addChargeItemsButton = page.getByRole("button", {
-      name: tr("add_charge_items"),
-      exact: true,
+  const addChargeItemsButtonLocator = () =>
+    page.getByRole("button", {
+      name: new RegExp(`^${escapeRegex(tr("add_charge_items"))}`, "i"),
     });
+
+  if (hasNoBillable) {
+    const addChargeItemsButton = addChargeItemsButtonLocator();
     await expect(addChargeItemsButton).toBeVisible({ timeout: 30_000 });
     await addChargeItemsButton.click({ timeout: 30_000 });
     await page.waitForLoadState("networkidle");
@@ -208,18 +212,23 @@ async function ensureAtLeastOneChargeItemSelected(
         facilityId,
       );
 
+      const reloadList = chargeItemsListResponsePromise();
       await page.goto(
         `/facility/${facilityId}/billing/account/${accountId}/invoices/create`,
+        { waitUntil: "domcontentloaded" },
       );
+      await reloadList;
       await page.waitForLoadState("networkidle");
       await expect(
         page.getByText(tr("create_invoice"), { exact: true }),
       ).toBeVisible();
 
-      await waitForChargeItemsLoadAttempt();
       noBillable = page.getByText(tr("no_billable_items"), { exact: true });
 
-      await page.getByRole("button", { name: tr("add_charge_items") }).click();
+      await expect(addChargeItemsButtonLocator()).toBeVisible({
+        timeout: 30_000,
+      });
+      await addChargeItemsButtonLocator().click({ timeout: 30_000 });
       await page.waitForLoadState("networkidle");
       sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
       await expect(sheet).toBeVisible();
@@ -239,8 +248,9 @@ async function ensureAtLeastOneChargeItemSelected(
     await expect(noBillable).not.toBeVisible();
   }
 
-  const rowCheckboxes = page.getByRole("checkbox");
-  await expect(rowCheckboxes.first()).toBeVisible({ timeout: 30_000 });
+  const invoiceForm = page.locator("form.space-y-6");
+  const rowCheckboxes = invoiceForm.getByRole("checkbox");
+  await expect(rowCheckboxes.first()).toBeVisible({ timeout: 60_000 });
 
   const checkboxCount = await rowCheckboxes.count();
   expect(checkboxCount).toBeGreaterThan(0);

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -1,11 +1,5 @@
 import { faker } from "@faker-js/faker";
-import {
-  expect,
-  test,
-  type Locator,
-  type Page,
-  type Response,
-} from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import en from "public/locale/en.json";
 import { closeAnyOpenPopovers, expectToast } from "tests/helper/ui";
 import { getAccountId } from "tests/support/accountId";
@@ -120,39 +114,13 @@ async function openAccountShow(
   await expect(tabLocator(page, tr("payments"))).toBeVisible();
 }
 
-function chargeItemsListResponsePredicate(
-  facilityId: string,
-  accountId: string,
-) {
-  const pathNeedle = `/api/v1/facility/${facilityId}/charge_item/`;
-  return (response: Response) =>
-    response.request().method() === "GET" &&
-    response.url().includes(pathNeedle) &&
-    response.url().includes(accountId) &&
-    (response.status() === 200 || response.status() === 304);
-}
-
-async function openCreateInvoiceFromAccountWorkspace(
+async function ensureAtLeastOneChargeItemSelected(
   page: Page,
   facilityId: string,
   accountId: string,
 ) {
   const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
-  const responsePromise = page.waitForResponse(
-    chargeItemsListResponsePredicate(facilityId, accountId),
-  );
-
-  const createInvoiceLink = page.getByRole("link", {
-    name: tr("create_invoice"),
-  });
-  const hasLink = await createInvoiceLink.isVisible().catch(() => false);
-  if (hasLink) {
-    await createInvoiceLink.click();
-  } else {
-    await page.getByRole("button", { name: tr("create_invoice") }).click();
-  }
-
-  await responsePromise;
+  await page.goto(createInvoiceUrl, { waitUntil: "domcontentloaded" });
   await page.waitForLoadState("networkidle");
 
   await expect(page).toHaveURL(
@@ -161,23 +129,6 @@ async function openCreateInvoiceFromAccountWorkspace(
   await expect(
     page.getByText(tr("create_invoice"), { exact: true }),
   ).toBeVisible();
-}
-
-async function openAddChargeItemsSheetDialog(page: Page) {
-  const toolbarBtn = page
-    .locator('button[data-slot="button"]')
-    .filter({ hasText: tr("add_charge_items") });
-  await expect(toolbarBtn.first()).toBeVisible();
-  await toolbarBtn.first().scrollIntoViewIfNeeded();
-  await toolbarBtn.first().click();
-}
-
-async function ensureAtLeastOneChargeItemSelected(
-  page: Page,
-  facilityId: string,
-  accountId: string,
-) {
-  await openCreateInvoiceFromAccountWorkspace(page, facilityId, accountId);
 
   const invoiceForm = page.locator("form.space-y-6");
   await expect(invoiceForm).toBeVisible();
@@ -189,7 +140,12 @@ async function ensureAtLeastOneChargeItemSelected(
   if (hasNoBillable) {
     const sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
 
-    await openAddChargeItemsSheetDialog(page);
+    const toolbarBtn = page
+      .locator('button[data-slot="button"]')
+      .filter({ hasText: tr("add_charge_items") });
+    await expect(toolbarBtn.first()).toBeVisible();
+    await toolbarBtn.first().scrollIntoViewIfNeeded();
+    await toolbarBtn.first().click();
     await page.waitForLoadState("networkidle");
     await expect(sheet).toBeVisible();
 

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -148,6 +148,12 @@ async function ensureAtLeastOneChargeItemSelected(
   facilityId: string,
   accountId: string,
 ) {
+  const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
+  if (!page.url().includes(createInvoiceUrl)) {
+    await page.goto(createInvoiceUrl);
+  }
+
+  await expect(page).toHaveURL(new RegExp(`${createInvoiceUrl}(?:\\?|$)`));
   await expect(
     page.getByText(tr("create_invoice"), { exact: true }),
   ).toBeVisible();
@@ -172,7 +178,12 @@ async function ensureAtLeastOneChargeItemSelected(
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
-    await page.getByRole("button", { name: tr("add_charge_items") }).click();
+    const addChargeItemsButton = page.getByRole("button", {
+      name: tr("add_charge_items"),
+      exact: true,
+    });
+    await expect(addChargeItemsButton).toBeVisible({ timeout: 30_000 });
+    await addChargeItemsButton.click({ timeout: 30_000 });
     await page.waitForLoadState("networkidle");
 
     let sheet = page.getByRole("dialog", { name: tr("add_charge_items") });

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -38,11 +38,34 @@ function createInvoiceForm(page: Page): Locator {
 }
 
 function addChargeItemsBillingSheetPanel(page: Page): Locator {
-  return page.getByRole("dialog", { name: tr("add_charge_items") }).or(
+  const titleText = tr("add_charge_items");
+  const titleInSheet = page.locator('[data-slot="sheet-title"]').filter({
+    hasText: titleText,
+  });
+  const bySheetSlots = page
+    .locator('[data-slot="sheet-content"]')
+    .filter({ has: titleInSheet })
+    .filter({ visible: true });
+  const byDialogRole = page.getByRole("dialog", { name: titleText }).or(
     page.getByRole("dialog").filter({
-      has: page.getByRole("heading", { name: tr("add_charge_items") }),
+      has: page.getByRole("heading", { name: titleText }),
     }),
   );
+  return bySheetSlots.or(byDialogRole);
+}
+
+async function dismissModalChargePickersBlockingPage(page: Page) {
+  await closeAnyOpenPopovers(page);
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const popper = page
+      .locator("[data-radix-popper-content-wrapper]")
+      .filter({ visible: true })
+      .first();
+    const blocking = await popper.isVisible().catch(() => false);
+    if (!blocking) break;
+    await page.keyboard.press("Escape");
+    await popper.waitFor({ state: "hidden" }).catch(() => {});
+  }
 }
 
 function chargeItemDefinitionPickerTrigger(scope: Locator): Locator {
@@ -227,6 +250,7 @@ async function ensureAtLeastOneChargeItemSelected(
     });
     await expect(toolbarBtn).toBeVisible();
     await toolbarBtn.scrollIntoViewIfNeeded();
+    await dismissModalChargePickersBlockingPage(page);
     await toolbarBtn.click();
     await page.waitForLoadState("networkidle");
     await expect(sheet).toBeVisible();

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -153,12 +153,19 @@ async function ensureAtLeastOneChargeItemSelected(
   ).toBeVisible();
   await page.waitForLoadState("networkidle");
 
-  const chargeItemsTable = page.getByRole("table").filter({
-    has: page.getByRole("columnheader", { name: tr("items") }),
-  });
-  await expect(chargeItemsTable).toBeVisible({ timeout: 30_000 });
+  async function chargeItemsTableWhenReady(): Promise<Locator> {
+    const invoiceForm = page.locator("form.space-y-6");
+    const firstFormCheckbox = invoiceForm.getByRole("checkbox").first();
+    await expect(firstFormCheckbox).toBeVisible({ timeout: 60_000 });
+    const chargeItemsTable = invoiceForm
+      .getByRole("table")
+      .filter({ has: firstFormCheckbox });
+    await expect(chargeItemsTable).toBeVisible();
+    return chargeItemsTable;
+  }
 
-  const noBillable = chargeItemsTable.getByText(tr("no_billable_items"), {
+  let chargeItemsTable = await chargeItemsTableWhenReady();
+  let noBillable = chargeItemsTable.getByText(tr("no_billable_items"), {
     exact: true,
   });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
@@ -196,6 +203,11 @@ async function ensureAtLeastOneChargeItemSelected(
       await expect(
         page.getByText(tr("create_invoice"), { exact: true }),
       ).toBeVisible();
+
+      chargeItemsTable = await chargeItemsTableWhenReady();
+      noBillable = chargeItemsTable.getByText(tr("no_billable_items"), {
+        exact: true,
+      });
 
       await page.getByRole("button", { name: tr("add_charge_items") }).click();
       await page.waitForLoadState("networkidle");

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -24,6 +24,14 @@ function tabLocator(page: Page, tabText: string) {
   });
 }
 
+function addChargeItemsBillingSheetPanel(page: Page): Locator {
+  return page.locator('[data-slot="sheet-content"]').filter({
+    has: page
+      .locator('[data-slot="sheet-title"]')
+      .getByText(tr("add_charge_items"), { exact: true }),
+  });
+}
+
 function firstNonEmptyLine(text: string) {
   return (
     text
@@ -138,24 +146,24 @@ async function ensureAtLeastOneChargeItemSelected(
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
-    await closeAnyOpenPopovers(page);
-    await page.keyboard.press("Escape");
     const definitionCombobox = invoiceForm.getByRole("combobox", {
       name: tr("select_charge_item_definition"),
     });
-    if (await definitionCombobox.isVisible().catch(() => false)) {
-      await expect(definitionCombobox).toHaveAttribute(
-        "aria-expanded",
-        "false",
-      );
-    }
+    await expect(definitionCombobox).toBeVisible();
+
+    await closeAnyOpenPopovers(page);
+    await page.keyboard.press("Escape");
+    await expect(definitionCombobox).toHaveAttribute("aria-expanded", "false");
     await page.waitForLoadState("networkidle");
 
-    const sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
+    const sheet = addChargeItemsBillingSheetPanel(page);
 
-    const toolbarBtn = page
-      .getByRole("button", { name: tr("add_charge_items") })
-      .first();
+    const invoiceHeader = page.locator("div.justify-between").filter({
+      has: page.getByText(tr("create_invoice"), { exact: true }),
+    });
+    const toolbarBtn = invoiceHeader.getByRole("button", {
+      name: tr("add_charge_items"),
+    });
     await expect(toolbarBtn).toBeVisible();
     await toolbarBtn.scrollIntoViewIfNeeded();
     await toolbarBtn.click();
@@ -173,7 +181,7 @@ async function ensureAtLeastOneChargeItemSelected(
       await page.keyboard.press("Escape");
       await page.waitForLoadState("networkidle");
 
-      const dialog = page.getByRole("dialog", { name: tr("add_charge_items") });
+      const dialog = addChargeItemsBillingSheetPanel(page);
       const cancelBtn = dialog.getByRole("button", { name: tr("cancel") });
       if (await cancelBtn.isVisible().catch(() => false)) {
         await cancelBtn.click();

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -34,7 +34,7 @@ function tabLocator(page: Page, tabText: string) {
 }
 
 function createInvoiceForm(page: Page): Locator {
-  return page.getByRole("form");
+  return page.locator("form").filter({ has: page.getByRole("table") });
 }
 
 function addChargeItemsBillingSheetPanel(page: Page): Locator {

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -213,15 +213,22 @@ async function ensureAtLeastOneChargeItemSelected(
     await expect(noBillable).not.toBeVisible();
   }
 
-  const bodyCheckbox = table.locator("tbody").getByRole("checkbox").first();
-  await expect(bodyCheckbox).toBeVisible();
+  const rowCheckboxes = table.getByRole("row").getByRole("checkbox");
+  await expect(rowCheckboxes.first()).toBeVisible();
+
+  const checkboxCount = await rowCheckboxes.count();
+  expect(checkboxCount).toBeGreaterThan(0);
+
+  const targetCheckbox =
+    checkboxCount > 1 ? rowCheckboxes.nth(1) : rowCheckboxes.first();
+  await expect(targetCheckbox).toBeVisible();
 
   const isChecked =
-    (await bodyCheckbox.getAttribute("aria-checked").catch(() => null)) ===
+    (await targetCheckbox.getAttribute("aria-checked").catch(() => null)) ===
     "true";
-  if (!isChecked) await bodyCheckbox.click();
+  if (!isChecked) await targetCheckbox.click();
 
-  await expect(bodyCheckbox).toHaveAttribute("aria-checked", "true");
+  await expect(targetCheckbox).toHaveAttribute("aria-checked", "true");
 }
 
 async function extractInvoiceNumber(page: Page) {
@@ -247,44 +254,64 @@ let createdInvoiceNumber = "";
 test.beforeAll(async () => {
   facilityId = getFacilityId();
   patientId = getPatientId();
-  accountId = getAccountId();
+  accountId = "";
+  try {
+    accountId = getAccountId();
+  } catch {
+    accountId = "";
+  }
 });
+
+async function ensureAccountExistsAndOpen(page: Page) {
+  await openAccountList(page, facilityId, patientId);
+
+  const table = page.getByRole("table");
+  const hasTable = await table.isVisible().catch(() => false);
+
+  const goToAccountName = tr("go_to_account");
+  const hasGoToAccount =
+    hasTable &&
+    (await table
+      .getByRole("button", { name: goToAccountName })
+      .first()
+      .isVisible()
+      .catch(() => false));
+
+  if (!hasGoToAccount) {
+    await page.getByRole("button", { name: tr("create_account") }).click();
+    await page.waitForLoadState("networkidle");
+
+    await page
+      .getByRole("textbox", { name: tr("name") })
+      .fill(
+        `E2E ${faker.finance.accountName()} ${faker.string.alphanumeric(6)}`,
+      );
+
+    await page.getByRole("button", { name: tr("create") }).click();
+    await page.waitForLoadState("networkidle");
+  }
+
+  const openButtons = page.getByRole("button", { name: goToAccountName });
+  await expect(openButtons.first()).toBeVisible();
+  await openButtons.first().click();
+  await page.waitForLoadState("networkidle");
+
+  const match = page.url().match(/\/billing\/account\/([a-f0-9-]+)/i);
+  if (!match?.[1])
+    throw new Error(`Failed to extract accountId from URL: ${page.url()}`);
+  accountId = match[1];
+
+  await expect(page).toHaveURL(
+    new RegExp(`/billing/account/${accountId}(?:/|$)`),
+  );
+}
 
 test.describe("Create Invoice (facility billing)", () => {
   test("Navigate Billing → Account List → open fixture account from list", async ({
     page,
   }) => {
-    await test.step("Open account list scoped to fixture patient", async () => {
-      await openAccountList(page, facilityId, patientId);
-    });
-
-    await test.step("Open the setup account from list (match URL to getAccountId)", async () => {
-      const table = page.getByRole("table");
-      await expect(table).toBeVisible();
-
-      const dataRows = table.getByRole("row").filter({
-        has: page.getByRole("button", { name: tr("go_to_account") }),
-      });
-      await expect(dataRows.first()).toBeVisible();
-
-      const accountPath = `/billing/account/${accountId}`;
-      let opened = false;
-      const rowCount = await dataRows.count();
-      for (let i = 0; i < rowCount; i += 1) {
-        await dataRows
-          .nth(i)
-          .getByRole("button", { name: tr("go_to_account") })
-          .click();
-        await page.waitForLoadState("networkidle");
-        if (page.url().includes(accountPath)) {
-          opened = true;
-          break;
-        }
-        await page.goBack();
-        await page.waitForLoadState("networkidle");
-        await expect(table).toBeVisible();
-      }
-      expect(opened).toBe(true);
+    await test.step("Ensure account exists and open it", async () => {
+      await ensureAccountExistsAndOpen(page);
     });
 
     await test.step("Verify account workspace tabs", async () => {

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -34,15 +34,15 @@ function tabLocator(page: Page, tabText: string) {
 }
 
 function createInvoiceForm(page: Page): Locator {
-  return page.locator("form").filter({
-    has: page.getByRole("button", { name: tr("create_invoice") }),
-  });
+  return page.locator("form.space-y-6");
 }
 
 function addChargeItemsBillingSheetPanel(page: Page): Locator {
-  return page.getByRole("dialog").filter({
-    has: page.getByRole("heading", { name: tr("add_charge_items") }),
-  });
+  return page.getByRole("dialog", { name: tr("add_charge_items") }).or(
+    page.getByRole("dialog").filter({
+      has: page.getByRole("heading", { name: tr("add_charge_items") }),
+    }),
+  );
 }
 
 function accountRetrieveResponsePredicate(
@@ -94,12 +94,20 @@ async function addChargeItemsFromPickerInSheet(
   await waitForChargeItemSearchSettled(page);
 
   const definitionSearchPlaceholder = tr("search_charge_item_definition");
-  const pickerPopover = page
+  const definitionPickerByDialog = page
+    .getByRole("dialog")
+    .filter({ has: page.getByPlaceholder(definitionSearchPlaceholder) })
+    .filter({ visible: true })
+    .last();
+  const definitionPickerByPopper = page
     .locator("[data-radix-popper-content-wrapper]")
     .filter({ has: page.getByPlaceholder(definitionSearchPlaceholder) })
     .filter({ visible: true })
     .last();
-  const listbox = pickerPopover.getByRole("listbox");
+  const definitionPickerSurface = definitionPickerByDialog.or(
+    definitionPickerByPopper,
+  );
+  const listbox = definitionPickerSurface.getByRole("listbox");
   const listboxVisible = await listbox.isVisible().catch(() => false);
   if (!listboxVisible) return null;
 
@@ -185,11 +193,6 @@ async function ensureAtLeastOneChargeItemSelected(
   await expect(
     page.getByText(tr("create_invoice"), { exact: true }),
   ).toBeVisible();
-
-  const submitInvoice = page.getByRole("button", {
-    name: tr("create_invoice"),
-  });
-  await expect(submitInvoice).toBeVisible();
 
   const invoiceForm = createInvoiceForm(page);
   await expect(invoiceForm).toBeVisible();
@@ -346,7 +349,8 @@ test.describe("Create Invoice (facility billing)", () => {
 
     await test.step("Submit invoice and verify success", async () => {
       await createInvoiceForm(page)
-        .getByRole("button", { name: tr("create_invoice") })
+        .locator('button[type="submit"]')
+        .filter({ has: page.getByText(tr("create_invoice"), { exact: true }) })
         .click();
       await expectToast(page, tr("invoice_created_successfully"));
 

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -45,6 +45,10 @@ function addChargeItemsBillingSheetPanel(page: Page): Locator {
   );
 }
 
+function chargeItemDefinitionPickerTrigger(scope: Locator): Locator {
+  return scope.locator('button[role="combobox"]').first();
+}
+
 function accountRetrieveResponsePredicate(
   facilityId: string,
   accountId: string,
@@ -81,9 +85,7 @@ async function addChargeItemsFromPickerInSheet(
 ) {
   await closeAnyOpenPopovers(page);
 
-  const picker = sheet.getByRole("combobox", {
-    name: tr("select_charge_item_definition"),
-  });
+  const picker = chargeItemDefinitionPickerTrigger(sheet);
   await expect(picker).toBeVisible();
   await picker.click();
 
@@ -203,14 +205,19 @@ async function ensureAtLeastOneChargeItemSelected(
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
-    const definitionCombobox = page.getByRole("combobox", {
-      name: tr("select_charge_item_definition"),
-    });
-    await expect(definitionCombobox).toBeVisible();
-
     await closeAnyOpenPopovers(page);
     await page.keyboard.press("Escape");
-    await expect(definitionCombobox).toHaveAttribute("aria-expanded", "false");
+
+    const inlinePickerButtons = invoiceForm.locator('button[role="combobox"]');
+    if ((await inlinePickerButtons.count()) > 0) {
+      const definitionPickerTrigger = inlinePickerButtons.first();
+      await expect(definitionPickerTrigger).toBeVisible();
+      await expect(definitionPickerTrigger).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    }
+
     await page.waitForLoadState("networkidle");
 
     const sheet = addChargeItemsBillingSheetPanel(page);

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -69,7 +69,13 @@ async function dismissModalChargePickersBlockingPage(page: Page) {
 }
 
 function chargeItemDefinitionPickerTrigger(scope: Locator): Locator {
-  return scope.locator('button[role="combobox"]').first();
+  return scope
+    .locator('button[role="combobox"][data-shortcut-id="keydown-action"]')
+    .or(
+      scope.getByRole("combobox", {
+        name: tr("select_charge_item_definition"),
+      }),
+    );
 }
 
 function accountRetrieveResponsePredicate(
@@ -106,13 +112,14 @@ async function addChargeItemsFromPickerInSheet(
   sheet: Locator,
   definitionSearch: string,
 ) {
-  await closeAnyOpenPopovers(page);
-
-  const picker = chargeItemDefinitionPickerTrigger(sheet);
-  await expect(picker).toBeVisible();
-  await picker.click();
-
   const search = page.getByPlaceholder(tr("search_charge_item_definition"));
+  if (!(await search.isVisible().catch(() => false))) {
+    const picker = chargeItemDefinitionPickerTrigger(sheet);
+    await expect(picker).toBeVisible();
+    await picker.scrollIntoViewIfNeeded();
+    await picker.click();
+  }
+
   await expect(search).toBeVisible();
   await search.fill("");
   await search.fill(definitionSearch);
@@ -259,8 +266,6 @@ async function ensureAtLeastOneChargeItemSelected(
 
     await page.waitForLoadState("networkidle");
 
-    const sheet = addChargeItemsBillingSheetPanel(page);
-
     const toolbarBtn = page.getByRole("button", {
       name: tr("add_charge_items"),
     });
@@ -269,17 +274,28 @@ async function ensureAtLeastOneChargeItemSelected(
     await dismissModalChargePickersBlockingPage(page);
     await toolbarBtn.click();
     await page.waitForLoadState("networkidle");
-    await expect(sheet).toBeVisible();
 
-    let picked = await addChargeItemsFromPickerInSheet(page, sheet, "");
+    const sheetOpen = addChargeItemsBillingSheetPanel(page);
+    await expect(sheetOpen).toBeVisible();
+    await expect(chargeItemDefinitionPickerTrigger(sheetOpen)).toBeVisible();
+
+    let picked = await addChargeItemsFromPickerInSheet(
+      page,
+      addChargeItemsBillingSheetPanel(page),
+      "",
+    );
     if (!picked) {
-      await page.keyboard.press("Escape");
+      await closeAnyOpenPopovers(page);
       await page.waitForLoadState("networkidle");
-      picked = await addChargeItemsFromPickerInSheet(page, sheet, "a");
+      picked = await addChargeItemsFromPickerInSheet(
+        page,
+        addChargeItemsBillingSheetPanel(page),
+        "a",
+      );
     }
 
     if (!picked) {
-      await page.keyboard.press("Escape");
+      await closeAnyOpenPopovers(page);
       await page.waitForLoadState("networkidle");
 
       const dialog = addChargeItemsBillingSheetPanel(page);

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -138,14 +138,27 @@ async function ensureAtLeastOneChargeItemSelected(
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
+    await closeAnyOpenPopovers(page);
+    await page.keyboard.press("Escape");
+    const definitionCombobox = invoiceForm.getByRole("combobox", {
+      name: tr("select_charge_item_definition"),
+    });
+    if (await definitionCombobox.isVisible().catch(() => false)) {
+      await expect(definitionCombobox).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    }
+    await page.waitForLoadState("networkidle");
+
     const sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
 
     const toolbarBtn = page
-      .locator('button[data-slot="button"]')
-      .filter({ hasText: tr("add_charge_items") });
-    await expect(toolbarBtn.first()).toBeVisible();
-    await toolbarBtn.first().scrollIntoViewIfNeeded();
-    await toolbarBtn.first().click();
+      .getByRole("button", { name: tr("add_charge_items") })
+      .first();
+    await expect(toolbarBtn).toBeVisible();
+    await toolbarBtn.scrollIntoViewIfNeeded();
+    await toolbarBtn.click();
     await page.waitForLoadState("networkidle");
     await expect(sheet).toBeVisible();
 

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -18,14 +18,20 @@ function escapeRegex(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function firstMeaningfulLine(text: string) {
-  return text
-    .split("\n")
-    .map((s) => s.trim())
-    .find((line) => line.length > 0);
+function tabLocator(page: Page, tabText: string) {
+  return page.getByRole("tab", {
+    name: new RegExp(`^${escapeRegex(tabText)}(\\b|\\s|$)`, "i"),
+  });
 }
 
-const CHARGE_ITEM_DEFINITION_CATEGORY = "Medications";
+function firstNonEmptyLine(text: string) {
+  return (
+    text
+      .split("\n")
+      .map((s) => s.trim())
+      .find((line) => line.length > 0) ?? ""
+  );
+}
 
 async function createMinimalChargeItemDefinition(
   page: Page,
@@ -34,16 +40,16 @@ async function createMinimalChargeItemDefinition(
   const title = `E2E ${faker.string.alphanumeric(12)}`;
   const slug = title.replace(/\s+/g, "-").toLowerCase().slice(0, 25);
   const basePrice = faker.commerce.price({ dec: 0 });
+  const categoryQuery = tr("medication");
 
   await page.goto(`/facility/${facilityId}/settings/charge_item_definitions/`);
   await page.waitForLoadState("networkidle");
 
-  await page
-    .getByRole("textbox", { name: tr("search") })
-    .fill(CHARGE_ITEM_DEFINITION_CATEGORY);
+  await page.getByRole("textbox", { name: tr("search") }).fill(categoryQuery);
   await page.waitForLoadState("networkidle");
   await page
-    .getByRole("heading", { name: CHARGE_ITEM_DEFINITION_CATEGORY })
+    .getByRole("heading", { name: new RegExp(escapeRegex(categoryQuery), "i") })
+    .first()
     .click();
   await page.waitForLoadState("networkidle");
   await page.getByRole("button", { name: tr("add_definition") }).click();
@@ -94,7 +100,7 @@ async function addChargeItemsFromPickerInSheet(
   const option = options.first();
   await expect(option).toBeVisible();
   const optionText = (await option.textContent()) ?? "";
-  const chargeItemTitle = firstMeaningfulLine(optionText) ?? "";
+  const chargeItemTitle = firstNonEmptyLine(optionText);
   if (!chargeItemTitle) return null;
 
   await option.click();
@@ -132,11 +138,9 @@ async function openAccountShow(
   await page.goto(`/facility/${facilityId}/billing/account/${accountId}`);
   await page.waitForLoadState("networkidle");
 
-  await expect(page.getByRole("tab", { name: tr("invoices") })).toBeVisible();
-  await expect(
-    page.getByRole("tab", { name: tr("charge_items") }),
-  ).toBeVisible();
-  await expect(page.getByRole("tab", { name: tr("payments") })).toBeVisible();
+  await expect(tabLocator(page, tr("invoices"))).toBeVisible();
+  await expect(tabLocator(page, tr("charge_items"))).toBeVisible();
+  await expect(tabLocator(page, tr("payments"))).toBeVisible();
 }
 
 async function ensureAtLeastOneChargeItemSelected(
@@ -212,7 +216,7 @@ async function ensureAtLeastOneChargeItemSelected(
 
     const titleCell = dataRow.getByRole("cell").nth(1);
     const titleText = (await titleCell.textContent()) ?? "";
-    chargeItemTitle = firstMeaningfulLine(titleText) ?? "";
+    chargeItemTitle = firstNonEmptyLine(titleText);
     expect(chargeItemTitle).not.toEqual("");
   }
 
@@ -292,15 +296,9 @@ test.describe("Create Invoice (facility billing)", () => {
     });
 
     await test.step("Verify account workspace tabs", async () => {
-      await expect(
-        page.getByRole("tab", { name: tr("invoices") }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole("tab", { name: tr("charge_items") }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole("tab", { name: tr("payments") }),
-      ).toBeVisible();
+      await expect(tabLocator(page, tr("invoices"))).toBeVisible();
+      await expect(tabLocator(page, tr("charge_items"))).toBeVisible();
+      await expect(tabLocator(page, tr("payments"))).toBeVisible();
     });
   });
 

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -39,19 +39,11 @@ function createInvoiceForm(page: Page): Locator {
 
 function addChargeItemsBillingSheetPanel(page: Page): Locator {
   const titleText = tr("add_charge_items");
-  const titleInSheet = page.locator('[data-slot="sheet-title"]').filter({
-    hasText: titleText,
-  });
-  const bySheetSlots = page
-    .locator('[data-slot="sheet-content"]')
-    .filter({ has: titleInSheet })
-    .filter({ visible: true });
-  const byDialogRole = page.getByRole("dialog", { name: titleText }).or(
+  return page.getByRole("dialog", { name: titleText }).or(
     page.getByRole("dialog").filter({
       has: page.getByRole("heading", { name: titleText }),
     }),
   );
-  return bySheetSlots.or(byDialogRole);
 }
 
 async function dismissModalChargePickersBlockingPage(page: Page) {
@@ -69,13 +61,10 @@ async function dismissModalChargePickersBlockingPage(page: Page) {
 }
 
 function chargeItemDefinitionPickerTrigger(scope: Locator): Locator {
+  const definitionComboboxLabel = tr("select_charge_item_definition");
   return scope
-    .locator('button[role="combobox"][data-shortcut-id="keydown-action"]')
-    .or(
-      scope.getByRole("combobox", {
-        name: tr("select_charge_item_definition"),
-      }),
-    );
+    .locator('[data-shortcut-id="keydown-action"]')
+    .or(scope.getByRole("combobox", { name: definitionComboboxLabel }));
 }
 
 function accountRetrieveResponsePredicate(
@@ -105,6 +94,36 @@ async function waitForChargeItemSearchSettled(page: Page) {
     await searchingIndicator.waitFor({ state: "hidden" });
   }
   await page.waitForLoadState("networkidle");
+}
+
+async function dismissChargeDefinitionSearchPopover(page: Page) {
+  const searchInput = page.getByPlaceholder(
+    tr("search_charge_item_definition"),
+  );
+  if (await searchInput.isVisible().catch(() => false)) {
+    await page.keyboard.press("Escape");
+    await searchInput.waitFor({ state: "hidden" }).catch(() => {});
+    await page.waitForLoadState("networkidle");
+  }
+}
+
+async function ensureAddChargeItemsSheetOpen(page: Page): Promise<Locator> {
+  const sheetPanel = addChargeItemsBillingSheetPanel(page);
+  if (
+    (await sheetPanel.isVisible().catch(() => false)) &&
+    (await chargeItemDefinitionPickerTrigger(sheetPanel)
+      .isVisible()
+      .catch(() => false))
+  ) {
+    return sheetPanel;
+  }
+
+  await page.getByRole("button", { name: tr("add_charge_items") }).click();
+  await page.waitForLoadState("networkidle");
+  const again = addChargeItemsBillingSheetPanel(page);
+  await expect(again).toBeVisible();
+  await expect(chargeItemDefinitionPickerTrigger(again)).toBeVisible();
+  return again;
 }
 
 async function addChargeItemsFromPickerInSheet(
@@ -285,8 +304,8 @@ async function ensureAtLeastOneChargeItemSelected(
       "",
     );
     if (!picked) {
-      await closeAnyOpenPopovers(page);
-      await page.waitForLoadState("networkidle");
+      await dismissChargeDefinitionSearchPopover(page);
+      await ensureAddChargeItemsSheetOpen(page);
       picked = await addChargeItemsFromPickerInSheet(
         page,
         addChargeItemsBillingSheetPanel(page),
@@ -295,8 +314,7 @@ async function ensureAtLeastOneChargeItemSelected(
     }
 
     if (!picked) {
-      await closeAnyOpenPopovers(page);
-      await page.waitForLoadState("networkidle");
+      await dismissChargeDefinitionSearchPopover(page);
 
       const dialog = addChargeItemsBillingSheetPanel(page);
       const cancelBtn = dialog.getByRole("button", { name: tr("cancel") });

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -136,24 +136,40 @@ async function addChargeItemsFromPickerInSheet(
   const listboxVisible = await listbox.isVisible().catch(() => false);
   if (!listboxVisible) return null;
 
-  const options = listbox.getByRole("option");
-  const count = await options.count();
-  if (count === 0) return null;
+  const folderChevron = page.locator('svg[class*="chevron-right"]');
 
-  const option = options.first();
-  await expect(option).toBeVisible();
-  const optionText = (await option.textContent()) ?? "";
-  const chargeItemTitle = firstNonEmptyLine(optionText);
-  if (!chargeItemTitle) return null;
+  for (let depth = 0; depth < 20; depth += 1) {
+    const lb = definitionPickerSurface.getByRole("listbox");
+    if (!(await lb.isVisible().catch(() => false))) return null;
 
-  await option.click();
-  await expect(
-    sheet.getByText(chargeItemTitle, { exact: false }),
-  ).toBeVisible();
-  await sheet.getByRole("button", { name: tr("add_items") }).click();
-  await expectToast(page, tr("charge_items_added_successfully"));
-  await page.waitForLoadState("networkidle");
-  return chargeItemTitle;
+    const definitionOptions = lb
+      .getByRole("option")
+      .filter({ hasNot: folderChevron });
+    const defCount = await definitionOptions.count();
+    if (defCount > 0) {
+      const option = definitionOptions.first();
+      await expect(option).toBeVisible();
+      const optionText = (await option.textContent()) ?? "";
+      const chargeItemTitle = firstNonEmptyLine(optionText);
+      if (!chargeItemTitle) return null;
+
+      await option.click();
+      await expect(
+        sheet.getByRole("button", { name: tr("add_items") }),
+      ).toBeEnabled();
+      await sheet.getByRole("button", { name: tr("add_items") }).click();
+      await expectToast(page, tr("charge_items_added_successfully"));
+      await page.waitForLoadState("networkidle");
+      return chargeItemTitle;
+    }
+
+    const folderOptions = lb.getByRole("option").filter({ has: folderChevron });
+    if ((await folderOptions.count()) === 0) return null;
+    await folderOptions.first().click();
+    await waitForChargeItemSearchSettled(page);
+  }
+
+  return null;
 }
 
 async function openAccountList(

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -1,5 +1,11 @@
 import { faker } from "@faker-js/faker";
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type Response,
+} from "@playwright/test";
 import en from "public/locale/en.json";
 import { closeAnyOpenPopovers, expectToast } from "tests/helper/ui";
 import { getAccountId } from "tests/support/accountId";
@@ -113,6 +119,55 @@ async function addChargeItemsFromPickerInSheet(
   return chargeItemTitle;
 }
 
+async function addChargeItemsViaInlinePicker(
+  page: Page,
+  scope: Locator,
+  definitionSearch: string,
+) {
+  await closeAnyOpenPopovers(page);
+
+  const picker = scope.getByRole("combobox", {
+    name: tr("select_charge_item_definition"),
+  });
+  await expect(picker).toBeVisible();
+  await picker.click();
+
+  const search = page.getByPlaceholder(tr("search_charge_item_definition"));
+  await expect(search).toBeVisible();
+  await search.fill("");
+  await search.fill(definitionSearch);
+  await waitForChargeItemSearchSettled(page);
+
+  const listbox = page.getByRole("listbox").last();
+  if (!(await listbox.isVisible().catch(() => false))) return null;
+
+  const options = listbox.getByRole("option");
+  if ((await options.count()) === 0) return null;
+
+  const option = options.first();
+  await expect(option).toBeVisible();
+  const optionText = (await option.textContent()) ?? "";
+  const chargeItemTitle = firstNonEmptyLine(optionText);
+  if (!chargeItemTitle) return null;
+
+  await option.click();
+  await expect(
+    scope.getByText(chargeItemTitle, { exact: false }),
+  ).toBeVisible();
+
+  const confirmBtn = scope
+    .locator(
+      `button[data-slot="button"][title*="${escapeRegex(tr("confirm"))}"]`,
+    )
+    .first();
+  await expect(confirmBtn).toBeVisible();
+  await confirmBtn.click();
+
+  await expectToast(page, tr("charge_items_added_successfully"));
+  await page.waitForLoadState("networkidle");
+  return chargeItemTitle;
+}
+
 async function openAccountList(
   page: Page,
   facilityId: string,
@@ -143,45 +198,26 @@ async function openAccountShow(
   await expect(tabLocator(page, tr("payments"))).toBeVisible();
 }
 
-async function findAddChargeItemsButton(page: Page): Promise<Locator | null> {
-  const labelKey = tr("add_charge_items");
-  const labelPattern = new RegExp(escapeRegex(labelKey), "i");
-
-  const byRole = page.getByRole("button", { name: labelPattern });
-  if ((await byRole.count()) > 0) return byRole.first();
-
-  const byFilter = page.getByRole("button").filter({ hasText: labelPattern });
-  if ((await byFilter.count()) > 0) return byFilter.first();
-
-  const allButtons = page.getByRole("button");
-  const count = await allButtons.count();
-  for (let i = 0; i < count; i++) {
-    const btn = allButtons.nth(i);
-    const text = (await btn.textContent()) ?? "";
-    const ariaLabel = (await btn.getAttribute("aria-label")) ?? "";
-    if (labelPattern.test(text.trim()) || labelPattern.test(ariaLabel.trim())) {
-      return btn;
-    }
-  }
-
-  return null;
+function chargeItemsListResponsePredicate(
+  facilityId: string,
+  accountId: string,
+) {
+  const pathNeedle = `/api/v1/facility/${facilityId}/charge_item/`;
+  return (response: Response) =>
+    response.request().method() === "GET" &&
+    response.url().includes(pathNeedle) &&
+    response.url().includes(accountId) &&
+    (response.status() === 200 || response.status() === 304);
 }
 
-async function navigateToCreateInvoicePage(
+async function gotoCreateInvoicePage(
   page: Page,
   facilityId: string,
   accountId: string,
 ) {
   const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
-  const pathNeedle = `/api/v1/facility/${facilityId}/charge_item/`;
-
   const responsePromise = page.waitForResponse(
-    (r) =>
-      r.request().method() === "GET" &&
-      r.url().includes(pathNeedle) &&
-      r.url().includes(accountId) &&
-      (r.status() === 200 || r.status() === 304),
-    { timeout: 60_000 },
+    chargeItemsListResponsePredicate(facilityId, accountId),
   );
 
   await page.goto(createInvoiceUrl, { waitUntil: "domcontentloaded" });
@@ -193,7 +229,47 @@ async function navigateToCreateInvoicePage(
   );
   await expect(
     page.getByText(tr("create_invoice"), { exact: true }),
-  ).toBeVisible({ timeout: 30_000 });
+  ).toBeVisible();
+}
+
+async function openCreateInvoiceFromAccountWorkspace(
+  page: Page,
+  facilityId: string,
+  accountId: string,
+) {
+  const createInvoiceUrl = `/facility/${facilityId}/billing/account/${accountId}/invoices/create`;
+  const responsePromise = page.waitForResponse(
+    chargeItemsListResponsePredicate(facilityId, accountId),
+  );
+
+  const createInvoiceLink = page.getByRole("link", {
+    name: tr("create_invoice"),
+  });
+  const hasLink = await createInvoiceLink.isVisible().catch(() => false);
+  if (hasLink) {
+    await createInvoiceLink.click();
+  } else {
+    await page.getByRole("button", { name: tr("create_invoice") }).click();
+  }
+
+  await responsePromise;
+  await page.waitForLoadState("networkidle");
+
+  await expect(page).toHaveURL(
+    new RegExp(`${escapeRegex(createInvoiceUrl)}(?:\\?|$)`),
+  );
+  await expect(
+    page.getByText(tr("create_invoice"), { exact: true }),
+  ).toBeVisible();
+}
+
+async function openAddChargeItemsSheetDialog(page: Page) {
+  const toolbarBtn = page
+    .locator('button[data-slot="button"]')
+    .filter({ hasText: tr("add_charge_items") });
+  await expect(toolbarBtn.first()).toBeVisible();
+  await toolbarBtn.first().scrollIntoViewIfNeeded();
+  await toolbarBtn.first().click();
 }
 
 async function ensureAtLeastOneChargeItemSelected(
@@ -201,36 +277,41 @@ async function ensureAtLeastOneChargeItemSelected(
   facilityId: string,
   accountId: string,
 ) {
-  await navigateToCreateInvoicePage(page, facilityId, accountId);
+  await openCreateInvoiceFromAccountWorkspace(page, facilityId, accountId);
 
   const invoiceForm = page.locator("form.space-y-6");
-  await expect(invoiceForm).toBeVisible({ timeout: 30_000 });
+  await expect(invoiceForm).toBeVisible();
 
   const noBillableText = tr("no_billable_items");
   const noBillable = invoiceForm.getByText(noBillableText, { exact: true });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
-    const addBtn = await findAddChargeItemsButton(page);
-    if (!addBtn) {
-      throw new Error(
-        `Could not find "${tr("add_charge_items")}" button on the create invoice page. ` +
-          `Ensure charge items are enabled for this facility.`,
-      );
+    const inlinePicker = invoiceForm.getByRole("combobox", {
+      name: tr("select_charge_item_definition"),
+    });
+
+    let picked: string | null = null;
+    if (await inlinePicker.isVisible().catch(() => false)) {
+      picked = await addChargeItemsViaInlinePicker(page, invoiceForm, "");
+      if (!picked) {
+        picked = await addChargeItemsViaInlinePicker(page, invoiceForm, "a");
+      }
     }
-    await expect(addBtn).toBeVisible({ timeout: 30_000 });
-    await addBtn.scrollIntoViewIfNeeded();
-    await addBtn.click();
-    await page.waitForLoadState("networkidle");
 
     let sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
-    await expect(sheet).toBeVisible({ timeout: 15_000 });
 
-    let picked = await addChargeItemsFromPickerInSheet(page, sheet, "");
     if (!picked) {
-      await page.keyboard.press("Escape");
+      await openAddChargeItemsSheetDialog(page);
       await page.waitForLoadState("networkidle");
-      picked = await addChargeItemsFromPickerInSheet(page, sheet, "a");
+      await expect(sheet).toBeVisible();
+
+      picked = await addChargeItemsFromPickerInSheet(page, sheet, "");
+      if (!picked) {
+        await page.keyboard.press("Escape");
+        await page.waitForLoadState("networkidle");
+        picked = await addChargeItemsFromPickerInSheet(page, sheet, "a");
+      }
     }
 
     if (!picked) {
@@ -250,28 +331,29 @@ async function ensureAtLeastOneChargeItemSelected(
         facilityId,
       );
 
-      await navigateToCreateInvoicePage(page, facilityId, accountId);
-      await expect(invoiceForm).toBeVisible({ timeout: 30_000 });
+      await gotoCreateInvoicePage(page, facilityId, accountId);
+      await expect(invoiceForm).toBeVisible();
 
-      const addBtn2 = await findAddChargeItemsButton(page);
-      if (!addBtn2) {
-        throw new Error(
-          `"${tr("add_charge_items")}" button not found after creating definition`,
+      picked = null;
+      if (await inlinePicker.isVisible().catch(() => false)) {
+        picked = await addChargeItemsViaInlinePicker(
+          page,
+          invoiceForm,
+          newDefinitionTitle,
         );
       }
-      await expect(addBtn2).toBeVisible({ timeout: 30_000 });
-      await addBtn2.scrollIntoViewIfNeeded();
-      await addBtn2.click();
-      await page.waitForLoadState("networkidle");
+      if (!picked) {
+        await openAddChargeItemsSheetDialog(page);
+        await page.waitForLoadState("networkidle");
+        sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
+        await expect(sheet).toBeVisible();
 
-      sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
-      await expect(sheet).toBeVisible({ timeout: 15_000 });
-
-      picked = await addChargeItemsFromPickerInSheet(
-        page,
-        sheet,
-        newDefinitionTitle,
-      );
+        picked = await addChargeItemsFromPickerInSheet(
+          page,
+          sheet,
+          newDefinitionTitle,
+        );
+      }
       if (!picked) {
         throw new Error(
           "Charge item picker had no options after creating a definition",
@@ -279,11 +361,11 @@ async function ensureAtLeastOneChargeItemSelected(
       }
     }
 
-    await expect(noBillable).not.toBeVisible({ timeout: 15_000 });
+    await expect(noBillable).not.toBeVisible();
   }
 
   const rowCheckboxes = invoiceForm.getByRole("checkbox");
-  await expect(rowCheckboxes.first()).toBeVisible({ timeout: 60_000 });
+  await expect(rowCheckboxes.first()).toBeVisible();
 
   const checkboxCount = await rowCheckboxes.count();
   expect(checkboxCount).toBeGreaterThan(0);
@@ -403,7 +485,7 @@ test.describe("Create Invoice (facility billing)", () => {
         name: tr("payment_terms_and_note"),
         exact: true,
       });
-      await expect(toggleOptional).toBeVisible({ timeout: 15_000 });
+      await expect(toggleOptional).toBeVisible();
       await toggleOptional.click();
 
       await page
@@ -432,7 +514,7 @@ test.describe("Create Invoice (facility billing)", () => {
         await back.click();
       } else {
         await openAccountShow(page, facilityId, accountId);
-        await page.getByRole("tab", { name: tr("invoices") }).click();
+        await tabLocator(page, tr("invoices")).click();
       }
       await page.waitForLoadState("networkidle");
     });

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -153,21 +153,22 @@ async function ensureAtLeastOneChargeItemSelected(
   ).toBeVisible();
   await page.waitForLoadState("networkidle");
 
-  async function chargeItemsTableWhenReady(): Promise<Locator> {
-    const invoiceForm = page.locator("form.space-y-6");
-    const firstFormCheckbox = invoiceForm.getByRole("checkbox").first();
-    await expect(firstFormCheckbox).toBeVisible({ timeout: 60_000 });
-    const chargeItemsTable = invoiceForm
-      .getByRole("table")
-      .filter({ has: firstFormCheckbox });
-    await expect(chargeItemsTable).toBeVisible();
-    return chargeItemsTable;
+  async function waitForChargeItemsLoadAttempt() {
+    const pathPart = `/api/v1/facility/${facilityId}/charge_item/`;
+    await page
+      .waitForResponse(
+        (r) =>
+          r.request().method() === "GET" &&
+          r.url().includes(pathPart) &&
+          r.url().includes(`account=${accountId}`),
+        { timeout: 30_000 },
+      )
+      .catch(() => null);
   }
 
-  let chargeItemsTable = await chargeItemsTableWhenReady();
-  let noBillable = chargeItemsTable.getByText(tr("no_billable_items"), {
-    exact: true,
-  });
+  await waitForChargeItemsLoadAttempt();
+
+  let noBillable = page.getByText(tr("no_billable_items"), { exact: true });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
@@ -204,10 +205,8 @@ async function ensureAtLeastOneChargeItemSelected(
         page.getByText(tr("create_invoice"), { exact: true }),
       ).toBeVisible();
 
-      chargeItemsTable = await chargeItemsTableWhenReady();
-      noBillable = chargeItemsTable.getByText(tr("no_billable_items"), {
-        exact: true,
-      });
+      await waitForChargeItemsLoadAttempt();
+      noBillable = page.getByText(tr("no_billable_items"), { exact: true });
 
       await page.getByRole("button", { name: tr("add_charge_items") }).click();
       await page.waitForLoadState("networkidle");
@@ -229,8 +228,8 @@ async function ensureAtLeastOneChargeItemSelected(
     await expect(noBillable).not.toBeVisible();
   }
 
-  const rowCheckboxes = chargeItemsTable.getByRole("row").getByRole("checkbox");
-  await expect(rowCheckboxes.first()).toBeVisible();
+  const rowCheckboxes = page.getByRole("checkbox");
+  await expect(rowCheckboxes.first()).toBeVisible({ timeout: 30_000 });
 
   const checkboxCount = await rowCheckboxes.count();
   expect(checkboxCount).toBeGreaterThan(0);

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -196,13 +196,14 @@ async function ensureAtLeastOneChargeItemSelected(
 
   const invoiceForm = createInvoiceForm(page);
   await expect(invoiceForm).toBeVisible();
+  await expect(page.getByText(tr("patient_name"))).toBeVisible();
 
   const noBillableText = tr("no_billable_items");
   const noBillable = invoiceForm.getByText(noBillableText, { exact: true });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
-    const definitionCombobox = invoiceForm.getByRole("combobox", {
+    const definitionCombobox = page.getByRole("combobox", {
       name: tr("select_charge_item_definition"),
     });
     await expect(definitionCombobox).toBeVisible();

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -176,18 +176,31 @@ async function ensureAtLeastOneChargeItemSelected(
     page.getByText(tr("create_invoice"), { exact: true }),
   ).toBeVisible();
 
-  let noBillable = page.getByText(tr("no_billable_items"), { exact: true });
+  const invoiceForm = page.locator("form.space-y-6");
+  await expect(invoiceForm).toBeVisible({ timeout: 30_000 });
+
+  async function clickOpenAddChargeItemsSheet() {
+    const labelPattern = new RegExp(escapeRegex(tr("add_charge_items")), "i");
+    const byRole = page.getByRole("button", { name: labelPattern });
+    const byFilter = page.getByRole("button").filter({ hasText: labelPattern });
+    const btn =
+      (await byRole.count()) > 0
+        ? byRole.first()
+        : (await byFilter.count()) > 0
+          ? byFilter.first()
+          : byRole.first();
+    await expect(btn).toBeVisible({ timeout: 30_000 });
+    await btn.scrollIntoViewIfNeeded();
+    await btn.click({ timeout: 30_000 });
+  }
+
+  let noBillable = invoiceForm.getByText(tr("no_billable_items"), {
+    exact: true,
+  });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
-  const addChargeItemsButtonLocator = () =>
-    page.getByRole("button", {
-      name: new RegExp(`^${escapeRegex(tr("add_charge_items"))}`, "i"),
-    });
-
   if (hasNoBillable) {
-    const addChargeItemsButton = addChargeItemsButtonLocator();
-    await expect(addChargeItemsButton).toBeVisible({ timeout: 30_000 });
-    await addChargeItemsButton.click({ timeout: 30_000 });
+    await clickOpenAddChargeItemsSheet();
     await page.waitForLoadState("networkidle");
 
     let sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
@@ -223,12 +236,11 @@ async function ensureAtLeastOneChargeItemSelected(
         page.getByText(tr("create_invoice"), { exact: true }),
       ).toBeVisible();
 
-      noBillable = page.getByText(tr("no_billable_items"), { exact: true });
-
-      await expect(addChargeItemsButtonLocator()).toBeVisible({
-        timeout: 30_000,
+      noBillable = invoiceForm.getByText(tr("no_billable_items"), {
+        exact: true,
       });
-      await addChargeItemsButtonLocator().click({ timeout: 30_000 });
+
+      await clickOpenAddChargeItemsSheet();
       await page.waitForLoadState("networkidle");
       sheet = page.getByRole("dialog", { name: tr("add_charge_items") });
       await expect(sheet).toBeVisible();
@@ -248,7 +260,6 @@ async function ensureAtLeastOneChargeItemSelected(
     await expect(noBillable).not.toBeVisible();
   }
 
-  const invoiceForm = page.locator("form.space-y-6");
   const rowCheckboxes = invoiceForm.getByRole("checkbox");
   await expect(rowCheckboxes.first()).toBeVisible({ timeout: 60_000 });
 

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -148,13 +148,16 @@ async function ensureAtLeastOneChargeItemSelected(
   facilityId: string,
   accountId: string,
 ) {
+  await expect(
+    page.getByText(tr("create_invoice"), { exact: true }),
+  ).toBeVisible();
+  await page.waitForLoadState("networkidle");
+
   const noBillable = page.getByText(tr("no_billable_items"), { exact: true });
   const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   const table = page.getByRole("table");
   await expect(table).toBeVisible();
-
-  let chargeItemTitle: string;
 
   if (hasNoBillable) {
     await page.getByRole("button", { name: tr("add_charge_items") }).click();
@@ -207,29 +210,18 @@ async function ensureAtLeastOneChargeItemSelected(
       }
     }
 
-    chargeItemTitle = picked;
     await expect(noBillable).not.toBeVisible();
-  } else {
-    const dataRow = table.getByRole("row").nth(1);
-    await expect(dataRow).toBeVisible();
-    await expect(dataRow).not.toContainText(tr("no_billable_items"));
-
-    const titleCell = dataRow.getByRole("cell").nth(1);
-    const titleText = (await titleCell.textContent()) ?? "";
-    chargeItemTitle = firstNonEmptyLine(titleText);
-    expect(chargeItemTitle).not.toEqual("");
   }
 
-  const itemRow = table
-    .getByRole("row")
-    .filter({ hasText: new RegExp(escapeRegex(chargeItemTitle), "i") });
-  await expect(itemRow.first()).toBeVisible();
+  const bodyCheckbox = table.locator("tbody").getByRole("checkbox").first();
+  await expect(bodyCheckbox).toBeVisible();
 
-  const rowCheckbox = itemRow.first().getByRole("checkbox").first();
   const isChecked =
-    (await rowCheckbox.getAttribute("aria-checked").catch(() => null)) ===
+    (await bodyCheckbox.getAttribute("aria-checked").catch(() => null)) ===
     "true";
-  if (!isChecked) await rowCheckbox.click();
+  if (!isChecked) await bodyCheckbox.click();
+
+  await expect(bodyCheckbox).toHaveAttribute("aria-checked", "true");
 }
 
 async function extractInvoiceNumber(page: Page) {

--- a/tests/facility/billing/createInvoice.spec.ts
+++ b/tests/facility/billing/createInvoice.spec.ts
@@ -153,11 +153,15 @@ async function ensureAtLeastOneChargeItemSelected(
   ).toBeVisible();
   await page.waitForLoadState("networkidle");
 
-  const noBillable = page.getByText(tr("no_billable_items"), { exact: true });
-  const hasNoBillable = await noBillable.isVisible().catch(() => false);
+  const chargeItemsTable = page.getByRole("table").filter({
+    has: page.getByRole("columnheader", { name: tr("items") }),
+  });
+  await expect(chargeItemsTable).toBeVisible({ timeout: 30_000 });
 
-  const table = page.getByRole("table");
-  await expect(table).toBeVisible();
+  const noBillable = chargeItemsTable.getByText(tr("no_billable_items"), {
+    exact: true,
+  });
+  const hasNoBillable = await noBillable.isVisible().catch(() => false);
 
   if (hasNoBillable) {
     await page.getByRole("button", { name: tr("add_charge_items") }).click();
@@ -213,7 +217,7 @@ async function ensureAtLeastOneChargeItemSelected(
     await expect(noBillable).not.toBeVisible();
   }
 
-  const rowCheckboxes = table.getByRole("row").getByRole("checkbox");
+  const rowCheckboxes = chargeItemsTable.getByRole("row").getByRole("checkbox");
   await expect(rowCheckboxes.first()).toBeVisible();
 
   const checkboxCount = await rowCheckboxes.count();


### PR DESCRIPTION
## Proposed Changes

Fixes #16154
- Added `tests/facility/billing/createInvoice.spec.ts` file covering all 3 playwright tests.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end billing test exercising the full invoice creation UI: verifies account workspace tabs, opens Create Invoice, ensures a billable item is selected (with fallback to add one), submits the invoice, confirms success toast, captures the generated invoice number, and verifies the created invoice appears in the invoices list with a visible draft badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->