### PR TITLE
fixes unsaved changes prompt being shown on save as draft on forms

### DIFF
--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { navigate, useNavigationPrompt, useQueryParams } from "raviger";
 import { useEffect, useMemo, useState } from "react";
+import { flushSync } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -508,7 +509,7 @@ export function QuestionnaireForm({
   const { mutate: createDraft, isPending: isCreateDraftPending } = useMutation({
     mutationFn: mutate(formSubmissionApi.create),
     onSuccess: () => {
-      setIsDirty(false);
+      flushSync(() => setIsDirty(false));
       toast.success(t("draft_saved_successfully"));
       navigate(
         `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
@@ -528,7 +529,7 @@ export function QuestionnaireForm({
         pathParams: { external_id: data.id },
       })(data.body),
     onSuccess: () => {
-      setIsDirty(false);
+      flushSync(() => setIsDirty(false));
       toast.success(t("draft_saved_successfully"));
       queryClient.invalidateQueries({
         queryKey: ["formSubmission", continueDraftId],


### PR DESCRIPTION
Navigation prompt triggers only when form is dirty. However, even though we are setting `isDirty` to false upon saving as draft, the state isn't updated by the time navigate isn't invoked since it's asynchronously updated. In this PR, we ensure the state update is done synchronously in order to achieve this.