### PR TITLE
ci: fix Playwright CI failures by pinning PostgreSQL to v17

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -43,6 +43,7 @@ jobs:
               - 'src/**'
               - 'package.json'
               - 'playwright.config.ts'
+              - '.github/workflows/playwright.yaml'
 
   # Build application once and cache for all test shards
   build:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -125,7 +125,11 @@ jobs:
           echo DISABLE_RATELIMIT=True >> docker/.local.env
           echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.local.env
           echo MAX_QUESTIONNAIRE_TEXT_RESPONSE_SIZE=500 >> docker/.local.env
-          make docker_config_file=docker-compose.local.yaml up load-fixtures
+          if ! make docker_config_file=docker-compose.local.yaml up load-fixtures; then
+            echo "::error::Docker containers failed to start. Dumping logs..."
+            docker compose -f docker-compose.yaml -f docker-compose.local.yaml logs --tail=200
+            exit 1
+          fi
           cd ..
         env:
           JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -123,6 +123,8 @@ jobs:
       - name: Start care docker containers
         run: |
           cd care
+          # Pin postgres to 17 to avoid PG 18+ data directory layout change
+          sed -i 's|image: postgres:alpine|image: postgres:17-alpine|' docker-compose.yaml
           echo DISABLE_RATELIMIT=True >> docker/.local.env
           echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.local.env
           echo MAX_QUESTIONNAIRE_TEXT_RESPONSE_SIZE=500 >> docker/.local.env


### PR DESCRIPTION
All Playwright CI runs have been failing since April 22 because `postgres:alpine` in the backend docker-compose now pulls PostgreSQL 18, which changed the data directory layout and breaks the volume mount at `/var/lib/postgresql/data`.

DB container crashes → celery times out waiting for DB → health check fails → no tests run.

### Changes
- Pin postgres to `17-alpine` via sed before starting containers
- Add `docker compose logs` capture on startup failure for easier debugging
- Include `playwright.yaml` in path filter so workflow changes trigger test runs

### Permanent fix
Pin `postgres:17-alpine` in `ohcnetwork/care` docker-compose.yaml (backend PR to follow).