### PR TITLE
Fix: Tooltip on facility names in dashboard

### DIFF
--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { TooltipComponent } from "@/components/ui/tooltip";
 
 import { Avatar } from "@/components/Common/Avatar";
 
@@ -232,9 +233,11 @@ export default function UserDashboard() {
                             className="size-12 md:size-14"
                           />
                           <div className="flex-1 min-w-0">
-                            <h3 className="font-medium truncate text-sm md:text-base">
-                              {facility.name}
-                            </h3>
+                            <TooltipComponent content={facility.name}>
+                              <h3 className="font-medium truncate text-sm md:text-base">
+                                {facility.name}
+                              </h3>
+                            </TooltipComponent>
                             <p className="text-xs md:text-sm text-gray-500 truncate">
                               {t("view_facility_details")}
                             </p>


### PR DESCRIPTION
## Proposed Changes

Fixes #16288
- Added TooltipComponent to the facility name in the dashboard's Facilities tab so the full name is visible on hover when it is truncated
- No new dependencies introduced — uses the existing shadcn/ui Tooltip wrapper already present in the codebase
- Screenshot of the fix:

<img width="1919" height="897" alt="Screenshot 2026-04-16 164647" src="https://github.com/user-attachments/assets/470310b8-3689-4e0d-ac66-975a1d37707c" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltip functionality to facility names in the user dashboard for improved visibility of truncated text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->