### PR TITLE
Add E2E test for department selector infinite scroll

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,9 +4,10 @@ import { defineConfig, devices } from "@playwright/test";
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+import dotenv from "dotenv";
+import path from "path";
+dotenv.config({ path: path.resolve(__dirname, ".env.local") });
+dotenv.config({ path: path.resolve(__dirname, ".env") });
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/tests/facility/users/departmentInfiniteScroll.spec.ts
+++ b/tests/facility/users/departmentInfiniteScroll.spec.ts
@@ -116,13 +116,24 @@ test.describe("Department Selector Infinite Scroll", () => {
     await test.step("Scroll to bottom to trigger infinite scroll", async () => {
       const initialCount = await items.count();
 
+      // Set up listener for the next-page API request before scrolling
+      const nextPageRequest = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/organizations/") &&
+          resp.url().includes("offset=") &&
+          resp.status() === 200,
+      );
+
       // Scroll the command list to the bottom to trigger the sentinel
       const commandList = page.locator("[cmdk-list]");
       await commandList.evaluate((el) => {
         el.scrollTop = el.scrollHeight;
       });
 
-      // Wait for more items to load
+      // Verify the paginated API request was fired
+      await nextPageRequest;
+
+      // Verify more items rendered from the response
       await expect(async () => {
         const newCount = await items.count();
         expect(newCount).toBeGreaterThan(initialCount);

--- a/tests/facility/users/departmentInfiniteScroll.spec.ts
+++ b/tests/facility/users/departmentInfiniteScroll.spec.ts
@@ -1,0 +1,132 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+import { getFacilityId } from "tests/support/facilityId";
+
+const DEPT_COUNT = 25; // > PAGE_LIMIT (20) to trigger infinite scroll
+const DEPT_PREFIX = "ScrollTest";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+function getAuthHeaders() {
+  const authFile = path.resolve("tests/.auth/user.json");
+  const storageState = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+  const localStorage = storageState.origins?.[0]?.localStorage ?? [];
+  const tokenEntry = localStorage.find(
+    (item: { name: string; value: string }) =>
+      item.name === "care_access_token",
+  );
+  if (!tokenEntry) throw new Error("No access token in auth storage state");
+  return {
+    Authorization: `Bearer ${tokenEntry.value}`,
+    "Content-Type": "application/json",
+  };
+}
+
+test.describe("Department Selector Infinite Scroll", () => {
+  test.beforeAll(async () => {
+    const facilityId = getFacilityId();
+    const apiUrl = process.env.REACT_CARE_API_URL || "http://localhost:9000";
+    const headers = getAuthHeaders();
+
+    // Check how many ScrollTest departments already exist
+    const listRes = await fetch(
+      `${apiUrl}/api/v1/facility/${facilityId}/organizations/?name=${DEPT_PREFIX}&limit=50`,
+      { headers },
+    );
+    if (!listRes.ok) throw new Error(`Failed to list orgs: ${listRes.status}`);
+    const listData = (await listRes.json()) as { count: number };
+
+    if (listData.count >= DEPT_COUNT) {
+      console.log(
+        `✅ Already have ${listData.count} ${DEPT_PREFIX} departments`,
+      );
+      return;
+    }
+
+    const toCreate = DEPT_COUNT - listData.count;
+    console.log(`Creating ${toCreate} departments...`);
+
+    for (let i = 0; i < toCreate; i++) {
+      const name = `${DEPT_PREFIX} ${faker.string.alphanumeric(6)}`;
+      const res = await fetch(
+        `${apiUrl}/api/v1/facility/${facilityId}/organizations/`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            name,
+            description: `Test department for infinite scroll`,
+            org_type: "dept",
+            facility: facilityId,
+          }),
+        },
+      );
+      if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(
+          `Failed to create department: ${res.status} — ${errorText}`,
+        );
+      }
+    }
+    console.log(`✅ Created ${toCreate} departments`);
+  });
+
+  test("dropdown loads first page and scrolling loads more", async ({
+    page,
+  }) => {
+    const facilityId = getFacilityId();
+
+    await test.step("Navigate to a user's Departments tab", async () => {
+      await page.goto(`/facility/${facilityId}/users`);
+      await expect(
+        page.getByRole("button", { name: "See Details" }).first(),
+      ).toBeVisible();
+      await page.getByRole("button", { name: "See Details" }).first().click();
+      await page.waitForLoadState("networkidle");
+      await page.getByText("Departments", { exact: true }).click();
+      await page.waitForLoadState("networkidle");
+    });
+
+    await test.step("Open Link Department sheet and switch to All Organizations", async () => {
+      await page.getByRole("button", { name: "Link Department" }).click();
+      await expect(page.getByText("Link User to Department")).toBeVisible();
+      // Switch tab before opening dropdown (clicking tab would close popover)
+      await page.getByRole("tab", { name: "All Organizations" }).click();
+      await page.waitForLoadState("networkidle");
+    });
+
+    await test.step("Open department dropdown", async () => {
+      await page
+        .getByRole("combobox")
+        .filter({ hasText: "Select Department" })
+        .click();
+    });
+
+    const items = page.getByRole("option");
+
+    await test.step("Verify first page of departments loads", async () => {
+      await expect(items.first()).toBeVisible();
+      const initialCount = await items.count();
+      expect(initialCount).toBeGreaterThan(0);
+    });
+
+    await test.step("Scroll to bottom to trigger infinite scroll", async () => {
+      const initialCount = await items.count();
+
+      // Scroll the command list to the bottom to trigger the sentinel
+      const commandList = page.locator("[cmdk-list]");
+      await commandList.evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+      });
+
+      // Wait for more items to load
+      await expect(async () => {
+        const newCount = await items.count();
+        expect(newCount).toBeGreaterThan(initialCount);
+      }).toPass();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds an E2E Playwright test that verifies infinite scroll works correctly in the department selector dropdown (`FacilityOrganizationSelector`).

### What the test does

1. **Creates 25 departments via API** in `beforeAll` — exceeds `PAGE_LIMIT` (20) to ensure pagination is triggered
2. Navigates to **Users → See Details → Departments → Link Department**
3. Switches to the **All Organizations** tab, opens the combobox dropdown
4. **Verifies first page** of departments loads (items visible as `role="option"`)
5. **Scrolls the command list** to the bottom to trigger the intersection observer sentinel
6. **Waits for the paginated API request** (`/organizations/` with `offset=` param, status 200) — proves `fetchNextPage` was actually called
7. **Verifies more items rendered** after the response — proves the data was processed into the UI

### Other changes

- Enables `dotenv` in `playwright.config.ts` so `REACT_CARE_API_URL` is available in test `beforeAll` hooks

### Note

The department creation via direct API calls in `beforeAll` is a **temporary hack** until the backend fixtures are updated to include enough departments for pagination testing. Once fixtures provide 20+ departments out of the box, the API creation logic can be removed.