### PR TITLE
feat: add DiagnosticReportOverride component and integrate into DiagnosticReportForm

### DIFF
--- a/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/DiagnosticReportForm.tsx
@@ -898,6 +898,16 @@ export function DiagnosticReportForm({
             />
             {hasReport && fullReport ? (
               <div className="space-y-6">
+                {fullReport.status !== DiagnosticReportStatus.final && (
+                  <PLUGIN_Component
+                    __name="DiagnosticReportOverride"
+                    observationDefinitions={observationDefinitions}
+                    handleComponentValueChange={handleComponentValueChange}
+                    handleValueChange={handleValueChange}
+                    handleUnitChange={handleUnitChange}
+                    disabled={disableEdit}
+                  />
+                )}
                 {fullReport.status !== DiagnosticReportStatus.final &&
                   observationDefinitions.map((definition) => {
                     const observationsList = observations[definition.id] || [

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -90,6 +90,31 @@ export type EncounterOverviewTopComponentType = React.FC<{
   encounterId: string;
 }>;
 
+export type DiagnosticReportOverrideComponentType = React.FC<{
+  observationDefinitions: {
+    id: string;
+    title?: string;
+    code?: { code: string; display?: string };
+    component?: { code: { code: string; display?: string } }[];
+    permitted_unit?: { code: string; display?: string; system?: string } | null;
+    permitted_data_type?: string;
+  }[];
+  handleComponentValueChange: (
+    definitionId: string,
+    index: number,
+    componentCode: string,
+    value: string,
+    unit: string,
+  ) => void;
+  handleValueChange: (
+    definitionId: string,
+    index: number,
+    value: string,
+  ) => void;
+  handleUnitChange: (definitionId: string, index: number, unit: string) => void;
+  disabled?: boolean;
+}>;
+
 // Define supported plugin components
 export type SupportedPluginComponents = {
   DoctorConnectButtons: DoctorConnectButtonComponentType;
@@ -106,6 +131,7 @@ export type SupportedPluginComponents = {
   PatientInfoCardActions: PatientInfoCardActionsComponentType;
   ServiceRequestAction: ServiceRequestComponentType;
   EncounterOverviewTop: EncounterOverviewTopComponentType;
+  DiagnosticReportOverride: DiagnosticReportOverrideComponentType;
 };
 
 // Create a type for lazy-loaded components


### PR DESCRIPTION


<img width="759" height="820" alt="image" src="https://github.com/user-attachments/assets/e37b5565-a44d-463a-bdab-8d3d99032e2b" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostic report editor now includes an enhanced editing interface for draft-status reports. When working with non-final diagnostic reports, users will see an additional override component that provides greater control over observation values and measurement units, enabling more precise adjustments and refinements before finalizing and submitting reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->