### PR TITLE
Add account id in print charge items

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -963,6 +963,7 @@
   "beta": "beta",
   "bill": "Bill",
   "bill_all_pending_prescriptions": "Bill All Pending Prescriptions",
+  "bill_id": "Bill ID",
   "bill_medication": "Bill Medication",
   "bill_medications": "Bill Medications",
   "bill_selected": "Bill Selected",
@@ -3261,6 +3262,7 @@
   "mark_as_deceased": "Mark as deceased",
   "mark_as_draft": "Mark as Draft",
   "mark_as_entered_in_error": "Mark as entered in error",
+  "mark_as_entered_in_error_confirmation": "Are you sure you want to mark the token {{tokenNumber}} for {{patientName}} as entered in error? This action cannot be undone.",
   "mark_as_entered_in_error_warning": "Mark as Entered in Error with Active Payments",
   "mark_as_error": "Mark as error",
   "mark_as_error_confirmation_message": "Are you sure you want to mark this payment as entered in error? This indicates that the payment record was created by mistake and should not have been recorded.",
@@ -6537,6 +6539,5 @@
   "your_request_order_list": "Your Request Order List",
   "zoom_in": "Zoom In",
   "zoom_out": "Zoom Out",
-  "mark_as_entered_in_error_confirmation": "Are you sure you want to mark the token {{tokenNumber}} for {{patientName}} as entered in error? This action cannot be undone.",
   "℞": "℞"
 }

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -480,7 +480,7 @@ export const PrintChargeItems = (props: {
                         </div>
                         <div className="space-y-1">
                           <DetailRow
-                            label={`${t("account_id")}`}
+                            label={`${t("bill_id")}`}
                             value={account?.id}
                             width="w-24"
                           />

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -441,7 +441,7 @@ export const PrintChargeItems = (props: {
                           <DetailRow
                             label={t("name")}
                             value={account?.patient?.name}
-                            width="w-16"
+                            width="w-22"
                           />
                           <DetailRow
                             label={`${t("age")} / ${t("sex")}`}
@@ -450,12 +450,22 @@ export const PrintChargeItems = (props: {
                                 ? `${formatPatientAge(account.patient, true)}, ${t(`GENDER__${account.patient.gender}`)}`
                                 : undefined
                             }
-                            width="w-16"
+                            width="w-22"
                           />
                           <DetailRow
                             label={`${t("address")}`}
                             value={account?.patient?.address}
-                            width="w-16"
+                            width="w-22"
+                          />
+                          <DetailRow
+                            label={t("mobile_number")}
+                            value={
+                              account?.patient &&
+                              formatPhoneNumberIntl(
+                                account.patient.phone_number,
+                              )
+                            }
+                            width="w-22"
                           />
                           {account?.primary_encounter?.current_location && (
                             <DetailRow
@@ -464,11 +474,16 @@ export const PrintChargeItems = (props: {
                                 account?.primary_encounter?.current_location
                                   ?.name
                               }
-                              width="w-16"
+                              width="w-22"
                             />
                           )}
                         </div>
                         <div className="space-y-1">
+                          <DetailRow
+                            label={`${t("account_id")}`}
+                            value={account?.id}
+                            width="w-24"
+                          />
                           <DetailRow
                             label={`${t("date")}`}
                             value={formatDateTime(new Date(), "DD-MM-YYYY")}
@@ -488,16 +503,7 @@ export const PrintChargeItems = (props: {
                                 width="w-24"
                               />
                             ))}
-                          <DetailRow
-                            label={t("mobile_number")}
-                            value={
-                              account?.patient &&
-                              formatPhoneNumberIntl(
-                                account.patient.phone_number,
-                              )
-                            }
-                            width="w-24"
-                          />
+
                           {account?.primary_encounter && (
                             <>
                               <DetailRow


### PR DESCRIPTION

<img width="764" height="320" alt="image" src="https://github.com/user-attachments/assets/67efaf83-6cef-43e9-850c-a0e3b1abf483" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted patient information field widths in the charge-items print view for improved layout consistency.
  * Moved mobile number into the patient details column for clearer organization.
  * Added account ID (Bill ID) to the charge-items print display.

* **New Features**
  * English locale updated to include a "Bill ID" label and refresh a confirmation message entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->