### PR TITLE
make queue board responsive for mobile devices

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -6535,5 +6535,6 @@
   "your_request_order_list": "Your Request Order List",
   "zoom_in": "Zoom In",
   "zoom_out": "Zoom Out",
+  "mark_as_entered_in_error_confirmation": "Are you sure you want to mark the token {{tokenNumber}} for {{patientName}} as entered in error? This action cannot be undone.",
   "℞": "℞"
 }

--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -124,8 +124,8 @@ export function ManageQueuePage({
       hideTitleOnPage
     >
       <div className="flex flex-col gap-6">
-        <div className="flex justify-between gap-3">
-          <div className="flex gap-2 items-center">
+        <div className="flex flex-wrap justify-between gap-3">
+          <div className="flex gap-2 items-center min-w-0 flex-1">
             <BackButton
               // TODO: move queue index page for practitioner to similar pattern path
               to={
@@ -139,11 +139,11 @@ export function ManageQueuePage({
               <ChevronLeft />
             </BackButton>
             {resource && (
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 min-w-0">
                 <ScheduleResourceIcon resource={resource} />
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold text-black">
+                <div className="flex flex-col min-w-0">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-semibold text-black truncate">
                       {t("queue_of_resource", {
                         resource: formatScheduleResourceName(resource),
                       })}
@@ -151,7 +151,7 @@ export function ManageQueuePage({
                     {queue.is_primary && (
                       <Badge
                         variant={queue.is_primary ? "primary" : "secondary"}
-                        className="hidden sm:block text-xs"
+                        className="hidden sm:block text-xs shrink-0"
                       >
                         {t("primary")}
                       </Badge>
@@ -165,7 +165,7 @@ export function ManageQueuePage({
               </div>
             )}
           </div>
-          <div className="flex gap-5 items-center justify-center">
+          <div className="flex gap-5 items-center justify-end shrink-0">
             <div className="hidden sm:flex flex-col-reverse sm:flex-row gap-2 items-center text-black font-medium text-md">
               <Switch
                 checked={shouldAutoRefresh}
@@ -350,7 +350,7 @@ function ManageServicePointsDialog({
 
   if (!allServicePoints) {
     return (
-      <DialogContent className="max-w-md">
+      <DialogContent className="w-[95vw] max-w-md">
         <DialogHeader>
           <Skeleton className="h-6 w-48" />
         </DialogHeader>
@@ -369,11 +369,11 @@ function ManageServicePointsDialog({
   return (
     <Dialog {...props}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="max-w-md">
+      <DialogContent className="w-[95vw] max-w-md">
         <DialogHeader>
           <DialogTitle>{t("assigned_service_points")}</DialogTitle>
         </DialogHeader>
-        <div>
+        <div className="max-h-[60vh] overflow-y-auto -mx-2 px-2">
           {allServicePoints.map((subQueue) => {
             const isSelected = assignedServicePointIds.includes(subQueue.id);
             return (

--- a/src/pages/Facility/queues/ManageQueue.tsx
+++ b/src/pages/Facility/queues/ManageQueue.tsx
@@ -387,9 +387,8 @@ function ManageServicePointsDialog({
                 <div className="flex items-center space-x-3">
                   <Checkbox
                     checked={isSelected}
-                    onCheckedChange={(checked) =>
-                      toggleServicePoint(subQueue.id, checked as boolean)
-                    }
+                    className="pointer-events-none"
+                    tabIndex={-1}
                   />
                   <span className="text-sm font-medium">{subQueue.name}</span>
                 </div>

--- a/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
@@ -31,7 +31,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { Link } from "raviger";
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useInView } from "react-intersection-observer";
 import { useTokenListInfiniteQuery } from "./utils";
@@ -68,92 +68,113 @@ export function ManageQueueFinishedTab({
   return (
     <div className="flex flex-col gap-4">
       {tokens.length > 0 ? (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>{t("token_number")}</TableHead>
-              <TableHead>{t("patient_name")}</TableHead>
-              <TableHead>{t("encounter")}</TableHead>
-              <TableHead>{t("service_points")}</TableHead>
-              <TableHead>{t("status")}</TableHead>
-              <TableHead className="w-[100px]">{t("actions")}</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
+        <>
+          {/* Desktop table */}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("token_number")}</TableHead>
+                  <TableHead>{t("patient_name")}</TableHead>
+                  <TableHead>{t("encounter")}</TableHead>
+                  <TableHead>{t("service_points")}</TableHead>
+                  <TableHead>{t("status")}</TableHead>
+                  <TableHead className="w-[100px]">{t("actions")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tokens.map((token, index) => (
+                  <TableRow
+                    key={token.id}
+                    ref={index === tokens.length - 1 ? ref : undefined}
+                  >
+                    <TableCell>
+                      <span className="font-mono font-semibold">
+                        {renderTokenNumber(token)}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      {token.patient ? (
+                        <Link
+                          href={`/facility/${facilityId}/patients/home?${new URLSearchParams(
+                            {
+                              phone_number: token.patient.phone_number,
+                              year_of_birth:
+                                token.patient.year_of_birth?.toString() ?? "",
+                              partial_id: token.patient.id.slice(0, 5),
+                              queue_id: token.queue.id,
+                              token_id: token.id,
+                            },
+                          ).toString()}`}
+                          className="hover:underline transition-colors flex items-center gap-1"
+                        >
+                          {token.patient.name}
+                          <ExternalLink className="size-3" />
+                        </Link>
+                      ) : (
+                        <span className="text-gray-500">-</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
+                        className="hover:underline transition-colors flex items-center gap-1"
+                      >
+                        {t("encounter")}
+                        <ExternalLink className="size-3" />
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      {token.sub_queue?.name || (
+                        <span className="text-gray-500">-</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          token.status === TokenStatus.FULFILLED
+                            ? "green"
+                            : token.status === TokenStatus.CANCELLED
+                              ? "destructive"
+                              : "secondary"
+                        }
+                        size="sm"
+                      >
+                        {t(token.status.toLowerCase())}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <FinishedTokenOptions
+                        token={token}
+                        facilityId={facilityId}
+                        queueId={queueId}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {isFetchingNextPage && (
+                  <FinishedTokensTableSkeleton count={5} />
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Mobile card list */}
+          <div className="md:hidden flex flex-col gap-3">
             {tokens.map((token, index) => (
-              <TableRow
+              <FinishedTokenCard
                 key={token.id}
+                token={token}
+                facilityId={facilityId}
+                queueId={queueId}
                 ref={index === tokens.length - 1 ? ref : undefined}
-              >
-                <TableCell>
-                  <span className="font-mono font-semibold">
-                    {renderTokenNumber(token)}
-                  </span>
-                </TableCell>
-                <TableCell>
-                  {token.patient ? (
-                    <Link
-                      href={`/facility/${facilityId}/patients/home?${new URLSearchParams(
-                        {
-                          phone_number: token.patient.phone_number,
-                          year_of_birth:
-                            token.patient.year_of_birth?.toString() ?? "",
-                          partial_id: token.patient.id.slice(0, 5),
-                          queue_id: token.queue.id,
-                          token_id: token.id,
-                        },
-                      ).toString()}`}
-                      className="hover:underline transition-colors flex items-center gap-1"
-                    >
-                      {token.patient.name}
-                      <ExternalLink className="size-3" />
-                    </Link>
-                  ) : (
-                    <span className="text-gray-500">-</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Link
-                    href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
-                    className="hover:underline transition-colors flex items-center gap-1"
-                  >
-                    {t("encounter")}
-                    <ExternalLink className="size-3" />
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  {token.sub_queue?.name || (
-                    <span className="text-gray-500">-</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Badge
-                    variant={
-                      token.status === TokenStatus.FULFILLED
-                        ? "green"
-                        : token.status === TokenStatus.CANCELLED
-                          ? "destructive"
-                          : "secondary"
-                    }
-                    size="sm"
-                  >
-                    {t(token.status.toLowerCase())}
-                  </Badge>
-                </TableCell>
-                <TableCell>
-                  <FinishedTokenOptions
-                    token={token}
-                    facilityId={facilityId}
-                    queueId={queueId}
-                  />
-                </TableCell>
-              </TableRow>
+              />
             ))}
-            {isFetchingNextPage && <FinishedTokensTableSkeleton count={5} />}
-          </TableBody>
-        </Table>
+            {isFetchingNextPage && <FinishedTokenCardSkeletons count={3} />}
+          </div>
+        </>
       ) : (
-        <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-20 border border-gray-100">
+        <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-16 md:py-20 px-4 text-center border border-gray-100">
           <DoorOpenIcon className="size-8 text-gray-700" />
           <span className="text-lg font-semibold text-gray-700">
             {t("no_tokens_finished")}
@@ -164,6 +185,107 @@ export function ManageQueueFinishedTab({
         </div>
       )}
     </div>
+  );
+}
+
+const FinishedTokenCard = forwardRef<
+  HTMLDivElement,
+  {
+    token: TokenRead;
+    facilityId: string;
+    queueId: string;
+  }
+>(function FinishedTokenCard({ token, facilityId, queueId }, ref) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg shadow-sm"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-1 min-w-0">
+          <span className="font-mono font-semibold text-sm">
+            {renderTokenNumber(token)}
+          </span>
+          {token.patient ? (
+            <Link
+              href={`/facility/${facilityId}/patients/home?${new URLSearchParams(
+                {
+                  phone_number: token.patient.phone_number,
+                  year_of_birth: token.patient.year_of_birth?.toString() ?? "",
+                  partial_id: token.patient.id.slice(0, 5),
+                  queue_id: token.queue.id,
+                  token_id: token.id,
+                },
+              ).toString()}`}
+              className="text-sm font-medium hover:underline flex items-center gap-1 min-w-0"
+            >
+              <span className="truncate">{token.patient.name}</span>
+              <ExternalLink className="size-3 shrink-0" />
+            </Link>
+          ) : (
+            <span className="text-sm text-gray-500">-</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Badge
+            variant={
+              token.status === TokenStatus.FULFILLED
+                ? "green"
+                : token.status === TokenStatus.CANCELLED
+                  ? "destructive"
+                  : "secondary"
+            }
+            size="sm"
+          >
+            {t(token.status.toLowerCase())}
+          </Badge>
+          <FinishedTokenOptions
+            token={token}
+            facilityId={facilityId}
+            queueId={queueId}
+          />
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-600">
+        <div className="flex items-center gap-1">
+          <span className="font-medium">{t("service_points")}:</span>
+          <span>
+            {token.sub_queue?.name || <span className="text-gray-500">-</span>}
+          </span>
+        </div>
+        <Link
+          href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
+          className="hover:underline transition-colors flex items-center gap-1 font-medium"
+        >
+          {t("encounter")}
+          <ExternalLink className="size-3" />
+        </Link>
+      </div>
+    </div>
+  );
+});
+
+function FinishedTokenCardSkeletons({ count = 3 }: { count?: number }) {
+  return (
+    <>
+      {Array.from({ length: count }, (_, index) => (
+        <div
+          key={index}
+          className="flex flex-col gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-col gap-1 flex-1">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <Skeleton className="h-6 w-16" />
+          </div>
+          <Skeleton className="h-3 w-40" />
+        </div>
+      ))}
+    </>
   );
 }
 

--- a/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueFinishedTab.tsx
@@ -70,7 +70,7 @@ export function ManageQueueFinishedTab({
       {tokens.length > 0 ? (
         <>
           {/* Desktop table */}
-          <div className="hidden md:block">
+          <div className="hidden lg:block">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -160,7 +160,7 @@ export function ManageQueueFinishedTab({
           </div>
 
           {/* Mobile card list */}
-          <div className="md:hidden flex flex-col gap-3">
+          <div className="lg:hidden flex flex-col gap-3">
             {tokens.map((token, index) => (
               <FinishedTokenCard
                 key={token.id}
@@ -174,7 +174,7 @@ export function ManageQueueFinishedTab({
           </div>
         </>
       ) : (
-        <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-16 md:py-20 px-4 text-center border border-gray-100">
+        <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-16 lg:py-20 px-4 text-center border border-gray-100">
           <DoorOpenIcon className="size-8 text-gray-700" />
           <span className="text-lg font-semibold text-gray-700">
             {t("no_tokens_finished")}

--- a/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
@@ -24,6 +24,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import { OngoingQueueTokenCardsList } from "@/pages/Facility/queues/OngoingQueueTokenCard";
 import { usePreferredServicePointCategory } from "@/pages/Facility/queues/usePreferredServicePointCategory";
 import { getTokenQueueStatusCount } from "@/pages/Facility/queues/utils";
@@ -59,6 +60,9 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
   });
   const [qParams, setQueryParams] = useQueryParams();
   const { autoRefresh, search, patient, patient_name } = qParams;
+  const [mobileSection, setMobileSection] = useState<"waiting" | "serving">(
+    "waiting",
+  );
   const { data: summary } = useQuery({
     queryKey: ["token-queue-summary", facilityId, queueId],
     queryFn: query(tokenQueueApi.summary, {
@@ -69,13 +73,13 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col sm:flex-row justify-between items-start mt-2 gap-4">
+      <div className="flex flex-col sm:flex-row justify-between items-stretch sm:items-start mt-2 gap-4">
         <div className="flex flex-col gap-2 w-full">
           <Label className="text-gray-950 text-sm font-medium">
             {t("search_patients")}
           </Label>
           <div className="flex flex-col sm:flex-row gap-2">
-            <div className="relative">
+            <div className="relative w-full sm:w-64">
               <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 size-4 text-gray-400" />
               <Input
                 type="search"
@@ -87,7 +91,7 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
                     { overwrite: false, replace: true },
                   )
                 }
-                className="pl-10 w-full sm:w-64 h-9"
+                className="pl-10 w-full h-9"
               />
             </div>
             <PatientIdentifierFilter
@@ -113,7 +117,7 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
             />
           </div>
         </div>
-        <div className="flex flex-col gap-2 w-full sm:items-end">
+        <div className="flex flex-col gap-2 w-full sm:w-auto sm:items-end">
           <Label className="text-gray-950 text-sm font-medium">
             {t("service_points")}
           </Label>
@@ -121,119 +125,161 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
         </div>
       </div>
 
-      <div className="flex space-x-4 overflow-x-auto w-full">
+      {/* Mobile section toggle */}
+      <div className="flex md:hidden rounded-lg bg-gray-100 border border-gray-200 p-1 gap-1">
+        <button
+          type="button"
+          onClick={() => setMobileSection("waiting")}
+          className={cn(
+            "flex-1 text-sm font-medium rounded-md py-2 transition-colors",
+            mobileSection === "waiting"
+              ? "bg-white shadow text-gray-950"
+              : "text-gray-600",
+          )}
+        >
+          {t("waiting")}
+        </button>
+        <button
+          type="button"
+          onClick={() => setMobileSection("serving")}
+          className={cn(
+            "flex-1 text-sm font-medium rounded-md py-2 transition-colors",
+            mobileSection === "serving"
+              ? "bg-white shadow text-gray-950"
+              : "text-gray-600",
+          )}
+        >
+          {t("called_plus_now_serving")}
+        </button>
+      </div>
+
+      <div className="flex flex-col md:flex-row md:space-x-4 gap-4 md:gap-0 md:overflow-x-auto w-full">
         {/* Waiting tokens list */}
-        <QueueColumn title={t("waiting")}>
-          <OngoingQueueTokenCardsList
-            facilityId={facilityId}
-            queueId={queueId}
-            qParams={{
-              sub_queue_is_null: true,
-              status: TokenStatus.CREATED,
-              patient_name: search || "",
-              patient: patient,
-            }}
-            emptyState={
-              <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-10 border border-gray-100">
-                <DoorOpenIcon className="size-6 text-gray-700" />
-                <span className="text-sm font-semibold text-gray-700">
-                  {t("no_patient_is_waiting")}
-                </span>
-              </div>
-            }
-          />
-        </QueueColumn>
+        <div
+          className={cn(
+            "flex flex-col flex-1 min-w-0",
+            mobileSection === "waiting" ? "flex" : "hidden md:flex",
+          )}
+        >
+          <QueueColumn title={t("waiting")}>
+            <OngoingQueueTokenCardsList
+              facilityId={facilityId}
+              queueId={queueId}
+              qParams={{
+                sub_queue_is_null: true,
+                status: TokenStatus.CREATED,
+                patient_name: search || "",
+                patient: patient,
+              }}
+              emptyState={
+                <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-10 border border-gray-100">
+                  <DoorOpenIcon className="size-6 text-gray-700" />
+                  <span className="text-sm font-semibold text-gray-700">
+                    {t("no_patient_is_waiting")}
+                  </span>
+                </div>
+              }
+            />
+          </QueueColumn>
+        </div>
 
         {/* Called + Now Serving tokens list */}
-        <QueueColumn
-          title={t("called_plus_now_serving")}
-          options={
-            summary && (
-              <AwaitingRecallTrigger
-                queueId={queueId}
-                facilityId={facilityId}
-                count={getTokenQueueStatusCount(
-                  summary,
-                  TokenStatus.UNFULFILLED,
-                )}
-              />
-            )
-          }
+        <div
+          className={cn(
+            "flex flex-col flex-1 min-w-0",
+            mobileSection === "serving" ? "flex" : "hidden md:flex",
+          )}
         >
-          <div className="flex flex-col gap-4">
-            {assignedServicePoints.map((subQueue, index) => (
-              <>
-                {index > 0 && (
-                  <hr className="h-px w-full border border-gray-300 border-dashed" />
-                )}
-                <div className="flex flex-col p-1 rounded-lg bg-gray-200">
-                  <div className="flex items-center justify-between p-1 pb-2">
-                    <div className="flex flex-col">
-                      <span className="text-sm font-medium">
-                        {subQueue.name}
-                      </span>
-                      <span className="text-xs">
-                        {t("category")}:{" "}
-                        {preferredServicePointCategories?.[subQueue.id]?.name ??
-                          t("all")}
-                      </span>
+          <QueueColumn
+            title={t("called_plus_now_serving")}
+            options={
+              summary && (
+                <AwaitingRecallTrigger
+                  queueId={queueId}
+                  facilityId={facilityId}
+                  count={getTokenQueueStatusCount(
+                    summary,
+                    TokenStatus.UNFULFILLED,
+                  )}
+                />
+              )
+            }
+          >
+            <div className="flex flex-col gap-4">
+              {assignedServicePoints.map((subQueue, index) => (
+                <div key={subQueue.id} className="flex flex-col gap-4">
+                  {index > 0 && (
+                    <hr className="h-px w-full border border-gray-300 border-dashed" />
+                  )}
+                  <div className="flex flex-col p-1 rounded-lg bg-gray-200">
+                    <div className="flex items-start justify-between gap-2 p-1 pb-2 flex-wrap">
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-sm font-medium truncate">
+                          {subQueue.name}
+                        </span>
+                        <span className="text-xs">
+                          {t("category")}:{" "}
+                          {preferredServicePointCategories?.[subQueue.id]
+                            ?.name ?? t("all")}
+                        </span>
+                      </div>
+                      <InServiceColumnOptions
+                        facilityId={facilityId}
+                        queueId={queueId}
+                        subQueueId={subQueue.id}
+                        tokens={[]}
+                      />
                     </div>
-                    <InServiceColumnOptions
-                      facilityId={facilityId}
-                      queueId={queueId}
-                      subQueueId={subQueue.id}
-                      tokens={[]}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-3">
-                    <div className="flex flex-col gap-1 pt-2">
-                      <span className="text-sm font-medium">
-                        {t("now_serving")}
-                      </span>
+                    <div className="flex flex-col gap-3">
+                      <div className="flex flex-col gap-1 pt-2">
+                        <span className="text-sm font-medium">
+                          {t("now_serving")}
+                        </span>
+                        <OngoingQueueTokenCardsList
+                          facilityId={facilityId}
+                          queueId={queueId}
+                          qParams={{
+                            status: TokenStatus.IN_PROGRESS,
+                            sub_queue: subQueue.id,
+                          }}
+                          emptyState={
+                            <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-3 border border-gray-100">
+                              <DoorOpenIcon className="size-6 text-gray-700" />
+                              <span className="text-sm font-semibold text-gray-700 text-center">
+                                {t("no_patient_is_being_served")}
+                              </span>
+                              <CallNextPatientButton
+                                subQueueId={subQueue.id}
+                                facilityId={facilityId}
+                                queueId={queueId}
+                                variant="outline"
+                                size="lg"
+                              >
+                                <Megaphone />
+                                {t("call_next_patient")}
+                              </CallNextPatientButton>
+                            </div>
+                          }
+                        />
+                      </div>
                       <OngoingQueueTokenCardsList
                         facilityId={facilityId}
                         queueId={queueId}
                         qParams={{
-                          status: TokenStatus.IN_PROGRESS,
+                          status: TokenStatus.CREATED,
                           sub_queue: subQueue.id,
                         }}
-                        emptyState={
-                          <div className="flex flex-col gap-2 items-center justify-center bg-gray-100 rounded-lg py-3 border border-gray-100">
-                            <DoorOpenIcon className="size-6 text-gray-700" />
-                            <span className="text-sm font-semibold text-gray-700">
-                              {t("no_patient_is_being_served")}
-                            </span>
-                            <CallNextPatientButton
-                              subQueueId={subQueue.id}
-                              facilityId={facilityId}
-                              queueId={queueId}
-                              variant="outline"
-                              size="lg"
-                            >
-                              <Megaphone />
-                              {t("call_next_patient")}
-                            </CallNextPatientButton>
-                          </div>
+                        header={
+                          <div className="border border-gray-300 border-dashed" />
                         }
                       />
                     </div>
-                    <OngoingQueueTokenCardsList
-                      facilityId={facilityId}
-                      queueId={queueId}
-                      qParams={{
-                        status: TokenStatus.CREATED,
-                        sub_queue: subQueue.id,
-                      }}
-                      header={
-                        <div className="border border-gray-300 border-dashed" />
-                      }
-                    />
                   </div>
                 </div>
-              </>
-            ))}
-          </div>
-        </QueueColumn>
+              ))}
+            </div>
+          </QueueColumn>
+        </div>
       </div>
     </div>
   );
@@ -249,14 +295,14 @@ export function QueueColumn({
   options?: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-3 p-3 rounded-lg bg-gray-100 border border-gray-200 min-w-xs flex-1">
-      <div className="flex items-center justify-between">
+    <div className="flex flex-col gap-3 p-3 rounded-lg bg-gray-100 border border-gray-200 w-full md:min-w-xs md:flex-1">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
         <div className="flex items-center gap-3">
           <span className="text-sm font-semibold">{title}</span>
         </div>
         {options}
       </div>
-      <div className="h-[calc(100vh-21.5rem)] overflow-y-auto pb-2">
+      <div className="max-h-[65svh] md:h-[calc(100vh-21.5rem)] overflow-y-auto pb-2">
         {children}
       </div>
     </div>
@@ -374,12 +420,12 @@ function AwaitingRecallTrigger({
         <Button
           variant="link"
           size="lg"
-          className="underline font-semibold"
+          className="underline font-semibold px-1 sm:px-3"
           disabled={count === 0}
           onClick={() => setShowAwaitingRecallDialog(true)}
         >
           <EyeIcon />
-          <span>{t("awaiting_recall")}</span>
+          <span className="hidden sm:inline">{t("awaiting_recall")}</span>
         </Button>
         <div>
           <Badge size="sm">{count}</Badge>
@@ -457,7 +503,7 @@ function AwaitingRecallDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+      <DialogContent className="w-[95vw] max-w-2xl max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>{t("awaiting_recall")}</DialogTitle>
         </DialogHeader>

--- a/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -126,32 +127,22 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
       </div>
 
       {/* Mobile section toggle */}
-      <div className="flex md:hidden rounded-lg bg-gray-100 border border-gray-200 p-1 gap-1">
-        <button
-          type="button"
-          onClick={() => setMobileSection("waiting")}
-          className={cn(
-            "flex-1 text-sm font-medium rounded-md py-2 transition-colors",
-            mobileSection === "waiting"
-              ? "bg-white shadow text-gray-950"
-              : "text-gray-600",
-          )}
-        >
-          {t("waiting")}
-        </button>
-        <button
-          type="button"
-          onClick={() => setMobileSection("serving")}
-          className={cn(
-            "flex-1 text-sm font-medium rounded-md py-2 transition-colors",
-            mobileSection === "serving"
-              ? "bg-white shadow text-gray-950"
-              : "text-gray-600",
-          )}
-        >
-          {t("called_plus_now_serving")}
-        </button>
-      </div>
+      <Tabs
+        value={mobileSection}
+        onValueChange={(value) =>
+          setMobileSection(value as "waiting" | "serving")
+        }
+        className="md:hidden"
+      >
+        <TabsList className="w-full">
+          <TabsTrigger value="waiting" className="flex-1">
+            {t("waiting")}
+          </TabsTrigger>
+          <TabsTrigger value="serving" className="flex-1">
+            {t("called_plus_now_serving")}
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
 
       <div className="flex flex-col md:flex-row md:space-x-4 gap-4 md:gap-0 md:overflow-x-auto w-full">
         {/* Waiting tokens list */}

--- a/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
@@ -118,6 +118,7 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
             patientName={patient_name}
             qParams={qParams}
             setQueryParams={setQueryParams}
+            hideSearchLabel
           />
         </CollapsibleContent>
       </Collapsible>
@@ -289,6 +290,7 @@ function FilterControls({
   patientName,
   qParams,
   setQueryParams,
+  hideSearchLabel,
 }: {
   search: string | undefined;
   patient: string | undefined;
@@ -298,14 +300,17 @@ function FilterControls({
     params: Record<string, string | undefined>,
     options?: { overwrite?: boolean; replace?: boolean },
   ) => void;
+  hideSearchLabel?: boolean;
 }) {
   const { t } = useTranslation();
   return (
     <>
       <div className="flex flex-col gap-2 w-full">
-        <Label className="text-gray-950 text-sm font-medium">
-          {t("search_patients")}
-        </Label>
+        {!hideSearchLabel && (
+          <Label className="text-gray-950 text-sm font-medium">
+            {t("search_patients")}
+          </Label>
+        )}
         <div className="flex flex-col sm:flex-row gap-2">
           <div className="relative w-full sm:w-64">
             <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 size-4 text-gray-400" />
@@ -346,7 +351,7 @@ function FilterControls({
           />
         </div>
       </div>
-      <div className="flex flex-col gap-2 w-full lg:w-auto lg:max-w-[55%] lg:items-end min-w-0">
+      <div className="pt-3 lg:pt-0 flex flex-col gap-2 w-full lg:w-auto lg:max-w-[55%] lg:items-end min-w-0">
         <Label className="text-gray-950 text-sm font-medium">
           {t("service_points")}
         </Label>

--- a/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
@@ -74,7 +74,7 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col sm:flex-row justify-between items-stretch sm:items-start mt-2 gap-4">
+      <div className="flex flex-col lg:flex-row justify-between items-stretch lg:items-start mt-2 gap-4">
         <div className="flex flex-col gap-2 w-full">
           <Label className="text-gray-950 text-sm font-medium">
             {t("search_patients")}
@@ -118,7 +118,7 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
             />
           </div>
         </div>
-        <div className="flex flex-col gap-2 w-full sm:w-auto sm:items-end">
+        <div className="flex flex-col gap-2 w-full lg:w-auto lg:max-w-[55%] lg:items-end min-w-0">
           <Label className="text-gray-950 text-sm font-medium">
             {t("service_points")}
           </Label>
@@ -126,13 +126,13 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
         </div>
       </div>
 
-      {/* Mobile section toggle */}
+      {/* Mobile/tablet section toggle */}
       <Tabs
         value={mobileSection}
         onValueChange={(value) =>
           setMobileSection(value as "waiting" | "serving")
         }
-        className="md:hidden"
+        className="lg:hidden"
       >
         <TabsList className="w-full">
           <TabsTrigger value="waiting" className="flex-1">
@@ -144,12 +144,12 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
         </TabsList>
       </Tabs>
 
-      <div className="flex flex-col md:flex-row md:space-x-4 gap-4 md:gap-0 md:overflow-x-auto w-full">
+      <div className="flex flex-col lg:flex-row lg:space-x-4 gap-4 lg:gap-0 lg:overflow-x-auto w-full">
         {/* Waiting tokens list */}
         <div
           className={cn(
             "flex flex-col flex-1 min-w-0",
-            mobileSection === "waiting" ? "flex" : "hidden md:flex",
+            mobileSection === "waiting" ? "flex" : "hidden lg:flex",
           )}
         >
           <QueueColumn title={t("waiting")}>
@@ -178,7 +178,7 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
         <div
           className={cn(
             "flex flex-col flex-1 min-w-0",
-            mobileSection === "serving" ? "flex" : "hidden md:flex",
+            mobileSection === "serving" ? "flex" : "hidden lg:flex",
           )}
         >
           <QueueColumn
@@ -286,14 +286,14 @@ export function QueueColumn({
   options?: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-3 p-3 rounded-lg bg-gray-100 border border-gray-200 w-full md:min-w-xs md:flex-1">
+    <div className="flex flex-col gap-3 p-3 rounded-lg bg-gray-100 border border-gray-200 w-full lg:min-w-xs lg:flex-1">
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <div className="flex items-center gap-3">
           <span className="text-sm font-semibold">{title}</span>
         </div>
         {options}
       </div>
-      <div className="max-h-[65svh] md:h-[calc(100vh-21.5rem)] overflow-y-auto pb-2">
+      <div className="max-h-[65svh] lg:h-[calc(100vh-21.5rem)] overflow-y-auto pb-2">
         {children}
       </div>
     </div>

--- a/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
+++ b/src/pages/Facility/queues/ManageQueueOngoingTab.tsx
@@ -3,6 +3,11 @@ import { useScheduleResourceFromPath } from "@/components/Schedule/useScheduleRe
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -36,11 +41,13 @@ import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  ChevronDownIcon,
   DoorOpenIcon,
   EyeIcon,
   Megaphone,
   SearchIcon,
   SettingsIcon,
+  SlidersHorizontalIcon,
 } from "lucide-react";
 import { useQueryParams } from "raviger";
 import { useState } from "react";
@@ -64,6 +71,8 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
   const [mobileSection, setMobileSection] = useState<"waiting" | "serving">(
     "waiting",
   );
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const activeFilterCount = [search, patient].filter(Boolean).length;
   const { data: summary } = useQuery({
     queryKey: ["token-queue-summary", facilityId, queueId],
     queryFn: query(tokenQueueApi.summary, {
@@ -74,56 +83,54 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col lg:flex-row justify-between items-stretch lg:items-start mt-2 gap-4">
-        <div className="flex flex-col gap-2 w-full">
-          <Label className="text-gray-950 text-sm font-medium">
-            {t("search_patients")}
-          </Label>
-          <div className="flex flex-col sm:flex-row gap-2">
-            <div className="relative w-full sm:w-64">
-              <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 size-4 text-gray-400" />
-              <Input
-                type="search"
-                placeholder={t("search_by_patient_name")}
-                value={search || ""}
-                onChange={(e) =>
-                  setQueryParams(
-                    { search: e.target.value || "" },
-                    { overwrite: false, replace: true },
-                  )
-                }
-                className="pl-10 w-full h-9"
-              />
-            </div>
-            <PatientIdentifierFilter
-              onSelect={(patientId, patientName) => {
-                if (patientId && patientName) {
-                  setQueryParams(
-                    {
-                      patient: patientId,
-                      patient_name: patientName,
-                    },
-                    { overwrite: false, replace: true },
-                  );
-                } else {
-                  delete qParams.patient;
-                  delete qParams.patient_name;
-                  setQueryParams(qParams, { replace: true });
-                }
-              }}
-              placeholder={t("filter_by_identifier")}
-              className="w-full sm:w-auto rounded-md h-9 text-gray-500 shadow-sm"
-              patientId={patient}
-              patientName={patient_name}
+      {/* Mobile/tablet: collapsible filter trigger */}
+      <Collapsible
+        open={filtersOpen}
+        onOpenChange={setFiltersOpen}
+        className="lg:hidden"
+      >
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="outline"
+            className="w-full justify-between h-9 text-sm font-medium"
+          >
+            <span className="flex items-center gap-2">
+              <SlidersHorizontalIcon className="size-4" />
+              {t("search_patients")}
+              {activeFilterCount > 0 && (
+                <Badge variant="primary" size="sm">
+                  {activeFilterCount}
+                </Badge>
+              )}
+            </span>
+            <ChevronDownIcon
+              className={cn(
+                "size-4 transition-transform",
+                filtersOpen && "rotate-180",
+              )}
             />
-          </div>
-        </div>
-        <div className="flex flex-col gap-2 w-full lg:w-auto lg:max-w-[55%] lg:items-end min-w-0">
-          <Label className="text-gray-950 text-sm font-medium">
-            {t("service_points")}
-          </Label>
-          <ServicePointsDropDown />
-        </div>
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-3">
+          <FilterControls
+            search={search}
+            patient={patient}
+            patientName={patient_name}
+            qParams={qParams}
+            setQueryParams={setQueryParams}
+          />
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Desktop: inline filters */}
+      <div className="hidden lg:flex flex-col lg:flex-row justify-between items-stretch lg:items-start mt-2 gap-4">
+        <FilterControls
+          search={search}
+          patient={patient}
+          patientName={patient_name}
+          qParams={qParams}
+          setQueryParams={setQueryParams}
+        />
       </div>
 
       {/* Mobile/tablet section toggle */}
@@ -276,6 +283,79 @@ export function ManageQueueOngoingTab({ facilityId, queueId }: Props) {
   );
 }
 
+function FilterControls({
+  search,
+  patient,
+  patientName,
+  qParams,
+  setQueryParams,
+}: {
+  search: string | undefined;
+  patient: string | undefined;
+  patientName: string | undefined;
+  qParams: Record<string, string | undefined>;
+  setQueryParams: (
+    params: Record<string, string | undefined>,
+    options?: { overwrite?: boolean; replace?: boolean },
+  ) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <div className="flex flex-col gap-2 w-full">
+        <Label className="text-gray-950 text-sm font-medium">
+          {t("search_patients")}
+        </Label>
+        <div className="flex flex-col sm:flex-row gap-2">
+          <div className="relative w-full sm:w-64">
+            <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 size-4 text-gray-400" />
+            <Input
+              type="search"
+              placeholder={t("search_by_patient_name")}
+              value={search || ""}
+              onChange={(e) =>
+                setQueryParams(
+                  { search: e.target.value || "" },
+                  { overwrite: false, replace: true },
+                )
+              }
+              className="pl-10 w-full h-9"
+            />
+          </div>
+          <PatientIdentifierFilter
+            onSelect={(patientId, patientNameVal) => {
+              if (patientId && patientNameVal) {
+                setQueryParams(
+                  {
+                    patient: patientId,
+                    patient_name: patientNameVal,
+                  },
+                  { overwrite: false, replace: true },
+                );
+              } else {
+                const next = { ...qParams };
+                delete next.patient;
+                delete next.patient_name;
+                setQueryParams(next, { replace: true });
+              }
+            }}
+            placeholder={t("filter_by_identifier")}
+            className="w-full sm:w-auto rounded-md h-9 text-gray-500 shadow-sm"
+            patientId={patient}
+            patientName={patientName}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2 w-full lg:w-auto lg:max-w-[55%] lg:items-end min-w-0">
+        <Label className="text-gray-950 text-sm font-medium">
+          {t("service_points")}
+        </Label>
+        <ServicePointsDropDown />
+      </div>
+    </>
+  );
+}
+
 export function QueueColumn({
   title,
   children,
@@ -293,7 +373,7 @@ export function QueueColumn({
         </div>
         {options}
       </div>
-      <div className="max-h-[65svh] lg:h-[calc(100vh-21.5rem)] overflow-y-auto pb-2">
+      <div className="lg:h-[calc(100vh-21.5rem)] lg:overflow-y-auto pb-2">
         {children}
       </div>
     </div>

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -7,6 +7,13 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { CancelTokenDialog } from "@/pages/Facility/queues/CancelTokenDialog";
@@ -34,11 +41,197 @@ import {
   TicketCheck,
 } from "lucide-react";
 import { Link } from "raviger";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useInView } from "react-intersection-observer";
 import { toast } from "sonner";
 import { useTokenListInfiniteQuery } from "./utils";
+
+interface TokenActionItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  onSelect: () => void;
+  danger?: boolean;
+  separatorBefore?: boolean;
+}
+
+function useTokenActions({
+  facilityId,
+  token,
+  onCancelClick,
+}: {
+  facilityId: string;
+  token: TokenRead;
+  onCancelClick: () => void;
+}): TokenActionItem[] {
+  const { t } = useTranslation();
+  const { assignedServicePoints } = useQueueServicePoints();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateToken } = useMutation({
+    mutationFn: mutate(tokenApi.update, {
+      pathParams: {
+        facility_id: facilityId,
+        queue_id: token.queue.id,
+        id: token.id,
+      },
+    }),
+    onSuccess: (data: TokenRead) => {
+      queryClient.invalidateQueries({
+        queryKey: ["infinite-tokens", facilityId, token.queue.id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["token-queue-summary", facilityId, token.queue.id],
+      });
+      if (data.status === TokenStatus.FULFILLED) {
+        toast.success(t("token_has_been_completed"));
+      }
+    },
+  });
+
+  const items: TokenActionItem[] = [];
+
+  if (token.status === TokenStatus.CREATED && token.sub_queue) {
+    items.push({
+      key: "mark_as_now_serving",
+      label: t("mark_as_now_serving"),
+      icon: <CircleDot className="size-4 mr-2" />,
+      onSelect: () =>
+        updateToken({
+          status: TokenStatus.IN_PROGRESS,
+          note: token.note,
+          sub_queue: token.sub_queue?.id || null,
+        }),
+    });
+  }
+
+  if (token.status === TokenStatus.IN_PROGRESS) {
+    items.push(
+      {
+        key: "move_to_calling",
+        label: t("move_to_calling"),
+        icon: <Megaphone className="size-4 mr-2" />,
+        onSelect: () =>
+          updateToken({
+            status: TokenStatus.CREATED,
+            note: token.note,
+            sub_queue: token.sub_queue?.id || null,
+          }),
+      },
+      {
+        key: "move_to_awaiting_recall_in_progress",
+        label: t("move_to_awaiting_recall"),
+        icon: <BringToFront className="size-4 mr-2" />,
+        onSelect: () =>
+          updateToken({
+            status: TokenStatus.UNFULFILLED,
+            note: token.note,
+            sub_queue: null,
+          }),
+      },
+    );
+  }
+
+  if (token.sub_queue) {
+    items.push({
+      key: "move_to_waiting",
+      label: t("move_to_waiting"),
+      icon: <RotateCcw className="size-4 mr-2" />,
+      onSelect: () =>
+        updateToken({
+          status: TokenStatus.CREATED,
+          note: token.note,
+          sub_queue: null,
+        }),
+    });
+  }
+
+  assignedServicePoints
+    .filter((service) => service.id !== token.sub_queue?.id)
+    .forEach((service) => {
+      items.push({
+        key: `assign_${service.id}`,
+        label: token.sub_queue
+          ? t("reassign_service_point", { name: service.name })
+          : t("mark_as_in_service", { name: service.name }),
+        icon: token.sub_queue ? (
+          <RedoDot className="size-4 mr-2" />
+        ) : (
+          <TicketCheck className="size-4 mr-2" />
+        ),
+        onSelect: () =>
+          updateToken({
+            status: TokenStatus.IN_PROGRESS,
+            note: token.note,
+            sub_queue: service.id,
+          }),
+      });
+    });
+
+  assignedServicePoints
+    .filter((service) => service.id !== token.sub_queue?.id)
+    .forEach((service) => {
+      items.push({
+        key: `call_to_${service.id}`,
+        label: t("call_to", { name: service.name }),
+        icon: <Megaphone className="size-4 mr-2" />,
+        onSelect: () =>
+          updateToken({
+            status: TokenStatus.CREATED,
+            note: token.note,
+            sub_queue: service.id,
+          }),
+      });
+    });
+
+  items.push({
+    key: "mark_as_complete",
+    label: t("mark_as_complete"),
+    icon: <Check className="size-4 mr-2" />,
+    onSelect: () =>
+      updateToken({
+        status: TokenStatus.FULFILLED,
+        note: token.note,
+        sub_queue: token.sub_queue?.id || null,
+      }),
+  });
+
+  const cancellable = ![
+    TokenStatus.CANCELLED,
+    TokenStatus.ENTERED_IN_ERROR,
+    TokenStatus.FULFILLED,
+  ].includes(token.status);
+
+  if (cancellable) {
+    items.push({
+      key: "cancel_token",
+      label: t("cancel_token"),
+      icon: <OctagonX className="size-4 mr-2 text-danger-700" />,
+      onSelect: onCancelClick,
+      danger: true,
+      separatorBefore: true,
+    });
+  }
+
+  if (token.status !== TokenStatus.ENTERED_IN_ERROR) {
+    items.push({
+      key: "mark_as_entered_in_error",
+      label: t("mark_as_entered_in_error"),
+      icon: <OctagonX className="size-4 mr-2 text-danger-700" />,
+      onSelect: () =>
+        updateToken({
+          status: TokenStatus.ENTERED_IN_ERROR,
+          note: token.note,
+          sub_queue: null,
+        }),
+      danger: true,
+      separatorBefore: !cancellable,
+    });
+  }
+
+  return items;
+}
 
 export function OngoingQueueTokenCard({
   facilityId,
@@ -50,276 +243,146 @@ export function OngoingQueueTokenCard({
   options?: React.ReactNode;
 }) {
   const { t } = useTranslation();
-  const contextMenuTriggerRef = useRef<HTMLDivElement>(null);
-  const queryClient = useQueryClient();
-  const { assignedServicePoints } = useQueueServicePoints();
-
   const [showCancelDialog, setShowCancelDialog] = useState(false);
 
-  const { mutate: updateToken } = useMutation({
-    mutationFn: mutate(tokenApi.update, {
-      pathParams: {
-        facility_id: facilityId,
-        queue_id: token?.queue.id ?? "",
-        id: token?.id ?? "",
-      },
-    }),
-    onSuccess: (data: TokenRead) => {
-      queryClient.invalidateQueries({
-        queryKey: ["infinite-tokens", facilityId, token?.queue.id ?? ""],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["token-queue-summary", facilityId, token?.queue.id ?? ""],
-      });
+  if (!token) {
+    return (
+      <div className="flex flex-col gap-2 p-3 bg-gray-50 rounded-lg shadow">
+        <Skeleton className="h-4 w-36 my-2" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+    );
+  }
 
-      if (data.status === TokenStatus.FULFILLED) {
-        toast.success(t("token_has_been_completed"));
-        return;
-      }
-    },
+  return (
+    <OngoingQueueTokenCardInner
+      facilityId={facilityId}
+      token={token}
+      options={options}
+      showCancelDialog={showCancelDialog}
+      setShowCancelDialog={setShowCancelDialog}
+      t={t}
+    />
+  );
+}
+
+function OngoingQueueTokenCardInner({
+  facilityId,
+  token,
+  options,
+  showCancelDialog,
+  setShowCancelDialog,
+  t,
+}: {
+  facilityId: string;
+  token: TokenRead;
+  options?: React.ReactNode;
+  showCancelDialog: boolean;
+  setShowCancelDialog: (open: boolean) => void;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  const actions = useTokenActions({
+    facilityId,
+    token,
+    onCancelClick: () => setShowCancelDialog(true),
   });
+
+  const renderItem = (
+    item: TokenActionItem,
+    Item: typeof ContextMenuItem | typeof DropdownMenuItem,
+    Separator: typeof ContextMenuSeparator | typeof DropdownMenuSeparator,
+  ) => (
+    <span key={item.key}>
+      {item.separatorBefore && <Separator />}
+      <Item onClick={item.onSelect}>
+        {item.icon}
+        <span className={item.danger ? "text-danger-700" : undefined}>
+          {item.label}
+        </span>
+      </Item>
+    </span>
+  );
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger ref={contextMenuTriggerRef}>
+      <ContextMenuTrigger>
         <div
           className={cn(
-            "relative flex flex-col md:flex-row gap-1 md:gap-3 items-start md:items-center justify-between p-3 bg-gray-50 rounded-lg shadow",
-            token?.status === TokenStatus.IN_PROGRESS &&
+            "relative flex flex-col md:flex-row gap-2 md:gap-3 items-stretch md:items-center justify-between p-3 bg-gray-50 rounded-lg shadow",
+            token.status === TokenStatus.IN_PROGRESS &&
               "border border-primary-500",
           )}
         >
-          <div className="w-full md:w-auto">
-            {token ? (
-              <Link
-                basePath="/"
-                href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
-                className="font-semibold hover:underline transition-colors"
-              >
-                <span className="font-semibold flex items-center gap-1">
+          <div className="flex items-center justify-between gap-2 md:w-auto w-full min-w-0">
+            <Link
+              basePath="/"
+              href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
+              className="font-semibold hover:underline transition-colors min-w-0"
+            >
+              <span className="font-semibold flex items-center gap-1 min-w-0">
+                <span className="truncate">
                   {token.patient
                     ? token.patient.name
                     : renderTokenNumber(token)}
-                  <ExternalLink className="size-4" />
                 </span>
-              </Link>
-            ) : (
-              <Skeleton className="h-4 w-36 my-2" />
-            )}
-            {/* TODO: do we show tags here? or something else? */}
-          </div>
-          <div className="flex w-full md:w-auto items-center gap-3 mt-1">
-            {token ? (
-              <>
-                <Button variant="outline" asChild>
-                  <Link
-                    basePath="/"
-                    href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
-                  >
-                    {t("encounter")}
-                  </Link>
+                <ExternalLink className="size-4 shrink-0" />
+              </span>
+            </Link>
+            {/* Kebab (visible on all sizes as primary action trigger) */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={t("actions")}
+                  onClick={(e) => e.preventDefault()}
+                >
+                  <MoreHorizontal className="size-4" />
                 </Button>
-                <div className="flex gap-2 items-center justify-center p-1 bg-gray-100 border border-gray-200 rounded-lg">
-                  <Badge
-                    variant={
-                      QUEUE_TOKEN_STATUS_COLORS[getQueueTokenStatus(token)]
-                    }
-                    className="h-2 w-2 rounded-full p-0 border"
-                  />
-
-                  <span className="text-base font-medium text-black">
-                    {t(`token_status__${getQueueTokenStatus(token)}`)}:
-                  </span>
-
-                  <span className="text-lg font-bold text-black">
-                    {renderTokenNumber(token)}
-                  </span>
-                </div>
-                {options}
-                <div className="ml-auto">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      const rect = e.currentTarget.getBoundingClientRect();
-                      const x = rect.left + rect.width / 2;
-                      const y = rect.bottom;
-                      contextMenuTriggerRef.current?.dispatchEvent(
-                        new MouseEvent("contextmenu", {
-                          bubbles: true,
-                          cancelable: true,
-                          clientX: x,
-                          clientY: y,
-                        }),
-                      );
-                    }}
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </div>
-              </>
-            ) : (
-              <Skeleton className="h-12 w-20" />
-            )}
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[220px]">
+                {actions.map((item) =>
+                  renderItem(item, DropdownMenuItem, DropdownMenuSeparator),
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="flex w-full md:w-auto items-center flex-wrap gap-2 md:gap-3">
+            <Button variant="outline" asChild size="sm">
+              <Link
+                basePath="/"
+                href={`/facility/${facilityId}/queue/${token.queue.id}/token/${token.id}`}
+              >
+                {t("encounter")}
+              </Link>
+            </Button>
+            <div className="flex gap-2 items-center justify-center p-1 bg-gray-100 border border-gray-200 rounded-lg">
+              <Badge
+                variant={QUEUE_TOKEN_STATUS_COLORS[getQueueTokenStatus(token)]}
+                className="h-2 w-2 rounded-full p-0 border"
+              />
+              <span className="text-sm sm:text-base font-medium text-black">
+                {t(`token_status__${getQueueTokenStatus(token)}`)}:
+              </span>
+              <span className="text-base sm:text-lg font-bold text-black">
+                {renderTokenNumber(token)}
+              </span>
+            </div>
+            {options}
           </div>
         </div>
       </ContextMenuTrigger>
-      {token && (
-        <>
-          <ContextMenuContent collisionPadding={8} avoidCollisions={true}>
-            {token.status === TokenStatus.CREATED && token.sub_queue && (
-              <>
-                <ContextMenuItem
-                  onClick={() =>
-                    updateToken({
-                      status: TokenStatus.IN_PROGRESS,
-                      note: token.note,
-                      sub_queue: token.sub_queue?.id || null,
-                    })
-                  }
-                >
-                  <CircleDot className="size-4 mr-2" />
-                  {t("mark_as_now_serving")}
-                </ContextMenuItem>
-              </>
-            )}
-            {token.status === TokenStatus.IN_PROGRESS && (
-              <>
-                <ContextMenuItem
-                  onClick={() =>
-                    updateToken({
-                      status: TokenStatus.CREATED,
-                      note: token.note,
-                      sub_queue: token.sub_queue?.id || null,
-                    })
-                  }
-                >
-                  <Megaphone className="size-4 mr-2" />
-                  {t("move_to_calling")}
-                </ContextMenuItem>
-                <ContextMenuItem
-                  onClick={() =>
-                    updateToken({
-                      status: TokenStatus.UNFULFILLED,
-                      note: token.note,
-                      sub_queue: null,
-                    })
-                  }
-                >
-                  <BringToFront className="size-4 mr-2" />
-                  {t("move_to_awaiting_recall")}
-                </ContextMenuItem>
-              </>
-            )}
-            {token.sub_queue && (
-              <ContextMenuItem
-                onClick={() =>
-                  updateToken({
-                    status: TokenStatus.CREATED,
-                    note: token.note,
-                    sub_queue: null,
-                  })
-                }
-              >
-                <RotateCcw className="size-4 mr-2" />
-                {t("move_to_waiting")}
-              </ContextMenuItem>
-            )}
+      <ContextMenuContent collisionPadding={8} avoidCollisions>
+        {actions.map((item) =>
+          renderItem(item, ContextMenuItem, ContextMenuSeparator),
+        )}
+      </ContextMenuContent>
 
-            {assignedServicePoints
-              .filter((service) => service.id !== token.sub_queue?.id)
-              .map((service) => (
-                <ContextMenuItem
-                  key={service.id}
-                  onClick={() =>
-                    updateToken({
-                      status: TokenStatus.IN_PROGRESS,
-                      note: token.note,
-                      sub_queue: service.id,
-                    })
-                  }
-                >
-                  {token.sub_queue ? (
-                    <RedoDot className="size-4 mr-2" />
-                  ) : (
-                    <TicketCheck className="size-4 mr-2" />
-                  )}
-                  {token.sub_queue
-                    ? t("reassign_service_point", { name: service.name })
-                    : t("mark_as_in_service", { name: service.name })}
-                </ContextMenuItem>
-              ))}
-
-            {assignedServicePoints
-              .filter((service) => service.id !== token.sub_queue?.id)
-              .map((service) => (
-                <ContextMenuItem
-                  key={service.id}
-                  onClick={() =>
-                    updateToken({
-                      status: TokenStatus.CREATED,
-                      note: token.note,
-                      sub_queue: service.id,
-                    })
-                  }
-                >
-                  <Megaphone className="size-4 mr-2" />
-                  {t("call_to", { name: service.name })}
-                </ContextMenuItem>
-              ))}
-
-            <ContextMenuItem
-              onClick={() =>
-                updateToken({
-                  status: TokenStatus.FULFILLED,
-                  note: token.note,
-                  sub_queue: token.sub_queue?.id || null,
-                })
-              }
-            >
-              <Check className="size-4 mr-2" />
-              {t("mark_as_complete")}
-            </ContextMenuItem>
-
-            <ContextMenuSeparator />
-            {/* Cancel Token */}
-            {![
-              TokenStatus.CANCELLED,
-              TokenStatus.ENTERED_IN_ERROR,
-              TokenStatus.FULFILLED,
-            ].includes(token.status) && (
-              <ContextMenuItem onClick={() => setShowCancelDialog(true)}>
-                <OctagonX className="size-4 mr-2 text-danger-700" />
-                <span className="text-danger-700">{t("cancel_token")}</span>
-              </ContextMenuItem>
-            )}
-
-            {token.status !== TokenStatus.ENTERED_IN_ERROR && (
-              <ContextMenuItem
-                onClick={() =>
-                  updateToken({
-                    status: TokenStatus.ENTERED_IN_ERROR,
-                    note: token.note,
-                    sub_queue: null,
-                  })
-                }
-              >
-                <OctagonX className="size-4 mr-2 text-danger-700" />
-                <span className="text-danger-700">
-                  {t("mark_as_entered_in_error")}
-                </span>
-              </ContextMenuItem>
-            )}
-          </ContextMenuContent>
-
-          <CancelTokenDialog
-            open={showCancelDialog}
-            onOpenChange={setShowCancelDialog}
-            token={token}
-          />
-        </>
-      )}
+      <CancelTokenDialog
+        open={showCancelDialog}
+        onOpenChange={setShowCancelDialog}
+        token={token}
+      />
     </ContextMenu>
   );
 }

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -147,43 +147,43 @@ function useTokenActions({
     });
   }
 
-  assignedServicePoints
-    .filter((service) => service.id !== token.sub_queue?.id)
-    .forEach((service) => {
-      items.push({
-        key: `assign_${service.id}`,
-        label: token.sub_queue
-          ? t("reassign_service_point", { name: service.name })
-          : t("mark_as_in_service", { name: service.name }),
-        icon: token.sub_queue ? (
-          <RedoDot className="size-4 mr-2" />
-        ) : (
-          <TicketCheck className="size-4 mr-2" />
-        ),
-        onSelect: () =>
-          updateToken({
-            status: TokenStatus.IN_PROGRESS,
-            note: token.note,
-            sub_queue: service.id,
-          }),
-      });
-    });
+  const otherServicePoints = assignedServicePoints.filter(
+    (service) => service.id !== token.sub_queue?.id,
+  );
 
-  assignedServicePoints
-    .filter((service) => service.id !== token.sub_queue?.id)
-    .forEach((service) => {
-      items.push({
-        key: `call_to_${service.id}`,
-        label: t("call_to", { name: service.name }),
-        icon: <Megaphone className="size-4 mr-2" />,
-        onSelect: () =>
-          updateToken({
-            status: TokenStatus.CREATED,
-            note: token.note,
-            sub_queue: service.id,
-          }),
-      });
+  otherServicePoints.forEach((service) => {
+    items.push({
+      key: `assign_${service.id}`,
+      label: token.sub_queue
+        ? t("reassign_service_point", { name: service.name })
+        : t("mark_as_in_service", { name: service.name }),
+      icon: token.sub_queue ? (
+        <RedoDot className="size-4 mr-2" />
+      ) : (
+        <TicketCheck className="size-4 mr-2" />
+      ),
+      onSelect: () =>
+        updateToken({
+          status: TokenStatus.IN_PROGRESS,
+          note: token.note,
+          sub_queue: service.id,
+        }),
     });
+  });
+
+  otherServicePoints.forEach((service) => {
+    items.push({
+      key: `call_to_${service.id}`,
+      label: t("call_to", { name: service.name }),
+      icon: <Megaphone className="size-4 mr-2" />,
+      onSelect: () =>
+        updateToken({
+          status: TokenStatus.CREATED,
+          note: token.note,
+          sub_queue: service.id,
+        }),
+    });
+  });
 
   items.push({
     key: "mark_as_complete",
@@ -294,7 +294,7 @@ function OngoingQueueTokenCardInner({
   ) => (
     <span key={item.key}>
       {item.separatorBefore && <Separator />}
-      <Item onClick={item.onSelect}>
+      <Item onSelect={item.onSelect}>
         {item.icon}
         <span className={item.danger ? "text-danger-700" : undefined}>
           {item.label}
@@ -331,12 +331,7 @@ function OngoingQueueTokenCardInner({
             {/* Kebab (visible on all sizes as primary action trigger) */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label={t("actions")}
-                  onClick={(e) => e.preventDefault()}
-                >
+                <Button variant="ghost" size="icon" aria-label={t("actions")}>
                   <MoreHorizontal className="size-4" />
                 </Button>
               </DropdownMenuTrigger>

--- a/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
+++ b/src/pages/Facility/queues/OngoingQueueTokenCard.tsx
@@ -1,3 +1,4 @@
+import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -60,10 +61,12 @@ function useTokenActions({
   facilityId,
   token,
   onCancelClick,
+  onEnteredInErrorClick,
 }: {
   facilityId: string;
   token: TokenRead;
   onCancelClick: () => void;
+  onEnteredInErrorClick: () => void;
 }): TokenActionItem[] {
   const { t } = useTranslation();
   const { assignedServicePoints } = useQueueServicePoints();
@@ -219,12 +222,7 @@ function useTokenActions({
       key: "mark_as_entered_in_error",
       label: t("mark_as_entered_in_error"),
       icon: <OctagonX className="size-4 mr-2 text-danger-700" />,
-      onSelect: () =>
-        updateToken({
-          status: TokenStatus.ENTERED_IN_ERROR,
-          note: token.note,
-          sub_queue: null,
-        }),
+      onSelect: onEnteredInErrorClick,
       danger: true,
       separatorBefore: !cancellable,
     });
@@ -244,6 +242,8 @@ export function OngoingQueueTokenCard({
 }) {
   const { t } = useTranslation();
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showEnteredInErrorDialog, setShowEnteredInErrorDialog] =
+    useState(false);
 
   if (!token) {
     return (
@@ -261,6 +261,8 @@ export function OngoingQueueTokenCard({
       options={options}
       showCancelDialog={showCancelDialog}
       setShowCancelDialog={setShowCancelDialog}
+      showEnteredInErrorDialog={showEnteredInErrorDialog}
+      setShowEnteredInErrorDialog={setShowEnteredInErrorDialog}
       t={t}
     />
   );
@@ -272,6 +274,8 @@ function OngoingQueueTokenCardInner({
   options,
   showCancelDialog,
   setShowCancelDialog,
+  showEnteredInErrorDialog,
+  setShowEnteredInErrorDialog,
   t,
 }: {
   facilityId: string;
@@ -279,12 +283,15 @@ function OngoingQueueTokenCardInner({
   options?: React.ReactNode;
   showCancelDialog: boolean;
   setShowCancelDialog: (open: boolean) => void;
+  showEnteredInErrorDialog: boolean;
+  setShowEnteredInErrorDialog: (open: boolean) => void;
   t: (key: string, options?: Record<string, unknown>) => string;
 }) {
   const actions = useTokenActions({
     facilityId,
     token,
     onCancelClick: () => setShowCancelDialog(true),
+    onEnteredInErrorClick: () => setShowEnteredInErrorDialog(true),
   });
 
   const renderItem = (
@@ -378,7 +385,70 @@ function OngoingQueueTokenCardInner({
         onOpenChange={setShowCancelDialog}
         token={token}
       />
+      <EnteredInErrorDialog
+        open={showEnteredInErrorDialog}
+        onOpenChange={setShowEnteredInErrorDialog}
+        facilityId={facilityId}
+        token={token}
+      />
     </ContextMenu>
+  );
+}
+
+function EnteredInErrorDialog({
+  open,
+  onOpenChange,
+  facilityId,
+  token,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  facilityId: string;
+  token: TokenRead;
+}) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateToken, isPending } = useMutation({
+    mutationFn: mutate(tokenApi.update, {
+      pathParams: {
+        facility_id: facilityId,
+        queue_id: token.queue.id,
+        id: token.id,
+      },
+    }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["infinite-tokens", facilityId, token.queue.id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["token-queue-summary", facilityId, token.queue.id],
+      });
+      onOpenChange(false);
+    },
+  });
+
+  return (
+    <ConfirmActionDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t("mark_as_entered_in_error")}
+      description={t("mark_as_entered_in_error_confirmation", {
+        patientName: token.patient?.name,
+        tokenNumber: renderTokenNumber(token),
+      })}
+      onConfirm={() =>
+        updateToken({
+          status: TokenStatus.ENTERED_IN_ERROR,
+          note: token.note,
+          sub_queue: null,
+        })
+      }
+      cancelText={t("cancel")}
+      confirmText={t("mark_as_entered_in_error")}
+      variant="destructive"
+      disabled={isPending}
+    />
   );
 }
 

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -39,98 +39,98 @@ export const ServicePointsDropDown = () => {
   ).length;
 
   return (
-    <div className="flex w-full sm:w-auto">
-      <div className="flex min-w-0 flex-1 sm:flex-initial sm:w-auto gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white overflow-hidden items-center">
-        {assignedServicePointIds.length === 0 ? (
-          <span className="text-sm font-medium px-2 py-1 text-gray-600 whitespace-nowrap">
-            {t("assign_service_points")}
-          </span>
-        ) : (
-          <div className="flex gap-1 items-center min-w-0 flex-wrap sm:flex-nowrap">
-            {allServicePoints
-              .filter((subQueue) =>
-                assignedServicePointIds.includes(subQueue.id),
-              )
-              .slice(0, defaultServicePoints)
-              .map((subQueue) => {
-                return (
-                  <div
-                    key={subQueue.id}
-                    className="flex max-w-40 items-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 min-w-0"
-                  >
-                    <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full shrink-0" />
-                    <span className="text-sm text-gray-950 font-medium truncate">
-                      {subQueue.name}
-                    </span>
-                  </div>
-                );
-              })}
-            {activeServicePointCount > defaultServicePoints && (
-              <span className="text-sm text-gray-950 font-medium whitespace-nowrap px-1">
-                {"+"}
-                {t("count_more", {
-                  count: activeServicePointCount - defaultServicePoints,
-                })}
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            className="rounded-l-none w-10 h-9 border border-gray-300 bg-white shrink-0"
-          >
-            <ChevronDownIcon />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
-          className="w-[min(90vw,20rem)] max-h-[60vh] overflow-y-auto rounded-lg border border-gray-300 shadow-xl"
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full sm:w-auto items-stretch text-left rounded-md border border-gray-300 bg-white hover:bg-gray-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500"
         >
-          <div className="flex flex-col gap-2 p-2 items-start justify-start">
-            <div className="w-full">
-              <DropdownMenuLabel className="text-xs font-medium px-3 text-gray-600">
-                {t("assigned_service_points")}
-              </DropdownMenuLabel>
-              <div>
-                {allServicePoints.map((subQueue) => {
-                  const isSelected = assignedServicePointIds.includes(
-                    subQueue.id,
-                  );
-                  return (
-                    <div
-                      key={subQueue.id}
-                      className="flex items-center justify-between rounded-sm w-full p-1 hover:bg-gray-100 cursor-pointer"
-                      onClick={() => {
-                        toggleServicePoint(subQueue.id, !isSelected);
-                      }}
-                    >
-                      <div className="flex items-center space-x-3 p-1">
-                        <Checkbox
-                          checked={isSelected}
-                          onCheckedChange={(checked) =>
-                            toggleServicePoint(subQueue.id, checked as boolean)
-                          }
-                        />
-                        <span className="text-sm font-medium">
+          <div className="flex min-w-0 flex-1 sm:flex-initial sm:w-auto gap-1 p-1 overflow-hidden items-center">
+            {assignedServicePointIds.length === 0 ? (
+              <span className="text-sm font-medium px-2 py-1 text-gray-600 whitespace-nowrap">
+                {t("assign_service_points")}
+              </span>
+            ) : (
+              <div className="flex gap-1 items-center min-w-0 flex-wrap sm:flex-nowrap">
+                {allServicePoints
+                  .filter((subQueue) =>
+                    assignedServicePointIds.includes(subQueue.id),
+                  )
+                  .slice(0, defaultServicePoints)
+                  .map((subQueue) => {
+                    return (
+                      <div
+                        key={subQueue.id}
+                        className="flex max-w-40 items-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 min-w-0"
+                      >
+                        <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full shrink-0" />
+                        <span className="text-sm text-gray-950 font-medium truncate">
                           {subQueue.name}
                         </span>
                       </div>
-                    </div>
-                  );
-                })}
+                    );
+                  })}
+                {activeServicePointCount > defaultServicePoints && (
+                  <span className="text-sm text-gray-950 font-medium whitespace-nowrap px-1">
+                    {"+"}
+                    {t("count_more", {
+                      count: activeServicePointCount - defaultServicePoints,
+                    })}
+                  </span>
+                )}
               </div>
-            </div>
-            <div className="border-t border-gray-200 w-full pt-3 pb-1 px-1">
-              <Button className="w-full" onClick={() => setIsOpen(false)}>
-                {t("done")}
-              </Button>
+            )}
+          </div>
+          <div className="flex items-center justify-center w-10 border-l border-gray-300 shrink-0">
+            <ChevronDownIcon className="size-4" />
+          </div>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-[min(90vw,20rem)] max-h-[60vh] overflow-y-auto rounded-lg border border-gray-300 shadow-xl"
+      >
+        <div className="flex flex-col gap-2 p-2 items-start justify-start">
+          <div className="w-full">
+            <DropdownMenuLabel className="text-xs font-medium px-3 text-gray-600">
+              {t("assigned_service_points")}
+            </DropdownMenuLabel>
+            <div>
+              {allServicePoints.map((subQueue) => {
+                const isSelected = assignedServicePointIds.includes(
+                  subQueue.id,
+                );
+                return (
+                  <div
+                    key={subQueue.id}
+                    className="flex items-center justify-between rounded-sm w-full p-1 hover:bg-gray-100 cursor-pointer"
+                    onClick={() => {
+                      toggleServicePoint(subQueue.id, !isSelected);
+                    }}
+                  >
+                    <div className="flex items-center space-x-3 p-1">
+                      <Checkbox
+                        checked={isSelected}
+                        onCheckedChange={(checked) =>
+                          toggleServicePoint(subQueue.id, checked as boolean)
+                        }
+                      />
+                      <span className="text-sm font-medium">
+                        {subQueue.name}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+          <div className="border-t border-gray-200 w-full pt-3 pb-1 px-1">
+            <Button className="w-full" onClick={() => setIsOpen(false)}>
+              {t("done")}
+            </Button>
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -3,11 +3,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import useBreakpoints from "@/hooks/useBreakpoints";
-import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu";
 import { ChevronDownIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -18,13 +18,18 @@ export const ServicePointsDropDown = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { assignedServicePointIds, allServicePoints, toggleServicePoint } =
     useQueueServicePoints();
-  const defaultServicePoints = useBreakpoints({ default: 4, sm: 6 });
+  const defaultServicePoints = useBreakpoints({
+    default: 1,
+    sm: 3,
+    md: 4,
+    lg: 6,
+  });
 
   if (!allServicePoints) {
     return (
-      <div className="flex">
-        <Skeleton className="h-11 w-40 rounded-r-none rounded-l-md" />
-        <Skeleton className="h-11 w-10 rounded-l-none rounded-r-md" />
+      <div className="flex w-full sm:w-auto">
+        <Skeleton className="h-9 w-full sm:w-40 rounded-r-none rounded-l-md" />
+        <Skeleton className="h-9 w-10 rounded-l-none rounded-r-md shrink-0" />
       </div>
     );
   }
@@ -34,14 +39,14 @@ export const ServicePointsDropDown = () => {
   ).length;
 
   return (
-    <div className="flex">
-      <div className="flex w-full sm:w-auto gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white">
+    <div className="flex w-full sm:w-auto">
+      <div className="flex min-w-0 flex-1 sm:flex-initial sm:w-auto gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white overflow-hidden items-center">
         {assignedServicePointIds.length === 0 ? (
-          <span className="text-sm font-medium">
+          <span className="text-sm font-medium px-2 py-1 text-gray-600">
             {t("assign_service_points")}
           </span>
         ) : (
-          <div className="flex gap-1 items-center justify-center">
+          <div className="flex gap-1 items-center min-w-0 flex-wrap sm:flex-nowrap">
             {allServicePoints
               .filter((subQueue) =>
                 assignedServicePointIds.includes(subQueue.id),
@@ -51,9 +56,9 @@ export const ServicePointsDropDown = () => {
                 return (
                   <div
                     key={subQueue.id}
-                    className="flex w-48 items-center justify-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 whitespace-nowrap"
+                    className="flex max-w-40 items-center gap-1 border border-gray-300 py-0.5 px-1.5 rounded-sm bg-gray-50 min-w-0"
                   >
-                    <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full" />
+                    <div className="bg-primary-200 border border-primary-500 w-2 h-2 rounded-full shrink-0" />
                     <span className="text-sm text-gray-950 font-medium truncate">
                       {subQueue.name}
                     </span>
@@ -61,7 +66,7 @@ export const ServicePointsDropDown = () => {
                 );
               })}
             {activeServicePointCount > defaultServicePoints && (
-              <span className="text-sm text-gray-950 font-medium">
+              <span className="text-sm text-gray-950 font-medium whitespace-nowrap px-1">
                 {"+"}
                 {t("count_more", {
                   count: activeServicePointCount - defaultServicePoints,
@@ -75,14 +80,14 @@ export const ServicePointsDropDown = () => {
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className="rounded-l-none w-10 h-9 border border-gray-300 bg-white"
+            className="rounded-l-none w-10 h-9 border border-gray-300 bg-white shrink-0"
           >
             <ChevronDownIcon />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="end"
-          className="min-w-55 rounded-lg border border-gray-300 shadow-xl  w-full"
+          className="w-[min(90vw,20rem)] max-h-[60vh] overflow-y-auto rounded-lg border border-gray-300 shadow-xl"
         >
           <div className="flex flex-col gap-2 p-2 items-start justify-start">
             <div className="w-full">

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -20,9 +20,9 @@ export const ServicePointsDropDown = () => {
     useQueueServicePoints();
   const defaultServicePoints = useBreakpoints({
     default: 1,
-    sm: 3,
-    md: 4,
-    lg: 6,
+    lg: 3,
+    xl: 4,
+    "2xl": 6,
   });
 
   if (!allServicePoints) {

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -111,9 +111,8 @@ export const ServicePointsDropDown = () => {
                     <div className="flex items-center space-x-3 p-1">
                       <Checkbox
                         checked={isSelected}
-                        onCheckedChange={(checked) =>
-                          toggleServicePoint(subQueue.id, checked as boolean)
-                        }
+                        className="pointer-events-none"
+                        tabIndex={-1}
                       />
                       <span className="text-sm font-medium">
                         {subQueue.name}

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -42,7 +42,7 @@ export const ServicePointsDropDown = () => {
     <div className="flex w-full sm:w-auto">
       <div className="flex min-w-0 flex-1 sm:flex-initial sm:w-auto gap-1 rounded-r-none border border-r-0 border-gray-300 rounded-l-md p-1 bg-white overflow-hidden items-center">
         {assignedServicePointIds.length === 0 ? (
-          <span className="text-sm font-medium px-2 py-1 text-gray-600">
+          <span className="text-sm font-medium px-2 py-1 text-gray-600 whitespace-nowrap">
             {t("assign_service_points")}
           </span>
         ) : (

--- a/src/pages/Facility/queues/ServicePointsDropDown.tsx
+++ b/src/pages/Facility/queues/ServicePointsDropDown.tsx
@@ -45,7 +45,7 @@ export const ServicePointsDropDown = () => {
           type="button"
           className="flex w-full sm:w-auto items-stretch text-left rounded-md border border-gray-300 bg-white hover:bg-gray-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500"
         >
-          <div className="flex min-w-0 flex-1 sm:flex-initial sm:w-auto gap-1 p-1 overflow-hidden items-center">
+          <div className="flex min-w-0 flex-1 gap-1 p-1 overflow-hidden items-center">
             {assignedServicePointIds.length === 0 ? (
               <span className="text-sm font-medium px-2 py-1 text-gray-600 whitespace-nowrap">
                 {t("assign_service_points")}


### PR DESCRIPTION

<img width="438" height="923" alt="image" src="https://github.com/user-attachments/assets/f90eb96b-ca4c-4e56-a343-6f6b77326361" />


<img width="444" height="933" alt="image" src="https://github.com/user-attachments/assets/4910fcdd-39a4-4c7c-b149-ea4691d15d7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile card view for finished tokens and mobile tabs to switch waiting/serving columns; mobile loading skeletons optimized.
  * Token action menu converted to a visible dropdown with consolidated, ordered actions.

* **Style**
  * Improved responsive headers, truncation, spacing, and control alignment to prevent overflow.
  * Updated modals/dialogs/dropdowns with constrained, scrollable sizing and improved chip/trigger layout.

* **Bug Fixes**
  * Fixed infinite-scroll attachment and small-viewport overflow/scrolling issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->