### PR TITLE
Reset fields on product re-select in Supply delivery form

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
@@ -96,6 +96,7 @@ export function useDeliveryRowItem({
       discount_components: [],
       charge_item_category: undefined,
       is_manually_edited: false,
+      is_tax_inclusive: false,
       supplied_item_pack_quantity: 1,
       supplied_item_pack_size: 1,
     };
@@ -158,18 +159,16 @@ export function useDeliveryRowItem({
   // Fill form from existing product
   const fillFromProduct = useCallback(
     (product: ProductRead) => {
-      setField("supplied_item", product);
+      resetFields();
 
-      if (product.batch?.lot_number) {
-        setField("batch_number", product.batch.lot_number);
-      }
+      setField("supplied_item", product);
+      setField("batch_number", product.batch?.lot_number || "");
       if (product.expiration_date) {
         setField(
           "expiry_date",
           format(new Date(product.expiration_date), "yyyy-MM-dd"),
         );
       }
-
       if (product.standard_pack_size) {
         setField("supplied_item_pack_size", product.standard_pack_size);
       }
@@ -228,14 +227,9 @@ export function useDeliveryRowItem({
         if (discounts.length) {
           setField("discount_components", discounts);
         }
-      } else {
-        setField("unit_price", "0");
       }
-
-      setField("is_manually_edited", false);
-      setIsCreatingNew(false);
     },
-    [setField, form, index],
+    [resetFields, setField, form, index],
   );
 
   // Auto-fill from last product when product knowledge is selected

--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/useDeliveryRowItem.ts
@@ -96,7 +96,6 @@ export function useDeliveryRowItem({
       discount_components: [],
       charge_item_category: undefined,
       is_manually_edited: false,
-      is_tax_inclusive: false,
       supplied_item_pack_quantity: 1,
       supplied_item_pack_size: 1,
     };


### PR DESCRIPTION
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured delivery order item form fully resets and repopulates all fields when selecting a product.
  * Batch number now consistently set from product batch data or cleared when absent.
  * Removed fallback forcing unit price to "0"; unit price follows form initialization.
  * Manual-edit and "creating new" flags are now initialized centrally for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->