### PR TITLE
Fix role org user accessibility 

### DIFF
--- a/src/components/ui/sidebar/responsibility-switcher.tsx
+++ b/src/components/ui/sidebar/responsibility-switcher.tsx
@@ -1,5 +1,4 @@
 import { CaretSortIcon, DashboardIcon } from "@radix-ui/react-icons";
-import { useQuery } from "@tanstack/react-query";
 import { ShieldCheck } from "lucide-react";
 import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
@@ -22,8 +21,7 @@ import {
 } from "@/components/ui/sidebar";
 import { NavMain } from "@/components/ui/sidebar/nav-main";
 
-import query from "@/Utils/request/query";
-import organizationApi from "@/types/organization/organizationApi";
+import { useAccessibleRoleOrganizationsList } from "@/hooks/useAccessibleRoleOrganizationsList";
 
 interface Props {
   selectedResponsibilityId: string;
@@ -33,12 +31,7 @@ export function ResponsibilitySwitcher({ selectedResponsibilityId }: Props) {
   const { isMobile } = useSidebar();
   const { t } = useTranslation();
 
-  const { data } = useQuery({
-    queryKey: ["accessibleRoleOrganizations", "sidebar"],
-    queryFn: query(organizationApi.accessibleRoleOrganizations, {
-      queryParams: {},
-    }),
-  });
+  const { data } = useAccessibleRoleOrganizationsList();
 
   const items = data?.results || [];
   const selectedItem = items.find(
@@ -113,12 +106,7 @@ export function ResponsibilitySwitcher({ selectedResponsibilityId }: Props) {
 }
 
 export function ResponsibilityNav() {
-  const { data } = useQuery({
-    queryKey: ["accessibleRoleOrganizations", "sidebar"],
-    queryFn: query(organizationApi.accessibleRoleOrganizations, {
-      queryParams: {},
-    }),
-  });
+  const { data } = useAccessibleRoleOrganizationsList();
 
   const items = data?.results || [];
 

--- a/src/hooks/useAccessibleRoleOrganizationsList.ts
+++ b/src/hooks/useAccessibleRoleOrganizationsList.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+
+import query from "@/Utils/request/query";
+import organizationApi, {
+  type AccessibleRoleOrganization,
+} from "@/types/organization/organizationApi";
+
+/**
+ * Unfiltered accessible role organizations (same payload as sidebar / dashboard).
+ * Central query key so all consumers share one cache.
+ */
+export function useAccessibleRoleOrganizationsList() {
+  return useQuery({
+    queryKey: ["accessibleRoleOrganizations", "list"],
+    queryFn: query(organizationApi.accessibleRoleOrganizations, {
+      queryParams: {},
+    }),
+  });
+}
+
+/**
+ * Backend lists these orgs in accessible_role_organizations even when `role` is
+ * null; organization GET may omit can_list_organization_users. Treat null role
+ * as sufficient to show the Users area for that responsibility.
+ */
+export function hasResponsibilityUsersAccessViaNullRoleAssignment(
+  organizationId: string,
+  results: AccessibleRoleOrganization[] | undefined,
+): boolean {
+  const entry = results?.find(
+    (item) => item.organization.id === organizationId,
+  );
+  return entry != null && entry.role == null;
+}

--- a/src/pages/Organization/ResponsibilityLanding.tsx
+++ b/src/pages/Organization/ResponsibilityLanding.tsx
@@ -2,8 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { navigate } from "raviger";
 import { useEffect } from "react";
 
-import query from "@/Utils/request/query";
+import { usePermissions } from "@/context/PermissionContext";
+import {
+  hasResponsibilityUsersAccessViaNullRoleAssignment,
+  useAccessibleRoleOrganizationsList,
+} from "@/hooks/useAccessibleRoleOrganizationsList";
 import organizationApi from "@/types/organization/organizationApi";
+import query from "@/Utils/request/query";
 
 import OrganizationUsers from "./OrganizationUsers";
 
@@ -14,8 +19,11 @@ interface Props {
 /**
  * Landing page for /responsibilities/:id
  * Checks if the user can list organization users. If not, redirects to patients.
+ * Entries from accessible_role_organizations with role null still get Users
+ * even when organization.permissions omits can_list_organization_users.
  */
 export default function ResponsibilityLanding({ id }: Props) {
+  const { hasPermission } = usePermissions();
   const { data: org, isLoading } = useQuery({
     queryKey: ["organization", id],
     queryFn: query(organizationApi.get, {
@@ -24,17 +32,26 @@ export default function ResponsibilityLanding({ id }: Props) {
     enabled: !!id,
   });
 
+  const { data: accessibleData, isLoading: isLoadingAccessible } =
+    useAccessibleRoleOrganizationsList();
+
+  const canListUsersViaNullRole =
+    hasResponsibilityUsersAccessViaNullRoleAssignment(
+      id,
+      accessibleData?.results,
+    );
   const canListUsers =
-    org?.permissions?.includes("can_list_organization_users") ?? false;
+    hasPermission("can_list_organization_users", org?.permissions) ||
+    canListUsersViaNullRole;
 
   useEffect(() => {
-    if (!isLoading && org && !canListUsers) {
+    if (!isLoading && !isLoadingAccessible && org && !canListUsers) {
       navigate(`/responsibilities/${id}/patients`, { replace: true });
     }
-  }, [isLoading, org, canListUsers, id]);
+  }, [isLoading, isLoadingAccessible, org, canListUsers, id]);
 
-  // While loading or if user can list users, show users page
-  if (isLoading || canListUsers) {
+  // Wait for accessible list so null-role access is not redirected away early
+  if (isLoading || isLoadingAccessible || canListUsers) {
     return <OrganizationUsers id={id} routeContext="responsibility" />;
   }
 

--- a/src/pages/Organization/components/OrganizationLayout.tsx
+++ b/src/pages/Organization/components/OrganizationLayout.tsx
@@ -29,6 +29,10 @@ import Page from "@/components/Common/Page";
 
 import query from "@/Utils/request/query";
 import { usePermissions } from "@/context/PermissionContext";
+import {
+  hasResponsibilityUsersAccessViaNullRoleAssignment,
+  useAccessibleRoleOrganizationsList,
+} from "@/hooks/useAccessibleRoleOrganizationsList";
 import { useCareApps } from "@/hooks/useCareApps";
 import OrganizationLayoutSkeleton from "@/pages/Organization/components/OrganizationLayoutSkeleton";
 import {
@@ -62,6 +66,7 @@ export default function OrganizationLayout({
   const { hasPermission } = usePermissions();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const careApps = useCareApps();
+  const { data: accessibleRoleData } = useAccessibleRoleOrganizationsList();
 
   const organizationTabs = careApps.flatMap(
     (c) => (!c.isLoading && c.organizationTabs) || [],
@@ -95,6 +100,13 @@ export default function OrganizationLayout({
   const effectiveContext: RouteContext =
     routeContext || (isRoleOrg ? "responsibility" : "organization");
 
+  const canShowUsersForNullRoleResponsibility =
+    effectiveContext === "responsibility" &&
+    hasResponsibilityUsersAccessViaNullRoleAssignment(
+      id,
+      accessibleRoleData?.results,
+    );
+
   const baseUrl = navOrganizationId
     ? `/organization/${navOrganizationId}/children`
     : effectiveContext === "responsibility"
@@ -111,14 +123,12 @@ export default function OrganizationLayout({
         !isRoleOrg && hasPermission("can_view_organization", org.permissions),
     },
     {
-      // For responsibilities, users is the landing page (no /users suffix)
-      url:
-        effectiveContext === "responsibility"
-          ? `${baseUrl}/${id}`
-          : `${baseUrl}/${id}/users`,
+      url: `${baseUrl}/${id}/users`,
       name: t("users"),
       icon: <CareIcon icon="d-people" />,
-      visibility: hasPermission("can_list_organization_users", org.permissions),
+      visibility:
+        hasPermission("can_list_organization_users", org.permissions) ||
+        canShowUsersForNullRoleResponsibility,
     },
     {
       url: `${baseUrl}/${id}/patients`,

--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { ChevronRight, LogOut, SquarePen, User2Icon } from "lucide-react";
 import { Link } from "raviger";
 import { useState } from "react";
@@ -17,14 +16,13 @@ import {
 
 import { Avatar } from "@/components/Common/Avatar";
 
+import { useAccessibleRoleOrganizationsList } from "@/hooks/useAccessibleRoleOrganizationsList";
 import useAuthUser, { useAuthContext } from "@/hooks/useAuthUser";
 import useBreakpoints from "@/hooks/useBreakpoints";
 
-import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
 import { FacilityBareMinimum } from "@/types/facility/facility";
 import { Organization, getOrgLabel } from "@/types/organization/organization";
-import organizationApi from "@/types/organization/organizationApi";
 
 enum DashboardTabs {
   TAB_FACILITIES = "Facilities",
@@ -50,12 +48,8 @@ export default function UserDashboard() {
   const governance = organizations.filter((org) => org.org_type === "govt");
 
   // Fetch accessible role organizations from dedicated API (includes user's role per org)
-  const { data: accessibleRoleOrgs, isLoading: isLoadingRoleOrgs } = useQuery({
-    queryKey: ["accessibleRoleOrganizations", "dashboard"],
-    queryFn: query(organizationApi.accessibleRoleOrganizations, {
-      queryParams: {},
-    }),
-  });
+  const { data: accessibleRoleOrgs, isLoading: isLoadingRoleOrgs } =
+    useAccessibleRoleOrganizationsList();
   const responsibilityItems = accessibleRoleOrgs?.results || [];
   // Extract organizations for tab items
   const responsibilities = responsibilityItems.map((item) => item.organization);


### PR DESCRIPTION
## Proposed Changes


This pull request introduces a new shared hook, `useAccessibleRoleOrganizationsList`, to centralize fetching and caching of accessible role organizations across the application. It refactors multiple components to use this hook, ensuring consistent data and improved cache usage. Additionally, it updates logic for user access to the Users area, allowing responsibilities with a `null` role to display the Users section even if the organization omits the explicit permission. 

The most important changes are:

**Centralized data fetching and caching:**
- Added the `useAccessibleRoleOrganizationsList` hook in `src/hooks/useAccessibleRoleOrganizationsList.ts` to provide a single source of truth and shared cache for accessible role organizations data. Also added `hasResponsibilityUsersAccessViaNullRoleAssignment` utility to handle `null` role logic.

**Component refactoring to use new hook:**
- Updated `src/components/ui/sidebar/responsibility-switcher.tsx`, `src/pages/UserDashboard.tsx`, `src/pages/Organization/ResponsibilityLanding.tsx`, and `src/pages/Organization/components/OrganizationLayout.tsx` to use `useAccessibleRoleOrganizationsList` instead of local `useQuery` calls, ensuring all consumers share the same cache and query key. [[1]](diffhunk://#diff-c050b4a590564bf56b2cc08a7fb2ba0f1e9bb5de80432f602341989a6a28df55L25-R24) [[2]](diffhunk://#diff-c050b4a590564bf56b2cc08a7fb2ba0f1e9bb5de80432f602341989a6a28df55L36-R34) [[3]](diffhunk://#diff-c050b4a590564bf56b2cc08a7fb2ba0f1e9bb5de80432f602341989a6a28df55L116-R109) [[4]](diffhunk://#diff-1d53bcdcd6e334edbfa6721db01c632f9ac5df9b9b47f4fca06572d27770ef7dR19-L27) [[5]](diffhunk://#diff-1d53bcdcd6e334edbfa6721db01c632f9ac5df9b9b47f4fca06572d27770ef7dL53-R52) [[6]](diffhunk://#diff-fbb67658ace0c1e51ce95b2bcc764e0b4f562a3d2939d5fb9b894cd46450d569L5-R11) [[7]](diffhunk://#diff-a94e819ffe0c517a6078cdd67d5a931c48e34227ed40508e8cdf600162c36b99R32-R35) [[8]](diffhunk://#diff-a94e819ffe0c517a6078cdd67d5a931c48e34227ed40508e8cdf600162c36b99R69)

**Improved responsibility Users area access logic:**
- Updated logic in `ResponsibilityLanding` and `OrganizationLayout` to allow access to the Users area for responsibilities with a `null` role, even if the explicit permission is missing, by using `hasResponsibilityUsersAccessViaNullRoleAssignment`. This prevents users from being redirected away or having the Users tab hidden in these cases. [[1]](diffhunk://#diff-fbb67658ace0c1e51ce95b2bcc764e0b4f562a3d2939d5fb9b894cd46450d569R22-R26) [[2]](diffhunk://#diff-fbb67658ace0c1e51ce95b2bcc764e0b4f562a3d2939d5fb9b894cd46450d569R35-R54) [[3]](diffhunk://#diff-a94e819ffe0c517a6078cdd67d5a931c48e34227ed40508e8cdf600162c36b99R103-R109) [[4]](diffhunk://#diff-a94e819ffe0c517a6078cdd67d5a931c48e34227ed40508e8cdf600162c36b99L114-R131)

**Code cleanup:**
- Removed redundant imports and local query logic now replaced by the shared hook. [[1]](diffhunk://#diff-c050b4a590564bf56b2cc08a7fb2ba0f1e9bb5de80432f602341989a6a28df55L2) [[2]](diffhunk://#diff-1d53bcdcd6e334edbfa6721db01c632f9ac5df9b9b47f4fca06572d27770ef7dL1)

These changes improve consistency, maintainability, and user experience around responsibility-based organization access.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated data fetching logic for organization roles into a shared hook for improved efficiency and maintainability.

* **New Features**
  * Organizations now support user access through responsibility assignments without explicit roles, expanding flexibility in access control configuration.

* **Bug Fixes**
  * Improved permission evaluation to account for multiple access paths when determining user list visibility in organization management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->