### PR TITLE
Show Payment ID throughout UI and print

### DIFF
--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -1280,11 +1280,18 @@ export const PrintChargeItems = (props: {
                                               className="bg-transparent hover:bg-transparent"
                                             >
                                               <TableCell>
-                                                {payment.payment_datetime &&
-                                                  formatDateTime(
-                                                    payment.payment_datetime,
-                                                    "DD-MM-YY",
-                                                  )}
+                                                <div className="flex flex-col mr-1">
+                                                  <span>
+                                                    {payment.payment_datetime &&
+                                                      formatDateTime(
+                                                        payment.payment_datetime,
+                                                        "DD-MM-YY",
+                                                      )}
+                                                  </span>
+                                                  <span className="font-mono text-xs text-gray-500">
+                                                    {payment.id}
+                                                  </span>
+                                                </div>
                                               </TableCell>
                                               <TableCell>
                                                 {payment.target_invoice?.number}
@@ -1502,11 +1509,18 @@ export const PrintChargeItems = (props: {
                                               className="bg-transparent hover:bg-transparent"
                                             >
                                               <TableCell>
-                                                {payment.payment_datetime &&
-                                                  formatDateTime(
-                                                    payment.payment_datetime,
-                                                    "DD-MM-YY",
-                                                  )}
+                                                <div className="flex flex-col">
+                                                  <span>
+                                                    {payment.payment_datetime &&
+                                                      formatDateTime(
+                                                        payment.payment_datetime,
+                                                        "DD-MM-YY",
+                                                      )}
+                                                  </span>
+                                                  <span className="font-mono text-xs text-gray-500">
+                                                    {payment.id}
+                                                  </span>
+                                                </div>
                                               </TableCell>
                                               <TableCell>
                                                 {payment.target_invoice?.number}

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -1245,7 +1245,7 @@ export function InvoiceShow({
                                 <TableCell
                                   className={cn(tableCellClass, "font-medium")}
                                 >
-                                  <span className="flex justify-between items-center flex-wrap gap-2">
+                                  <div className="flex justify-between items-center flex-wrap gap-2">
                                     <div className="flex flex-col">
                                       <span>
                                         {payment.payment_datetime
@@ -1294,7 +1294,7 @@ export function InvoiceShow({
                                         </>
                                       </Button>
                                     </div>
-                                  </span>
+                                  </div>
                                 </TableCell>
                                 <TableCell
                                   className={cn(tableCellClass, "text-left")}
@@ -1393,7 +1393,7 @@ export function InvoiceShow({
                               <TableCell
                                 className={cn(tableCellClass, "font-medium")}
                               >
-                                <span className="flex justify-between items-center flex-wrap gap-2">
+                                <div className="flex justify-between items-center flex-wrap gap-2">
                                   <div className="flex flex-col">
                                     <span>
                                       {creditNote.payment_datetime
@@ -1442,7 +1442,7 @@ export function InvoiceShow({
                                       </>
                                     </Button>
                                   </div>
-                                </span>
+                                </div>
                               </TableCell>
                               <TableCell
                                 className={cn(tableCellClass, "text-left")}

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -1246,12 +1246,21 @@ export function InvoiceShow({
                                   className={cn(tableCellClass, "font-medium")}
                                 >
                                   <span className="flex justify-between items-center flex-wrap gap-2">
-                                    {payment.payment_datetime
-                                      ? format(
-                                          new Date(payment.payment_datetime),
-                                          "d MMM yyyy, hh:mm a",
-                                        )
-                                      : "-"}
+                                    <div className="flex flex-col">
+                                      <span>
+                                        {payment.payment_datetime
+                                          ? format(
+                                              new Date(
+                                                payment.payment_datetime,
+                                              ),
+                                              "d MMM yyyy, hh:mm a",
+                                            )
+                                          : "-"}
+                                      </span>
+                                      <span className="font-mono text-xs text-gray-500">
+                                        {payment.id}
+                                      </span>
+                                    </div>
 
                                     <div className="flex gap-2">
                                       <Button
@@ -1385,12 +1394,21 @@ export function InvoiceShow({
                                 className={cn(tableCellClass, "font-medium")}
                               >
                                 <span className="flex justify-between items-center flex-wrap gap-2">
-                                  {creditNote.payment_datetime
-                                    ? format(
-                                        new Date(creditNote.payment_datetime),
-                                        "d MMM yyyy, hh:mm a",
-                                      )
-                                    : "-"}
+                                  <div className="flex flex-col">
+                                    <span>
+                                      {creditNote.payment_datetime
+                                        ? format(
+                                            new Date(
+                                              creditNote.payment_datetime,
+                                            ),
+                                            "d MMM yyyy, hh:mm a",
+                                          )
+                                        : "-"}
+                                    </span>
+                                    <span className="font-mono text-xs text-gray-500">
+                                      {creditNote.id}
+                                    </span>
+                                  </div>
 
                                   <div className="flex gap-2">
                                     <Button
@@ -1671,6 +1689,10 @@ export function InvoiceShow({
                           >
                             <span className="text-gray-600">
                               {index + 1}.{" "}
+                              <span className="font-mono text-xs">
+                                {payment.id}
+                              </span>
+                              {" - "}
                               {
                                 PAYMENT_RECONCILIATION_METHOD_MAP[
                                   payment.method
@@ -1713,6 +1735,10 @@ export function InvoiceShow({
                           >
                             <span className="text-gray-600">
                               {index + 1}.{" "}
+                              <span className="font-mono text-xs">
+                                {creditNote.id}
+                              </span>
+                              {" - "}
                               {
                                 PAYMENT_RECONCILIATION_METHOD_MAP[
                                   creditNote.method

--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -527,12 +527,19 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
                             <TableCell
                               className={cn(tableCellClass, "font-medium")}
                             >
-                              {payment.payment_datetime
-                                ? format(
-                                    new Date(payment.payment_datetime),
-                                    "d MMM yyyy, hh:mm a",
-                                  )
-                                : "-"}
+                              <div className="flex flex-col">
+                                <span>
+                                  {payment.payment_datetime
+                                    ? format(
+                                        new Date(payment.payment_datetime),
+                                        "d MMM yyyy, hh:mm a",
+                                      )
+                                    : "-"}
+                                </span>
+                                <span className="font-mono text-xs text-gray-500">
+                                  {payment.id}
+                                </span>
+                              </div>
                             </TableCell>
                             <TableCell
                               className={cn(tableCellClass, "text-left")}
@@ -619,12 +626,19 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
                             <TableCell
                               className={cn(tableCellClass, "font-medium")}
                             >
-                              {creditNote.payment_datetime
-                                ? format(
-                                    new Date(creditNote.payment_datetime),
-                                    "d MMM yyyy, hh:mm a",
-                                  )
-                                : "-"}
+                              <div className="flex flex-col">
+                                <span>
+                                  {creditNote.payment_datetime
+                                    ? format(
+                                        new Date(creditNote.payment_datetime),
+                                        "d MMM yyyy, hh:mm a",
+                                      )
+                                    : "-"}
+                                </span>
+                                <span className="font-mono text-xs text-gray-500">
+                                  {creditNote.id}
+                                </span>
+                              </div>
                             </TableCell>
                             <TableCell
                               className={cn(tableCellClass, "text-left")}

--- a/src/pages/Facility/billing/invoice/PrintInvoices.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoices.tsx
@@ -609,12 +609,21 @@ export function PrintInvoices({ facilityId, invoiceIds }: PrintInvoicesProps) {
                                       "font-medium",
                                     )}
                                   >
-                                    {payment.payment_datetime
-                                      ? format(
-                                          new Date(payment.payment_datetime),
-                                          "d MMM yyyy, hh:mm a",
-                                        )
-                                      : "-"}
+                                    <div className="flex flex-col">
+                                      <span>
+                                        {payment.payment_datetime
+                                          ? format(
+                                              new Date(
+                                                payment.payment_datetime,
+                                              ),
+                                              "d MMM yyyy, hh:mm a",
+                                            )
+                                          : "-"}
+                                      </span>
+                                      <span className="font-mono text-xs text-gray-500">
+                                        {payment.id}
+                                      </span>
+                                    </div>
                                   </TableCell>
                                   <TableCell
                                     className={cn(tableCellClass, "text-left")}

--- a/src/pages/Facility/billing/invoice/PrintInvoices.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoices.tsx
@@ -725,12 +725,21 @@ export function PrintInvoices({ facilityId, invoiceIds }: PrintInvoicesProps) {
                                       "font-medium",
                                     )}
                                   >
-                                    {creditNote.payment_datetime
-                                      ? format(
-                                          new Date(creditNote.payment_datetime),
-                                          "d MMM yyyy, hh:mm a",
-                                        )
-                                      : "-"}
+                                    <div className="flex flex-col">
+                                      <span>
+                                        {creditNote.payment_datetime
+                                          ? format(
+                                              new Date(
+                                                creditNote.payment_datetime,
+                                              ),
+                                              "d MMM yyyy, hh:mm a",
+                                            )
+                                          : "-"}
+                                      </span>
+                                      <span className="font-mono text-xs text-gray-500">
+                                        {creditNote.id}
+                                      </span>
+                                    </div>
                                   </TableCell>
                                   <TableCell
                                     className={cn(tableCellClass, "text-left")}

--- a/src/pages/Facility/billing/paymentReconciliation/ChangePaymentAccountSheet.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/ChangePaymentAccountSheet.tsx
@@ -137,10 +137,8 @@ export default function ChangePaymentAccountSheet({
                     {t(payment.reconciliation_type)}
                     <span className="font-mono text-xs">{payment.id}</span>
                   </span>
-                  <div>
-                    {" - "}
-                    <MonetaryDisplay amount={payment.amount} />
-                  </div>
+                  {" - "}
+                  <MonetaryDisplay amount={payment.amount} />
                 </div>
               ))}
             </div>

--- a/src/pages/Facility/billing/paymentReconciliation/ChangePaymentAccountSheet.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/ChangePaymentAccountSheet.tsx
@@ -133,10 +133,14 @@ export default function ChangePaymentAccountSheet({
                   key={payment.id}
                   className="text-sm text-gray-600 flex justify-between"
                 >
-                  <span className="truncate">
+                  <span className="truncate flex flex-col">
                     {t(payment.reconciliation_type)}
+                    <span className="font-mono text-xs">{payment.id}</span>
                   </span>
-                  <MonetaryDisplay amount={payment.amount} />
+                  <div>
+                    {" - "}
+                    <MonetaryDisplay amount={payment.amount} />
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/pages/Facility/billing/paymentReconciliation/PaymentReconciliationShow.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PaymentReconciliationShow.tsx
@@ -126,12 +126,12 @@ export function PaymentReconciliationShow({
       {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start gap-4">
         <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
+          <h1 className="text-2xl font-bold">
             {t(payment.is_credit_note ? "refund" : "payment")}
-            <span className="text-lg font-normal text-gray-500">
-              #{payment.id}
-            </span>
           </h1>
+          <p className="text-sm text-gray-500">
+            {t("payment_id")}: {payment.id}
+          </p>
           <div className="flex flex-wrap gap-2 mt-2">
             <Badge
               variant={PAYMENT_RECONCILIATION_STATUS_COLORS[payment.status]}

--- a/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PaymentsData.tsx
@@ -424,12 +424,19 @@ export default function PaymentsData({
                     </TableCell>
                   )}
                   <TableCell>
-                    {payment.payment_datetime
-                      ? format(
-                          new Date(payment.payment_datetime),
-                          "MMM d, yyyy hh:mm a",
-                        )
-                      : "-"}
+                    <div className="flex flex-col">
+                      <span>
+                        {payment.payment_datetime
+                          ? format(
+                              new Date(payment.payment_datetime),
+                              "MMM d, yyyy hh:mm a",
+                            )
+                          : "-"}
+                      </span>
+                      <span className="font-mono text-xs text-gray-500">
+                        {payment.id}
+                      </span>
+                    </div>
                   </TableCell>
                   <TableCell>
                     {payment.target_invoice && (

--- a/src/pages/Facility/billing/paymentReconciliation/PrintPaymentReconciliation.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PrintPaymentReconciliation.tsx
@@ -156,6 +156,11 @@ export function PrintPaymentReconciliation({
                 value={formatDateTime(payment.created_date, "DD-MM-YYYY")}
                 width="w-24"
               />
+              <DetailRow
+                label={t("payment_id")}
+                value={payment.id}
+                width="w-24"
+              />
               {payment.account.patient?.instance_identifiers
                 ?.filter(
                   ({ config }) =>


### PR DESCRIPTION
<img width="1204" height="307" alt="image" src="https://github.com/user-attachments/assets/d8635248-fa12-4de7-ab0e-ddcbf752965e" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Payment date cells across billing tables now show the formatted date plus the record ID on a second, monospaced muted line.
  * Invoice payments and credit notes lists/dialogs display IDs alongside datetimes.
  * Payment reconciliation lists and selected-payment rows include IDs beneath reconciliation types with a separator before amounts.
  * Print/export views include payment identifier in header details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->