### PR TITLE
Prevent empty interpretation creation on popover dismiss

### DIFF
--- a/src/pages/Facility/settings/observationDefinition/ObservationInterpretation.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationInterpretation.tsx
@@ -533,7 +533,10 @@ export function ObservationInterpretation<
       )}
 
       <Sheet open={isSheetOpen} onOpenChange={handleSheetState}>
-        <SheetContent className="sm:max-w-3xl flex flex-col">
+        <SheetContent
+          className="sm:max-w-3xl flex flex-col"
+          onInteractOutside={(e) => e.preventDefault()}
+        >
           <SheetHeader>
             <SheetTitle>{t("add_edit_interpretation")}</SheetTitle>
             <SheetDescription>{t("configure_interpretation")}</SheetDescription>


### PR DESCRIPTION
## Proposed Changes

Fixes #16285

- Disabled sheet dismissal on outside click using `onInteractOutside`
- Prevented unintended creation of empty interpretation entries when closing the Add/Edit Interpretation popover

## Additional Context
Previously, clicking outside the popover would close it and unintentionally commit an empty interpretation. This change ensures the sheet can only be closed through explicit user actions.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update product documentation
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes 


https://github.com/user-attachments/assets/d9efc87a-3573-448e-b921-37e96af9404a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of external interactions in modal dialogs to prevent unintended event propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->